### PR TITLE
Remove gci linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - dupword
     - durationcheck
     - fatcontext
-    - gci
     - ginkgolinter
     - gocritic
     - govet


### PR DESCRIPTION
since we are not enforcing a specific order of imports, it is already causing failed presubmit tests: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/286