### PR TITLE
Add TLS support with self-signed certificate.

### DIFF
--- a/pkg/ext-proc/main.go
+++ b/pkg/ext-proc/main.go
@@ -71,7 +71,13 @@ var (
 		"refreshPrometheusMetricsInterval",
 		runserver.DefaultRefreshPrometheusMetricsInterval,
 		"interval to flush prometheus metrics")
-	logVerbosity = flag.Int("v", logging.DEFAULT, "number for the log level verbosity")
+	logVerbosity  = flag.Int("v", logging.DEFAULT, "number for the log level verbosity")
+	secureServing = flag.Bool(
+		"secureServing", runserver.DefaultSecureServing, "Enables secure serving. Defaults to true.")
+	certPath = flag.String(
+		"certPath", "", "The path to the certificate for secure serving. The certificate and private key files "+
+			"are assumed to be named tls.crt and tls.key, respectively. If not set, and secureServing is enabled, "+
+			"then a self-signed certificate is used.")
 
 	scheme = runtime.NewScheme()
 )
@@ -133,6 +139,8 @@ func run() error {
 		RefreshMetricsInterval:           *refreshMetricsInterval,
 		RefreshPrometheusMetricsInterval: *refreshPrometheusMetricsInterval,
 		Datastore:                        datastore,
+		SecureServing:                    *secureServing,
+		CertPath:                         *certPath,
 	}
 	if err := serverRunner.SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "Failed to setup ext-proc server")

--- a/pkg/manifests/gateway/patch_policy.yaml
+++ b/pkg/manifests/gateway/patch_policy.yaml
@@ -35,6 +35,20 @@ spec:
               max_pending_requests: 40000
               max_requests: 40000
 
+    # This ensures that envoy accepts untrusted certificates. We tried to explicitly
+    # set TrustChainVerification to ACCEPT_UNSTRUSTED, but that actually didn't work
+    # and what worked is setting the common_tls_context to empty.
+    - type: "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+      name: "envoyextensionpolicy/default/ext-proc-policy/extproc/0"
+      operation:
+        op: add
+        path: "/transport_socket"
+        value:
+          name: "envoy.transport_sockets.tls"
+          typed_config:
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+            common_tls_context: {}
+
     - type: "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
       name: default/inference-gateway/llm-gw
       operation:

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -479,6 +479,7 @@ func BeforeSuit() {
 	// Adjust from defaults
 	serverRunner.PoolName = "vllm-llama2-7b-pool"
 	serverRunner.Datastore = backend.NewK8sDataStore()
+	serverRunner.SecureServing = false
 
 	if err := serverRunner.SetupWithManager(mgr); err != nil {
 		log.Fatalf("Failed to start server runner: %v", err)

--- a/test/testdata/envoy.yaml
+++ b/test/testdata/envoy.yaml
@@ -169,6 +169,15 @@ data:
                 max_pending_requests: 40000
                 max_requests: 40000
                 max_retries: 1024
+          # This ensures that envoy accepts untrusted certificates. We tried to explicitly
+          # set TrustChainVerification to ACCEPT_UNSTRUSTED, but that actually didn't work
+          # and what worked is setting the common_tls_context to empty.                
+          transport_socket:
+            name: "envoy.transport_sockets.tls"
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                validation_context:
           typed_extension_protocol_options:
             envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
               "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -219,7 +228,7 @@ spec:
           - "--service-node"
           - "$(ENVOY_POD_NAME)"
           - "--log-level"
-          - "debug"
+          - "trace"
           - "--cpuset-threads"
           - "--drain-strategy"
           - "immediate"


### PR DESCRIPTION
Fixes #225 

By default, secure serving is enabled and the server will create a self-signed certificate. Users can also provide their own certificate by setting the certPath.