### PR TITLE
ext-proc: remove unused fields from EndpointSliceReconciler

### DIFF
--- a/pkg/ext-proc/backend/endpointslice_reconciler.go
+++ b/pkg/ext-proc/backend/endpointslice_reconciler.go
@@ -23,10 +23,8 @@ type EndpointSliceReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
 	Record      record.EventRecorder
-	PoolName    string
 	ServiceName string
 	Zone        string
-	Namespace   string
 	Datastore   *K8sDatastore
 }
 

--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -142,7 +142,6 @@ func main() {
 		Record:      mgr.GetEventRecorderFor("endpointslice"),
 		ServiceName: *serviceName,
 		Zone:        *zone,
-		PoolName:    *poolName,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Error(err, "Error setting up EndpointSliceReconciler")
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/157

(the above issue is obsolete now that we are removing the field itself)