### PR TITLE
site-source: Fix 'Bakcground' misspell in API concepts page

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -1,7 +1,7 @@
 # API Overview
 
-## Bakcground
-The Gateway API Inference Extension project is an extension of the Kubernetes Gateway API for serving Generative AI models on Kubernetes. Gateway API Inference Extension facilitates standardization of APIs for Kubernetes cluster operators and developers running generative AI inference, while allowing flexibility for underlying gateway implementations (such as Envoy Proxy) to iterate on mechanisms for optimized serving of models. 
+## Background
+The Gateway API Inference Extension project is an extension of the Kubernetes Gateway API for serving Generative AI models on Kubernetes. Gateway API Inference Extension facilitates standardization of APIs for Kubernetes cluster operators and developers running generative AI inference, while allowing flexibility for underlying gateway implementations (such as Envoy Proxy) to iterate on mechanisms for optimized serving of models.
 
 <img src="/images/inference-overview.svg" alt="Overview of API integration" class="center" width="1000" />
 


### PR DESCRIPTION
Quick PR for fixing a misspell in the API concepts overview page.