### PR TITLE
Adding new maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ArangoGutierrez
-- Jeffwan
-- SergeyKanzhelev
-- terrytangyuan
-- smarterclayton
-- ahg-g
-- kfswain
+- gateway-api-inference-extension-maintainers
+- wg-serving-leads
 
 reviewers:
-- ahg-g
-- robscott
-- kfswain
-- liu-cong
+- gateway-api-inference-extension-reviewers
+- gateway-api-inference-extension-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,18 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file should be kept in sync with k/org.
+
+gateway-api-inference-extension-maintainers:
+- ahg-g
+- danehans
+- jeffwan
+- kfswain
+
+gateway-api-inference-extension-reviewers:
+- cong-liu
+- robscott
+
+wg-serving-leads:
+- ArangoGutierrez
+- Jeffwan
+- SergeyKanzhelev
+- terrytangyuan


### PR DESCRIPTION
This formally adds a set of maintainers that have already been actively leading this project. Once this is broadly approved and merged, we can mirror this in k/org to make it easier to release v0.1 of the API.