### PR TITLE
Fix: Go Mod Imports

### DIFF
--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api

--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains API Schema definitions for the
+// inference.networking.x-k8s.io API group.
+//
+// +k8s:openapi-gen=true
+// +kubebuilder:object:generate=true
+// +groupName=inference.networking.x-k8s.io
+package v1alpha1

--- a/client-go/applyconfiguration/api/v1alpha1/extension.go
+++ b/client-go/applyconfiguration/api/v1alpha1/extension.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // ExtensionApplyConfiguration represents a declarative configuration of the Extension type for use

--- a/client-go/applyconfiguration/api/v1alpha1/extensionconnection.go
+++ b/client-go/applyconfiguration/api/v1alpha1/extensionconnection.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // ExtensionConnectionApplyConfiguration represents a declarative configuration of the ExtensionConnection type for use

--- a/client-go/applyconfiguration/api/v1alpha1/inferencemodel.go
+++ b/client-go/applyconfiguration/api/v1alpha1/inferencemodel.go
@@ -39,7 +39,7 @@ func InferenceModel(name, namespace string) *InferenceModelApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("InferenceModel")
-	b.WithAPIVersion("api/v1alpha1")
+	b.WithAPIVersion("inference.networking.x-k8s.io/v1alpha1")
 	return b
 }
 

--- a/client-go/applyconfiguration/api/v1alpha1/inferencemodelspec.go
+++ b/client-go/applyconfiguration/api/v1alpha1/inferencemodelspec.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // InferenceModelSpecApplyConfiguration represents a declarative configuration of the InferenceModelSpec type for use

--- a/client-go/applyconfiguration/api/v1alpha1/inferencepool.go
+++ b/client-go/applyconfiguration/api/v1alpha1/inferencepool.go
@@ -39,7 +39,7 @@ func InferencePool(name, namespace string) *InferencePoolApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("InferencePool")
-	b.WithAPIVersion("api/v1alpha1")
+	b.WithAPIVersion("inference.networking.x-k8s.io/v1alpha1")
 	return b
 }
 

--- a/client-go/applyconfiguration/api/v1alpha1/inferencepoolspec.go
+++ b/client-go/applyconfiguration/api/v1alpha1/inferencepoolspec.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // InferencePoolSpecApplyConfiguration represents a declarative configuration of the InferencePoolSpec type for use

--- a/client-go/applyconfiguration/utils.go
+++ b/client-go/applyconfiguration/utils.go
@@ -18,12 +18,12 @@ limitations under the License.
 package applyconfiguration
 
 import (
-	v1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
-	internal "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/internal"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	testing "k8s.io/client-go/testing"
+	v1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
+	internal "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/internal"
 )
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no

--- a/client-go/applyconfiguration/utils.go
+++ b/client-go/applyconfiguration/utils.go
@@ -30,7 +30,7 @@ import (
 // apply configuration type exists for the given GroupVersionKind.
 func ForKind(kind schema.GroupVersionKind) interface{} {
 	switch kind {
-	// Group=api, Version=v1alpha1
+	// Group=inference.networking.x-k8s.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("EndpointPickerConfig"):
 		return &apiv1alpha1.EndpointPickerConfigApplyConfiguration{}
 	case v1alpha1.SchemeGroupVersion.WithKind("Extension"):

--- a/client-go/clientset/versioned/clientset.go
+++ b/client-go/clientset/versioned/clientset.go
@@ -21,10 +21,10 @@ import (
 	fmt "fmt"
 	http "net/http"
 
-	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	inferencev1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 )
 
 type Interface interface {

--- a/client-go/clientset/versioned/clientset.go
+++ b/client-go/clientset/versioned/clientset.go
@@ -21,7 +21,7 @@ import (
 	fmt "fmt"
 	http "net/http"
 
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
+	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -29,18 +29,18 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	ApiV1alpha1() apiv1alpha1.ApiV1alpha1Interface
+	InferenceV1alpha1() inferencev1alpha1.InferenceV1alpha1Interface
 }
 
 // Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	apiV1alpha1 *apiv1alpha1.ApiV1alpha1Client
+	inferenceV1alpha1 *inferencev1alpha1.InferenceV1alpha1Client
 }
 
-// ApiV1alpha1 retrieves the ApiV1alpha1Client
-func (c *Clientset) ApiV1alpha1() apiv1alpha1.ApiV1alpha1Interface {
-	return c.apiV1alpha1
+// InferenceV1alpha1 retrieves the InferenceV1alpha1Client
+func (c *Clientset) InferenceV1alpha1() inferencev1alpha1.InferenceV1alpha1Interface {
+	return c.inferenceV1alpha1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -87,7 +87,7 @@ func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset,
 
 	var cs Clientset
 	var err error
-	cs.apiV1alpha1, err = apiv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.inferenceV1alpha1, err = inferencev1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.apiV1alpha1 = apiv1alpha1.New(c)
+	cs.inferenceV1alpha1 = inferencev1alpha1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/client-go/clientset/versioned/fake/clientset_generated.go
+++ b/client-go/clientset/versioned/fake/clientset_generated.go
@@ -18,15 +18,15 @@ limitations under the License.
 package fake
 
 import (
-	applyconfiguration "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration"
-	clientset "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
-	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
-	fakeinferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+	applyconfiguration "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration"
+	clientset "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
+	inferencev1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
+	fakeinferencev1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/client-go/clientset/versioned/fake/clientset_generated.go
+++ b/client-go/clientset/versioned/fake/clientset_generated.go
@@ -20,8 +20,8 @@ package fake
 import (
 	applyconfiguration "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration"
 	clientset "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
-	fakeapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1/fake"
+	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
+	fakeinferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -115,7 +115,7 @@ var (
 	_ testing.FakeClient  = &Clientset{}
 )
 
-// ApiV1alpha1 retrieves the ApiV1alpha1Client
-func (c *Clientset) ApiV1alpha1() apiv1alpha1.ApiV1alpha1Interface {
-	return &fakeapiv1alpha1.FakeApiV1alpha1{Fake: &c.Fake}
+// InferenceV1alpha1 retrieves the InferenceV1alpha1Client
+func (c *Clientset) InferenceV1alpha1() inferencev1alpha1.InferenceV1alpha1Interface {
+	return &fakeinferencev1alpha1.FakeInferenceV1alpha1{Fake: &c.Fake}
 }

--- a/client-go/clientset/versioned/fake/register.go
+++ b/client-go/clientset/versioned/fake/register.go
@@ -18,12 +18,12 @@ limitations under the License.
 package fake
 
 import (
-	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	inferencev1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/client-go/clientset/versioned/fake/register.go
+++ b/client-go/clientset/versioned/fake/register.go
@@ -18,7 +18,7 @@ limitations under the License.
 package fake
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,7 +30,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	apiv1alpha1.AddToScheme,
+	inferencev1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/client-go/clientset/versioned/scheme/register.go
+++ b/client-go/clientset/versioned/scheme/register.go
@@ -18,12 +18,12 @@ limitations under the License.
 package scheme
 
 import (
-	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	inferencev1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/client-go/clientset/versioned/scheme/register.go
+++ b/client-go/clientset/versioned/scheme/register.go
@@ -18,7 +18,7 @@ limitations under the License.
 package scheme
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	inferencev1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,7 +30,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	apiv1alpha1.AddToScheme,
+	inferencev1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/client-go/clientset/versioned/typed/api/v1alpha1/api_client.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/api_client.go
@@ -20,9 +20,9 @@ package v1alpha1
 import (
 	http "net/http"
 
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	scheme "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/scheme"
 )
 
 type InferenceV1alpha1Interface interface {

--- a/client-go/clientset/versioned/typed/api/v1alpha1/api_client.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/api_client.go
@@ -25,29 +25,29 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type ApiV1alpha1Interface interface {
+type InferenceV1alpha1Interface interface {
 	RESTClient() rest.Interface
 	InferenceModelsGetter
 	InferencePoolsGetter
 }
 
-// ApiV1alpha1Client is used to interact with features provided by the api group.
-type ApiV1alpha1Client struct {
+// InferenceV1alpha1Client is used to interact with features provided by the inference.networking.x-k8s.io group.
+type InferenceV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ApiV1alpha1Client) InferenceModels(namespace string) InferenceModelInterface {
+func (c *InferenceV1alpha1Client) InferenceModels(namespace string) InferenceModelInterface {
 	return newInferenceModels(c, namespace)
 }
 
-func (c *ApiV1alpha1Client) InferencePools(namespace string) InferencePoolInterface {
+func (c *InferenceV1alpha1Client) InferencePools(namespace string) InferencePoolInterface {
 	return newInferencePools(c, namespace)
 }
 
-// NewForConfig creates a new ApiV1alpha1Client for the given config.
+// NewForConfig creates a new InferenceV1alpha1Client for the given config.
 // NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
 // where httpClient was generated with rest.HTTPClientFor(c).
-func NewForConfig(c *rest.Config) (*ApiV1alpha1Client, error) {
+func NewForConfig(c *rest.Config) (*InferenceV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -59,9 +59,9 @@ func NewForConfig(c *rest.Config) (*ApiV1alpha1Client, error) {
 	return NewForConfigAndClient(&config, httpClient)
 }
 
-// NewForConfigAndClient creates a new ApiV1alpha1Client for the given config and http client.
+// NewForConfigAndClient creates a new InferenceV1alpha1Client for the given config and http client.
 // Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*ApiV1alpha1Client, error) {
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*InferenceV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -70,12 +70,12 @@ func NewForConfigAndClient(c *rest.Config, h *http.Client) (*ApiV1alpha1Client, 
 	if err != nil {
 		return nil, err
 	}
-	return &ApiV1alpha1Client{client}, nil
+	return &InferenceV1alpha1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new ApiV1alpha1Client for the given config and
+// NewForConfigOrDie creates a new InferenceV1alpha1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *ApiV1alpha1Client {
+func NewForConfigOrDie(c *rest.Config) *InferenceV1alpha1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -83,9 +83,9 @@ func NewForConfigOrDie(c *rest.Config) *ApiV1alpha1Client {
 	return client
 }
 
-// New creates a new ApiV1alpha1Client for the given RESTClient.
-func New(c rest.Interface) *ApiV1alpha1Client {
-	return &ApiV1alpha1Client{c}
+// New creates a new InferenceV1alpha1Client for the given RESTClient.
+func New(c rest.Interface) *InferenceV1alpha1Client {
+	return &InferenceV1alpha1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -103,7 +103,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *ApiV1alpha1Client) RESTClient() rest.Interface {
+func (c *InferenceV1alpha1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
@@ -23,21 +23,21 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeApiV1alpha1 struct {
+type FakeInferenceV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeApiV1alpha1) InferenceModels(namespace string) v1alpha1.InferenceModelInterface {
+func (c *FakeInferenceV1alpha1) InferenceModels(namespace string) v1alpha1.InferenceModelInterface {
 	return newFakeInferenceModels(c, namespace)
 }
 
-func (c *FakeApiV1alpha1) InferencePools(namespace string) v1alpha1.InferencePoolInterface {
+func (c *FakeInferenceV1alpha1) InferencePools(namespace string) v1alpha1.InferencePoolInterface {
 	return newFakeInferencePools(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeApiV1alpha1) RESTClient() rest.Interface {
+func (c *FakeInferenceV1alpha1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
@@ -18,9 +18,9 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+	v1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 )
 
 type FakeInferenceV1alpha1 struct {

--- a/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencemodel.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencemodel.go
@@ -18,10 +18,10 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
-	typedapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
+	v1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
+	typedapiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 )
 
 // fakeInferenceModels implements InferenceModelInterface

--- a/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencemodel.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencemodel.go
@@ -27,10 +27,10 @@ import (
 // fakeInferenceModels implements InferenceModelInterface
 type fakeInferenceModels struct {
 	*gentype.FakeClientWithListAndApply[*v1alpha1.InferenceModel, *v1alpha1.InferenceModelList, *apiv1alpha1.InferenceModelApplyConfiguration]
-	Fake *FakeApiV1alpha1
+	Fake *FakeInferenceV1alpha1
 }
 
-func newFakeInferenceModels(fake *FakeApiV1alpha1, namespace string) typedapiv1alpha1.InferenceModelInterface {
+func newFakeInferenceModels(fake *FakeInferenceV1alpha1, namespace string) typedapiv1alpha1.InferenceModelInterface {
 	return &fakeInferenceModels{
 		gentype.NewFakeClientWithListAndApply[*v1alpha1.InferenceModel, *v1alpha1.InferenceModelList, *apiv1alpha1.InferenceModelApplyConfiguration](
 			fake.Fake,

--- a/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencepool.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencepool.go
@@ -18,10 +18,10 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
-	typedapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 	gentype "k8s.io/client-go/gentype"
+	v1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
+	typedapiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/typed/api/v1alpha1"
 )
 
 // fakeInferencePools implements InferencePoolInterface

--- a/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencepool.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/fake/fake_inferencepool.go
@@ -27,10 +27,10 @@ import (
 // fakeInferencePools implements InferencePoolInterface
 type fakeInferencePools struct {
 	*gentype.FakeClientWithListAndApply[*v1alpha1.InferencePool, *v1alpha1.InferencePoolList, *apiv1alpha1.InferencePoolApplyConfiguration]
-	Fake *FakeApiV1alpha1
+	Fake *FakeInferenceV1alpha1
 }
 
-func newFakeInferencePools(fake *FakeApiV1alpha1, namespace string) typedapiv1alpha1.InferencePoolInterface {
+func newFakeInferencePools(fake *FakeInferenceV1alpha1, namespace string) typedapiv1alpha1.InferencePoolInterface {
 	return &fakeInferencePools{
 		gentype.NewFakeClientWithListAndApply[*v1alpha1.InferencePool, *v1alpha1.InferencePoolList, *apiv1alpha1.InferencePoolApplyConfiguration](
 			fake.Fake,

--- a/client-go/clientset/versioned/typed/api/v1alpha1/inferencemodel.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/inferencemodel.go
@@ -20,13 +20,13 @@ package v1alpha1
 import (
 	context "context"
 
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	applyconfigurationapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
-	scheme "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	applyconfigurationapiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/scheme"
 )
 
 // InferenceModelsGetter has a method to return a InferenceModelInterface.

--- a/client-go/clientset/versioned/typed/api/v1alpha1/inferencemodel.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/inferencemodel.go
@@ -59,7 +59,7 @@ type inferenceModels struct {
 }
 
 // newInferenceModels returns a InferenceModels
-func newInferenceModels(c *ApiV1alpha1Client, namespace string) *inferenceModels {
+func newInferenceModels(c *InferenceV1alpha1Client, namespace string) *inferenceModels {
 	return &inferenceModels{
 		gentype.NewClientWithListAndApply[*apiv1alpha1.InferenceModel, *apiv1alpha1.InferenceModelList, *applyconfigurationapiv1alpha1.InferenceModelApplyConfiguration](
 			"inferencemodels",

--- a/client-go/clientset/versioned/typed/api/v1alpha1/inferencepool.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/inferencepool.go
@@ -59,7 +59,7 @@ type inferencePools struct {
 }
 
 // newInferencePools returns a InferencePools
-func newInferencePools(c *ApiV1alpha1Client, namespace string) *inferencePools {
+func newInferencePools(c *InferenceV1alpha1Client, namespace string) *inferencePools {
 	return &inferencePools{
 		gentype.NewClientWithListAndApply[*apiv1alpha1.InferencePool, *apiv1alpha1.InferencePoolList, *applyconfigurationapiv1alpha1.InferencePoolApplyConfiguration](
 			"inferencepools",

--- a/client-go/clientset/versioned/typed/api/v1alpha1/inferencepool.go
+++ b/client-go/clientset/versioned/typed/api/v1alpha1/inferencepool.go
@@ -20,13 +20,13 @@ package v1alpha1
 import (
 	context "context"
 
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	applyconfigurationapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
-	scheme "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	applyconfigurationapiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/applyconfiguration/api/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned/scheme"
 )
 
 // InferencePoolsGetter has a method to return a InferencePoolInterface.

--- a/client-go/informers/externalversions/api/interface.go
+++ b/client-go/informers/externalversions/api/interface.go
@@ -18,8 +18,8 @@ limitations under the License.
 package api
 
 import (
-	v1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/api/v1alpha1"
-	internalinterfaces "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/api/v1alpha1"
+	internalinterfaces "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/client-go/informers/externalversions/api/v1alpha1/inferencemodel.go
+++ b/client-go/informers/externalversions/api/v1alpha1/inferencemodel.go
@@ -21,14 +21,14 @@ import (
 	context "context"
 	time "time"
 
-	gatewayapiinferenceextensionapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	versioned "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
-	internalinterfaces "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/listers/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+	gatewayapiinferenceextensionapiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/listers/api/v1alpha1"
 )
 
 // InferenceModelInformer provides access to a shared informer and lister for

--- a/client-go/informers/externalversions/api/v1alpha1/inferencemodel.go
+++ b/client-go/informers/externalversions/api/v1alpha1/inferencemodel.go
@@ -61,13 +61,13 @@ func NewFilteredInferenceModelInformer(client versioned.Interface, namespace str
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiV1alpha1().InferenceModels(namespace).List(context.TODO(), options)
+				return client.InferenceV1alpha1().InferenceModels(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiV1alpha1().InferenceModels(namespace).Watch(context.TODO(), options)
+				return client.InferenceV1alpha1().InferenceModels(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&gatewayapiinferenceextensionapiv1alpha1.InferenceModel{},

--- a/client-go/informers/externalversions/api/v1alpha1/inferencepool.go
+++ b/client-go/informers/externalversions/api/v1alpha1/inferencepool.go
@@ -61,13 +61,13 @@ func NewFilteredInferencePoolInformer(client versioned.Interface, namespace stri
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiV1alpha1().InferencePools(namespace).List(context.TODO(), options)
+				return client.InferenceV1alpha1().InferencePools(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ApiV1alpha1().InferencePools(namespace).Watch(context.TODO(), options)
+				return client.InferenceV1alpha1().InferencePools(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&gatewayapiinferenceextensionapiv1alpha1.InferencePool{},

--- a/client-go/informers/externalversions/api/v1alpha1/inferencepool.go
+++ b/client-go/informers/externalversions/api/v1alpha1/inferencepool.go
@@ -21,14 +21,14 @@ import (
 	context "context"
 	time "time"
 
-	gatewayapiinferenceextensionapiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	versioned "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
-	internalinterfaces "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/listers/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
+	gatewayapiinferenceextensionapiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/client-go/listers/api/v1alpha1"
 )
 
 // InferencePoolInformer provides access to a shared informer and lister for

--- a/client-go/informers/externalversions/api/v1alpha1/interface.go
+++ b/client-go/informers/externalversions/api/v1alpha1/interface.go
@@ -18,7 +18,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
+	internalinterfaces "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/client-go/informers/externalversions/factory.go
+++ b/client-go/informers/externalversions/factory.go
@@ -22,13 +22,13 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
-	api "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/api"
-	internalinterfaces "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+	versioned "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
+	api "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/api"
+	internalinterfaces "sigs.k8s.io/gateway-api-inference-extension/client-go/informers/externalversions/internalinterfaces"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/client-go/informers/externalversions/factory.go
+++ b/client-go/informers/externalversions/factory.go
@@ -253,9 +253,9 @@ type SharedInformerFactory interface {
 	// client.
 	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
 
-	Api() api.Interface
+	Inference() api.Interface
 }
 
-func (f *sharedInformerFactory) Api() api.Interface {
+func (f *sharedInformerFactory) Inference() api.Interface {
 	return api.New(f, f.namespace, f.tweakListOptions)
 }

--- a/client-go/informers/externalversions/generic.go
+++ b/client-go/informers/externalversions/generic.go
@@ -20,9 +20,9 @@ package externalversions
 import (
 	fmt "fmt"
 
-	v1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
+	v1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // GenericInformer is type of SharedIndexInformer which will locate and delegate to other

--- a/client-go/informers/externalversions/generic.go
+++ b/client-go/informers/externalversions/generic.go
@@ -51,11 +51,11 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=api, Version=v1alpha1
+	// Group=inference.networking.x-k8s.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("inferencemodels"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Api().V1alpha1().InferenceModels().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Inference().V1alpha1().InferenceModels().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("inferencepools"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Api().V1alpha1().InferencePools().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Inference().V1alpha1().InferencePools().Informer()}, nil
 
 	}
 

--- a/client-go/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/client-go/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -20,10 +20,10 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "inference.networking.x-k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
+	versioned "sigs.k8s.io/gateway-api-inference-extension/client-go/clientset/versioned"
 )
 
 // NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.

--- a/client-go/listers/api/v1alpha1/inferencemodel.go
+++ b/client-go/listers/api/v1alpha1/inferencemodel.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // InferenceModelLister helps list InferenceModels.

--- a/client-go/listers/api/v1alpha1/inferencepool.go
+++ b/client-go/listers/api/v1alpha1/inferencepool.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	apiv1alpha1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers"
 	cache "k8s.io/client-go/tools/cache"
+	apiv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // InferencePoolLister helps list InferencePools.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module inference.networking.x-k8s.io/gateway-api-inference-extension
+module sigs.k8s.io/gateway-api-inference-extension
 
 go 1.23.0
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -23,7 +23,7 @@ echo "$SCRIPT_ROOT script"
 CODEGEN_PKG=${2:-bin}
 echo $CODEGEN_PKG
 source "${CODEGEN_PKG}/kube_codegen.sh"
-THIS_PKG="inference.networking.x-k8s.io/gateway-api-inference-extension"
+THIS_PKG="sigs.k8s.io/gateway-api-inference-extension"
 
 
 kube::codegen::gen_helpers \

--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -5,10 +5,10 @@ import (
 	"math/rand"
 	"sync"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 func NewK8sDataStore(options ...K8sDatastoreOption) *K8sDatastore {

--- a/pkg/ext-proc/backend/datastore_test.go
+++ b/pkg/ext-proc/backend/datastore_test.go
@@ -3,8 +3,8 @@ package backend
 import (
 	"testing"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 func TestHasSynced(t *testing.T) {

--- a/pkg/ext-proc/backend/endpointslice_reconciler.go
+++ b/pkg/ext-proc/backend/endpointslice_reconciler.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -15,6 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 var (

--- a/pkg/ext-proc/backend/endpointslice_reconcilier_test.go
+++ b/pkg/ext-proc/backend/endpointslice_reconcilier_test.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"testing"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 var (

--- a/pkg/ext-proc/backend/fake.go
+++ b/pkg/ext-proc/backend/fake.go
@@ -3,8 +3,8 @@ package backend
 import (
 	"context"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 type FakePodMetricsClient struct {

--- a/pkg/ext-proc/backend/inferencemodel_reconciler.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler.go
@@ -3,8 +3,6 @@ package backend
 import (
 	"context"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +10,8 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type InferenceModelReconciler struct {

--- a/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
@@ -10,9 +10,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 var (

--- a/pkg/ext-proc/backend/inferencepool_reconciler.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler.go
@@ -3,13 +3,13 @@ package backend
 import (
 	"context"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // InferencePoolReconciler utilizes the controller runtime to reconcile Instance Gateway resources

--- a/pkg/ext-proc/backend/inferencepool_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 var (

--- a/pkg/ext-proc/backend/provider.go
+++ b/pkg/ext-proc/backend/provider.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"go.uber.org/multierr"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 const (

--- a/pkg/ext-proc/backend/vllm/metrics.go
+++ b/pkg/ext-proc/backend/vllm/metrics.go
@@ -12,9 +12,9 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"go.uber.org/multierr"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 const (

--- a/pkg/ext-proc/backend/vllm/metrics_test.go
+++ b/pkg/ext-proc/backend/vllm/metrics_test.go
@@ -7,7 +7,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 )
 
 func TestPromToPodMetrics(t *testing.T) {

--- a/pkg/ext-proc/handlers/request.go
+++ b/pkg/ext-proc/handlers/request.go
@@ -9,10 +9,10 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/protobuf/types/known/structpb"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 // HandleRequestBody handles body of the request to the backend server, such as parsing the "model"

--- a/pkg/ext-proc/handlers/response.go
+++ b/pkg/ext-proc/handlers/response.go
@@ -6,8 +6,8 @@ import (
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 // HandleResponseHeaders processes response headers from the backend model server.

--- a/pkg/ext-proc/handlers/server.go
+++ b/pkg/ext-proc/handlers/server.go
@@ -8,12 +8,12 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 func NewServer(pp PodProvider, scheduler Scheduler, targetEndpointKey string, datastore ModelDataStore) *Server {

--- a/pkg/ext-proc/health.go
+++ b/pkg/ext-proc/health.go
@@ -6,8 +6,8 @@ import (
 	"google.golang.org/grpc/codes"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 )
 
 type healthServer struct {

--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -11,11 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend/vllm"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
-	runserver "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -24,6 +19,11 @@ import (
 	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend/vllm"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
+	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
 )
 
 const (

--- a/pkg/ext-proc/scheduling/filter.go
+++ b/pkg/ext-proc/scheduling/filter.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"math"
 
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type Filter interface {

--- a/pkg/ext-proc/scheduling/filter_test.go
+++ b/pkg/ext-proc/scheduling/filter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 )
 
 func TestFilter(t *testing.T) {

--- a/pkg/ext-proc/scheduling/scheduler.go
+++ b/pkg/ext-proc/scheduling/scheduler.go
@@ -7,9 +7,9 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	logutil "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 const (

--- a/pkg/ext-proc/server/runserver.go
+++ b/pkg/ext-proc/server/runserver.go
@@ -7,14 +7,14 @@ import (
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 )
 
 // ExtProcServerRunner provides methods to manage an external process server.

--- a/pkg/ext-proc/test/benchmark/benchmark.go
+++ b/pkg/ext-proc/test/benchmark/benchmark.go
@@ -10,11 +10,11 @@ import (
 	"github.com/bojand/ghz/runner"
 	"github.com/jhump/protoreflect/desc"
 	"google.golang.org/protobuf/proto"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	runserver "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/test"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/test"
 )
 
 var (

--- a/pkg/ext-proc/test/utils.go
+++ b/pkg/ext-proc/test/utils.go
@@ -9,11 +9,11 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 )
 
 func StartExtProc(port int, refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration, pods []*backend.PodMetrics, models map[string]*v1alpha1.InferenceModel) *grpc.Server {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	infextv1a1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	testutils "inference.networking.x-k8s.io/gateway-api-inference-extension/test/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -40,6 +38,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	infextv1a1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
 const (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	infextv1a1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	testutils "inference.networking.x-k8s.io/gateway-api-inference-extension/test/utils"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	infextv1a1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
 var _ = ginkgo.Describe("InferencePool", func() {

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -23,10 +23,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	"inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
-	runserver "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
-	extprocutils "inference.networking.x-k8s.io/gateway-api-inference-extension/pkg/ext-proc/test"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -34,6 +30,10 @@ import (
 	klog "k8s.io/klog/v2"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
+	extprocutils "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/test"
 	"sigs.k8s.io/yaml"
 )
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	infextv1a1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -37,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	infextv1a1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // DeleteClusterResources deletes all cluster-scoped objects the tests typically create.

--- a/test/utils/wrappers.go
+++ b/test/utils/wrappers.go
@@ -17,8 +17,8 @@ limitations under the License.
 package utils
 
 import (
-	infextv1a1 "inference.networking.x-k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infextv1a1 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 // InferenceModelWrapper wraps an InferenceModel.


### PR DESCRIPTION
- Replaces default API group name with inference.networking.x-k8s.io
- Renames go mod prefix to sigs.k8s.io

Fixes #316 