### PR TITLE
Use structured logging

### DIFF
--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -98,7 +98,7 @@ func RandomWeightedDraw(model *v1alpha1.InferenceModel, seed int64) string {
 	for _, model := range model.Spec.TargetModels {
 		weights += *model.Weight
 	}
-	klog.V(logutil.VERBOSE).Infof("Weights for Model(%v) total to: %v", model.Name, weights)
+	klog.V(logutil.VERBOSE).InfoS("Weights for model computed", "model", model.Name, "weights", weights)
 	randomVal := r.Int31n(weights)
 	for _, model := range model.Spec.TargetModels {
 		if randomVal < *model.Weight {

--- a/pkg/ext-proc/backend/fake.go
+++ b/pkg/ext-proc/backend/fake.go
@@ -5,6 +5,7 @@ import (
 
 	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type FakePodMetricsClient struct {
@@ -16,7 +17,7 @@ func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, pod Pod, existi
 	if err, ok := f.Err[pod]; ok {
 		return nil, err
 	}
-	klog.V(1).Infof("pod: %+v\n existing: %+v \n new: %+v \n", pod, existing, f.Res[pod])
+	klog.V(logutil.VERBOSE).InfoS("Fetching metrics for pod", "pod", pod, "existing", existing, "new", f.Res[pod])
 	return f.Res[pod], nil
 }
 

--- a/pkg/ext-proc/backend/inferencepool_reconciler.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler.go
@@ -11,6 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 // InferencePoolReconciler utilizes the controller runtime to reconcile Instance Gateway resources
@@ -28,11 +29,12 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if req.NamespacedName.Name != c.PoolNamespacedName.Name || req.NamespacedName.Namespace != c.PoolNamespacedName.Namespace {
 		return ctrl.Result{}, nil
 	}
-	klog.V(1).Info("reconciling InferencePool", req.NamespacedName)
+	klogV := klog.V(logutil.DEFAULT)
+	klogV.InfoS("Reconciling InferencePool", "name", req.NamespacedName)
 
 	serverPool := &v1alpha1.InferencePool{}
 	if err := c.Get(ctx, req.NamespacedName, serverPool); err != nil {
-		klog.Error(err, ": unable to get InferencePool")
+		klogV.ErrorS(err, "Unable to get InferencePool", "name", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
 	if c.Datastore.inferencePool == nil || !reflect.DeepEqual(serverPool.Spec.Selector, c.Datastore.inferencePool.Spec.Selector) {
@@ -49,7 +51,7 @@ func (c *InferencePoolReconciler) updateDatastore(serverPool *v1alpha1.Inference
 	pool, _ := c.Datastore.getInferencePool()
 	if pool == nil ||
 		serverPool.ObjectMeta.ResourceVersion != pool.ObjectMeta.ResourceVersion {
-		klog.Infof("Updating inference pool to %v/%v", serverPool.ObjectMeta.Namespace, serverPool.ObjectMeta.Name)
+		klog.V(logutil.DEFAULT).InfoS("Updating inference pool", "target", klog.KMetadata(&serverPool.ObjectMeta))
 		c.Datastore.setInferencePool(serverPool)
 	}
 }

--- a/pkg/ext-proc/handlers/response.go
+++ b/pkg/ext-proc/handlers/response.go
@@ -12,9 +12,9 @@ import (
 
 // HandleResponseHeaders processes response headers from the backend model server.
 func (s *Server) HandleResponseHeaders(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klog.V(logutil.VERBOSE).Info("Processing ResponseHeaders")
+	klog.V(logutil.VERBOSE).InfoS("Processing ResponseHeaders")
 	h := req.Request.(*extProcPb.ProcessingRequest_ResponseHeaders)
-	klog.V(logutil.VERBOSE).Infof("Headers before: %+v\n", h)
+	klog.V(logutil.VERBOSE).InfoS("Headers before", "headers", h)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseHeaders{
@@ -66,7 +66,7 @@ func (s *Server) HandleResponseHeaders(reqCtx *RequestContext, req *extProcPb.Pr
     }
 }*/
 func (s *Server) HandleResponseBody(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klog.V(logutil.VERBOSE).Info("Processing HandleResponseBody")
+	klog.V(logutil.VERBOSE).InfoS("Processing HandleResponseBody")
 	body := req.Request.(*extProcPb.ProcessingRequest_ResponseBody)
 
 	res := Response{}
@@ -81,7 +81,7 @@ func (s *Server) HandleResponseBody(reqCtx *RequestContext, req *extProcPb.Proce
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/178)
 	// will add the processing for streaming case.
 	reqCtx.ResponseComplete = true
-	klog.V(logutil.VERBOSE).Infof("Response: %+v", res)
+	klog.V(logutil.VERBOSE).InfoS("Response generated", "response", res)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseBody{

--- a/pkg/ext-proc/health.go
+++ b/pkg/ext-proc/health.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type healthServer struct {
@@ -16,10 +17,10 @@ type healthServer struct {
 
 func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckRequest) (*healthPb.HealthCheckResponse, error) {
 	if !s.datastore.HasSynced() {
-		klog.Infof("gRPC health check not serving: %s", in.String())
+		klog.V(logutil.VERBOSE).InfoS("gRPC health check not serving", "service", in.Service)
 		return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_NOT_SERVING}, nil
 	}
-	klog.Infof("gRPC health check serving: %s", in.String())
+	klog.V(logutil.VERBOSE).InfoS("gRPC health check serving", "service", in.Service)
 	return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_SERVING}, nil
 }
 

--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -102,11 +102,11 @@ func run() error {
 	}
 
 	// Print all flag values
-	flags := "Flags: "
+	flags := make(map[string]any)
 	flag.VisitAll(func(f *flag.Flag) {
-		flags += fmt.Sprintf("%s=%v; ", f.Name, f.Value)
+		flags[f.Name] = f.Value
 	})
-	klog.Info(flags)
+	klog.InfoS("Flags processed", "flags", flags)
 
 	datastore := backend.NewK8sDataStore()
 

--- a/pkg/ext-proc/scheduling/filter.go
+++ b/pkg/ext-proc/scheduling/filter.go
@@ -42,7 +42,7 @@ func (f *filter) Name() string {
 }
 
 func (f *filter) Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
-	klog.V(logutil.VERBOSE).Infof("Running filter %q on request %v with %v pods", f.name, req, len(pods))
+	klog.V(logutil.VERBOSE).InfoS("Running a filter", "name", f.Name(), "request", req, "podCount", len(pods))
 
 	filtered, err := f.filter(req, pods)
 
@@ -55,7 +55,7 @@ func (f *filter) Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend
 		if f.nextOnSuccess != nil {
 			next = f.nextOnSuccess
 		}
-		klog.V(logutil.VERBOSE).Infof("onSuccess %q -> %q, filtered: %v", f.name, next.Name(), len(filtered))
+		klog.V(logutil.VERBOSE).InfoS("Filter succeeded", "filter", f.Name(), "next", next.Name(), "filteredPodCount", len(filtered))
 		// On success, pass the filtered result to the next filter.
 		return next.Filter(req, filtered)
 	} else {
@@ -66,7 +66,7 @@ func (f *filter) Filter(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend
 		if f.nextOnFailure != nil {
 			next = f.nextOnFailure
 		}
-		klog.V(logutil.VERBOSE).Infof("onFailure %q -> %q", f.name, next.Name())
+		klog.V(logutil.VERBOSE).InfoS("Filter failed", "filter", f.Name(), "next", next.Name())
 		// On failure, pass the initial set of pods to the next filter.
 		return next.Filter(req, pods)
 	}

--- a/pkg/ext-proc/util/logging/fatal.go
+++ b/pkg/ext-proc/util/logging/fatal.go
@@ -1,0 +1,11 @@
+package logging
+
+import "k8s.io/klog/v2"
+
+// Fatal calls klog.ErrorS followed by klog.FlushAndExit(1).
+//
+// This is a utility function and should not be used in production code!
+func Fatal(err error, msg string, keysAndValues ...interface{}) {
+	klog.ErrorS(err, msg, keysAndValues...)
+	klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+}

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
 	extprocutils "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/test"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 	"sigs.k8s.io/yaml"
 )
 
@@ -420,7 +420,7 @@ func setUpHermeticServer(pods []*backend.PodMetrics) (client extProcPb.ExternalP
 		if err := serverRunner.AsRunnable(
 			backend.NewK8sDataStore(backend.WithPods(pods)), pmc,
 		).Start(serverCtx); err != nil {
-			log.Fatalf("Failed to start ext-proc server: %v", err)
+			logutil.Fatal(err, "Failed to start ext-proc server")
 		}
 	}()
 
@@ -431,13 +431,13 @@ func setUpHermeticServer(pods []*backend.PodMetrics) (client extProcPb.ExternalP
 	// Create a grpc connection
 	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("Failed to connect to %v: %v", address, err)
+		logutil.Fatal(err, "Failed to connect", "address", address)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	client, err = extProcPb.NewExternalProcessorClient(conn).Process(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		logutil.Fatal(err, "Failed to create client")
 	}
 	return client, func() {
 		cancel()
@@ -455,7 +455,7 @@ func BeforeSuit() {
 	}
 	cfg, err := testEnv.Start()
 	if err != nil {
-		log.Fatalf("Failed to start test environment, cfg: %v error: %v", cfg, err)
+		logutil.Fatal(err, "Failed to start test environment", "config", cfg)
 	}
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -463,16 +463,15 @@ func BeforeSuit() {
 
 	k8sClient, err = k8sclient.New(cfg, k8sclient.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatalf("Failed to start k8s Client: %v", err)
+		logutil.Fatal(err, "Failed to start k8s Client")
 	} else if k8sClient == nil {
-		log.Fatalf("No error, but returned kubernetes client is nil, cfg: %v", cfg)
+		logutil.Fatal(nil, "No error, but returned kubernetes client is nil", "config", cfg)
 	}
 
 	// Init runtime.
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
 	if err != nil {
-		klog.ErrorS(err, "Failed to create controller manager")
-		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		logutil.Fatal(err, "Failed to create controller manager")
 	}
 
 	serverRunner = runserver.NewDefaultExtProcServerRunner()
@@ -481,13 +480,13 @@ func BeforeSuit() {
 	serverRunner.Datastore = backend.NewK8sDataStore()
 
 	if err := serverRunner.SetupWithManager(mgr); err != nil {
-		log.Fatalf("Failed to start server runner: %v", err)
+		logutil.Fatal(err, "Failed to setup server runner")
 	}
 
 	// Start the controller manager in go routine, not blocking
 	go func() {
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-			log.Fatalf("Failed to start manager: %v", err)
+			logutil.Fatal(err, "Failed to start manager")
 		}
 	}()
 
@@ -501,30 +500,30 @@ func BeforeSuit() {
 	manifestsPath := filepath.Join("..", "testdata", "inferencepool-with-model-hermetic.yaml")
 	docs, err := readDocuments(manifestsPath)
 	if err != nil {
-		log.Fatalf("Can't read object manifests at path %v, %v", manifestsPath, err)
+		logutil.Fatal(err, "Can't read object manifests", "path", manifestsPath)
 	}
 
 	for _, doc := range docs {
 		inferenceModel := &v1alpha1.InferenceModel{}
 		if err = yaml.Unmarshal(doc, inferenceModel); err != nil {
-			log.Fatalf("Can't unmarshal object: %v", doc)
+			logutil.Fatal(err, "Can't unmarshal object", "document", doc)
 		}
 		if inferenceModel.Kind == "InferenceModel" {
 			klog.InfoS("Creating inference model", "model", inferenceModel)
 			if err := k8sClient.Create(context.Background(), inferenceModel); err != nil {
-				log.Fatalf("unable to create inferenceModel %v: %v", inferenceModel.Name, err)
+				logutil.Fatal(err, "Unable to create inferenceModel", "modelName", inferenceModel.Name)
 			}
 		}
 	}
 	for _, doc := range docs {
 		inferencePool := &v1alpha1.InferencePool{}
 		if err = yaml.Unmarshal(doc, inferencePool); err != nil {
-			log.Fatalf("Can't unmarshal object: %v", doc)
+			logutil.Fatal(err, "Can't unmarshal object", "document", doc)
 		}
 		if inferencePool.Kind == "InferencePool" {
 			klog.InfoS("Creating inference pool", "pool", inferencePool)
 			if err := k8sClient.Create(context.Background(), inferencePool); err != nil {
-				log.Fatalf("unable to create inferencePool %v: %v", inferencePool.Name, err)
+				logutil.Fatal(err, "Unable to create inferencePool", "poolName", inferencePool.Name)
 			}
 		}
 	}

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -491,7 +491,7 @@ func BeforeSuit() {
 		}
 	}()
 
-	klog.Info("Setting up hermetic ExtProc server")
+	klog.InfoS("Setting up hermetic ExtProc server")
 	klog.InitFlags(nil)
 	flag.Parse()
 	// Configure klog verbosity levels to print ext proc logs.
@@ -510,7 +510,7 @@ func BeforeSuit() {
 			log.Fatalf("Can't unmarshal object: %v", doc)
 		}
 		if inferenceModel.Kind == "InferenceModel" {
-			klog.Infof("Creating inference model: %+v", inferenceModel)
+			klog.InfoS("Creating inference model", "model", inferenceModel)
 			if err := k8sClient.Create(context.Background(), inferenceModel); err != nil {
 				log.Fatalf("unable to create inferenceModel %v: %v", inferenceModel.Name, err)
 			}
@@ -522,7 +522,7 @@ func BeforeSuit() {
 			log.Fatalf("Can't unmarshal object: %v", doc)
 		}
 		if inferencePool.Kind == "InferencePool" {
-			klog.Infof("Creating inference pool: %+v", inferencePool)
+			klog.InfoS("Creating inference pool", "pool", inferencePool)
 			if err := k8sClient.Create(context.Background(), inferencePool); err != nil {
 				log.Fatalf("unable to create inferencePool %v: %v", inferencePool.Name, err)
 			}


### PR DESCRIPTION
All logging calls are rewritten to use structured logging.

I did `go run k8s.io/klog/hack/tools/logcheck -check-structured ./...` and fixed all issues detected.

Related to #251 