### PR TITLE
manifests: remove unused curl image from EPP manifest

### DIFF
--- a/pkg/manifests/ext_proc.yaml
+++ b/pkg/manifests/ext_proc.yaml
@@ -59,10 +59,6 @@ spec:
         - "vllm-llama2-7b-pool"
         ports:
         - containerPort: 9002
-        
-      - name: curl
-        image: curlimages/curl
-        command: ["sleep", "3600"]
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/173

cc @danehans @kfswain 