### PR TITLE
Lint fixes/updating .golangci to not use deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
   enable:
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - ginkgolinter
     - goconst
     - gocyclo

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
-generate: controller-gen code-generator ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: controller-gen code-generator manifests## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	./hack/update-codegen.sh
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
-generate: controller-gen code-generator manifests## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: controller-gen code-generator manifests ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	./hack/update-codegen.sh
 

--- a/api/v1alpha1/inferencepool_types.go
+++ b/api/v1alpha1/inferencepool_types.go
@@ -36,7 +36,7 @@ type InferencePoolSpec struct {
 	Selector map[LabelKey]LabelValue `json:"selector,omitempty"`
 
 	// TargetPortNumber is the port number that the model servers within the pool expect
-	// to recieve traffic from.
+	// to receive traffic from.
 	// This maps to the TargetPort in: https://pkg.go.dev/k8s.io/api/core/v1#ServicePort
 	//
 	// +kubebuilder:validation:Minimum=0

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
@@ -68,7 +68,7 @@ spec:
               targetPortNumber:
                 description: |-
                   TargetPortNumber is the port number that the model servers within the pool expect
-                  to recieve traffic from.
+                  to receive traffic from.
                   This maps to the TargetPort in: https://pkg.go.dev/k8s.io/api/core/v1#ServicePort
                 format: int32
                 maximum: 65535

--- a/pkg/ext-proc/test/hermetic_test.go
+++ b/pkg/ext-proc/test/hermetic_test.go
@@ -38,7 +38,7 @@ func TestHandleRequestBody(t *testing.T) {
 			name: "success",
 			req:  GenerateRequest("my-model"),
 			models: map[string]*v1alpha1.InferenceModel{
-				"my-model": &v1alpha1.InferenceModel{
+				"my-model": {
 					Spec: v1alpha1.InferenceModelSpec{
 						ModelName: "my-model",
 						TargetModels: []v1alpha1.TargetModel{


### PR DESCRIPTION
This does not fix all linter issues, just the ones in the main file. 

Much of them were just overly long lines.

Part of completing #124 