### PR TITLE
Updates EPP Deployment and Release Doc/Script

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -34,10 +34,10 @@ This document defines the process for releasing Gateway API Inference Extension.
    export RC=1
    ```
 
-4. The vLLM image tag defaults to `v0.7.1` for a release. Optionally, change the vLLM image tag. For example:
+4. The vLLM image tag defaults to `0.7.2` for a release. Optionally, change the vLLM image tag. For example:
 
    ```shell
-   export VLLM=0.7.2
+   export VLLM=0.7.3
    ```
 
 ## Release Process
@@ -114,7 +114,8 @@ This document defines the process for releasing Gateway API Inference Extension.
 
 9. Pushing the tag triggers Prow to build and publish the container image to the [staging registry][].
 10. Submit a PR against [k8s.io][] to add the staging image tag and SHA to [`k8s-staging-gateway-api-inference-extension/images.yaml`][yaml]. This will
-   promote the image to the production registry. **Note:** Add a link to this issue when the PR is merged.
+    promote the image to the production registry, e.g. `registry.k8s.io/gateway-api-inference-extension/epp:v${MAJOR}.${MINOR}.0`.
+    **Note:** Add a link to this issue when the PR is merged.
 11. Test the steps in the tagged quickstart guide after the PR merges, for example: `https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v0.1.0-rc.1/pkg/README.md`.
 12. Create a [new release][]:
     1. Choose the tag that you created for the release.

--- a/pkg/manifests/ext_proc.yaml
+++ b/pkg/manifests/ext_proc.yaml
@@ -72,6 +72,7 @@ spec:
       containers:
       - name: inference-gateway-ext-proc
         image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+        imagePullPolicy: Always
         args:
         - -poolName
         - "vllm-llama2-7b-pool"


### PR DESCRIPTION
- https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/301 reverted EPP changes from a different PR. Since the EPP image was already loaded in my cluster nodes, e2e failed due to CLI flag changes in the reverted PR. For the main branch, the EPP imagePullPolicy should be `Always` to ensure cached images are not being used.
- Updates release script to use correct and latest vLLM image.
- Updates release script to use production instead of staging image registry.