### PR TITLE
Actually init logging using Zap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 	k8s.io/api v0.32.1
@@ -62,6 +63,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -114,7 +116,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.22.0 // indirect


### PR DESCRIPTION
This is bit of an optimistic attempt of mine to push Zap through
since controllers typically use Zap these days AFAIK.

Feel free to push back since there is a potential issue with the flags not being compatible.
This is somehow mitigated by supporting `-v` manually.

Related to #251 

You can compare the output before vs after:

```
I0131 20:00:45.986907   15562 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0131 20:00:45.986921   15562 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0131 20:00:45.986926   15562 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0131 20:00:45.986931   15562 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0131 20:00:45.987145   15562 runserver.go:150] Starting controller manager
I0131 20:00:45.987181   15562 main.go:176] Starting metrics HTTP handler ...
I0131 20:00:45.987356   15562 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
I0131 20:00:45.987387   15562 main.go:160] Health server listening on port: 9003
I0131 20:00:45.987393   15562 runserver.go:122] Ext-proc server listening on port: 9002
I0131 20:00:45.987464   15562 provider.go:68] Initialized pods and metrics: []
I0131 20:00:45.987485   15562 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress=":8080" secure=false
I0131 20:00:45.987724   15562 controller.go:198] "Starting EventSource" controller="inferencemodel" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferenceModel" source="kind source: *v1alpha1.InferenceModel"
I0131 20:00:45.987724   15562 controller.go:198] "Starting EventSource" controller="endpointslice" controllerGroup="discovery.k8s.io" controllerKind="EndpointSlice" source="kind source: *v1.EndpointSlice"
I0131 20:00:45.987724   15562 controller.go:198] "Starting EventSource" controller="inferencepool" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferencePool" source="kind source: *v1alpha1.InferencePool"
E0131 20:00:45.999749   15562 kind.go:76] "failed to get informer from cache" err="unable to retrieve the complete list of server APIs: inference.networking.x-k8s.io/v1alpha1: no matches for inference.networking.x-k8s.io/v1alpha1, Resource=" logger="controller-runtime.source.EventHandler"
E0131 20:00:46.001241   15562 kind.go:71] "if kind is a CRD, it should be installed before calling Start" err="no matches for kind \"InferencePool\" in version \"inference.networking.x-k8s.io/v1alpha1\"" logger="controller-runtime.source.EventHandler" kind="InferencePool.inference.networking.x-k8s.io"
I0131 20:00:46.002027   15562 reflector.go:376] Caches populated for *v1.EndpointSlice from pkg/mod/k8s.io/client-go@v0.32.1/tools/cache/reflector.go:251
I0131 20:00:46.100242   15562 controller.go:233] "Starting Controller" controller="endpointslice" controllerGroup="discovery.k8s.io" controllerKind="EndpointSlice"
I0131 20:00:46.100289   15562 controller.go:242] "Starting workers" controller="endpointslice" controllerGroup="discovery.k8s.io" controllerKind="EndpointSlice" worker count=1
^CI0131 20:00:52.654601   15562 internal.go:538] "Stopping and waiting for non leader election runnables"
I0131 20:00:52.654651   15562 internal.go:542] "Stopping and waiting for leader election runnables"
I0131 20:00:52.654695   15562 controller.go:262] "Shutdown signal received, waiting for all workers to finish" controller="endpointslice" controllerGroup="discovery.k8s.io" controllerKind="EndpointSlice"
I0131 20:00:52.654722   15562 controller.go:264] "All workers finished" controller="endpointslice" controllerGroup="discovery.k8s.io" controllerKind="EndpointSlice"
I0131 20:00:52.654706   15562 controller.go:233] "Starting Controller" controller="inferencemodel" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferenceModel"
I0131 20:00:52.654729   15562 controller.go:233] "Starting Controller" controller="inferencepool" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferencePool"
I0131 20:00:52.654752   15562 controller.go:242] "Starting workers" controller="inferencemodel" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferenceModel" worker count=1
I0131 20:00:52.654780   15562 controller.go:262] "Shutdown signal received, waiting for all workers to finish" controller="inferencemodel" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferenceModel"
I0131 20:00:52.654797   15562 controller.go:264] "All workers finished" controller="inferencemodel" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferenceModel"
I0131 20:00:52.654791   15562 controller.go:242] "Starting workers" controller="inferencepool" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferencePool" worker count=1
I0131 20:00:52.654842   15562 controller.go:262] "Shutdown signal received, waiting for all workers to finish" controller="inferencepool" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferencePool"
I0131 20:00:52.654853   15562 controller.go:264] "All workers finished" controller="inferencepool" controllerGroup="inference.networking.x-k8s.io" controllerKind="InferencePool"
I0131 20:00:52.654869   15562 internal.go:550] "Stopping and waiting for caches"
I0131 20:00:52.655007   15562 internal.go:554] "Stopping and waiting for webhooks"
I0131 20:00:52.655037   15562 internal.go:557] "Stopping and waiting for HTTP servers"
I0131 20:00:52.655075   15562 server.go:254] "Shutting down metrics server with timeout of 1 minute" logger="controller-runtime.metrics"
I0131 20:00:52.655168   15562 internal.go:561] "Wait completed, proceeding to shutdown the manager"
I0131 20:00:52.655186   15562 runserver.go:155] Controller manager shutting down
I0131 20:00:52.655197   15562 main.go:133] Health server shutting down
I0131 20:00:52.655250   15562 main.go:137] Ext-proc server shutting down
I0131 20:00:52.655268   15562 main.go:166] Health server shutting down
I0131 20:00:52.655282   15562 main.go:147] All components shutdown
I0131 20:00:52.655292   15562 runserver.go:140] Ext-proc server shutting down
```
```
2025-01-31T20:02:31+01:00	INFO	Starting controller manager
2025-01-31T20:02:31+01:00	INFO	Starting metrics HTTP handler ...
2025-01-31T20:02:31+01:00	INFO	controller-runtime.metrics	Starting metrics server
2025-01-31T20:02:31+01:00	INFO	Health server listening on port: 9003
2025-01-31T20:02:31+01:00	INFO	controller-runtime.metrics	Serving metrics server	{"bindAddress": ":8080", "secure": false}
2025-01-31T20:02:31+01:00	INFO	Ext-proc server listening on port: 9002
2025-01-31T20:02:31+01:00	INFO	Initialized pods and metrics: []
2025-01-31T20:02:31+01:00	INFO	Starting EventSource	{"controller": "endpointslice", "controllerGroup": "discovery.k8s.io", "controllerKind": "EndpointSlice", "source": "kind source: *v1.EndpointSlice"}
2025-01-31T20:02:31+01:00	INFO	Starting EventSource	{"controller": "inferencepool", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferencePool", "source": "kind source: *v1alpha1.InferencePool"}
2025-01-31T20:02:31+01:00	INFO	Starting EventSource	{"controller": "inferencemodel", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferenceModel", "source": "kind source: *v1alpha1.InferenceModel"}
2025-01-31T20:02:32+01:00	ERROR	controller-runtime.source.EventHandler	if kind is a CRD, it should be installed before calling Start	{"kind": "InferenceModel.inference.networking.x-k8s.io", "error": "no matches for kind \"InferenceModel\" in version \"inference.networking.x-k8s.io/v1alpha1\""}
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1
	/Users/ondrejkupka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/source/kind.go:71
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1
	/Users/ondrejkupka/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/wait/loop.go:53
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	/Users/ondrejkupka/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/wait/loop.go:54
k8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel
	/Users/ondrejkupka/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/wait/poll.go:33
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1
	/Users/ondrejkupka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/source/kind.go:64
2025-01-31T20:02:32+01:00	ERROR	controller-runtime.source.EventHandler	if kind is a CRD, it should be installed before calling Start	{"kind": "InferencePool.inference.networking.x-k8s.io", "error": "no matches for kind \"InferencePool\" in version \"inference.networking.x-k8s.io/v1alpha1\""}
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1
	/Users/ondrejkupka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/source/kind.go:71
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1
	/Users/ondrejkupka/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/wait/loop.go:53
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	/Users/ondrejkupka/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/wait/loop.go:54
k8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel
	/Users/ondrejkupka/go/pkg/mod/k8s.io/apimachinery@v0.32.1/pkg/util/wait/poll.go:33
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1
	/Users/ondrejkupka/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/source/kind.go:64
2025-01-31T20:02:32+01:00	INFO	Starting Controller	{"controller": "endpointslice", "controllerGroup": "discovery.k8s.io", "controllerKind": "EndpointSlice"}
2025-01-31T20:02:32+01:00	INFO	Starting workers	{"controller": "endpointslice", "controllerGroup": "discovery.k8s.io", "controllerKind": "EndpointSlice", "worker count": 1}
^C2025-01-31T20:02:33+01:00	INFO	Stopping and waiting for non leader election runnables
2025-01-31T20:02:33+01:00	INFO	Stopping and waiting for leader election runnables
2025-01-31T20:02:33+01:00	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "endpointslice", "controllerGroup": "discovery.k8s.io", "controllerKind": "EndpointSlice"}
2025-01-31T20:02:33+01:00	INFO	Starting Controller	{"controller": "inferencepool", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferencePool"}
2025-01-31T20:02:33+01:00	INFO	All workers finished	{"controller": "endpointslice", "controllerGroup": "discovery.k8s.io", "controllerKind": "EndpointSlice"}
2025-01-31T20:02:33+01:00	INFO	Starting Controller	{"controller": "inferencemodel", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferenceModel"}
2025-01-31T20:02:33+01:00	INFO	Starting workers	{"controller": "inferencemodel", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferenceModel", "worker count": 1}
2025-01-31T20:02:33+01:00	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "inferencemodel", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferenceModel"}
2025-01-31T20:02:33+01:00	INFO	All workers finished	{"controller": "inferencemodel", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferenceModel"}
2025-01-31T20:02:33+01:00	INFO	Starting workers	{"controller": "inferencepool", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferencePool", "worker count": 1}
2025-01-31T20:02:33+01:00	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "inferencepool", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferencePool"}
2025-01-31T20:02:33+01:00	INFO	All workers finished	{"controller": "inferencepool", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferencePool"}
2025-01-31T20:02:33+01:00	INFO	Stopping and waiting for caches
2025-01-31T20:02:33+01:00	INFO	Stopping and waiting for webhooks
2025-01-31T20:02:33+01:00	INFO	Stopping and waiting for HTTP servers
2025-01-31T20:02:33+01:00	INFO	controller-runtime.metrics	Shutting down metrics server with timeout of 1 minute
2025-01-31T20:02:33+01:00	INFO	Wait completed, proceeding to shutdown the manager
2025-01-31T20:02:33+01:00	INFO	Controller manager shutting down
2025-01-31T20:02:33+01:00	INFO	Health server shutting down
2025-01-31T20:02:33+01:00	INFO	Ext-proc server shutting down
2025-01-31T20:02:33+01:00	INFO	Health server shutting down
2025-01-31T20:02:33+01:00	INFO	All components shutdown
2025-01-31T20:02:33+01:00	INFO	Ext-proc server shutting down
```