### PR TITLE
Use contextual logging

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,27 +1,33 @@
 <!-- Dev guide -->
 
-
 ## Logging
 
+We use `logr.Logger` interface for logging everywhere.
+The logger instance is loaded from `context.Context` or passed around as an argument directly.
+This is aligned with contextual logging as explained in [k8s instrumentation logging guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md).
+
+In other words, we explicitly don't use `klog` global logging calls.
+Using `klog` log value helpers like `klog.KObj` is just fine.
+
 ### Change log verbosity
-We use the `k8s.io/klog/v2` package to manage logging. 
 
 We generally follow the [k8s instrumentation logging guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md), which states "the practical default level is V(2). Developers and QE environments may wish to run at V(3) or V(4)".
 
-To configure logging verbosity, specify the `v` flag such as  `--v=2`.
+To configure logging verbosity, specify the `v` flag such as `--v=2`.
 
 ### Add logs
 
 The [k8s instrumentation logging guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) has the following definitions:
 
-* `klog.V(0).InfoS` = `klog.InfoS` - Generally useful for this to **always** be visible to a cluster operator
-* `klog.V(1).InfoS` - A reasonable default log level if you don't want verbosity.
-* `klog.V(2).InfoS` - Useful steady state information about the service and important log messages that may correlate to significant changes in the system.  This is the recommended default log level for most systems.
-* `klog.V(3).InfoS` - Extended information about changes
-* `klog.V(4).InfoS` - Debug level verbosity
-* `klog.V(5).InfoS` - Trace level verbosity
+- `logger.V(0).Info` = `logger.Info` - Generally useful for this to **always** be visible to a cluster operator
+- `logger.V(1).Info` - A reasonable default log level if you don't want verbosity.
+- `logger.V(2).Info` - Useful steady state information about the service and important log messages that may correlate to significant changes in the system. This is the recommended default log level for most systems.
+- `logger.V(3).Info` - Extended information about changes
+- `logger.V(4).Info` - Debug level verbosity
+- `logger.V(5).Info` - Trace level verbosity
 
 We choose to simplify to the following 3 common levels.
+
 ```
 const(
     DEFAULT=2
@@ -33,34 +39,46 @@ const(
 
 The guidelines are written in the context of a k8s controller. Our [ext-proc](../pkg/ext-proc/) does more things such as handling requests and scraping metrics, therefore we adapt the guidelines as follows:
 
-1. The server startup process and configuration. 
-   * `klog.InfoS`  Logging at the `V(0)` verbosity level is generally welcome here as this is only logged once at startup, and provides useful info for debugging.
+1. The server startup process and configuration.
+
+   - `logger.Info` Logging at the `V(0)` verbosity level is generally welcome here as this is only logged once at startup, and provides useful info for debugging.
 
 2. Reconciler loops. The reconciler loops watch for CR changes such as the `InferenceModel` CR. And given changes in these CRs significantly affect the behavior of the extension, we recommend using v=1 verbosity level as default, and sparsely use higher verbosity levels.
-   
-   * `klog.V(DEFAULT).InfoS`
-      * Default log level in the reconcilers.
-      * Information about config (listening on X, watching Y)
-      * Errors that repeat frequently that relate to conditions that can be corrected (e.g., inference model not initialized yet)
-      * System state changing (adding/removing objects in the data store)
-   * `V(VERBOSE)` and above: Use your best judgement. 
+
+   - `logger.V(DEFAULT)`
+     - Default log level in the reconcilers.
+     - Information about config (listening on X, watching Y)
+     - Errors that repeat frequently that relate to conditions that can be corrected (e.g., inference model not initialized yet)
+     - System state changing (adding/removing objects in the data store)
+   - `logger.V(VERBOSE)` and above: Use your best judgement.
 
 3. Inference request handling. These requests are expected to be much higher volume than the control flow in the reconcilers and therefore we should be mindful of log spamming. We recommend using v=2 to log important info about a request, such as the HTTP response code, and higher verbosity levels for less important info.
 
-   * `klog.V(DEFAULT).InfoS`
-      * Logging the status code of an HTTP request
-      * Important decision making such as picking the target model, target pod
-   * `klog.V(VERBOSE).InfoS`
-      * Detailed request scheduling algorithm operations, such as running the filtering logic
-   * `V(DEBUG)` and above: Use your best judgement. 
+   - `logger.V(DEFAULT)`
+     - Logging the status code of an HTTP request
+     - Important decision making such as picking the target model, target pod
+   - `logger.V(VERBOSE)`
+     - Detailed request scheduling algorithm operations, such as running the filtering logic
+   - `logger.V(DEBUG)` and above: Use your best judgement.
 
 4. Metric scraping loops. These loops run at a very high frequency, and logs can be very spammy if not handled properly.
-    * `klog.V(TRACE).InfoS`
-      * Transient errors/warnings, such as failure to get response from a pod.
-      * Important state changes, such as updating a metric.
 
-5. Misc 
+   - `logger.V(TRACE)`
+     - Transient errors/warnings, such as failure to get response from a pod.
+     - Important state changes, such as updating a metric.
+
+5. Misc
    1. Periodic (every 5s) debug loop which prints the current pods and metrics.
-      * `klog.WarningS` If the metrics are not fresh enough, which indicates an error occurred during the metric scraping loop.
-      * `klog.V(DEBUG).InfoS`
-         *  This is very important to debug the request scheduling algorithm, and yet not spammy compared to the metric scraping loop logs.
+      - `logger.V(DEFAULT).Error` If the metrics are not fresh enough, which indicates an error occurred during the metric scraping loop.
+      - `logger.V(DEBUG)`
+        - This is very important to debug the request scheduling algorithm, and yet not spammy compared to the metric scraping loop logs.
+
+### Passing Logger Around
+
+You can pass around a `context.Context` that contains a logger or a `logr.Logger` instance directly.
+You need to make the call which one to use. Passing a `context.Context` is more standard,
+on the other hand you then need to call `log.FromContext` everywhere.
+
+As `logger.V` calls are cummulative, i.e. `logger.V(2).V(3)` results in `logger.V(5)`,
+a logger should be passed around with no verbosity level set so that `logger.V(DEFAULT)`
+actually uses `DEFAULT` verbosity level.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bojand/ghz v0.120.0
 	github.com/elastic/crd-ref-docs v0.1.0
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4
+	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/jhump/protoreflect v1.17.0
 	github.com/onsi/ginkgo/v2 v2.22.2
@@ -61,7 +62,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/ext-proc/backend/datastore_test.go
+++ b/pkg/ext-proc/backend/datastore_test.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 func TestHasSynced(t *testing.T) {
@@ -46,6 +47,7 @@ func TestHasSynced(t *testing.T) {
 }
 
 func TestRandomWeightedDraw(t *testing.T) {
+	logger := logutil.NewTestLogger()
 	tests := []struct {
 		name  string
 		model *v1alpha1.InferenceModel
@@ -118,7 +120,7 @@ func TestRandomWeightedDraw(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for range 10000 {
-				model := RandomWeightedDraw(test.model, seedVal)
+				model := RandomWeightedDraw(logger, test.model, seedVal)
 				if model != test.want {
 					t.Errorf("Model returned!: %v", model)
 					break

--- a/pkg/ext-proc/backend/fake.go
+++ b/pkg/ext-proc/backend/fake.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"context"
 
-	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
@@ -17,7 +17,7 @@ func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, pod Pod, existi
 	if err, ok := f.Err[pod]; ok {
 		return nil, err
 	}
-	klog.V(logutil.VERBOSE).InfoS("Fetching metrics for pod", "pod", pod, "existing", existing, "new", f.Res[pod])
+	log.FromContext(ctx).V(logutil.VERBOSE).Info("Fetching metrics for pod", "pod", pod, "existing", existing, "new", f.Res[pod])
 	return f.Res[pod], nil
 }
 

--- a/pkg/ext-proc/backend/inferencemodel_reconciler.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler.go
@@ -3,13 +3,14 @@ package backend
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
@@ -27,38 +28,39 @@ func (c *InferenceModelReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	klogV := klog.V(logutil.DEFAULT)
-	klogV.InfoS("Reconciling InferenceModel", "name", req.NamespacedName)
+	logger := log.FromContext(ctx)
+	loggerDefault := logger.V(logutil.DEFAULT)
+	loggerDefault.Info("Reconciling InferenceModel", "name", req.NamespacedName)
 
 	infModel := &v1alpha1.InferenceModel{}
 	if err := c.Get(ctx, req.NamespacedName, infModel); err != nil {
 		if errors.IsNotFound(err) {
-			klogV.InfoS("InferenceModel not found. Removing from datastore since object must be deleted", "name", req.NamespacedName)
+			loggerDefault.Info("InferenceModel not found. Removing from datastore since object must be deleted", "name", req.NamespacedName)
 			c.Datastore.InferenceModels.Delete(infModel.Spec.ModelName)
 			return ctrl.Result{}, nil
 		}
-		klogV.ErrorS(err, "Unable to get InferenceModel", "name", req.NamespacedName)
+		loggerDefault.Error(err, "Unable to get InferenceModel", "name", req.NamespacedName)
 		return ctrl.Result{}, err
 	} else if !infModel.DeletionTimestamp.IsZero() {
-		klogV.InfoS("InferenceModel is marked for deletion. Removing from datastore", "name", req.NamespacedName)
+		loggerDefault.Info("InferenceModel is marked for deletion. Removing from datastore", "name", req.NamespacedName)
 		c.Datastore.InferenceModels.Delete(infModel.Spec.ModelName)
 		return ctrl.Result{}, nil
 	}
 
-	c.updateDatastore(infModel)
+	c.updateDatastore(logger, infModel)
 	return ctrl.Result{}, nil
 }
 
-func (c *InferenceModelReconciler) updateDatastore(infModel *v1alpha1.InferenceModel) {
-	klogV := klog.V(logutil.DEFAULT)
+func (c *InferenceModelReconciler) updateDatastore(logger logr.Logger, infModel *v1alpha1.InferenceModel) {
+	loggerDefault := logger.V(logutil.DEFAULT)
 
 	if infModel.Spec.PoolRef.Name == c.PoolNamespacedName.Name {
-		klogV.InfoS("Updating datastore", "poolRef", infModel.Spec.PoolRef, "serverPoolName", c.PoolNamespacedName)
-		klogV.InfoS("Adding/Updating InferenceModel", "modelName", infModel.Spec.ModelName)
+		loggerDefault.Info("Updating datastore", "poolRef", infModel.Spec.PoolRef, "serverPoolName", c.PoolNamespacedName)
+		loggerDefault.Info("Adding/Updating InferenceModel", "modelName", infModel.Spec.ModelName)
 		c.Datastore.InferenceModels.Store(infModel.Spec.ModelName, infModel)
 		return
 	}
-	klogV.InfoS("Removing/Not adding InferenceModel", "modelName", infModel.Spec.ModelName)
+	loggerDefault.Info("Removing/Not adding InferenceModel", "modelName", infModel.Spec.ModelName)
 	// If we get here. The model is not relevant to this pool, remove.
 	c.Datastore.InferenceModels.Delete(infModel.Spec.ModelName)
 }

--- a/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 var (
@@ -46,6 +47,8 @@ var (
 )
 
 func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
+	logger := logutil.NewTestLogger()
+
 	tests := []struct {
 		name                string
 		datastore           *K8sDatastore
@@ -135,7 +138,7 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 				Datastore:          test.datastore,
 				PoolNamespacedName: types.NamespacedName{Name: test.datastore.inferencePool.Name},
 			}
-			reconciler.updateDatastore(test.incomingService)
+			reconciler.updateDatastore(logger, test.incomingService)
 
 			if ok := mapsEqual(reconciler.Datastore.InferenceModels, test.wantInferenceModels); !ok {
 				t.Error("Maps are not equal")

--- a/pkg/ext-proc/backend/inferencepool_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 var (
@@ -41,6 +42,8 @@ var (
 )
 
 func TestUpdateDatastore_InferencePoolReconciler(t *testing.T) {
+	logger := logutil.NewTestLogger()
+
 	tests := []struct {
 		name         string
 		datastore    *K8sDatastore
@@ -74,7 +77,7 @@ func TestUpdateDatastore_InferencePoolReconciler(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			inferencePoolReconciler := &InferencePoolReconciler{Datastore: test.datastore}
-			inferencePoolReconciler.updateDatastore(test.incomingPool)
+			inferencePoolReconciler.updateDatastore(logger, test.incomingPool)
 
 			gotPool := inferencePoolReconciler.Datastore.inferencePool
 			if !reflect.DeepEqual(gotPool, test.wantPool) {

--- a/pkg/ext-proc/backend/pod_reconciler.go
+++ b/pkg/ext-proc/backend/pod_reconciler.go
@@ -26,7 +26,7 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	logger := log.FromContext(ctx)
 	inferencePool, err := c.Datastore.getInferencePool()
 	if err != nil {
-		logger.V(logutil.DEFAULT).Info("Skipping reconciling Pod because the InferencePool is not available yet", "error", err)
+		logger.V(logutil.TRACE).Info("Skipping reconciling Pod because the InferencePool is not available yet", "error", err)
 		// When the inferencePool is initialized it lists the appropriate pods and populates the datastore, so no need to requeue.
 		return ctrl.Result{}, nil
 	} else if inferencePool.Namespace != req.Namespace {

--- a/pkg/ext-proc/backend/pod_reconciler.go
+++ b/pkg/ext-proc/backend/pod_reconciler.go
@@ -8,9 +8,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
@@ -23,20 +23,21 @@ type PodReconciler struct {
 }
 
 func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
 	inferencePool, err := c.Datastore.getInferencePool()
 	if err != nil {
-		klog.V(logutil.DEFAULT).Infof("Skipping reconciling Pod because the InferencePool is not available yet: %v", err)
+		logger.V(logutil.DEFAULT).Info("Skipping reconciling Pod because the InferencePool is not available yet", "error", err)
 		// When the inferencePool is initialized it lists the appropriate pods and populates the datastore, so no need to requeue.
 		return ctrl.Result{}, nil
 	} else if inferencePool.Namespace != req.Namespace {
 		return ctrl.Result{}, nil
 	}
 
-	klog.V(logutil.VERBOSE).Info("reconciling Pod", req.NamespacedName)
+	logger.V(logutil.VERBOSE).Info("Pod being reconciled", "name", req.NamespacedName)
 
 	pod := &corev1.Pod{}
 	if err := c.Get(ctx, req.NamespacedName, pod); err != nil {
-		klog.Error(err, ": unable to get pod")
+		logger.V(logutil.DEFAULT).Error(err, "Unabled to get pod", "name", req.NamespacedName)
 		if apierrors.IsNotFound(err) {
 			c.Datastore.pods.Delete(pod)
 			return ctrl.Result{}, nil

--- a/pkg/ext-proc/backend/pod_reconciler.go
+++ b/pkg/ext-proc/backend/pod_reconciler.go
@@ -37,11 +37,11 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	pod := &corev1.Pod{}
 	if err := c.Get(ctx, req.NamespacedName, pod); err != nil {
-		logger.V(logutil.DEFAULT).Error(err, "Unabled to get pod", "name", req.NamespacedName)
 		if apierrors.IsNotFound(err) {
 			c.Datastore.pods.Delete(pod)
 			return ctrl.Result{}, nil
 		}
+		logger.V(logutil.DEFAULT).Error(err, "Unable to get pod", "name", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/ext-proc/backend/provider_test.go
+++ b/pkg/ext-proc/backend/provider_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 var (
@@ -38,6 +39,8 @@ var (
 )
 
 func TestProvider(t *testing.T) {
+	logger := logutil.NewTestLogger()
+
 	tests := []struct {
 		name      string
 		pmc       PodMetricsClient
@@ -90,7 +93,7 @@ func TestProvider(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := NewProvider(test.pmc, test.datastore)
-			err := p.Init(time.Millisecond, time.Millisecond, time.Millisecond)
+			err := p.Init(logger, time.Millisecond, time.Millisecond, time.Millisecond)
 			if test.initErr != (err != nil) {
 				t.Fatalf("Unexpected error, got: %v, want: %v", err, test.initErr)
 			}

--- a/pkg/ext-proc/backend/vllm/metrics_test.go
+++ b/pkg/ext-proc/backend/vllm/metrics_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 func TestPromToPodMetrics(t *testing.T) {
+	logger := logutil.NewTestLogger()
+
 	testCases := []struct {
 		name              string
 		metricFamilies    map[string]*dto.MetricFamily
@@ -219,7 +222,7 @@ func TestPromToPodMetrics(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			updated, err := promToPodMetrics(tc.metricFamilies, tc.initialPodMetrics)
+			updated, err := promToPodMetrics(logger, tc.metricFamilies, tc.initialPodMetrics)
 			if tc.expectedErr != nil {
 				assert.Error(t, err)
 			} else {

--- a/pkg/ext-proc/handlers/request.go
+++ b/pkg/ext-proc/handlers/request.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,7 +10,7 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/protobuf/types/known/structpb"
-	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
@@ -18,25 +19,30 @@ import (
 // HandleRequestBody handles body of the request to the backend server, such as parsing the "model"
 // parameter.
 // Envoy sends the request body to ext proc before sending the request to the backend server.
-func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klogV := klog.V(logutil.VERBOSE)
-	klogV.InfoS("Handling request body")
+func (s *Server) HandleRequestBody(
+	ctx context.Context,
+	reqCtx *RequestContext,
+	req *extProcPb.ProcessingRequest,
+) (*extProcPb.ProcessingResponse, error) {
+	logger := log.FromContext(ctx)
+	loggerVerbose := logger.V(logutil.VERBOSE)
+	loggerVerbose.Info("Handling request body")
 
 	// Unmarshal request body (must be JSON).
 	v := req.Request.(*extProcPb.ProcessingRequest_RequestBody)
 	var rb map[string]interface{}
 	if err := json.Unmarshal(v.RequestBody.Body, &rb); err != nil {
-		klog.V(logutil.DEFAULT).ErrorS(err, "Error unmarshaling request body")
+		logger.V(logutil.DEFAULT).Error(err, "Error unmarshaling request body")
 		return nil, fmt.Errorf("error unmarshaling request body: %v", err)
 	}
-	klogV.InfoS("Request body unmarshalled", "body", rb)
+	loggerVerbose.Info("Request body unmarshalled", "body", rb)
 
 	// Resolve target models.
 	model, ok := rb["model"].(string)
 	if !ok {
 		return nil, errors.New("model not found in request")
 	}
-	klogV.InfoS("Model requested", "model", model)
+	loggerVerbose.Info("Model requested", "model", model)
 	modelName := model
 
 	// NOTE: The nil checking for the modelObject means that we DO allow passthrough currently.
@@ -47,7 +53,7 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 		return nil, fmt.Errorf("error finding a model object in InferenceModel for input %v", model)
 	}
 	if len(modelObj.Spec.TargetModels) > 0 {
-		modelName = backend.RandomWeightedDraw(modelObj, 0)
+		modelName = backend.RandomWeightedDraw(logger, modelObj, 0)
 		if modelName == "" {
 			return nil, fmt.Errorf("error getting target model name for model %v", modelObj.Name)
 		}
@@ -57,7 +63,7 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 		ResolvedTargetModel: modelName,
 		Critical:            backend.IsCritical(modelObj),
 	}
-	klogV.InfoS("LLM request assembled", "request", llmReq)
+	loggerVerbose.Info("LLM request assembled", "request", llmReq)
 
 	requestBody := v.RequestBody.Body
 	var err error
@@ -66,17 +72,17 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 		rb["model"] = llmReq.ResolvedTargetModel
 		requestBody, err = json.Marshal(rb)
 		if err != nil {
-			klog.V(logutil.DEFAULT).ErrorS(err, "Error marshaling request body")
+			logger.V(logutil.DEFAULT).Error(err, "Error marshaling request body")
 			return nil, fmt.Errorf("error marshaling request body: %v", err)
 		}
-		klogV.InfoS("Updated request body marshalled", "body", string(requestBody))
+		loggerVerbose.Info("Updated request body marshalled", "body", string(requestBody))
 	}
 
-	targetPod, err := s.scheduler.Schedule(llmReq)
+	targetPod, err := s.scheduler.Schedule(ctx, llmReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find target pod: %w", err)
 	}
-	klogV.InfoS("Target model and pod selected", "model", llmReq.ResolvedTargetModel, "pod", targetPod)
+	loggerVerbose.Info("Target model and pod selected", "model", llmReq.ResolvedTargetModel, "pod", targetPod)
 
 	reqCtx.Model = llmReq.Model
 	reqCtx.ResolvedTargetModel = llmReq.ResolvedTargetModel
@@ -102,7 +108,7 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 	}
 	// Print headers for debugging
 	for _, header := range headers {
-		klog.V(logutil.DEBUG).InfoS("Request body header", "key", header.Header.Key, "value", header.Header.RawValue)
+		logger.V(logutil.DEBUG).Info("Request body header", "key", header.Header.Key, "value", header.Header.RawValue)
 	}
 
 	resp := &extProcPb.ProcessingResponse{
@@ -136,10 +142,14 @@ func (s *Server) HandleRequestBody(reqCtx *RequestContext, req *extProcPb.Proces
 	return resp, nil
 }
 
-func HandleRequestHeaders(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) *extProcPb.ProcessingResponse {
+func HandleRequestHeaders(
+	ctx context.Context,
+	reqCtx *RequestContext,
+	req *extProcPb.ProcessingRequest,
+) *extProcPb.ProcessingResponse {
 	r := req.Request
 	h := r.(*extProcPb.ProcessingRequest_RequestHeaders)
-	klog.V(logutil.VERBOSE).InfoS("Handling request headers", "headers", h)
+	log.FromContext(ctx).Info("Handling request headers", "headers", h)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestHeaders{

--- a/pkg/ext-proc/handlers/request.go
+++ b/pkg/ext-proc/handlers/request.go
@@ -82,7 +82,8 @@ func (s *Server) HandleRequestBody(
 	if err != nil {
 		return nil, fmt.Errorf("failed to find target pod: %w", err)
 	}
-	loggerVerbose.Info("Target model and pod selected", "model", llmReq.ResolvedTargetModel, "pod", targetPod)
+	logger.V(logutil.DEFAULT).Info("Request handled",
+		"model", llmReq.Model, "targetModel", llmReq.ResolvedTargetModel, "endpoint", targetPod)
 
 	reqCtx.Model = llmReq.Model
 	reqCtx.ResolvedTargetModel = llmReq.ResolvedTargetModel
@@ -149,7 +150,7 @@ func HandleRequestHeaders(
 ) *extProcPb.ProcessingResponse {
 	r := req.Request
 	h := r.(*extProcPb.ProcessingRequest_RequestHeaders)
-	log.FromContext(ctx).Info("Handling request headers", "headers", h)
+	log.FromContext(ctx).V(logutil.VERBOSE).Info("Handling request headers", "headers", h)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestHeaders{

--- a/pkg/ext-proc/handlers/response.go
+++ b/pkg/ext-proc/handlers/response.go
@@ -1,20 +1,26 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 // HandleResponseHeaders processes response headers from the backend model server.
-func (s *Server) HandleResponseHeaders(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klog.V(logutil.VERBOSE).InfoS("Processing ResponseHeaders")
+func (s *Server) HandleResponseHeaders(
+	ctx context.Context,
+	reqCtx *RequestContext,
+	req *extProcPb.ProcessingRequest,
+) (*extProcPb.ProcessingResponse, error) {
+	loggerVerbose := log.FromContext(ctx).V(logutil.VERBOSE)
+	loggerVerbose.Info("Processing ResponseHeaders")
 	h := req.Request.(*extProcPb.ProcessingRequest_ResponseHeaders)
-	klog.V(logutil.VERBOSE).InfoS("Headers before", "headers", h)
+	loggerVerbose.Info("Headers before", "headers", h)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseHeaders{
@@ -65,8 +71,14 @@ func (s *Server) HandleResponseHeaders(reqCtx *RequestContext, req *extProcPb.Pr
         "completion_tokens": 100
     }
 }*/
-func (s *Server) HandleResponseBody(reqCtx *RequestContext, req *extProcPb.ProcessingRequest) (*extProcPb.ProcessingResponse, error) {
-	klog.V(logutil.VERBOSE).InfoS("Processing HandleResponseBody")
+func (s *Server) HandleResponseBody(
+	ctx context.Context,
+	reqCtx *RequestContext,
+	req *extProcPb.ProcessingRequest,
+) (*extProcPb.ProcessingResponse, error) {
+	logger := log.FromContext(ctx)
+	loggerVerbose := logger.V(logutil.VERBOSE)
+	loggerVerbose.Info("Processing HandleResponseBody")
 	body := req.Request.(*extProcPb.ProcessingRequest_ResponseBody)
 
 	res := Response{}
@@ -81,7 +93,7 @@ func (s *Server) HandleResponseBody(reqCtx *RequestContext, req *extProcPb.Proce
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/178)
 	// will add the processing for streaming case.
 	reqCtx.ResponseComplete = true
-	klog.V(logutil.VERBOSE).InfoS("Response generated", "response", res)
+	loggerVerbose.Info("Response generated", "response", res)
 
 	resp := &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_ResponseBody{

--- a/pkg/ext-proc/handlers/response_test.go
+++ b/pkg/ext-proc/handlers/response_test.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/google/go-cmp/cmp"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 const (
@@ -34,6 +36,8 @@ const (
 )
 
 func TestHandleResponseBody(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
 	tests := []struct {
 		name    string
 		req     *extProcPb.ProcessingRequest_ResponseBody
@@ -70,8 +74,7 @@ func TestHandleResponseBody(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			server := &Server{}
 			reqCtx := &RequestContext{}
-			_, err := server.HandleResponseBody(reqCtx, &extProcPb.ProcessingRequest{Request: test.req})
-
+			_, err := server.HandleResponseBody(ctx, reqCtx, &extProcPb.ProcessingRequest{Request: test.req})
 			if err != nil {
 				if !test.wantErr {
 					t.Fatalf("HandleResponseBody returned unexpected error: %v, want %v", err, test.wantErr)

--- a/pkg/ext-proc/handlers/server.go
+++ b/pkg/ext-proc/handlers/server.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
@@ -37,7 +38,7 @@ type Server struct {
 }
 
 type Scheduler interface {
-	Schedule(b *scheduling.LLMRequest) (targetPod backend.Pod, err error)
+	Schedule(ctx context.Context, b *scheduling.LLMRequest) (targetPod backend.Pod, err error)
 }
 
 // PodProvider is an interface to provide set of pods in the backend and information such as metrics.
@@ -51,8 +52,11 @@ type ModelDataStore interface {
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
-	klog.V(logutil.VERBOSE).InfoS("Processing")
 	ctx := srv.Context()
+	logger := log.FromContext(ctx)
+	loggerVerbose := logger.V(logutil.VERBOSE)
+	loggerVerbose.Info("Processing")
+
 	// Create request context to share states during life time of an HTTP request.
 	// See https://github.com/envoyproxy/envoy/issues/17540.
 	reqCtx := &RequestContext{}
@@ -71,7 +75,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		if err != nil {
 			// This error occurs very frequently, though it doesn't seem to have any impact.
 			// TODO Figure out if we can remove this noise.
-			klog.V(logutil.VERBOSE).ErrorS(err, "Cannot receive stream request")
+			loggerVerbose.Error(err, "Cannot receive stream request")
 			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", err)
 		}
 
@@ -79,34 +83,34 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
 			reqCtx.RequestReceivedTimestamp = time.Now()
-			resp = HandleRequestHeaders(reqCtx, req)
-			klog.V(logutil.VERBOSE).InfoS("Request context after HandleRequestHeaders", "context", reqCtx)
+			resp = HandleRequestHeaders(ctx, reqCtx, req)
+			loggerVerbose.Info("Request context after HandleRequestHeaders", "context", reqCtx)
 		case *extProcPb.ProcessingRequest_RequestBody:
-			resp, err = s.HandleRequestBody(reqCtx, req)
+			resp, err = s.HandleRequestBody(ctx, reqCtx, req)
 			if err == nil {
 				metrics.RecordRequestCounter(reqCtx.Model, reqCtx.ResolvedTargetModel)
 				metrics.RecordRequestSizes(reqCtx.Model, reqCtx.ResolvedTargetModel, reqCtx.RequestSize)
 			}
-			klog.V(logutil.VERBOSE).InfoS("Request context after HandleRequestBody", "context", reqCtx)
+			loggerVerbose.Info("Request context after HandleRequestBody", "context", reqCtx)
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
-			resp, err = s.HandleResponseHeaders(reqCtx, req)
-			klog.V(logutil.VERBOSE).InfoS("Request context after HandleResponseHeaders", "context", reqCtx)
+			resp, err = s.HandleResponseHeaders(ctx, reqCtx, req)
+			loggerVerbose.Info("Request context after HandleResponseHeaders", "context", reqCtx)
 		case *extProcPb.ProcessingRequest_ResponseBody:
-			resp, err = s.HandleResponseBody(reqCtx, req)
+			resp, err = s.HandleResponseBody(ctx, reqCtx, req)
 			if err == nil && reqCtx.ResponseComplete {
 				reqCtx.ResponseCompleteTimestamp = time.Now()
-				metrics.RecordRequestLatencies(reqCtx.Model, reqCtx.ResolvedTargetModel, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
+				metrics.RecordRequestLatencies(ctx, reqCtx.Model, reqCtx.ResolvedTargetModel, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
 				metrics.RecordResponseSizes(reqCtx.Model, reqCtx.ResolvedTargetModel, reqCtx.ResponseSize)
 				metrics.RecordInputTokens(reqCtx.Model, reqCtx.ResolvedTargetModel, reqCtx.Response.Usage.PromptTokens)
 				metrics.RecordOutputTokens(reqCtx.Model, reqCtx.ResolvedTargetModel, reqCtx.Response.Usage.CompletionTokens)
 			}
-			klog.V(logutil.VERBOSE).InfoS("Request context after HandleResponseBody", "context", reqCtx)
+			loggerVerbose.Info("Request context after HandleResponseBody", "context", reqCtx)
 		default:
-			klog.V(logutil.DEFAULT).ErrorS(nil, "Unknown Request type", "request", v)
+			logger.V(logutil.DEFAULT).Error(nil, "Unknown Request type", "request", v)
 			return status.Error(codes.Unknown, "unknown request type")
 		}
 		if err != nil {
-			klog.V(logutil.DEFAULT).ErrorS(err, "Failed to process request", "request", req)
+			logger.V(logutil.DEFAULT).Error(err, "Failed to process request", "request", req)
 			switch status.Code(err) {
 			// This code can be returned by scheduler when there is no capacity for sheddable
 			// requests.
@@ -125,9 +129,9 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			}
 		}
 
-		klog.V(logutil.VERBOSE).InfoS("Response generated", "response", resp)
+		loggerVerbose.Info("Response generated", "response", resp)
 		if err := srv.Send(resp); err != nil {
-			klog.V(logutil.DEFAULT).ErrorS(err, "Send failed")
+			logger.V(logutil.DEFAULT).Error(err, "Send failed")
 			return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
 		}
 	}

--- a/pkg/ext-proc/handlers/server.go
+++ b/pkg/ext-proc/handlers/server.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 
@@ -69,7 +70,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		}
 
 		req, err := srv.Recv()
-		if err == io.EOF {
+		if err == io.EOF || errors.Is(err, context.Canceled) {
 			return nil
 		}
 		if err != nil {

--- a/pkg/ext-proc/health.go
+++ b/pkg/ext-proc/health.go
@@ -3,24 +3,25 @@ package main
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc/codes"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type healthServer struct {
+	logger    logr.Logger
 	datastore *backend.K8sDatastore
 }
 
 func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckRequest) (*healthPb.HealthCheckResponse, error) {
 	if !s.datastore.HasSynced() {
-		klog.V(logutil.VERBOSE).InfoS("gRPC health check not serving", "service", in.Service)
+		s.logger.V(logutil.VERBOSE).Info("gRPC health check not serving", "service", in.Service)
 		return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_NOT_SERVING}, nil
 	}
-	klog.V(logutil.VERBOSE).InfoS("gRPC health check serving", "service", in.Service)
+	s.logger.V(logutil.VERBOSE).Info("gRPC health check serving", "service", in.Service)
 	return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_SERVING}, nil
 }
 

--- a/pkg/ext-proc/metrics/metrics.go
+++ b/pkg/ext-proc/metrics/metrics.go
@@ -1,12 +1,13 @@
 package metrics
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
@@ -144,9 +145,9 @@ func RecordRequestSizes(modelName, targetModelName string, reqSize int) {
 }
 
 // RecordRequestLatencies records duration of request.
-func RecordRequestLatencies(modelName, targetModelName string, received time.Time, complete time.Time) bool {
+func RecordRequestLatencies(ctx context.Context, modelName, targetModelName string, received time.Time, complete time.Time) bool {
 	if !complete.After(received) {
-		klog.V(logutil.DEFAULT).ErrorS(nil, "Request latency values are invalid",
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "Request latency values are invalid",
 			"modelName", modelName, "targetModelName", targetModelName, "completeTime", complete, "receivedTime", received)
 		return false
 	}

--- a/pkg/ext-proc/scheduling/filter_test.go
+++ b/pkg/ext-proc/scheduling/filter_test.go
@@ -4,11 +4,15 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 func TestFilter(t *testing.T) {
+	logger := logutil.NewTestLogger()
+
 	tests := []struct {
 		name   string
 		req    *LLMRequest
@@ -19,7 +23,7 @@ func TestFilter(t *testing.T) {
 	}{
 		{
 			name: "simple filter without successor, failure",
-			filter: &filter{filter: func(req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
+			filter: &filter{filter: func(logger logr.Logger, req *LLMRequest, pods []*backend.PodMetrics) ([]*backend.PodMetrics, error) {
 				return nil, errors.New("filter error")
 			}},
 			err: true,
@@ -201,7 +205,7 @@ func TestFilter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.filter.Filter(test.req, test.input)
+			got, err := test.filter.Filter(logger, test.req, test.input)
 			if test.err != (err != nil) {
 				t.Errorf("Unexpected error, got %v, want %v", err, test.err)
 			}
@@ -214,6 +218,8 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterFunc(t *testing.T) {
+	logger := logutil.NewTestLogger()
+
 	tests := []struct {
 		name   string
 		f      filterFunc
@@ -395,7 +401,7 @@ func TestFilterFunc(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.f(test.req, test.input)
+			got, err := test.f(logger, test.req, test.input)
 			if test.err != (err != nil) {
 				t.Errorf("Unexpected error, got %v, want %v", err, test.err)
 			}

--- a/pkg/ext-proc/server/runserver_test.go
+++ b/pkg/ext-proc/server/runserver_test.go
@@ -6,11 +6,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/server"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 func TestRunnable(t *testing.T) {
 	// Make sure AsRunnable() does not use leader election.
-	runner := server.NewDefaultExtProcServerRunner().AsRunnable(nil, nil)
+	runner := server.NewDefaultExtProcServerRunner().AsRunnable(logutil.NewTestLogger(), nil, nil)
 	r, ok := runner.(manager.LeaderElectionRunnable)
 	if !ok {
 		t.Fatal("runner is not LeaderElectionRunnable")

--- a/pkg/ext-proc/test/utils.go
+++ b/pkg/ext-proc/test/utils.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
@@ -17,7 +17,13 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
-func StartExtProc(port int, refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration, pods []*backend.PodMetrics, models map[string]*v1alpha1.InferenceModel) *grpc.Server {
+func StartExtProc(
+	logger logr.Logger,
+	port int,
+	refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration,
+	pods []*backend.PodMetrics,
+	models map[string]*v1alpha1.InferenceModel,
+) *grpc.Server {
 	ps := make(backend.PodSet)
 	pms := make(map[backend.Pod]*backend.PodMetrics)
 	for _, pod := range pods {
@@ -26,35 +32,35 @@ func StartExtProc(port int, refreshPodsInterval, refreshMetricsInterval, refresh
 	}
 	pmc := &backend.FakePodMetricsClient{Res: pms}
 	pp := backend.NewProvider(pmc, backend.NewK8sDataStore(backend.WithPods(pods)))
-	if err := pp.Init(refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval); err != nil {
-		logutil.Fatal(err, "Failed to initialize")
+	if err := pp.Init(logger, refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval); err != nil {
+		logutil.Fatal(logger, err, "Failed to initialize")
 	}
-	return startExtProc(port, pp, models)
+	return startExtProc(logger, port, pp, models)
 }
 
 // startExtProc starts an extProc server with fake pods.
-func startExtProc(port int, pp *backend.Provider, models map[string]*v1alpha1.InferenceModel) *grpc.Server {
+func startExtProc(logger logr.Logger, port int, pp *backend.Provider, models map[string]*v1alpha1.InferenceModel) *grpc.Server {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		logutil.Fatal(err, "Failed to listen", "port", port)
+		logutil.Fatal(logger, err, "Failed to listen", "port", port)
 	}
 
 	s := grpc.NewServer()
 
 	extProcPb.RegisterExternalProcessorServer(s, handlers.NewServer(pp, scheduling.NewScheduler(pp), "target-pod", &backend.FakeDataStore{Res: models}))
 
-	klog.InfoS("gRPC server starting", "port", port)
+	logger.Info("gRPC server starting", "port", port)
 	reflection.Register(s)
 	go func() {
 		err := s.Serve(lis)
 		if err != nil {
-			logutil.Fatal(err, "Ext-proc failed with the err")
+			logutil.Fatal(logger, err, "Ext-proc failed with the err")
 		}
 	}()
 	return s
 }
 
-func GenerateRequest(model string) *extProcPb.ProcessingRequest {
+func GenerateRequest(logger logr.Logger, model string) *extProcPb.ProcessingRequest {
 	j := map[string]interface{}{
 		"model":       model,
 		"prompt":      "hello",
@@ -64,7 +70,7 @@ func GenerateRequest(model string) *extProcPb.ProcessingRequest {
 
 	llmReq, err := json.Marshal(j)
 	if err != nil {
-		logutil.Fatal(err, "Failed to unmarshal LLM request")
+		logutil.Fatal(logger, err, "Failed to unmarshal LLM request")
 	}
 	req := &extProcPb.ProcessingRequest{
 		Request: &extProcPb.ProcessingRequest_RequestBody{

--- a/pkg/ext-proc/util/logging/fatal.go
+++ b/pkg/ext-proc/util/logging/fatal.go
@@ -1,11 +1,15 @@
 package logging
 
-import "k8s.io/klog/v2"
+import (
+	"os"
 
-// Fatal calls klog.ErrorS followed by klog.FlushAndExit(1).
+	"github.com/go-logr/logr"
+)
+
+// Fatal calls logger.Error followed by os.Exit(1).
 //
 // This is a utility function and should not be used in production code!
-func Fatal(err error, msg string, keysAndValues ...interface{}) {
-	klog.ErrorS(err, msg, keysAndValues...)
-	klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+func Fatal(logger logr.Logger, err error, msg string, keysAndValues ...interface{}) {
+	logger.Error(err, msg, keysAndValues...)
+	os.Exit(1)
 }

--- a/pkg/ext-proc/util/logging/logger.go
+++ b/pkg/ext-proc/util/logging/logger.go
@@ -1,0 +1,20 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	uberzap "go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// NewTestLogger creates a new Zap logger using the dev mode.
+func NewTestLogger() logr.Logger {
+	return zap.New(zap.UseDevMode(true), zap.RawZapOpts(uberzap.AddCaller()))
+}
+
+// NewTestLoggerIntoContext creates a new Zap logger using the dev mode and inserts it into the given context.
+func NewTestLoggerIntoContext(ctx context.Context) context.Context {
+	return log.IntoContext(ctx, zap.New(zap.UseDevMode(true), zap.RawZapOpts(uberzap.AddCaller())))
+}


### PR DESCRIPTION
All possible direct klog calls are removed.
Instead logr.Logger is loaded from the context
or passed around as an argument.

Related to #251 , this basically concludes the issue.

### Testing

Regarding testing, this is pretty hard to test. I am not really able to run integration tests and failing to call `ctrl.SetLogger` and loading a logger from the context would result, I guess, in log entries being dropped. I don't think this can really happen as `ctrl.SetLogger` is being called for sure, but it does seem a bit fragile.