### PR TITLE
[v0.1 API Review] Grammatical fixes and TypedCondition creation/defaulting

### DIFF
--- a/api/v1alpha1/inferencemodel_types.go
+++ b/api/v1alpha1/inferencemodel_types.go
@@ -178,7 +178,7 @@ type InferenceModelStatus struct {
 	//
 	// Known condition types are:
 	//
-	// * "Ready"
+	// * "Accepted"
 	//
 	// +optional
 	// +listType=map
@@ -195,11 +195,11 @@ type InferenceModelConditionType string
 type InferenceModelConditionReason string
 
 const (
-	// This condition indicates if the model is ready to accept traffic, and if not, why.
+	// This condition indicates if the model config is accepted, and if not, why.
 	//
 	// Possible reasons for this condition to be True are:
 	//
-	// * "Ready"
+	// * "Accepted"
 	//
 	// Possible reasons for this condition to be False are:
 	//
@@ -209,10 +209,10 @@ const (
 	//
 	// * "Pending"
 	//
-	ModelConditionReady InferenceModelConditionType = "Ready"
+	ModelConditionReady InferenceModelConditionType = "Accepted"
 
-	// Desired state. Model is ready for serving with no conflicts or issues.
-	ModelReasonReady InferenceModelConditionReason = "Ready"
+	// Desired state. Model conforms to the state of the pool.
+	ModelReasonReady InferenceModelConditionReason = "Accepted"
 
 	// This reason is used when a given ModelName already exists within the pool.
 	// Details about naming conflict resolution are on the ModelName field itself.

--- a/api/v1alpha1/inferencemodel_types.go
+++ b/api/v1alpha1/inferencemodel_types.go
@@ -144,7 +144,7 @@ const (
 // to exist at request time, the error is processed by the Inference Gateway
 // and emitted on the appropriate InferenceModel object.
 type TargetModel struct {
-	// Name is the name of the adapter as expected by the ModelServer.
+	// Name is the name of the adapter or base model, as expected by the ModelServer.
 	//
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Required
@@ -174,9 +174,40 @@ type TargetModel struct {
 
 // InferenceModelStatus defines the observed state of InferenceModel
 type InferenceModelStatus struct {
-	// Conditions track the state of the InferencePool.
+	// Conditions track the state of the InferenceModel.
+	//
+	// Known condition types are:
+	//
+	// * "Ready"
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:default={{type: "Ready", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// InferenceModelConditionType is a type of condition for the InferenceModel.
+type InferenceModelConditionType string
+
+// InferenceModelConditionReason is the reason for a given InferenceModelConditionType.
+type InferenceModelConditionReason string
+
+const (
+	// This condition indicates whether the model is ready for traffic or not, and why.
+	ModelConditionReady InferenceModelConditionType = "Ready"
+
+	// Desired state. Model is ready for serving with no conflicts or issues.
+	ModelReasonReady InferenceModelConditionReason = "Ready"
+
+	// This reason is used when a given ModelName already exists within the pool.
+	// Details about naming conflict resolution are on the ModelName field itself.
+	ModelReasonNameInUse InferenceModelConditionReason = "ModelNameInUse"
+
+	// This reason is the initial state, and indicates that the controller has not yet reconciled the InferenceModel.
+	ModelReasonPending InferenceModelConditionReason = "Pending"
+)
 
 func init() {
 	SchemeBuilder.Register(&InferenceModel{}, &InferenceModelList{})

--- a/api/v1alpha1/inferencemodel_types.go
+++ b/api/v1alpha1/inferencemodel_types.go
@@ -195,7 +195,20 @@ type InferenceModelConditionType string
 type InferenceModelConditionReason string
 
 const (
-	// This condition indicates whether the model is ready for traffic or not, and why.
+	// This condition indicates if the model is ready to accept traffic, and if not, why.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Ready"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "ModelNameInUse"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	ModelConditionReady InferenceModelConditionType = "Ready"
 
 	// Desired state. Model is ready for serving with no conflicts or issues.

--- a/api/v1alpha1/inferencemodel_types.go
+++ b/api/v1alpha1/inferencemodel_types.go
@@ -209,10 +209,10 @@ const (
 	//
 	// * "Pending"
 	//
-	ModelConditionReady InferenceModelConditionType = "Accepted"
+	ModelConditionAccepted InferenceModelConditionType = "Accepted"
 
 	// Desired state. Model conforms to the state of the pool.
-	ModelReasonReady InferenceModelConditionReason = "Accepted"
+	ModelReasonAccepted InferenceModelConditionReason = "Accepted"
 
 	// This reason is used when a given ModelName already exists within the pool.
 	// Details about naming conflict resolution are on the ModelName field itself.

--- a/api/v1alpha1/inferencepool_types.go
+++ b/api/v1alpha1/inferencepool_types.go
@@ -127,7 +127,20 @@ type InferencePoolConditionType string
 type InferencePoolConditionReason string
 
 const (
-	// This condition indicates whether the pool is ready for traffic or not, and why.
+	// This condition indicates if the pool is ready to accept traffic, and if not, why.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Ready"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "EndpointPickerNotHealthy"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	PoolConditionReady InferencePoolConditionType = "Ready"
 
 	// Desired state. The pool and its components are initialized and ready for traffic.

--- a/api/v1alpha1/inferencepool_types.go
+++ b/api/v1alpha1/inferencepool_types.go
@@ -68,7 +68,7 @@ type InferencePoolSpec struct {
 //
 // LabelKey is the key of a label. This is used for validation
 // of maps. This matches the Kubernetes "qualified name" validation that is used for labels.
-// // Labels are case sensitive, so: my-label and My-Label are considered distinct.
+// Labels are case sensitive, so: my-label and My-Label are considered distinct.
 //
 // Valid values include:
 //

--- a/api/v1alpha1/inferencepool_types.go
+++ b/api/v1alpha1/inferencepool_types.go
@@ -68,6 +68,7 @@ type InferencePoolSpec struct {
 //
 // LabelKey is the key of a label. This is used for validation
 // of maps. This matches the Kubernetes "qualified name" validation that is used for labels.
+// // Labels are case sensitive, so: my-label and My-Label are considered distinct.
 //
 // Valid values include:
 //
@@ -106,8 +107,38 @@ type LabelValue string
 // InferencePoolStatus defines the observed state of InferencePool
 type InferencePoolStatus struct {
 	// Conditions track the state of the InferencePool.
+	//
+	// Known condition types are:
+	//
+	// * "Ready"
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:default={{type: "Ready", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// InferencePoolConditionType is a type of condition for the InferencePool
+type InferencePoolConditionType string
+
+// InferencePoolConditionReason is the reason for a given InferencePoolConditionType
+type InferencePoolConditionReason string
+
+const (
+	// This condition indicates whether the pool is ready for traffic or not, and why.
+	PoolConditionReady InferencePoolConditionType = "Ready"
+
+	// Desired state. The pool and its components are initialized and ready for traffic.
+	PoolReasonReady InferencePoolConditionReason = "Ready"
+
+	// This reason is used when the EPP has not yet passed health checks, or has started failing them.
+	PoolReasonEPPNotHealthy InferencePoolConditionReason = "EndpointPickerNotHealthy"
+
+	// This reason is the initial state, and indicates that the controller has not yet reconciled this pool.
+	PoolReasonPending InferencePoolConditionReason = "Pending"
+)
 
 func init() {
 	SchemeBuilder.Register(&InferencePool{}, &InferencePoolList{})

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml
@@ -165,7 +165,7 @@ spec:
 
                   Known condition types are:
 
-                  * "Ready"
+                  * "Accepted"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml
@@ -116,8 +116,8 @@ spec:
                     and emitted on the appropriate InferenceModel object.
                   properties:
                     name:
-                      description: Name is the name of the adapter as expected by
-                        the ModelServer.
+                      description: Name is the name of the adapter or base model,
+                        as expected by the ModelServer.
                       maxLength: 253
                       type: string
                     weight:
@@ -154,7 +154,18 @@ spec:
             description: InferenceModelStatus defines the observed state of InferenceModel
             properties:
               conditions:
-                description: Conditions track the state of the InferencePool.
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Ready
+                description: |-
+                  Conditions track the state of the InferenceModel.
+
+                  Known condition types are:
+
+                  * "Ready"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -209,7 +220,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
@@ -81,7 +81,18 @@ spec:
             description: InferencePoolStatus defines the observed state of InferencePool
             properties:
               conditions:
-                description: Conditions track the state of the InferencePool.
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Ready
+                description: |-
+                  Conditions track the state of the InferencePool.
+
+                  Known condition types are:
+
+                  * "Ready"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -136,7 +147,11 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true


### PR DESCRIPTION
This addresses comments:

https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/154/commits/3f971caccd22ef0cacb708005f67d86b20172c07#r1907775587

https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/154/commits/3f971caccd22ef0cacb708005f67d86b20172c07#r1907785698

https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/154/commits/3f971caccd22ef0cacb708005f67d86b20172c07#r1907790075

and other smaller ones (can make the list exhaustive if needed but they are mostly grammatical or more detailed wording