### PR TITLE
configurable filter chains

### DIFF
--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -29,9 +29,23 @@ type K8sDatastore struct {
 	inferencePool   *v1alpha1.InferencePool
 	InferenceModels *sync.Map
 	pods            *sync.Map
+
+	filterConfigMap *corev1.ConfigMap
 }
 
 type K8sDatastoreOption func(*K8sDatastore)
+
+func (ds *K8sDatastore) GetFilterConfigMap() *corev1.ConfigMap {
+	ds.poolMu.RLock()
+	defer ds.poolMu.RUnlock()
+	return ds.filterConfigMap
+}
+
+func WithFilterConfigMap(filterConfigMap *corev1.ConfigMap) K8sDatastoreOption {
+	return func(store *K8sDatastore) {
+		store.filterConfigMap = filterConfigMap
+	}
+}
 
 // WithPods can be used in tests to override the pods.
 func WithPods(pods []*PodMetrics) K8sDatastoreOption {

--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -36,6 +36,9 @@ type K8sDatastore struct {
 type K8sDatastoreOption func(*K8sDatastore)
 
 func (ds *K8sDatastore) GetFilterConfigMap() *corev1.ConfigMap {
+	if ds == nil {
+		return nil
+	}
 	ds.poolMu.RLock()
 	defer ds.poolMu.RUnlock()
 	return ds.filterConfigMap

--- a/pkg/ext-proc/backend/filterconfig_reconciler.go
+++ b/pkg/ext-proc/backend/filterconfig_reconciler.go
@@ -1,0 +1,53 @@
+package backend
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type FilterConfigReconciler struct {
+	client.Client
+	Datastore *K8sDatastore
+}
+
+func (c *FilterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, req.NamespacedName, cm); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			klog.Errorf("unable to get ConfigMap, err: %v", err)
+			return ctrl.Result{}, err
+		}
+		c.Datastore.poolMu.Lock()
+		defer c.Datastore.poolMu.Unlock()
+		klog.V(1).Info("filter config deleted, reset filter config")
+		c.Datastore.filterConfigMap = nil
+		return ctrl.Result{}, nil
+	}
+
+	c.Datastore.poolMu.Lock()
+	defer c.Datastore.poolMu.Unlock()
+
+	if cm.DeletionTimestamp != nil {
+		klog.V(1).Info("filter config deleting, reset filter config")
+		c.Datastore.filterConfigMap = nil
+		return ctrl.Result{}, nil
+	}
+
+	klog.V(1).Infof("update filter config to: %++v", cm.Data)
+	c.Datastore.filterConfigMap = cm.DeepCopy()
+	return ctrl.Result{}, nil
+}
+
+func (c *FilterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			return object.GetName() == "filter-config" && object.GetNamespace() == "default"
+		})).
+		Complete(c)
+}

--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -207,7 +207,7 @@ func startExternalProcessorServer(
 ) *grpc.Server {
 	svr := grpc.NewServer()
 
-	var orchestrator *scheduling.FilterOrchestratorImpl
+	var orchestrator scheduling.FilterOrchestrator
 	if *enableFilterConfiguration {
 		orchestrator = scheduling.NewFilterOrchestrator(datastore)
 	}

--- a/pkg/ext-proc/scheduling/filter.go
+++ b/pkg/ext-proc/scheduling/filter.go
@@ -4,43 +4,46 @@ import (
 	"errors"
 	"math"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+
 	klog "k8s.io/klog/v2"
 )
 
-type Filter interface {
+type FilterChain interface {
 	Name() string
 	Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error)
 }
 
-// filter applies current filterFunc, and then recursively applies next filters depending success or
+// filterChainImpl applies current filterFunc, and then recursively applies next filters depending success or
 // failure of the current filterFunc.
 // It can be used to construct a flow chart algorithm.
-type filter struct {
+type filterChainImpl struct {
 	name   string
-	filter filterFunc
+	filter filter
 	// nextOnSuccess filter will be applied after successfully applying the current filter.
 	// The filtered results will be passed to the next filter.
-	nextOnSuccess *filter
+	nextOnSuccess *filterChainImpl
 	// nextOnFailure filter will be applied if current filter fails.
 	// The original input will be passed to the next filter.
-	nextOnFailure *filter
+	nextOnFailure *filterChainImpl
 	// nextOnSuccessOrFailure is a convenience field to configure the next filter regardless of the
 	// success or failure of the current filter.
 	// NOTE: When using nextOnSuccessOrFailure, both nextOnSuccess and nextOnFailure SHOULD be nil.
 	// However if that's not the case, nextOnSuccess and nextOnFailure will be used, instead of
 	// nextOnSuccessOrFailure,  in the success and failure scenarios, respectively.
-	nextOnSuccessOrFailure *filter
+	nextOnSuccessOrFailure *filterChainImpl
 }
 
-func (f *filter) Name() string {
+func (f *filterChainImpl) Name() string {
 	if f == nil {
 		return "nil"
 	}
 	return f.name
 }
 
-func (f *filter) Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
+func (f *filterChainImpl) Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
 	klog.V(3).Infof("Running filter %q on request %v with %v pods", f.name, req, len(pods))
 
 	filtered, err := f.filter(req, pods)
@@ -71,11 +74,11 @@ func (f *filter) Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend
 	}
 }
 
-// filterFunc filters a set of input pods to a subset.
-type filterFunc func(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error)
+// filter filters a set of input pods to a subset.
+type filter func(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error)
 
-// toFilterFunc is a helper function to convert a per pod filter func to the FilterFunc.
-func toFilterFunc(pp podPredicate) filterFunc {
+// toFilter is a helper function to convert a per pod filter func to the FilterFunc.
+func toFilter(pp podPredicate) filter {
 	return func(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
 		filtered := []*backend.PodMetrics{}
 		for _, pod := range pods {
@@ -150,6 +153,12 @@ func leastKVCacheFilterFunc(req *LLMRequest, pods []*backend.PodMetrics) ([]*bac
 		}
 	}
 	return filtered, nil
+}
+
+func dropRequestFilterFunc(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
+	klog.Infof("Dropping request %v", req)
+	return []*backend.PodMetrics{}, status.Errorf(
+		codes.ResourceExhausted, "dropping request due to limited backend resources")
 }
 
 // podPredicate is a filter function to check whether a pod is desired.

--- a/pkg/ext-proc/scheduling/filter.go
+++ b/pkg/ext-proc/scheduling/filter.go
@@ -123,10 +123,6 @@ func leastQueuingFilterFunc(req *LLMRequest, pods []*backend.PodMetrics) ([]*bac
 	return filtered, nil
 }
 
-func lowQueueingPodPredicate(_ *LLMRequest, pod *backend.PodMetrics) bool {
-	return pod.WaitingQueueSize < queueingThresholdLoRA
-}
-
 // leastKVCacheFilterFunc finds the max and min KV cache of all pods, divides the whole range
 // (max-min) by the number of pods, and finds the pods that fall into the first range.
 // The intuition is that if there are multiple pods that share similar KV cache in the low range, we
@@ -192,5 +188,11 @@ func criticalRequestPredicate(req *LLMRequest, pod *backend.PodMetrics) bool {
 func noQueueAndLessThanKVCacheThresholdPredicate(queueThreshold int, kvCacheThreshold float64) podPredicate {
 	return func(req *LLMRequest, pod *backend.PodMetrics) bool {
 		return pod.WaitingQueueSize <= queueThreshold && pod.KVCacheUsagePercent <= kvCacheThreshold
+	}
+}
+
+func lowQueueingPodPredicate(queueingThresholdLoRA int) podPredicate {
+	return func(_ *LLMRequest, pod *backend.PodMetrics) bool {
+		return pod.WaitingQueueSize < queueingThresholdLoRA
 	}
 }

--- a/pkg/ext-proc/scheduling/filtergen.go
+++ b/pkg/ext-proc/scheduling/filtergen.go
@@ -1,5 +1,7 @@
 package scheduling
 
+import "fmt"
+
 const (
 	FilterCriticalRequestName  = "critical_request"
 	FilterLeastQueuingName     = "least_queuing"
@@ -118,7 +120,18 @@ var (
 			}
 			return toFilter(noQueueAndLessThanKVCacheThresholdPredicate(qtc, kct))
 		},
-		validator: func(fo *FilterOption) error { return nil },
+		validator: func(fo *FilterOption) error {
+			if fo == nil {
+				return nil
+			}
+			if fo.KvCacheThreshold != nil && *fo.KvCacheThreshold < 0 {
+				return fmt.Errorf("invalid kvCacheThreshold: %f", *fo.KvCacheThreshold)
+			}
+			if fo.QueueThresholdCritical != nil && *fo.QueueThresholdCritical < 0 {
+				return fmt.Errorf("invalid queueThresholdCritical: %d", *fo.QueueThresholdCritical)
+			}
+			return nil
+		},
 	}
 
 	FilterLeastKvCache FilterGen = &filterGenImpl{

--- a/pkg/ext-proc/scheduling/filtergen.go
+++ b/pkg/ext-proc/scheduling/filtergen.go
@@ -1,0 +1,147 @@
+package scheduling
+
+const (
+	FilterCriticalRequestName  = "critical_request"
+	FilterLeastQueuingName     = "least_queuing"
+	FilterLowCostLoraName      = "low_cost_lora"
+	FilterLowLatencyName       = "low_latency"
+	FilterAffinityLoraName     = "affinity_lora"
+	FilterSheddableRequestName = "sheddable_request"
+	FilterLeastKvCacheName     = "least_kv_cache"
+	FilterDropRequestName      = "drop_request"
+	FilterCanAcceptNewLoraName = "can_accept_new_lora"
+)
+
+const (
+	TopKByWaitingQueueSize    = "waiting_queue_size"
+	TopKByKVCacheUsagePercent = "kv_cache_usage_percent"
+)
+
+var filterMap = map[string]FilterGen{
+	FilterLowLatencyName:       FilterLowLatency,
+	FilterCriticalRequestName:  FilterCriticalRequest,
+	FilterLeastQueuingName:     FilterLeastQueuing,
+	FilterCanAcceptNewLoraName: FilterCanAcceptNewLora,
+	FilterSheddableRequestName: FilterSheddableRequest,
+	FilterDropRequestName:      FilterDropRequest,
+	FilterAffinityLoraName:     FilterAffinityLora,
+	FilterLowCostLoraName:      FilterLowCostLora,
+	FilterLeastKvCacheName:     FilterLeastKvCache,
+}
+
+// FilterGen generate a filter from a filter option
+type FilterGen interface {
+	Name() string
+	Get(*FilterOption) filter
+	Validate(*FilterOption) error
+}
+
+type FilterOption struct {
+	KvCacheThreshold *float64 `json:"kvCacheThreshold,omitempty"`
+
+	QueueThresholdCritical *int `json:"queueThresholdCritical,omitempty"`
+	QueueingThresholdLoRA  *int `json:"queueingThresholdLoRA,omitempty"`
+}
+
+type filterGenImpl struct {
+	name      string
+	getter    func(*FilterOption) filter
+	validator func(*FilterOption) error
+}
+
+var _ FilterGen = &filterGenImpl{}
+
+func (fg *filterGenImpl) Name() string {
+	return fg.name
+}
+
+func (fg *filterGenImpl) Get(fo *FilterOption) filter {
+	return fg.getter(fo)
+}
+
+func (fg *filterGenImpl) Validate(fo *FilterOption) error {
+	return fg.validator(fo)
+}
+
+var (
+	FilterCriticalRequest FilterGen = &filterGenImpl{
+		name: FilterCriticalRequestName,
+		getter: func(fo *FilterOption) filter {
+			return toFilter(criticalRequestPredicate)
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterLeastQueuing FilterGen = &filterGenImpl{
+		name: FilterLeastQueuingName,
+		getter: func(fo *FilterOption) filter {
+			return leastQueuingFilterFunc
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterLowCostLora FilterGen = &filterGenImpl{
+		name: FilterLowCostLoraName,
+		getter: func(fo *FilterOption) filter {
+			return toFilter(lowLoRACostPredicate)
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterLowLatency FilterGen = &filterGenImpl{
+		name: FilterLowLatencyName,
+		getter: func(fo *FilterOption) filter {
+			return toFilter(lowQueueingPodPredicate)
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterAffinityLora FilterGen = &filterGenImpl{
+		name: FilterAffinityLoraName,
+		getter: func(fo *FilterOption) filter {
+			return toFilter(loRAAffinityPredicate)
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterSheddableRequest FilterGen = &filterGenImpl{
+		name: FilterSheddableRequestName,
+		getter: func(opt *FilterOption) filter {
+			qtc, kct := queueThresholdCritical, kvCacheThreshold
+			if opt != nil {
+				if opt.KvCacheThreshold != nil {
+					kct = *opt.KvCacheThreshold
+				}
+				if opt.QueueThresholdCritical != nil {
+					qtc = *opt.QueueThresholdCritical
+				}
+			}
+			return toFilter(noQueueAndLessThanKVCacheThresholdPredicate(qtc, kct))
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterLeastKvCache FilterGen = &filterGenImpl{
+		name: FilterLeastKvCacheName,
+		getter: func(fo *FilterOption) filter {
+			return leastKVCacheFilterFunc
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterDropRequest FilterGen = &filterGenImpl{
+		name: FilterDropRequestName,
+		getter: func(fo *FilterOption) filter {
+			return dropRequestFilterFunc
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+
+	FilterCanAcceptNewLora FilterGen = &filterGenImpl{
+		name: FilterCanAcceptNewLoraName,
+		getter: func(fo *FilterOption) filter {
+			return toFilter(canAcceptNewLoraPredicate)
+		},
+		validator: func(fo *FilterOption) error { return nil },
+	}
+)

--- a/pkg/ext-proc/scheduling/filtergen_test.go
+++ b/pkg/ext-proc/scheduling/filtergen_test.go
@@ -1,0 +1,79 @@
+package scheduling
+
+import "testing"
+
+func TestFilterGenValidation(t *testing.T) {
+	testCases := []struct {
+		name      string
+		fo        *FilterOption
+		filterGen FilterGen
+		wantErr   bool
+	}{
+		{
+			name: "valid sheddable_request filter option",
+			fo: &FilterOption{
+				KvCacheThreshold:       toPtr(0.8),
+				QueueThresholdCritical: toPtr(5),
+			},
+			filterGen: FilterSheddableRequest,
+			wantErr:   false,
+		},
+		{
+			name:      "valid sheddable_request filter option, nil option",
+			fo:        &FilterOption{},
+			filterGen: FilterSheddableRequest,
+			wantErr:   false,
+		},
+		{
+			name: "valid sheddable_request filter option, nil QueueThresholdCritical",
+			fo: &FilterOption{
+				KvCacheThreshold: toPtr(0.8),
+			},
+			filterGen: FilterSheddableRequest,
+			wantErr:   false,
+		},
+		{
+			name: "invalid sheddable_request filter option",
+			fo: &FilterOption{
+				KvCacheThreshold:       toPtr(-1.0),
+				QueueThresholdCritical: toPtr(5),
+			},
+			filterGen: FilterSheddableRequest,
+			wantErr:   true,
+		},
+		{
+			name: "valid low_latency filter option",
+			fo: &FilterOption{
+				QueueingThresholdLoRA: toPtr(50),
+			},
+			filterGen: FilterLowLatency,
+			wantErr:   false,
+		},
+		{
+			name:      "valid low_latency filter option, nil option",
+			fo:        &FilterOption{},
+			filterGen: FilterLowLatency,
+			wantErr:   false,
+		},
+		{
+			name: "invalid low_latency filter option",
+			fo: &FilterOption{
+				QueueingThresholdLoRA: toPtr(-1),
+			},
+			filterGen: FilterLowLatency,
+			wantErr:   true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.filterGen.Validate(tc.fo)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func toPtr[T any](v T) *T {
+	return &v
+}

--- a/pkg/ext-proc/scheduling/orchestrate.go
+++ b/pkg/ext-proc/scheduling/orchestrate.go
@@ -39,18 +39,20 @@ func (o *FilterOrchestratorImpl) Orchestrate() FilterChain {
 	if o == nil {
 		return defaultFilter
 	}
-	if o.datastore == nil || o.datastore.GetFilterConfigMap() == nil {
+
+	cm := o.datastore.GetFilterConfigMap()
+	if cm == nil {
 		return defaultFilter
 	}
 
-	if o.lastUpdated == lastUpdatedKey(o.datastore.GetFilterConfigMap()) {
+	if o.lastUpdated == lastUpdatedKey(cm) {
 		return o.storedFilter
 	}
 
-	o.lastUpdated = lastUpdatedKey(o.datastore.GetFilterConfigMap())
+	o.lastUpdated = lastUpdatedKey(cm)
 
 	f := &FilterOrchestration{}
-	if err := json.Unmarshal([]byte(o.datastore.GetFilterConfigMap().Data["filter"]), f); err != nil {
+	if err := json.Unmarshal([]byte(cm.Data["filter"]), f); err != nil {
 		o.storedFilter = defaultFilter
 		klog.Errorf("error unmarshalling filter config: %v", err)
 		return defaultFilter

--- a/pkg/ext-proc/scheduling/orchestrate.go
+++ b/pkg/ext-proc/scheduling/orchestrate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	corev1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
 )
 
@@ -42,11 +43,11 @@ func (o *FilterOrchestratorImpl) Orchestrate() FilterChain {
 		return defaultFilter
 	}
 
-	if o.lastUpdated == string(o.datastore.GetFilterConfigMap().UID)+o.datastore.GetFilterConfigMap().ResourceVersion {
+	if o.lastUpdated == lastUpdatedKey(o.datastore.GetFilterConfigMap()) {
 		return o.storedFilter
 	}
 
-	o.lastUpdated = string(o.datastore.GetFilterConfigMap().UID) + o.datastore.GetFilterConfigMap().ResourceVersion
+	o.lastUpdated = lastUpdatedKey(o.datastore.GetFilterConfigMap())
 
 	f := &FilterOrchestration{}
 	if err := json.Unmarshal([]byte(o.datastore.GetFilterConfigMap().Data["filter"]), f); err != nil {
@@ -101,4 +102,8 @@ func (o *FilterOrchestratorImpl) orchestrate(fo *FilterOrchestration) (*filterCh
 	filter.nextOnSuccess = nextOnSuccess
 	filter.nextOnSuccessOrFailure = nextOnSuccessOrFailure
 	return filter, nil
+}
+
+func lastUpdatedKey(cm *corev1.ConfigMap) string {
+	return string(cm.UID) + cm.ResourceVersion
 }

--- a/pkg/ext-proc/scheduling/orchestrate.go
+++ b/pkg/ext-proc/scheduling/orchestrate.go
@@ -19,6 +19,21 @@ func NewFilterOrchestrator(datastore *backend.K8sDatastore) *FilterOrchestratorI
 	}
 }
 
+func NewDefaultFilterOrchestrator() *DefaultFilterOrchestrator {
+	return &DefaultFilterOrchestrator{}
+}
+
+// DefaultFilterOrchestrator is a filter orchestrator that returns the default filter chain
+type DefaultFilterOrchestrator struct{}
+
+var _ FilterOrchestrator = &DefaultFilterOrchestrator{}
+
+func (DefaultFilterOrchestrator) Orchestrate() FilterChain {
+	return defaultFilter
+}
+
+// FilterOrchestratorImpl is a filter orchestrator that reads the filter configuration
+// from configmap and orchestrate the filter chain
 type FilterOrchestratorImpl struct {
 	datastore    *backend.K8sDatastore
 	lastUpdated  string

--- a/pkg/ext-proc/scheduling/scheduler.go
+++ b/pkg/ext-proc/scheduling/scheduler.go
@@ -13,13 +13,13 @@ import (
 
 const (
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16) Make this configurable.
-	kvCacheThreshold = 0.8
+	defaultKvCacheThreshold = 0.8
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16) Make this configurable.
-	queueThresholdCritical = 5
+	defaultQueueThresholdCritical = 5
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16) Make this configurable.
 	// the threshold for queued requests to be considered low below which we can prioritize LoRA affinity.
 	// The value of 50 is arrived heuristicically based on experiments.
-	queueingThresholdLoRA = 50
+	defaultQueueingThresholdLoRA = 50
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 
 	lowLatencyFilter = &filterChainImpl{
 		name:   "low queueing filter",
-		filter: toFilter((lowQueueingPodPredicate)),
+		filter: toFilter((lowQueueingPodPredicate(defaultQueueingThresholdLoRA))),
 		nextOnSuccess: &filterChainImpl{
 			name:          "affinity LoRA",
 			filter:        toFilter(loRAAffinityPredicate),
@@ -75,7 +75,7 @@ var (
 		// cache below a certain threshold, we consider this model server has capacity to handle
 		// a sheddable request without impacting critical requests.
 		name:          "has capacity for sheddable requests",
-		filter:        toFilter(noQueueAndLessThanKVCacheThresholdPredicate(queueThresholdCritical, kvCacheThreshold)),
+		filter:        toFilter(noQueueAndLessThanKVCacheThresholdPredicate(defaultQueueThresholdCritical, defaultKvCacheThreshold)),
 		nextOnSuccess: queueLoRAAndKVCacheFilter,
 		// If all pods are queuing or running above the KVCache threshold, we drop the sheddable
 		// request to make room for critical requests.

--- a/pkg/ext-proc/scheduling/scheduler.go
+++ b/pkg/ext-proc/scheduling/scheduler.go
@@ -94,6 +94,7 @@ func NewScheduler(pmp PodMetricsProvider, opts ...SchedulerOption) *Scheduler {
 	s := &Scheduler{
 		podMetricsProvider: pmp,
 		filter:             defaultFilter,
+		filterOrchestrator: &FilterOrchestratorImpl{},
 	}
 
 	for _, opt := range opts {

--- a/pkg/ext-proc/scheduling/scheduler.go
+++ b/pkg/ext-proc/scheduling/scheduler.go
@@ -94,7 +94,7 @@ func NewScheduler(pmp PodMetricsProvider, opts ...SchedulerOption) *Scheduler {
 	s := &Scheduler{
 		podMetricsProvider: pmp,
 		filter:             defaultFilter,
-		filterOrchestrator: &FilterOrchestratorImpl{},
+		filterOrchestrator: NewDefaultFilterOrchestrator(),
 	}
 
 	for _, opt := range opts {
@@ -105,7 +105,9 @@ func NewScheduler(pmp PodMetricsProvider, opts ...SchedulerOption) *Scheduler {
 
 func WithOrchestrator(orchestrator FilterOrchestrator) SchedulerOption {
 	return func(s *Scheduler) {
-		s.filterOrchestrator = orchestrator
+		if orchestrator != nil {
+			s.filterOrchestrator = orchestrator
+		}
 	}
 }
 

--- a/pkg/manifests/ext_proc.yaml
+++ b/pkg/manifests/ext_proc.yaml
@@ -15,6 +15,9 @@ rules:
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
 --- 
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Motivation
Recently, I have been conducting tests in my environment based on your efforts. I wanted to evaluate the performance of different filter logics, but it is quite time-consuming to modify the filters through source code changes, followed by rebuilding and redeploying the application. During this process, I also noticed two TODOs in the code that align well with my needs:

```go
// TODO(https://github.com/kubernetes-sigs/llm-instance-gateway/issues/16) Make this configurable.
kvCacheThreshold = 0.8
```
and 
```go
// TODO: Compare this strategy with other strategies such as top K.
func leastKVCacheFilterFunc(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error)
```

As a result, I wrote some code to address these points and would like to know if it meets your approval.

## Design

First, I renamed `Filter` interface to `FilterChain` and `filterFunc` to `filter` since I think this may better describe their functionality (Maybe this is not needed). 

Then I added some interfaces.

### Filters generation

`FilterGen` is responsible for generating filters with filter options by calling `Get`, and filter options should be validated before `Get` by calling `Validate`

```go
// FilterGen generate a filter from a filter option
type FilterGen interface {
	Name() string
	Get(*FilterOption) filter
	Validate(*FilterOption) error
}

type FilterOption struct {
	KvCacheThreshold *float64 `json:"kvCacheThreshold,omitempty"`

	QueueThresholdCritical *int `json:"queueThresholdCritical,omitempty"`
	QueueingThresholdLoRA  *int `json:"queueingThresholdLoRA,omitempty"`

	// TopK defines the top k pods to be selected, if not specified, 3 will be used
	TopK *int `json:"topK,omitempty"`
	// TopKBy defines the metric to be used for top k selection,
	// `waiting_queue_size` and `kv_cache_usage_percent` are available
	TopKBy *string `json:"topKBy,omitempty"`
}
```

And I added a topk filter, though the performance of this filter have not been tested yet.

```go
func filterTopKGetter(opt *FilterOption) filter {
        // defaults to 3
	k := DefaultTopK
	if opt.TopK != nil {
		k = *opt.TopK
	}
	var cmp func(a, b *backend.PodMetrics) bool
	switch *opt.TopKBy {
	case TopKByKVCacheUsagePercent:
		cmp = func(a, b *backend.PodMetrics) bool {
			return a.KVCacheUsagePercent > b.KVCacheUsagePercent
		}
	case TopKByWaitingQueueSize:
		cmp = func(a, b *backend.PodMetrics) bool {
			return a.WaitingQueueSize > b.WaitingQueueSize
		}
	}
	topk := algorithms.NewHeapTopK(cmp)
	return func(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
		return topk.TopK(pods, k), nil
	}
}
```

### Orchestrate filter chains

`FilterOrchestrator` is responsible to orchestrate a filter chain with `FilterOrchestration` configuration which is loaded from configmap for now (maybe use a CRD?).

```go
type FilterOrchestrator interface {
	Orchestrate() FilterChain
}

type FilterOrchestration struct {
	Name                   string               `json:"name"`
	NextOnSuccess          *FilterOrchestration `json:"nextOnSuccess,omitempty"`
	NextOnFailure          *FilterOrchestration `json:"nextOnFailure,omitempty"`
	NextOnSuccessOrFailure *FilterOrchestration `json:"nextOnSuccessOrFailure,omitempty"`
	FilterOption           *FilterOption        `json:"filterOption,omitempty"`
}
```

I also added a reconciler for configmaps and store the configmap in the datastore. It is quite simple and need to be improved.

```go
func (c *FilterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
	if req.NamespacedName.Name != "filter-config" || req.NamespacedName.Namespace != "default" {
		return ctrl.Result{}, nil
	}
	cm := &corev1.ConfigMap{}
	if err := c.Get(ctx, req.NamespacedName, cm); err != nil {
		klog.Errorf("unable to get ConfigMap, err: %v", err)
		return ctrl.Result{}, err
	}
	klog.Infof("updating filter config to: %++v", cm.Data)
	c.Datastore.filterConfigMap = cm.DeepCopy()
	return ctrl.Result{}, nil
}
```

### Configurable filter chains

By doing this, the scheduler can be initialized with a `FilterOrchestrator` and dynamically configure filters now.

```go
func WithOrchestrator(orchestrator FilterOrchestrator) SchedulerOption {
	return func(s *Scheduler) {
		s.filterOrchestrator = orchestrator
	}
}

type SchedulerOption func(*Scheduler)

type Scheduler struct {
	podMetricsProvider PodMetricsProvider
	filter             FilterChain
	filterOrchestrator FilterOrchestrator
}
```

```go
pods, err := s.filterOrchestrator.Orchestrate().Filter(req, s.podMetricsProvider.AllPodMetrics())
```

A configmap demo is shown in `pkg/ext-proc/scheduling/orchestrate_test.go` which can be orchestrated to a default filter.