### PR TITLE
feat: adds initial release automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -4,42 +4,147 @@ about: Propose a new release
 title: Release v0.x.0
 labels: ''
 assignees: ''
-
 ---
 
-## Release Checklist
-- [ ] For major or minor releases (v$MAJ.$MIN.0), create a new release branch.
-  - [ ] A maintainer creates a vanilla release branch with
-        `git branch release-$MAJ.$MIN main`
-  - [ ] A maintainer pushes the new release branch with
-        `git push release-$MAJ.$MIN` (e.g., release-0.1)
-- [ ] Update content and artifacts such as README, deployment templates, docs, configuration, test/e2e flags.
-      Submit a PR against the release branch.
-- [ ] A maintainer [prepares a draft release](https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases)
-  - [ ] Write the change log into the draft release.
-  - [ ] Run
-      `make artifacts`
-      to generate the artifacts and upload the files in the `artifacts` folder to the draft release.
-- [ ] A maintainer creates a signed tag running (e.g., VERSION=v0.1.0)
-     `git tag -s $VERSION`
-      and inserts the changelog into the tag description.
-      To perform this step, you need [a PGP key registered on github](https://docs.github.com/en/authentication/managing-commit-signature-verification/checking-for-existing-gpg-keys).
-- [ ] A maintainer pushes the tag with
-      `git push $VERSION`
-  - Triggers prow to build and publish a staging container image
-    [`us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:$VERSION`](https://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp)
-- [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io), 
-      updating [`k8s-staging-gateway-api-inference-extension/images.yaml`](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml) to
-      promote the container images from staging to production. <!-- link to example PR once we have one -->
-- [ ] Wait for the PR to be merged and verify that the image `registry.k8s.io/gateway-api-inference-extension/epp:$VERSION` is available.
-- [ ] Publish the draft release prepared at the [Github releases page](https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases).
-- [ ] Add a link to the tagged release in this issue: <!-- example https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/tag/v0.1.0 -->
-- [ ] Send an announcement email to `wg-serving@kubernetes.io` and `dev@kubernetes.io` with the subject `[ANNOUNCE] Gateway API Inference Extension  $VERSION is released`
-- [ ] Add a link to the release announcement in this issue: <!-- link to an example email once we have one -->
-- [ ] Update docs in `main` branch: <!-- link to example PR once we have one -->
-- [ ] Close this issue
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Release Process](#release-process)
+- [Announce the Release](#announce-the-release)
+- [Final Steps](#final-steps)
 
-## Changelog
-<!--
-Describe changes since the last release here.
--->
+## Introduction
+
+This document defines the process for releasing Gateway API Inference Extension.
+
+## Prerequisites
+
+1. Permissions to push to the Gateway API Inference Extension repository.
+
+2. Set the required environment variables based on the expected release number:
+
+   ```shell
+   export MAJOR=0
+   export MINOR=1
+   export REMOTE=origin
+   ```
+
+3. If creating a release candidate, set the release candidate number.
+
+   ```shell
+   export RC=1
+   ```
+
+4. The vLLM image tag defaults to `v0.7.1` for a release. Optionally, change the vLLM image tag. For example:
+
+   ```shell
+   export VLLM=0.7.2
+   ```
+
+## Release Process
+
+1. If needed, clone the Gateway API Inference Extension [repo][repo].
+
+   ```shell
+   git clone https://github.com/kubernetes-sigs/gateway-api-inference-extension.git -b main
+   ```
+
+2. If you already have the repo cloned, ensure it’s up-to-date and your local branch is clean.
+
+3. Create a new release branch from the `main` branch. The release branch should be named `release-v${MAJOR}.${MINOR}`, e.g. `release-v0.1`.
+
+   ```shell
+   git checkout -b release-v${MAJOR}.${MINOR}
+   ```
+
+4. Update release-specific content, generate release artifacts, and stage the changes.
+
+   ```shell
+   make release
+   ```
+
+5. Sign, commit, and push the changes to the Gateway API Inference Extension repo.
+
+   For a release candidate:
+
+    ```shell
+    git commit -s -m "Updates artifacts for v${MAJOR}.${MINOR}.0-rc.${RC} release"
+    ```
+
+   For a major or minor release:
+
+    ```shell
+    git commit -s -m "Updates artifacts for v${MAJOR}.${MINOR}.0 release"
+    ```
+
+6. Push your release branch to the Gateway API Inference Extension remote.
+
+    ```shell
+    git push ${REMOTE} release-v${MAJOR}.${MINOR}
+    ```
+
+7. Tag the head of your release branch with the number.
+
+   For a release candidate:
+
+    ```shell
+    git tag -a v${MAJOR}.${MINOR}.0-rc.${RC} -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.0-rc.${RC} Release Candidate'
+    ```
+
+   For a major or minor release:
+
+    ```shell
+    git tag -a v${MAJOR}.${MINOR}.0 -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.0 Release'
+    ```
+
+   **Note:** A PGP key must be [registered] to your GitHub account.
+
+8. Push the tag to the Gateway API Inference Extension repo.
+
+   For a release candidate:
+
+    ```shell
+    git push ${REMOTE} v${MAJOR}.${MINOR}.0-rc.${RC}
+    ```
+
+   For a major or minor release:
+
+    ```shell
+    git push ${REMOTE} v${MAJOR}.${MINOR}.0
+    ```
+
+9. Pushing the tag triggers Prow to build and publish the container image to the [staging registry][].
+10. Submit a PR against [k8s.io][] to add the staging image tag and SHA to [`k8s-staging-gateway-api-inference-extension/images.yaml`][yaml]. This will
+   promote the image to the production registry. **Note:** Add a link to this issue when the PR is merged.
+11. Test the steps in the tagged quickstart guide after the PR merges, for example: `https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v0.1.0-rc.1/pkg/README.md`.
+12. Create a [new release][]:
+    1. Choose the tag that you created for the release.
+    2. Use the tag as the release title, i.e. `v0.1.0` refer to previous release for the content of the release body.
+    3. Click "Generate release notes" and preview the release body.
+    4. Click "Attach binaries by dropping them here or selecting them." and add the contents of the `artifacts` directory generated from `make release`.
+    5. If this is a release candidate, select the "This is a pre-release" checkbox.
+13. If you find any bugs in this process, create an [issue][].
+
+## Announce the Release
+
+Use the following steps to announce the release.
+
+1. Send an announcement email to `wg-serving@kubernetes.io` and `dev@kubernetes.io` with the subject:
+
+   ```shell
+   [ANNOUNCE] Gateway API Inference Extension v${MAJOR}.${MINOR}.0 is released
+   ```
+
+2. Add a link to the release announcement in this issue. <!-- link to an example email once we have one -->
+
+## Final Steps
+
+1. Update docs in the `main` branch. <!-- link to example PR once we have one -->
+2. Close this issue.
+
+[repo]: https://github.com/kubernetes-sigs/gateway-api-inference-extension
+[staging registry]: https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/gateway-api-inference-extension/epp
+[new release]: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/new
+[registered]: https://docs.github.com/en/authentication/managing-commit-signature-verification/checking-for-existing-gpg-keys
+[k8s.io]: https://github.com/kubernetes/k8s.io
+[yaml]: https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
+[issue]: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/new/choose

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ code-generator:
 	cp -f $(CODEGEN_ROOT)/generate-internal-groups.sh $(PROJECT_DIR)/bin/
 	cp -f $(CODEGEN_ROOT)/kube_codegen.sh $(PROJECT_DIR)/bin/
 
-
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
@@ -155,7 +154,6 @@ image-build:
 image-push: PUSH=--push
 image-push: image-build
 
-
 ##@ Docs
 
 .PHONY: build-docs
@@ -196,12 +194,20 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Release
+
+.PHONY: release-quickstart
+release-quickstart: ## Update the quickstart guide for a release.
+	./hack/release-quickstart.sh
+
 .PHONY: artifacts
 artifacts: kustomize
 	if [ -d artifacts ]; then rm -rf artifacts; fi
 	mkdir -p artifacts
 	$(KUSTOMIZE) build config/crd -o artifacts/manifests.yaml
 	@$(call clean-manifests)
+
+.PHONY: release
+release: artifacts release-quickstart verify test # Create a release.
 
 ##@ Dependencies
 

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Environment variables (defaults)
+# -----------------------------------------------------------------------------
+# MAJOR and MINOR are required (defaults provided here if not already set)
+MAJOR="${MAJOR:-0}"
+MINOR="${MINOR:-1}"
+
+# If RC is defined (non-empty) then include the rc suffix; otherwise omit it.
+if [[ -z "${RC-}" ]]; then
+  RELEASE_TAG="v${MAJOR}.${MINOR}.0"
+else
+  RELEASE_TAG="v${MAJOR}.${MINOR}.0-rc.${RC}"
+fi
+
+# vLLM image version (default to 0.7.1 if not defined)
+VLLM="${VLLM:-0.7.1}"
+
+echo "Using release tag: ${RELEASE_TAG}"
+echo "Using vLLM image version: ${VLLM}"
+
+# -----------------------------------------------------------------------------
+# Update pkg/README.md
+# -----------------------------------------------------------------------------
+README="pkg/README.md"
+echo "Updating ${README} ..."
+
+# Replace URLs that refer to a tag (whether via refs/tags or releases/download)
+# This regex matches any version in the form v<MAJOR>.<MINOR>.0-rc[.]?<number>
+sed -i.bak -E "s|(refs/tags/)v[0-9]+\.[0-9]+\.0-rc\.?[0-9]+|\1${RELEASE_TAG}|g" "$README"
+sed -i.bak -E "s|(releases/download/)v[0-9]+\.[0-9]+\.0-rc\.?[0-9]+|\1${RELEASE_TAG}|g" "$README"
+
+# Replace the CRD installation line: change "kubectl apply -k" to "kubectl apply -f" with the proper URL
+sed -i.bak "s|kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd|kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${RELEASE_TAG}/manifests.yaml|g" "$README"
+
+# -----------------------------------------------------------------------------
+# Update pkg/manifests/ext_proc.yaml
+# -----------------------------------------------------------------------------
+EXT_PROC="pkg/manifests/ext_proc.yaml"
+echo "Updating ${EXT_PROC} ..."
+
+# Update any image reference for the EPP container.
+# For images from registry.k8s.io:
+sed -i.bak -E "s|(registry\.k8s\.io/gateway-api-inference-extension/epp:)[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$EXT_PROC"
+# In case there is still any reference from us-central1-docker.pkg.dev:
+sed -i.bak -E "s|(us-central1-docker\.pkg\.dev/k8s-staging-images/gateway-api-inference-extension/epp:)[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$EXT_PROC"
+
+# -----------------------------------------------------------------------------
+# Update pkg/manifests/vllm/deployment.yaml
+# -----------------------------------------------------------------------------
+VLLM_DEPLOY="pkg/manifests/vllm/deployment.yaml"
+echo "Updating ${VLLM_DEPLOY} ..."
+
+# Update the vLLM image version
+sed -i.bak -E "s|(vllm/vllm-openai:)[^\"[:space:]]+|\1${VLLM}|g" "$VLLM_DEPLOY"
+
+# Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM image.
+sed -i.bak "/vllm\/vllm-openai/ s/Always/IfNotPresent/g" "$VLLM_DEPLOY"
+
+# -----------------------------------------------------------------------------
+# Stage the changes
+# -----------------------------------------------------------------------------
+echo "Staging $README $EXT_PROC $VLLM_DEPLOY files..."
+git add $README $EXT_PROC $VLLM_DEPLOY
+
+# -----------------------------------------------------------------------------
+# Cleanup backup files and finish
+# -----------------------------------------------------------------------------
+echo "Cleaning up temporary backup files..."
+find . -name "*.bak" -delete
+
+echo "Release quickstart update complete."


### PR DESCRIPTION
- `.github/ISSUE_TEMPLATE/new-release.md`: Updates the release github template.
- `Makefile`: Adds targets to support initial release automation.
- `hack/release-quickstart.sh`: A script to automate quickstart guide changes required for a release.

fixes: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/291