### PR TITLE
ext-proc: change Inference* APIs to use NamespacedName

### DIFF
--- a/pkg/ext-proc/backend/inferencemodel_reconciler.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler.go
@@ -5,6 +5,7 @@ import (
 
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -13,15 +14,14 @@ import (
 
 type InferenceModelReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Record        record.EventRecorder
-	Datastore     *K8sDatastore
-	PoolName      string
-	PoolNamespace string
+	Scheme             *runtime.Scheme
+	Record             record.EventRecorder
+	Datastore          *K8sDatastore
+	PoolNamespacedName types.NamespacedName
 }
 
 func (c *InferenceModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if req.Namespace != c.PoolNamespace {
+	if req.Namespace != c.PoolNamespacedName.Namespace {
 		return ctrl.Result{}, nil
 	}
 	klog.V(1).Info("reconciling InferenceModel", req.NamespacedName)
@@ -43,8 +43,8 @@ func (c *InferenceModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (c *InferenceModelReconciler) updateDatastore(infModel *v1alpha1.InferenceModel) {
-	if infModel.Spec.PoolRef.Name == c.PoolName {
-		klog.V(1).Infof("Incoming pool ref %v, server pool name: %v", infModel.Spec.PoolRef, c.PoolName)
+	if infModel.Spec.PoolRef.Name == c.PoolNamespacedName.Name {
+		klog.V(1).Infof("Incoming pool ref %v, server pool name: %v", infModel.Spec.PoolRef, c.PoolNamespacedName.Name)
 		klog.V(1).Infof("Adding/Updating inference model: %v", infModel.Spec.ModelName)
 		c.Datastore.InferenceModels.Store(infModel.Spec.ModelName, infModel)
 		return

--- a/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -125,8 +126,8 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			InferenceModelReconciler := &InferenceModelReconciler{
-				Datastore: test.datastore,
-				PoolName:  test.datastore.inferencePool.Name,
+				Datastore:          test.datastore,
+				PoolNamespacedName: types.NamespacedName{Name: test.datastore.inferencePool.Name},
 			}
 			InferenceModelReconciler.updateDatastore(test.incomingService)
 

--- a/pkg/ext-proc/backend/inferencepool_reconciler.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler.go
@@ -5,6 +5,7 @@ import (
 
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,16 +17,15 @@ import (
 // will have the proper controller that will create/manage objects on behalf of the server pool.
 type InferencePoolReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Record        record.EventRecorder
-	PoolName      string
-	PoolNamespace string
-	Datastore     *K8sDatastore
-	Zone          string
+	Scheme             *runtime.Scheme
+	Record             record.EventRecorder
+	PoolNamespacedName types.NamespacedName
+	Datastore          *K8sDatastore
+	Zone               string
 }
 
 func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if req.NamespacedName.Name != c.PoolName || req.NamespacedName.Namespace != c.PoolNamespace {
+	if req.NamespacedName.Name != c.PoolNamespacedName.Name || req.NamespacedName.Namespace != c.PoolNamespacedName.Namespace {
 		return ctrl.Result{}, nil
 	}
 	klog.V(1).Info("reconciling InferencePool", req.NamespacedName)

--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -21,6 +21,7 @@ import (
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
 	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	klog "k8s.io/klog/v2"
@@ -114,23 +115,27 @@ func main() {
 	}
 
 	if err := (&backend.InferencePoolReconciler{
-		Datastore:     datastore,
-		Scheme:        mgr.GetScheme(),
-		Client:        mgr.GetClient(),
-		PoolName:      *poolName,
-		PoolNamespace: *poolNamespace,
-		Record:        mgr.GetEventRecorderFor("InferencePool"),
+		Datastore: datastore,
+		Scheme:    mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		PoolNamespacedName: types.NamespacedName{
+			Name:      *poolName,
+			Namespace: *poolNamespace,
+		},
+		Record: mgr.GetEventRecorderFor("InferencePool"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.Error(err, "Error setting up InferencePoolReconciler")
 	}
 
 	if err := (&backend.InferenceModelReconciler{
-		Datastore:     datastore,
-		Scheme:        mgr.GetScheme(),
-		Client:        mgr.GetClient(),
-		PoolName:      *poolName,
-		PoolNamespace: *poolNamespace,
-		Record:        mgr.GetEventRecorderFor("InferenceModel"),
+		Datastore: datastore,
+		Scheme:    mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		PoolNamespacedName: types.NamespacedName{
+			Name:      *poolName,
+			Namespace: *poolNamespace,
+		},
+		Record: mgr.GetEventRecorderFor("InferenceModel"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.Error(err, "Error setting up InferenceModelReconciler")
 	}


### PR DESCRIPTION
Follow up from https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/165

Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/157