### PR TITLE
Downgrades golangci-lint to v1.60.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module inference.networking.x-k8s.io/llm-instance-gateway
 
-go 1.22.7
-
-toolchain go1.23.2
+go 1.23.4
 
 require (
 	github.com/bojand/ghz v0.120.0


### PR DESCRIPTION
Downgrade the version of golangci-lint to v1.60.0 to make the version of the go toolchain directive. v1.60.0 is the only version of golangci-lint built using Go v1.23. This PR also adds the `-v` flag to the `lint` target to produce verbose output.

Fixes: #140 