### PR TITLE
Removes unintended % in e2e InferenceModel

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 func newInferenceModel(ns string) *infextv1a1.InferenceModel {
 	targets := []infextv1a1.TargetModel{
 		{
-			Name:   modelName + "%-0",
+			Name:   modelName + "-0",
 			Weight: ptr.To(int32(50)),
 		},
 		{


### PR DESCRIPTION
Removes an unintended `%` character in the e2e InferenceModel. The e2e test now passes and validates load balancing across two LoRA adapters (`tweet-summary-0` and `tweet-summary-1`):

```sh
$ make test-e2e
...
Ran 1 of 1 Specs in 174.487 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (174.49s)
PASS
ok  	inference.networking.x-k8s.io/gateway-api-inference-extension/test/e2e	174.515s
```

Fixes #249 