### PR TITLE
Adding myself & ahg-g to owners directly while we figure out alias bug

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- kfswain
+- ahg-g
 - gateway-api-inference-extension-maintainers
 - wg-serving-leads
 


### PR DESCRIPTION
https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/203 swapped us over to aliases (which is great) but there seems to be a bug where the aliases arent recognized, adding back myself and @ahg-g directly to the approvers file to keep PR's flowing & using [k8s-ci-robot](https://github.com/k8s-ci-robot) rather than having admins merge directly.