### PR TITLE
Fixes gomega.Eventually() in e2e Test

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -51,6 +51,8 @@ const (
 	defaultModelReadyTimeout = 10 * time.Minute
 	// defaultInterval is the default interval to check if a resource exists or ready conditions.
 	defaultInterval = time.Millisecond * 250
+	// defaultCurlInterval is the default interval to run the test curl command.
+	defaultCurlInterval = time.Second * 5
 	// nsName is the name of the Namespace used for tests.
 	// TODO [danehans]: Must be "default" until https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/227 is fixed
 	nsName = "default"
@@ -168,6 +170,7 @@ var (
 	readyTimeout      = getTimeout("READY_TIMEOUT", defaultReadyTimeout)
 	modelReadyTimeout = getTimeout("MODEL_READY_TIMEOUT", defaultModelReadyTimeout)
 	interval          = defaultInterval
+	curlInterval      = defaultCurlInterval
 )
 
 // namespaceExists ensures that a specified namespace exists and is ready for use.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -67,20 +67,25 @@ var _ = ginkgo.Describe("InferencePool", func() {
 			actual := []string{}
 			gomega.Eventually(func() error {
 				resp, err := testutils.ExecCommandInPod(ctx, cfg, scheme, kubeCli, nsName, "curl", "curl", curlCmd)
-				if err != nil || !strings.Contains(resp, "200 OK") {
+				if err != nil {
 					return err
+				}
+				if !strings.Contains(resp, "200 OK") {
+					return fmt.Errorf("did not get 200 OK: %s", resp)
 				}
 				for _, m := range expected {
 					if strings.Contains(resp, m) {
 						actual = append(actual, m)
 					}
 				}
-				// Compare expected and actual models in responses, ignoring order.
+				// Compare ignoring order
 				if !cmp.Equal(actual, expected, cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
-					return err
+					return fmt.Errorf("actual (%v) != expected (%v); resp=%q", actual, expected, resp)
 				}
+
 				return nil
 			}, existsTimeout, interval).Should(gomega.Succeed())
+
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 				}
 
 				return nil
-			}, existsTimeout, interval).Should(gomega.Succeed())
+			}, readyTimeout, curlInterval).Should(gomega.Succeed())
 
 		})
 	})

--- a/test/testdata/client.yaml
+++ b/test/testdata/client.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: curl
   name: curl
-  namespace: inf-ext-e2e
 spec:
   containers:
   - command:

--- a/test/testdata/envoy.yaml
+++ b/test/testdata/envoy.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: envoy
-  namespace: inf-ext-e2e
   labels:
     app: envoy
 data:
@@ -101,7 +100,7 @@ data:
                           grpc_service:
                             envoy_grpc:
                               cluster_name: ext_proc
-                              authority: inference-gateway-ext-proc.inf-ext-e2e:9002
+                              authority: inference-gateway-ext-proc.default:9002
                             timeout: 10s
                           processing_mode:
                             request_header_mode: SEND
@@ -186,7 +185,7 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: inference-gateway-ext-proc.inf-ext-e2e
+                          address: inference-gateway-ext-proc.default
                           port_value: 9002
                     health_status: HEALTHY
                     load_balancing_weight: 1
@@ -195,7 +194,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy
-  namespace: inf-ext-e2e
   labels:
     app: envoy
 spec:
@@ -276,7 +274,6 @@ metadata:
   labels:
     app: envoy
   name: envoy
-  namespace: inf-ext-e2e
 spec:
   ports:
   - name: http-8081


### PR DESCRIPTION
Previously, `gomega.Eventually` would return `nil` even if a non-200 status code was returned in the curl request. This PR fixes:

- The conditional logic for checking the status code
- The return value when comparing the `targetModel` in the curl response to validate load-balancing functionality.
- Adds curl-specific timeout and interval.

Fixes #239 