### PR TITLE
Consolidating all storage behind datastore

### DIFF
--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"math/rand"
-	"strconv"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -150,14 +149,12 @@ func (ds *datastore) PodDelete(namespacedName types.NamespacedName) {
 }
 
 func (ds *datastore) PodAddIfNotExist(pod *corev1.Pod) bool {
-	// new pod, add to the store for probing
-	pool, _ := ds.PoolGet()
 	new := &PodMetrics{
 		NamespacedName: types.NamespacedName{
 			Name:      pod.Name,
 			Namespace: pod.Namespace,
 		},
-		Address: pod.Status.PodIP + ":" + strconv.Itoa(int(pool.Spec.TargetPortNumber)),
+		Address: pod.Status.PodIP,
 		Metrics: Metrics{
 			ActiveModels: make(map[string]int),
 		},

--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -10,82 +10,199 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
-func NewK8sDataStore(options ...K8sDatastoreOption) *K8sDatastore {
-	store := &K8sDatastore{
-		poolMu:          sync.RWMutex{},
-		InferenceModels: &sync.Map{},
-		pods:            &sync.Map{},
-	}
-	for _, opt := range options {
-		opt(store)
+// The datastore is a local cache of relevant data for the given InferencePool (currently all pulled from k8s-api)
+type Datastore interface {
+	// InferencePool operations
+	PoolSet(pool *v1alpha1.InferencePool)
+	PoolGet() (*v1alpha1.InferencePool, error)
+	PoolHasSynced() bool
+	PoolLabelsMatch(podLabels map[string]string) bool
+
+	// InferenceModel operations
+	ModelSet(infModel *v1alpha1.InferenceModel)
+	ModelGet(modelName string) (returnModel *v1alpha1.InferenceModel)
+	ModelDelete(modelName string)
+
+	// PodMetrics operations
+	PodAddIfNotExist(pod *corev1.Pod) bool
+	PodUpdateMetricsIfExist(pm *PodMetrics)
+	PodGet(namespacedName types.NamespacedName) (*PodMetrics, bool)
+	PodDelete(namespacedName types.NamespacedName)
+	PodFlush(ctx context.Context, ctrlClient client.Client)
+	PodGetAll() []*PodMetrics
+	PodRange(f func(key, value any) bool)
+	PodDeleteAll() // This is only for testing.
+}
+
+func NewDatastore() Datastore {
+	store := &datastore{
+		poolMu: sync.RWMutex{},
+		models: &sync.Map{},
+		pods:   &sync.Map{},
 	}
 	return store
 }
 
-// The datastore is a local cache of relevant data for the given InferencePool (currently all pulled from k8s-api)
-type K8sDatastore struct {
+type datastore struct {
 	// poolMu is used to synchronize access to the inferencePool.
-	poolMu          sync.RWMutex
-	inferencePool   *v1alpha1.InferencePool
-	InferenceModels *sync.Map
-	pods            *sync.Map
+	poolMu sync.RWMutex
+	pool   *v1alpha1.InferencePool
+	models *sync.Map
+	// key: types.NamespacedName, value: *PodMetrics
+	pods *sync.Map
 }
 
-type K8sDatastoreOption func(*K8sDatastore)
-
-// WithPods can be used in tests to override the pods.
-func WithPods(pods []*PodMetrics) K8sDatastoreOption {
-	return func(store *K8sDatastore) {
-		store.pods = &sync.Map{}
-		for _, pod := range pods {
-			store.pods.Store(pod.Pod, true)
-		}
-	}
-}
-
-func (ds *K8sDatastore) setInferencePool(pool *v1alpha1.InferencePool) {
+// /// InferencePool APIs ///
+func (ds *datastore) PoolSet(pool *v1alpha1.InferencePool) {
 	ds.poolMu.Lock()
 	defer ds.poolMu.Unlock()
-	ds.inferencePool = pool
+	ds.pool = pool
 }
 
-func (ds *K8sDatastore) getInferencePool() (*v1alpha1.InferencePool, error) {
+func (ds *datastore) PoolGet() (*v1alpha1.InferencePool, error) {
 	ds.poolMu.RLock()
 	defer ds.poolMu.RUnlock()
-	if !ds.HasSynced() {
+	if !ds.PoolHasSynced() {
 		return nil, errors.New("InferencePool is not initialized in data store")
 	}
-	return ds.inferencePool, nil
+	return ds.pool, nil
 }
 
-func (ds *K8sDatastore) GetPodIPs() []string {
-	var ips []string
-	ds.pods.Range(func(name, pod any) bool {
-		ips = append(ips, pod.(*corev1.Pod).Status.PodIP)
-		return true
-	})
-	return ips
+func (ds *datastore) PoolHasSynced() bool {
+	ds.poolMu.RLock()
+	defer ds.poolMu.RUnlock()
+	return ds.pool != nil
 }
 
-func (s *K8sDatastore) FetchModelData(modelName string) (returnModel *v1alpha1.InferenceModel) {
-	infModel, ok := s.InferenceModels.Load(modelName)
+func (ds *datastore) PoolLabelsMatch(podLabels map[string]string) bool {
+	poolSelector := selectorFromInferencePoolSelector(ds.pool.Spec.Selector)
+	podSet := labels.Set(podLabels)
+	return poolSelector.Matches(podSet)
+}
+
+// /// InferenceModel APIs ///
+func (ds *datastore) ModelSet(infModel *v1alpha1.InferenceModel) {
+	ds.models.Store(infModel.Spec.ModelName, infModel)
+}
+
+func (ds *datastore) ModelGet(modelName string) (returnModel *v1alpha1.InferenceModel) {
+	infModel, ok := ds.models.Load(modelName)
 	if ok {
 		returnModel = infModel.(*v1alpha1.InferenceModel)
 	}
 	return
 }
 
-// HasSynced returns true if InferencePool is set in the data store.
-func (ds *K8sDatastore) HasSynced() bool {
-	ds.poolMu.RLock()
-	defer ds.poolMu.RUnlock()
-	return ds.inferencePool != nil
+func (ds *datastore) ModelDelete(modelName string) {
+	ds.models.Delete(modelName)
+}
+
+// /// Pods/endpoints APIs ///
+func (ds *datastore) PodUpdateMetricsIfExist(pm *PodMetrics) {
+	if val, ok := ds.pods.Load(pm.NamespacedName); ok {
+		existing := val.(*PodMetrics)
+		existing.Metrics = pm.Metrics
+	}
+}
+
+func (ds *datastore) PodGet(namespacedName types.NamespacedName) (*PodMetrics, bool) {
+	val, ok := ds.pods.Load(namespacedName)
+	if ok {
+		return val.(*PodMetrics), true
+	}
+	return nil, false
+}
+
+func (ds *datastore) PodGetAll() []*PodMetrics {
+	res := []*PodMetrics{}
+	fn := func(k, v any) bool {
+		res = append(res, v.(*PodMetrics))
+		return true
+	}
+	ds.pods.Range(fn)
+	return res
+}
+
+func (ds *datastore) PodRange(f func(key, value any) bool) {
+	ds.pods.Range(f)
+}
+
+func (ds *datastore) PodDelete(namespacedName types.NamespacedName) {
+	ds.pods.Delete(namespacedName)
+}
+
+func (ds *datastore) PodAddIfNotExist(pod *corev1.Pod) bool {
+	// new pod, add to the store for probing
+	pool, _ := ds.PoolGet()
+	new := &PodMetrics{
+		NamespacedName: types.NamespacedName{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		Address: pod.Status.PodIP + ":" + strconv.Itoa(int(pool.Spec.TargetPortNumber)),
+		Metrics: Metrics{
+			ActiveModels: make(map[string]int),
+		},
+	}
+	if _, ok := ds.pods.Load(new.NamespacedName); !ok {
+		ds.pods.Store(new.NamespacedName, new)
+		return true
+	}
+	return false
+}
+
+func (ds *datastore) PodFlush(ctx context.Context, ctrlClient client.Client) {
+	// Pool must exist to invoke this function.
+	pool, _ := ds.PoolGet()
+	podList := &corev1.PodList{}
+	if err := ctrlClient.List(ctx, podList, &client.ListOptions{
+		LabelSelector: selectorFromInferencePoolSelector(pool.Spec.Selector),
+		Namespace:     pool.Namespace,
+	}); err != nil {
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(err, "Failed to list clients")
+		return
+	}
+
+	activePods := make(map[string]bool)
+	for _, pod := range podList.Items {
+		if podIsReady(&pod) {
+			activePods[pod.Name] = true
+			ds.PodAddIfNotExist(&pod)
+		}
+	}
+
+	// Remove pods that don't exist or not ready any more.
+	deleteFn := func(k, v any) bool {
+		pm := v.(*PodMetrics)
+		if exist := activePods[pm.NamespacedName.Name]; !exist {
+			ds.pods.Delete(pm.NamespacedName)
+		}
+		return true
+	}
+	ds.pods.Range(deleteFn)
+}
+
+func (ds *datastore) PodDeleteAll() {
+	ds.pods.Clear()
+}
+
+func selectorFromInferencePoolSelector(selector map[v1alpha1.LabelKey]v1alpha1.LabelValue) labels.Selector {
+	return labels.SelectorFromSet(stripLabelKeyAliasFromLabelMap(selector))
+}
+
+func stripLabelKeyAliasFromLabelMap(labels map[v1alpha1.LabelKey]v1alpha1.LabelValue) map[string]string {
+	outMap := make(map[string]string)
+	for k, v := range labels {
+		outMap[string(k)] = string(v)
+	}
+	return outMap
 }
 
 func RandomWeightedDraw(logger logr.Logger, model *v1alpha1.InferenceModel, seed int64) string {
@@ -115,41 +232,4 @@ func IsCritical(model *v1alpha1.InferenceModel) bool {
 		return true
 	}
 	return false
-}
-
-func (ds *K8sDatastore) LabelsMatch(podLabels map[string]string) bool {
-	poolSelector := selectorFromInferencePoolSelector(ds.inferencePool.Spec.Selector)
-	podSet := labels.Set(podLabels)
-	return poolSelector.Matches(podSet)
-}
-
-func (ds *K8sDatastore) flushPodsAndRefetch(ctx context.Context, ctrlClient client.Client, newServerPool *v1alpha1.InferencePool) {
-	podList := &corev1.PodList{}
-	if err := ctrlClient.List(ctx, podList, &client.ListOptions{
-		LabelSelector: selectorFromInferencePoolSelector(newServerPool.Spec.Selector),
-		Namespace:     newServerPool.Namespace,
-	}); err != nil {
-		log.FromContext(ctx).V(logutil.DEFAULT).Error(err, "Failed to list clients")
-	}
-	ds.pods.Clear()
-
-	for _, k8sPod := range podList.Items {
-		pod := Pod{
-			Name:    k8sPod.Name,
-			Address: k8sPod.Status.PodIP + ":" + strconv.Itoa(int(newServerPool.Spec.TargetPortNumber)),
-		}
-		ds.pods.Store(pod, true)
-	}
-}
-
-func selectorFromInferencePoolSelector(selector map[v1alpha1.LabelKey]v1alpha1.LabelValue) labels.Selector {
-	return labels.SelectorFromSet(stripLabelKeyAliasFromLabelMap(selector))
-}
-
-func stripLabelKeyAliasFromLabelMap(labels map[v1alpha1.LabelKey]v1alpha1.LabelValue) map[string]string {
-	outMap := make(map[string]string)
-	for k, v := range labels {
-		outMap[string(k)] = string(v)
-	}
-	return outMap
 }

--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -31,7 +31,7 @@ type Datastore interface {
 
 	// PodMetrics operations
 	PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool
-	PodUpdateMetricsIfExist(pm *PodMetrics) bool
+	PodUpdateMetricsIfExist(namespacedName types.NamespacedName, m *Metrics) bool
 	PodGet(namespacedName types.NamespacedName) (*PodMetrics, bool)
 	PodDelete(namespacedName types.NamespacedName)
 	PodResyncAll(ctx context.Context, ctrlClient client.Client)
@@ -115,10 +115,10 @@ func (ds *datastore) ModelDelete(modelName string) {
 }
 
 // /// Pods/endpoints APIs ///
-func (ds *datastore) PodUpdateMetricsIfExist(pm *PodMetrics) bool {
-	if val, ok := ds.pods.Load(pm.NamespacedName); ok {
+func (ds *datastore) PodUpdateMetricsIfExist(namespacedName types.NamespacedName, m *Metrics) bool {
+	if val, ok := ds.pods.Load(namespacedName); ok {
 		existing := val.(*PodMetrics)
-		existing.Metrics = pm.Metrics
+		existing.Metrics = *m
 		return true
 	}
 	return false

--- a/pkg/ext-proc/backend/datastore.go
+++ b/pkg/ext-proc/backend/datastore.go
@@ -34,7 +34,7 @@ type Datastore interface {
 	PodUpdateMetricsIfExist(pm *PodMetrics)
 	PodGet(namespacedName types.NamespacedName) (*PodMetrics, bool)
 	PodDelete(namespacedName types.NamespacedName)
-	PodFlushAll(ctx context.Context, ctrlClient client.Client)
+	PodResyncAll(ctx context.Context, ctrlClient client.Client)
 	PodGetAll() []*PodMetrics
 	PodDeleteAll() // This is only for testing.
 	PodRange(f func(key, value any) bool)
@@ -172,7 +172,7 @@ func (ds *datastore) PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool {
 	return false
 }
 
-func (ds *datastore) PodFlushAll(ctx context.Context, ctrlClient client.Client) {
+func (ds *datastore) PodResyncAll(ctx context.Context, ctrlClient client.Client) {
 	// Pool must exist to invoke this function.
 	pool, _ := ds.PoolGet()
 	podList := &corev1.PodList{}

--- a/pkg/ext-proc/backend/datastore_test.go
+++ b/pkg/ext-proc/backend/datastore_test.go
@@ -32,13 +32,13 @@ func TestHasSynced(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			datastore := NewK8sDataStore()
+			datastore := NewDatastore()
 			// Set the inference pool
 			if tt.inferencePool != nil {
-				datastore.setInferencePool(tt.inferencePool)
+				datastore.PoolSet(tt.inferencePool)
 			}
 			// Check if the data store has been initialized
-			hasSynced := datastore.HasSynced()
+			hasSynced := datastore.PoolHasSynced()
 			if hasSynced != tt.hasSynced {
 				t.Errorf("IsInitialized() = %v, want %v", hasSynced, tt.hasSynced)
 			}

--- a/pkg/ext-proc/backend/fake.go
+++ b/pkg/ext-proc/backend/fake.go
@@ -3,22 +3,23 @@ package backend
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type FakePodMetricsClient struct {
-	Err map[Pod]error
-	Res map[Pod]*PodMetrics
+	Err map[types.NamespacedName]error
+	Res map[types.NamespacedName]*PodMetrics
 }
 
-func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, pod Pod, existing *PodMetrics) (*PodMetrics, error) {
-	if err, ok := f.Err[pod]; ok {
+func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, existing *PodMetrics) (*PodMetrics, error) {
+	if err, ok := f.Err[existing.NamespacedName]; ok {
 		return nil, err
 	}
-	log.FromContext(ctx).V(logutil.VERBOSE).Info("Fetching metrics for pod", "pod", pod, "existing", existing, "new", f.Res[pod])
-	return f.Res[pod], nil
+	log.FromContext(ctx).V(logutil.VERBOSE).Info("Fetching metrics for pod", "existing", existing, "new", f.Res[existing.NamespacedName])
+	return f.Res[existing.NamespacedName], nil
 }
 
 type FakeDataStore struct {

--- a/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
@@ -242,7 +242,7 @@ func TestReconcile_ModelMarkedForDeletion(t *testing.T) {
 	}
 
 	// Verify that the datastore was not updated.
-	if infModel := datastore.ModelGet(existingModel.Spec.ModelName); infModel != nil {
+	if _, exist := datastore.ModelGet(existingModel.Spec.ModelName); exist {
 		t.Errorf("expected datastore to not contain model %q", existingModel.Spec.ModelName)
 	}
 }
@@ -299,7 +299,7 @@ func TestReconcile_ResourceExists(t *testing.T) {
 	}
 
 	// Verify that the datastore was updated.
-	if infModel := datastore.ModelGet(existingModel.Spec.ModelName); infModel == nil {
+	if _, exist := datastore.ModelGet(existingModel.Spec.ModelName); !exist {
 		t.Errorf("expected datastore to contain model %q", existingModel.Spec.ModelName)
 	}
 }

--- a/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencemodel_reconciler_test.go
@@ -51,14 +51,14 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		datastore           *K8sDatastore
+		datastore           *datastore
 		incomingService     *v1alpha1.InferenceModel
 		wantInferenceModels *sync.Map
 	}{
 		{
 			name: "No Services registered; valid, new service incoming.",
-			datastore: &K8sDatastore{
-				inferencePool: &v1alpha1.InferencePool{
+			datastore: &datastore{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
 					},
@@ -67,15 +67,15 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 						ResourceVersion: "Old and boring",
 					},
 				},
-				InferenceModels: &sync.Map{},
+				models: &sync.Map{},
 			},
 			incomingService:     infModel1,
 			wantInferenceModels: populateServiceMap(infModel1),
 		},
 		{
 			name: "Removing existing service.",
-			datastore: &K8sDatastore{
-				inferencePool: &v1alpha1.InferencePool{
+			datastore: &datastore{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
 					},
@@ -84,15 +84,15 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 						ResourceVersion: "Old and boring",
 					},
 				},
-				InferenceModels: populateServiceMap(infModel1),
+				models: populateServiceMap(infModel1),
 			},
 			incomingService:     infModel1Modified,
 			wantInferenceModels: populateServiceMap(),
 		},
 		{
 			name: "Unrelated service, do nothing.",
-			datastore: &K8sDatastore{
-				inferencePool: &v1alpha1.InferencePool{
+			datastore: &datastore{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
 					},
@@ -101,7 +101,7 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 						ResourceVersion: "Old and boring",
 					},
 				},
-				InferenceModels: populateServiceMap(infModel1),
+				models: populateServiceMap(infModel1),
 			},
 			incomingService: &v1alpha1.InferenceModel{
 				Spec: v1alpha1.InferenceModelSpec{
@@ -116,8 +116,8 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 		},
 		{
 			name: "Add to existing",
-			datastore: &K8sDatastore{
-				inferencePool: &v1alpha1.InferencePool{
+			datastore: &datastore{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
 					},
@@ -126,7 +126,7 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 						ResourceVersion: "Old and boring",
 					},
 				},
-				InferenceModels: populateServiceMap(infModel1),
+				models: populateServiceMap(infModel1),
 			},
 			incomingService:     infModel2,
 			wantInferenceModels: populateServiceMap(infModel1, infModel2),
@@ -136,11 +136,11 @@ func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			reconciler := &InferenceModelReconciler{
 				Datastore:          test.datastore,
-				PoolNamespacedName: types.NamespacedName{Name: test.datastore.inferencePool.Name},
+				PoolNamespacedName: types.NamespacedName{Name: test.datastore.pool.Name},
 			}
 			reconciler.updateDatastore(logger, test.incomingService)
 
-			if ok := mapsEqual(reconciler.Datastore.InferenceModels, test.wantInferenceModels); !ok {
+			if ok := mapsEqual(test.datastore.models, test.wantInferenceModels); !ok {
 				t.Error("Maps are not equal")
 			}
 		})
@@ -156,9 +156,9 @@ func TestReconcile_ResourceNotFound(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	// Create a minimal datastore.
-	datastore := &K8sDatastore{
-		InferenceModels: &sync.Map{},
-		inferencePool: &v1alpha1.InferencePool{
+	datastore := &datastore{
+		models: &sync.Map{},
+		pool: &v1alpha1.InferencePool{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
 		},
 	}
@@ -211,9 +211,9 @@ func TestReconcile_ModelMarkedForDeletion(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingModel).Build()
 
 	// Create a minimal datastore.
-	datastore := &K8sDatastore{
-		InferenceModels: &sync.Map{},
-		inferencePool: &v1alpha1.InferencePool{
+	datastore := &datastore{
+		models: &sync.Map{},
+		pool: &v1alpha1.InferencePool{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
 		},
 	}
@@ -242,7 +242,7 @@ func TestReconcile_ModelMarkedForDeletion(t *testing.T) {
 	}
 
 	// Verify that the datastore was not updated.
-	if _, ok := datastore.InferenceModels.Load(existingModel.Spec.ModelName); ok {
+	if infModel := datastore.ModelGet(existingModel.Spec.ModelName); infModel != nil {
 		t.Errorf("expected datastore to not contain model %q", existingModel.Spec.ModelName)
 	}
 }
@@ -268,9 +268,9 @@ func TestReconcile_ResourceExists(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingModel).Build()
 
 	// Create a minimal datastore.
-	datastore := &K8sDatastore{
-		InferenceModels: &sync.Map{},
-		inferencePool: &v1alpha1.InferencePool{
+	datastore := &datastore{
+		models: &sync.Map{},
+		pool: &v1alpha1.InferencePool{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
 		},
 	}
@@ -299,7 +299,7 @@ func TestReconcile_ResourceExists(t *testing.T) {
 	}
 
 	// Verify that the datastore was updated.
-	if _, ok := datastore.InferenceModels.Load(existingModel.Spec.ModelName); !ok {
+	if infModel := datastore.ModelGet(existingModel.Spec.ModelName); infModel == nil {
 		t.Errorf("expected datastore to contain model %q", existingModel.Spec.ModelName)
 	}
 }

--- a/pkg/ext-proc/backend/inferencepool_reconciler.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler.go
@@ -63,7 +63,7 @@ func (c *InferencePoolReconciler) updateDatastore(ctx context.Context, newPool *
 	c.Datastore.PoolSet(newPool)
 	if oldPool == nil || !reflect.DeepEqual(newPool.Spec.Selector, oldPool.Spec.Selector) {
 		logger.V(logutil.DEFAULT).Info("Updating inference pool endpoints", "target", klog.KMetadata(&newPool.ObjectMeta))
-		c.Datastore.PodFlushAll(ctx, c.Client)
+		c.Datastore.PodResyncAll(ctx, c.Client)
 	}
 }
 

--- a/pkg/ext-proc/backend/inferencepool_reconciler.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -59,10 +58,10 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 func (c *InferencePoolReconciler) updateDatastore(ctx context.Context, newPool *v1alpha1.InferencePool) {
 	logger := log.FromContext(ctx)
-	oldPool, _ := c.Datastore.PoolGet()
+	oldPool, err := c.Datastore.PoolGet()
 	c.Datastore.PoolSet(newPool)
-	if oldPool == nil || !reflect.DeepEqual(newPool.Spec.Selector, oldPool.Spec.Selector) {
-		logger.V(logutil.DEFAULT).Info("Updating inference pool endpoints", "target", klog.KMetadata(&newPool.ObjectMeta))
+	if err != nil || !reflect.DeepEqual(newPool.Spec.Selector, oldPool.Spec.Selector) {
+		logger.V(logutil.DEFAULT).Info("Updating inference pool endpoints", "selector", newPool.Spec.Selector)
 		c.Datastore.PodResyncAll(ctx, c.Client)
 	}
 }

--- a/pkg/ext-proc/backend/inferencepool_reconciler_test.go
+++ b/pkg/ext-proc/backend/inferencepool_reconciler_test.go
@@ -1,88 +1,118 @@
 package backend
 
 import (
-	"reflect"
+	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
+	utiltesting "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/testing"
 )
 
 var (
-	pool1 = &v1alpha1.InferencePool{
-		Spec: v1alpha1.InferencePoolSpec{
-			Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
-		},
+	selector_v1 = map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm_v1"}
+	selector_v2 = map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm_v2"}
+	pool1       = &v1alpha1.InferencePool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-pool",
-			ResourceVersion: "50",
+			Name:      "pool1",
+			Namespace: "pool1-ns",
+		},
+		Spec: v1alpha1.InferencePoolSpec{Selector: selector_v1},
+	}
+	pool2 = &v1alpha1.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pool2",
+			Namespace: "pool2-ns",
 		},
 	}
-	// Different name, same RV doesn't really make sense, but helps with testing the
-	// updateStore impl which relies on the equality of RVs alone.
-	modPool1SameRV = &v1alpha1.InferencePool{
-		Spec: v1alpha1.InferencePoolSpec{
-			Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-pool-mod",
-			ResourceVersion: "50",
-		},
-	}
-	modPool1DiffRV = &v1alpha1.InferencePool{
-		Spec: v1alpha1.InferencePoolSpec{
-			Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{"app": "vllm"},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-pool-mod",
-			ResourceVersion: "51",
-		},
+	pods = []corev1.Pod{
+		// Two ready pods matching pool1
+		utiltesting.MakePod("pod1", "pool1-ns").Labels(stripLabelKeyAliasFromLabelMap(selector_v1)).ReadyCondition().Obj(),
+		utiltesting.MakePod("pod2", "pool1-ns").Labels(stripLabelKeyAliasFromLabelMap(selector_v1)).ReadyCondition().Obj(),
+		// A not ready pod matching pool1
+		utiltesting.MakePod("pod3", "pool1-ns").Labels(stripLabelKeyAliasFromLabelMap(selector_v1)).Obj(),
+		// A pod not matching pool1 namespace
+		utiltesting.MakePod("pod4", "pool2-ns").Labels(stripLabelKeyAliasFromLabelMap(selector_v1)).ReadyCondition().Obj(),
+		// A ready pod matching pool1 with a new selector
+		utiltesting.MakePod("pod5", "pool1-ns").Labels(stripLabelKeyAliasFromLabelMap(selector_v2)).ReadyCondition().Obj(),
 	}
 )
 
-func TestUpdateDatastore_InferencePoolReconciler(t *testing.T) {
-	logger := logutil.NewTestLogger()
+func TestReconcile_InferencePoolReconciler(t *testing.T) {
+	// Set up the scheme.
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = v1alpha1.AddToScheme(scheme)
 
-	tests := []struct {
-		name         string
-		datastore    *K8sDatastore
-		incomingPool *v1alpha1.InferencePool
-		wantPool     *v1alpha1.InferencePool
-	}{
-		{
-			name:         "InferencePool not set, should set InferencePool",
-			datastore:    &K8sDatastore{},
-			incomingPool: pool1.DeepCopy(),
-			wantPool:     pool1,
-		},
-		{
-			name: "InferencePool set, matching RVs, do nothing",
-			datastore: &K8sDatastore{
-				inferencePool: pool1.DeepCopy(),
-			},
-			incomingPool: modPool1SameRV.DeepCopy(),
-			wantPool:     pool1,
-		},
-		{
-			name: "InferencePool set, differing RVs, re-set InferencePool",
-			datastore: &K8sDatastore{
-				inferencePool: pool1.DeepCopy(),
-			},
-			incomingPool: modPool1DiffRV.DeepCopy(),
-			wantPool:     modPool1DiffRV,
-		},
+	// Create a fake client with the pool and the pods.
+	initialObjects := []client.Object{pool1, pool2}
+	for i := range pods {
+		initialObjects = append(initialObjects, &pods[i])
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initialObjects...).
+		Build()
+
+		// Create a request for the existing resource.
+	namespacedName := types.NamespacedName{Name: pool1.Name, Namespace: pool1.Namespace}
+	req := ctrl.Request{NamespacedName: namespacedName}
+	ctx := context.Background()
+
+	datastore := NewDatastore()
+	inferencePoolReconciler := &InferencePoolReconciler{PoolNamespacedName: namespacedName, Client: fakeClient, Datastore: datastore}
+
+	// Step 1: Inception, only ready pods matching pool1 are added to the store.
+	if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {
+		t.Errorf("Unexpected InferencePool reconcile error: %v", err)
+	}
+	if diff := diffPool(datastore, pool1, []string{"pod1", "pod2"}); diff != "" {
+		t.Errorf("Unexpected diff (+got/-want): %s", diff)
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			inferencePoolReconciler := &InferencePoolReconciler{Datastore: test.datastore}
-			inferencePoolReconciler.updateDatastore(logger, test.incomingPool)
-
-			gotPool := inferencePoolReconciler.Datastore.inferencePool
-			if !reflect.DeepEqual(gotPool, test.wantPool) {
-				t.Errorf("Unexpected InferencePool: want %#v, got: %#v", test.wantPool, gotPool)
-			}
-		})
+	// Step 2: A reconcile on pool2 should not change anything.
+	if _, err := inferencePoolReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pool2.Name, Namespace: pool2.Namespace}}); err != nil {
+		t.Errorf("Unexpected InferencePool reconcile error: %v", err)
 	}
+	if diff := diffPool(datastore, pool1, []string{"pod1", "pod2"}); diff != "" {
+		t.Errorf("Unexpected diff (+got/-want): %s", diff)
+	}
+
+	// Step 3: update the pool selector to include more pods
+	newPool1 := &v1alpha1.InferencePool{}
+	if err := fakeClient.Get(ctx, req.NamespacedName, newPool1); err != nil {
+		t.Errorf("Unexpected pool get error: %v", err)
+	}
+	newPool1.Spec.Selector = selector_v2
+	if err := fakeClient.Update(ctx, newPool1, &client.UpdateOptions{}); err != nil {
+		t.Errorf("Unexpected pool update error: %v", err)
+	}
+
+	if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {
+		t.Errorf("Unexpected InferencePool reconcile error: %v", err)
+	}
+	if diff := diffPool(datastore, newPool1, []string{"pod5"}); diff != "" {
+		t.Errorf("Unexpected diff (+got/-want): %s", diff)
+	}
+}
+
+func diffPool(datastore Datastore, wantPool *v1alpha1.InferencePool, wantPods []string) string {
+	gotPool, _ := datastore.PoolGet()
+	if diff := cmp.Diff(wantPool, gotPool); diff != "" {
+		return diff
+	}
+	gotPods := []string{}
+	for _, pm := range datastore.PodGetAll() {
+		gotPods = append(gotPods, pm.NamespacedName.Name)
+	}
+	return cmp.Diff(wantPods, gotPods, cmpopts.SortSlices(func(a, b string) bool { return a < b }))
 }

--- a/pkg/ext-proc/backend/pod_reconciler.go
+++ b/pkg/ext-proc/backend/pod_reconciler.go
@@ -61,7 +61,7 @@ func (c *PodReconciler) updateDatastore(logger logr.Logger, pod *corev1.Pod) {
 		logger.V(logutil.DEFAULT).Info("Pod removed or not added", "name", namespacedName)
 		c.Datastore.PodDelete(namespacedName)
 	} else {
-		if c.Datastore.PodAddIfNotExist(pod) {
+		if c.Datastore.PodUpdateOrAddIfNotExist(pod) {
 			logger.V(logutil.DEFAULT).Info("Pod added", "name", namespacedName)
 		} else {
 			logger.V(logutil.DEFAULT).Info("Pod already exists", "name", namespacedName)

--- a/pkg/ext-proc/backend/pod_reconciler.go
+++ b/pkg/ext-proc/backend/pod_reconciler.go
@@ -2,29 +2,29 @@ package backend
 
 import (
 	"context"
-	"strconv"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
 type PodReconciler struct {
 	client.Client
-	Datastore *K8sDatastore
+	Datastore Datastore
 	Scheme    *runtime.Scheme
 	Record    record.EventRecorder
 }
 
 func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	inferencePool, err := c.Datastore.getInferencePool()
+	inferencePool, err := c.Datastore.PoolGet()
 	if err != nil {
 		logger.V(logutil.TRACE).Info("Skipping reconciling Pod because the InferencePool is not available yet", "error", err)
 		// When the inferencePool is initialized it lists the appropriate pods and populates the datastore, so no need to requeue.
@@ -38,15 +38,14 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	pod := &corev1.Pod{}
 	if err := c.Get(ctx, req.NamespacedName, pod); err != nil {
 		if apierrors.IsNotFound(err) {
-			c.Datastore.pods.Delete(pod)
+			c.Datastore.PodDelete(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		logger.V(logutil.DEFAULT).Error(err, "Unable to get pod", "name", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
 
-	c.updateDatastore(pod, inferencePool)
-
+	c.updateDatastore(logger, pod)
 	return ctrl.Result{}, nil
 }
 
@@ -56,15 +55,17 @@ func (c *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(c)
 }
 
-func (c *PodReconciler) updateDatastore(k8sPod *corev1.Pod, inferencePool *v1alpha1.InferencePool) {
-	pod := Pod{
-		Name:    k8sPod.Name,
-		Address: k8sPod.Status.PodIP + ":" + strconv.Itoa(int(inferencePool.Spec.TargetPortNumber)),
-	}
-	if !k8sPod.DeletionTimestamp.IsZero() || !c.Datastore.LabelsMatch(k8sPod.ObjectMeta.Labels) || !podIsReady(k8sPod) {
-		c.Datastore.pods.Delete(pod)
+func (c *PodReconciler) updateDatastore(logger logr.Logger, pod *corev1.Pod) {
+	namespacedName := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+	if !pod.DeletionTimestamp.IsZero() || !c.Datastore.PoolLabelsMatch(pod.Labels) || !podIsReady(pod) {
+		logger.V(logutil.DEFAULT).Info("Pod removed or not added", "name", namespacedName)
+		c.Datastore.PodDelete(namespacedName)
 	} else {
-		c.Datastore.pods.Store(pod, true)
+		if c.Datastore.PodAddIfNotExist(pod) {
+			logger.V(logutil.DEFAULT).Info("Pod added", "name", namespacedName)
+		} else {
+			logger.V(logutil.DEFAULT).Info("Pod already exists", "name", namespacedName)
+		}
 	}
 }
 

--- a/pkg/ext-proc/backend/pod_reconciler_test.go
+++ b/pkg/ext-proc/backend/pod_reconciler_test.go
@@ -1,33 +1,42 @@
 package backend
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 )
 
 var (
-	basePod1 = Pod{Name: "pod1", Address: ":8000"}
-	basePod2 = Pod{Name: "pod2", Address: ":8000"}
-	basePod3 = Pod{Name: "pod3", Address: ":8000"}
+	basePod1 = &PodMetrics{NamespacedName: types.NamespacedName{Name: "pod1"}, Address: ":8000"}
+	basePod2 = &PodMetrics{NamespacedName: types.NamespacedName{Name: "pod2"}, Address: ":8000"}
+	basePod3 = &PodMetrics{NamespacedName: types.NamespacedName{Name: "pod3"}, Address: ":8000"}
 )
 
 func TestUpdateDatastore_PodReconciler(t *testing.T) {
+	now := metav1.Now()
 	tests := []struct {
 		name        string
-		datastore   *K8sDatastore
+		datastore   Datastore
 		incomingPod *corev1.Pod
-		wantPods    []string
+		wantPods    []types.NamespacedName
+		req         *ctrl.Request
 	}{
 		{
 			name: "Add new pod",
-			datastore: &K8sDatastore{
+			datastore: &datastore{
 				pods: populateMap(basePod1, basePod2),
-				inferencePool: &v1alpha1.InferencePool{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						TargetPortNumber: int32(8000),
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{
@@ -52,13 +61,62 @@ func TestUpdateDatastore_PodReconciler(t *testing.T) {
 					},
 				},
 			},
-			wantPods: []string{basePod1.Name, basePod2.Name, basePod3.Name},
+			wantPods: []types.NamespacedName{basePod1.NamespacedName, basePod2.NamespacedName, basePod3.NamespacedName},
+		},
+		{
+			name: "Delete pod with DeletionTimestamp",
+			datastore: &datastore{
+				pods: populateMap(basePod1, basePod2),
+				pool: &v1alpha1.InferencePool{
+					Spec: v1alpha1.InferencePoolSpec{
+						TargetPortNumber: int32(8000),
+						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{
+							"some-key": "some-val",
+						},
+					},
+				},
+			},
+			incomingPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod1",
+					Labels: map[string]string{
+						"some-key": "some-val",
+					},
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"finalizer"},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantPods: []types.NamespacedName{basePod2.NamespacedName},
+		},
+		{
+			name: "Delete notfound pod",
+			datastore: &datastore{
+				pods: populateMap(basePod1, basePod2),
+				pool: &v1alpha1.InferencePool{
+					Spec: v1alpha1.InferencePoolSpec{
+						TargetPortNumber: int32(8000),
+						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{
+							"some-key": "some-val",
+						},
+					},
+				},
+			},
+			req:      &ctrl.Request{NamespacedName: types.NamespacedName{Name: "pod1"}},
+			wantPods: []types.NamespacedName{basePod2.NamespacedName},
 		},
 		{
 			name: "New pod, not ready, valid selector",
-			datastore: &K8sDatastore{
+			datastore: &datastore{
 				pods: populateMap(basePod1, basePod2),
-				inferencePool: &v1alpha1.InferencePool{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						TargetPortNumber: int32(8000),
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{
@@ -83,13 +141,13 @@ func TestUpdateDatastore_PodReconciler(t *testing.T) {
 					},
 				},
 			},
-			wantPods: []string{basePod1.Name, basePod2.Name},
+			wantPods: []types.NamespacedName{basePod1.NamespacedName, basePod2.NamespacedName},
 		},
 		{
 			name: "Remove pod that does not match selector",
-			datastore: &K8sDatastore{
+			datastore: &datastore{
 				pods: populateMap(basePod1, basePod2),
-				inferencePool: &v1alpha1.InferencePool{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						TargetPortNumber: int32(8000),
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{
@@ -114,13 +172,13 @@ func TestUpdateDatastore_PodReconciler(t *testing.T) {
 					},
 				},
 			},
-			wantPods: []string{basePod2.Name},
+			wantPods: []types.NamespacedName{basePod2.NamespacedName},
 		},
 		{
 			name: "Remove pod that is not ready",
-			datastore: &K8sDatastore{
+			datastore: &datastore{
 				pods: populateMap(basePod1, basePod2),
-				inferencePool: &v1alpha1.InferencePool{
+				pool: &v1alpha1.InferencePool{
 					Spec: v1alpha1.InferencePoolSpec{
 						TargetPortNumber: int32(8000),
 						Selector: map[v1alpha1.LabelKey]v1alpha1.LabelValue{
@@ -145,22 +203,41 @@ func TestUpdateDatastore_PodReconciler(t *testing.T) {
 					},
 				},
 			},
-			wantPods: []string{basePod2.Name},
+			wantPods: []types.NamespacedName{basePod2.NamespacedName},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			podReconciler := &PodReconciler{Datastore: test.datastore}
-			podReconciler.updateDatastore(test.incomingPod, test.datastore.inferencePool)
-			var gotPods []string
-			test.datastore.pods.Range(func(k, v any) bool {
-				pod := k.(Pod)
+			// Set up the scheme.
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			initialObjects := []client.Object{}
+			if test.incomingPod != nil {
+				initialObjects = append(initialObjects, test.incomingPod)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(initialObjects...).
+				Build()
+
+			podReconciler := &PodReconciler{Client: fakeClient, Datastore: test.datastore}
+			namespacedName := types.NamespacedName{Name: test.incomingPod.Name, Namespace: test.incomingPod.Namespace}
+			if test.req == nil {
+				test.req = &ctrl.Request{NamespacedName: namespacedName}
+			}
+			if _, err := podReconciler.Reconcile(context.Background(), *test.req); err != nil {
+				t.Errorf("Unexpected InferencePool reconcile error: %v", err)
+			}
+
+			var gotPods []types.NamespacedName
+			test.datastore.PodRange(func(k, v any) bool {
+				pod := v.(*PodMetrics)
 				if v != nil {
-					gotPods = append(gotPods, pod.Name)
+					gotPods = append(gotPods, pod.NamespacedName)
 				}
 				return true
 			})
-			if !cmp.Equal(gotPods, test.wantPods, cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
+			if !cmp.Equal(gotPods, test.wantPods, cmpopts.SortSlices(func(a, b types.NamespacedName) bool { return a.String() < b.String() })) {
 				t.Errorf("got (%v) != want (%v);", gotPods, test.wantPods)
 			}
 		})

--- a/pkg/ext-proc/backend/provider.go
+++ b/pkg/ext-proc/backend/provider.go
@@ -109,7 +109,7 @@ func (p *Provider) refreshMetricsOnce(logger logr.Logger) error {
 				errCh <- fmt.Errorf("failed to parse metrics from %s: %v", existing.NamespacedName, err)
 				return
 			}
-			p.datastore.PodUpdateMetricsIfExist(updated)
+			p.datastore.PodUpdateMetricsIfExist(updated.NamespacedName, &updated.Metrics)
 			loggerTrace.Info("Updated metrics for pod", "pod", updated.NamespacedName, "metrics", updated.Metrics)
 		}()
 		return true

--- a/pkg/ext-proc/backend/provider.go
+++ b/pkg/ext-proc/backend/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.uber.org/multierr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
@@ -16,72 +17,38 @@ const (
 	fetchMetricsTimeout = 5 * time.Second
 )
 
-func NewProvider(pmc PodMetricsClient, datastore *K8sDatastore) *Provider {
+func NewProvider(pmc PodMetricsClient, datastore Datastore) *Provider {
 	p := &Provider{
-		podMetrics: sync.Map{},
-		pmc:        pmc,
-		datastore:  datastore,
+		pmc:       pmc,
+		datastore: datastore,
 	}
 	return p
 }
 
 // Provider provides backend pods and information such as metrics.
 type Provider struct {
-	// key: Pod, value: *PodMetrics
-	podMetrics sync.Map
-	pmc        PodMetricsClient
-	datastore  *K8sDatastore
+	pmc       PodMetricsClient
+	datastore Datastore
 }
 
 type PodMetricsClient interface {
-	FetchMetrics(ctx context.Context, pod Pod, existing *PodMetrics) (*PodMetrics, error)
+	FetchMetrics(ctx context.Context, existing *PodMetrics) (*PodMetrics, error)
 }
 
-func (p *Provider) AllPodMetrics() []*PodMetrics {
-	res := []*PodMetrics{}
-	fn := func(k, v any) bool {
-		res = append(res, v.(*PodMetrics))
-		return true
-	}
-	p.podMetrics.Range(fn)
-	return res
-}
-
-func (p *Provider) UpdatePodMetrics(pod Pod, pm *PodMetrics) {
-	p.podMetrics.Store(pod, pm)
-}
-
-func (p *Provider) GetPodMetrics(pod Pod) (*PodMetrics, bool) {
-	val, ok := p.podMetrics.Load(pod)
-	if ok {
-		return val.(*PodMetrics), true
-	}
-	return nil, false
-}
-
-func (p *Provider) Init(logger logr.Logger, refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration) error {
-	p.refreshPodsOnce()
-
-	if err := p.refreshMetricsOnce(logger); err != nil {
-		logger.Error(err, "Failed to init metrics")
-	}
-
-	logger.Info("Initialized pods and metrics", "metrics", p.AllPodMetrics())
-
-	// periodically refresh pods
-	go func() {
-		for {
-			time.Sleep(refreshPodsInterval)
-			p.refreshPodsOnce()
-		}
-	}()
-
+func (p *Provider) Init(ctx context.Context, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration) error {
 	// periodically refresh metrics
+	logger := log.FromContext(ctx)
 	go func() {
 		for {
-			time.Sleep(refreshMetricsInterval)
-			if err := p.refreshMetricsOnce(logger); err != nil {
-				logger.V(logutil.DEFAULT).Error(err, "Failed to refresh metrics")
+			select {
+			case <-ctx.Done():
+				logger.V(logutil.DEFAULT).Info("Shutting down metrics prober")
+				return
+			default:
+				time.Sleep(refreshMetricsInterval)
+				if err := p.refreshMetricsOnce(logger); err != nil {
+					logger.V(logutil.DEFAULT).Error(err, "Failed to refresh metrics")
+				}
 			}
 		}
 	}()
@@ -89,8 +56,14 @@ func (p *Provider) Init(logger logr.Logger, refreshPodsInterval, refreshMetricsI
 	// Periodically flush prometheus metrics for inference pool
 	go func() {
 		for {
-			time.Sleep(refreshPrometheusMetricsInterval)
-			p.flushPrometheusMetricsOnce(logger)
+			select {
+			case <-ctx.Done():
+				logger.V(logutil.DEFAULT).Info("Shutting down prometheus metrics thread")
+				return
+			default:
+				time.Sleep(refreshPrometheusMetricsInterval)
+				p.flushPrometheusMetricsOnce(logger)
+			}
 		}
 	}()
 
@@ -98,43 +71,19 @@ func (p *Provider) Init(logger logr.Logger, refreshPodsInterval, refreshMetricsI
 	if logger := logger.V(logutil.DEBUG); logger.Enabled() {
 		go func() {
 			for {
-				time.Sleep(5 * time.Second)
-				logger.Info("Current Pods and metrics gathered", "metrics", p.AllPodMetrics())
+				select {
+				case <-ctx.Done():
+					logger.V(logutil.DEFAULT).Info("Shutting down metrics logger thread")
+					return
+				default:
+					time.Sleep(5 * time.Second)
+					logger.Info("Current Pods and metrics gathered", "metrics", p.datastore.PodGetAll())
+				}
 			}
 		}()
 	}
 
 	return nil
-}
-
-// refreshPodsOnce lists pods and updates keys in the podMetrics map.
-// Note this function doesn't update the PodMetrics value, it's done separately.
-func (p *Provider) refreshPodsOnce() {
-	// merge new pods with cached ones.
-	// add new pod to the map
-	addNewPods := func(k, v any) bool {
-		pod := k.(Pod)
-		if _, ok := p.podMetrics.Load(pod); !ok {
-			new := &PodMetrics{
-				Pod: pod,
-				Metrics: Metrics{
-					ActiveModels: make(map[string]int),
-				},
-			}
-			p.podMetrics.Store(pod, new)
-		}
-		return true
-	}
-	// remove pods that don't exist any more.
-	mergeFn := func(k, v any) bool {
-		pod := k.(Pod)
-		if _, ok := p.datastore.pods.Load(pod); !ok {
-			p.podMetrics.Delete(pod)
-		}
-		return true
-	}
-	p.podMetrics.Range(mergeFn)
-	p.datastore.pods.Range(addNewPods)
 }
 
 func (p *Provider) refreshMetricsOnce(logger logr.Logger) error {
@@ -151,22 +100,21 @@ func (p *Provider) refreshMetricsOnce(logger logr.Logger) error {
 	errCh := make(chan error)
 	processOnePod := func(key, value any) bool {
 		loggerTrace.Info("Pod and metric being processed", "pod", key, "metric", value)
-		pod := key.(Pod)
 		existing := value.(*PodMetrics)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			updated, err := p.pmc.FetchMetrics(ctx, pod, existing)
+			updated, err := p.pmc.FetchMetrics(ctx, existing)
 			if err != nil {
-				errCh <- fmt.Errorf("failed to parse metrics from %s: %v", pod, err)
+				errCh <- fmt.Errorf("failed to parse metrics from %s: %v", existing.NamespacedName, err)
 				return
 			}
-			p.UpdatePodMetrics(pod, updated)
-			loggerTrace.Info("Updated metrics for pod", "pod", pod, "metrics", updated.Metrics)
+			p.datastore.PodUpdateMetricsIfExist(updated)
+			loggerTrace.Info("Updated metrics for pod", "pod", updated.NamespacedName, "metrics", updated.Metrics)
 		}()
 		return true
 	}
-	p.podMetrics.Range(processOnePod)
+	p.datastore.PodRange(processOnePod)
 
 	// Wait for metric collection for all pods to complete and close the error channel in a
 	// goroutine so this is unblocking, allowing the code to proceed to the error collection code
@@ -188,7 +136,7 @@ func (p *Provider) refreshMetricsOnce(logger logr.Logger) error {
 func (p *Provider) flushPrometheusMetricsOnce(logger logr.Logger) {
 	logger.V(logutil.DEBUG).Info("Flushing Prometheus Metrics")
 
-	pool, _ := p.datastore.getInferencePool()
+	pool, _ := p.datastore.PoolGet()
 	if pool == nil {
 		// No inference pool or not initialize.
 		return
@@ -197,7 +145,7 @@ func (p *Provider) flushPrometheusMetricsOnce(logger logr.Logger) {
 	var kvCacheTotal float64
 	var queueTotal int
 
-	podMetrics := p.AllPodMetrics()
+	podMetrics := p.datastore.PodGetAll()
 	if len(podMetrics) == 0 {
 		return
 	}

--- a/pkg/ext-proc/backend/provider_test.go
+++ b/pkg/ext-proc/backend/provider_test.go
@@ -15,8 +15,10 @@ import (
 
 var (
 	pod1 = &PodMetrics{
-		NamespacedName: types.NamespacedName{
-			Name: "pod1",
+		Pod: Pod{
+			NamespacedName: types.NamespacedName{
+				Name: "pod1",
+			},
 		},
 		Metrics: Metrics{
 			WaitingQueueSize:    0,
@@ -29,8 +31,10 @@ var (
 		},
 	}
 	pod2 = &PodMetrics{
-		NamespacedName: types.NamespacedName{
-			Name: "pod2",
+		Pod: Pod{
+			NamespacedName: types.NamespacedName{
+				Name: "pod2",
+			},
 		},
 		Metrics: Metrics{
 			WaitingQueueSize:    1,
@@ -99,7 +103,7 @@ func TestProvider(t *testing.T) {
 				pod1,
 				// Failed to fetch pod2 metrics so it remains the default values.
 				{
-					NamespacedName: pod2.NamespacedName,
+					Pod: Pod{NamespacedName: pod2.NamespacedName},
 					Metrics: Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0,
@@ -130,7 +134,7 @@ func TestProvider(t *testing.T) {
 func populateMap(pods ...*PodMetrics) *sync.Map {
 	newMap := &sync.Map{}
 	for _, pod := range pods {
-		newMap.Store(pod.NamespacedName, &PodMetrics{NamespacedName: pod.NamespacedName})
+		newMap.Store(pod.NamespacedName, &PodMetrics{Pod: Pod{NamespacedName: pod.NamespacedName, Address: pod.Address}})
 	}
 	return newMap
 }

--- a/pkg/ext-proc/backend/types.go
+++ b/pkg/ext-proc/backend/types.go
@@ -7,6 +7,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+type Pod struct {
+	NamespacedName types.NamespacedName
+	Address        string
+}
+
 type Metrics struct {
 	// ActiveModels is a set of models(including LoRA adapters) that are currently cached to GPU.
 	ActiveModels map[string]int
@@ -19,8 +24,7 @@ type Metrics struct {
 }
 
 type PodMetrics struct {
-	NamespacedName types.NamespacedName
-	Address        string
+	Pod
 	Metrics
 }
 
@@ -34,8 +38,10 @@ func (pm *PodMetrics) Clone() *PodMetrics {
 		cm[k] = v
 	}
 	clone := &PodMetrics{
-		NamespacedName: pm.NamespacedName,
-		Address:        pm.Address,
+		Pod: Pod{
+			NamespacedName: pm.NamespacedName,
+			Address:        pm.Address,
+		},
 		Metrics: Metrics{
 			ActiveModels:            cm,
 			RunningQueueSize:        pm.RunningQueueSize,

--- a/pkg/ext-proc/backend/types.go
+++ b/pkg/ext-proc/backend/types.go
@@ -1,18 +1,11 @@
 // Package backend is a library to interact with backend model servers such as probing metrics.
 package backend
 
-import "fmt"
+import (
+	"fmt"
 
-type PodSet map[Pod]bool
-
-type Pod struct {
-	Name    string
-	Address string
-}
-
-func (p Pod) String() string {
-	return p.Name + ":" + p.Address
-}
+	"k8s.io/apimachinery/pkg/types"
+)
 
 type Metrics struct {
 	// ActiveModels is a set of models(including LoRA adapters) that are currently cached to GPU.
@@ -26,12 +19,13 @@ type Metrics struct {
 }
 
 type PodMetrics struct {
-	Pod
+	NamespacedName types.NamespacedName
+	Address        string
 	Metrics
 }
 
 func (pm *PodMetrics) String() string {
-	return fmt.Sprintf("Pod: %+v; Metrics: %+v", pm.Pod, pm.Metrics)
+	return fmt.Sprintf("Pod: %+v; Address: %+v; Metrics: %+v", pm.NamespacedName, pm.Address, pm.Metrics)
 }
 
 func (pm *PodMetrics) Clone() *PodMetrics {
@@ -40,7 +34,8 @@ func (pm *PodMetrics) Clone() *PodMetrics {
 		cm[k] = v
 	}
 	clone := &PodMetrics{
-		Pod: pm.Pod,
+		NamespacedName: pm.NamespacedName,
+		Address:        pm.Address,
 		Metrics: Metrics{
 			ActiveModels:            cm,
 			RunningQueueSize:        pm.RunningQueueSize,

--- a/pkg/ext-proc/handlers/request.go
+++ b/pkg/ext-proc/handlers/request.go
@@ -48,8 +48,8 @@ func (s *Server) HandleRequestBody(
 	// NOTE: The nil checking for the modelObject means that we DO allow passthrough currently.
 	// This might be a security risk in the future where adapters not registered in the InferenceModel
 	// are able to be requested by using their distinct name.
-	modelObj := s.datastore.ModelGet(model)
-	if modelObj == nil {
+	modelObj, exist := s.datastore.ModelGet(model)
+	if !exist {
 		return nil, fmt.Errorf("error finding a model object in InferenceModel for input %v", model)
 	}
 	if len(modelObj.Spec.TargetModels) > 0 {

--- a/pkg/ext-proc/handlers/request.go
+++ b/pkg/ext-proc/handlers/request.go
@@ -48,7 +48,7 @@ func (s *Server) HandleRequestBody(
 	// NOTE: The nil checking for the modelObject means that we DO allow passthrough currently.
 	// This might be a security risk in the future where adapters not registered in the InferenceModel
 	// are able to be requested by using their distinct name.
-	modelObj := s.datastore.FetchModelData(model)
+	modelObj := s.datastore.ModelGet(model)
 	if modelObj == nil {
 		return nil, fmt.Errorf("error finding a model object in InferenceModel for input %v", model)
 	}
@@ -88,7 +88,8 @@ func (s *Server) HandleRequestBody(
 	reqCtx.Model = llmReq.Model
 	reqCtx.ResolvedTargetModel = llmReq.ResolvedTargetModel
 	reqCtx.RequestSize = len(v.RequestBody.Body)
-	reqCtx.TargetPod = targetPod
+	reqCtx.TargetPod = targetPod.NamespacedName.String()
+	reqCtx.TargetPodAddress = targetPod.Address
 
 	// Insert target endpoint to instruct Envoy to route requests to the specified target pod.
 	headers := []*configPb.HeaderValueOption{

--- a/pkg/ext-proc/handlers/server.go
+++ b/pkg/ext-proc/handlers/server.go
@@ -11,17 +11,15 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
 
-func NewServer(pp PodProvider, scheduler Scheduler, targetEndpointKey string, datastore ModelDataStore) *Server {
+func NewServer(scheduler Scheduler, targetEndpointKey string, datastore backend.Datastore) *Server {
 	return &Server{
 		scheduler:         scheduler,
-		podProvider:       pp,
 		targetEndpointKey: targetEndpointKey,
 		datastore:         datastore,
 	}
@@ -30,26 +28,15 @@ func NewServer(pp PodProvider, scheduler Scheduler, targetEndpointKey string, da
 // Server implements the Envoy external processing server.
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto
 type Server struct {
-	scheduler   Scheduler
-	podProvider PodProvider
+	scheduler Scheduler
 	// The key of the header to specify the target pod address. This value needs to match Envoy
 	// configuration.
 	targetEndpointKey string
-	datastore         ModelDataStore
+	datastore         backend.Datastore
 }
 
 type Scheduler interface {
-	Schedule(ctx context.Context, b *scheduling.LLMRequest) (targetPod backend.Pod, err error)
-}
-
-// PodProvider is an interface to provide set of pods in the backend and information such as metrics.
-type PodProvider interface {
-	GetPodMetrics(pod backend.Pod) (*backend.PodMetrics, bool)
-	UpdatePodMetrics(pod backend.Pod, pm *backend.PodMetrics)
-}
-
-type ModelDataStore interface {
-	FetchModelData(modelName string) (returnModel *v1alpha1.InferenceModel)
+	Schedule(ctx context.Context, b *scheduling.LLMRequest) (targetPod backend.PodMetrics, err error)
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
@@ -140,7 +127,8 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 
 // RequestContext stores context information during the life time of an HTTP request.
 type RequestContext struct {
-	TargetPod                 backend.Pod
+	TargetPod                 string
+	TargetPodAddress          string
 	Model                     string
 	ResolvedTargetModel       string
 	RequestReceivedTimestamp  time.Time

--- a/pkg/ext-proc/handlers/server.go
+++ b/pkg/ext-proc/handlers/server.go
@@ -128,7 +128,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 // RequestContext stores context information during the life time of an HTTP request.
 type RequestContext struct {
 	TargetPod                 string
-	TargetPodAddress          string
+	TargetEndpoint            string
 	Model                     string
 	ResolvedTargetModel       string
 	RequestReceivedTimestamp  time.Time

--- a/pkg/ext-proc/health.go
+++ b/pkg/ext-proc/health.go
@@ -13,11 +13,11 @@ import (
 
 type healthServer struct {
 	logger    logr.Logger
-	datastore *backend.K8sDatastore
+	datastore backend.Datastore
 }
 
 func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckRequest) (*healthPb.HealthCheckResponse, error) {
-	if !s.datastore.HasSynced() {
+	if !s.datastore.PoolHasSynced() {
 		s.logger.V(logutil.VERBOSE).Info("gRPC health check not serving", "service", in.Service)
 		return &healthPb.HealthCheckResponse{Status: healthPb.HealthCheckResponse_NOT_SERVING}, nil
 	}

--- a/pkg/ext-proc/scheduling/filter_test.go
+++ b/pkg/ext-proc/scheduling/filter_test.go
@@ -41,7 +41,7 @@ func TestFilter(t *testing.T) {
 			// model being active, and has low KV cache.
 			input: []*backend.PodMetrics{
 				{
-					NamespacedName: types.NamespacedName{Name: "pod1"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -53,7 +53,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					NamespacedName: types.NamespacedName{Name: "pod2"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod2"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
@@ -65,7 +65,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					NamespacedName: types.NamespacedName{Name: "pod3"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod3"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.2,
@@ -78,7 +78,7 @@ func TestFilter(t *testing.T) {
 			},
 			output: []*backend.PodMetrics{
 				{
-					NamespacedName: types.NamespacedName{Name: "pod2"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod2"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
@@ -102,7 +102,7 @@ func TestFilter(t *testing.T) {
 			// pod1 will be picked because it has capacity for the sheddable request.
 			input: []*backend.PodMetrics{
 				{
-					NamespacedName: types.NamespacedName{Name: "pod1"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -114,7 +114,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					NamespacedName: types.NamespacedName{Name: "pod2"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod2"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
@@ -126,7 +126,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					NamespacedName: types.NamespacedName{Name: "pod3"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod3"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.2,
@@ -139,7 +139,7 @@ func TestFilter(t *testing.T) {
 			},
 			output: []*backend.PodMetrics{
 				{
-					NamespacedName: types.NamespacedName{Name: "pod1"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -164,7 +164,7 @@ func TestFilter(t *testing.T) {
 			// dropped.
 			input: []*backend.PodMetrics{
 				{
-					NamespacedName: types.NamespacedName{Name: "pod1"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.9,
@@ -176,7 +176,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					NamespacedName: types.NamespacedName{Name: "pod2"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod2"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.85,
@@ -188,7 +188,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					NamespacedName: types.NamespacedName{Name: "pod3"},
+					Pod: backend.Pod{NamespacedName: types.NamespacedName{Name: "pod3"}},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.85,

--- a/pkg/ext-proc/scheduling/filter_test.go
+++ b/pkg/ext-proc/scheduling/filter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
 )
@@ -40,7 +41,7 @@ func TestFilter(t *testing.T) {
 			// model being active, and has low KV cache.
 			input: []*backend.PodMetrics{
 				{
-					Pod: backend.Pod{Name: "pod1"},
+					NamespacedName: types.NamespacedName{Name: "pod1"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -52,7 +53,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					Pod: backend.Pod{Name: "pod2"},
+					NamespacedName: types.NamespacedName{Name: "pod2"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
@@ -64,7 +65,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					Pod: backend.Pod{Name: "pod3"},
+					NamespacedName: types.NamespacedName{Name: "pod3"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.2,
@@ -77,7 +78,7 @@ func TestFilter(t *testing.T) {
 			},
 			output: []*backend.PodMetrics{
 				{
-					Pod: backend.Pod{Name: "pod2"},
+					NamespacedName: types.NamespacedName{Name: "pod2"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
@@ -101,7 +102,7 @@ func TestFilter(t *testing.T) {
 			// pod1 will be picked because it has capacity for the sheddable request.
 			input: []*backend.PodMetrics{
 				{
-					Pod: backend.Pod{Name: "pod1"},
+					NamespacedName: types.NamespacedName{Name: "pod1"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -113,7 +114,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					Pod: backend.Pod{Name: "pod2"},
+					NamespacedName: types.NamespacedName{Name: "pod2"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
@@ -125,7 +126,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					Pod: backend.Pod{Name: "pod3"},
+					NamespacedName: types.NamespacedName{Name: "pod3"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.2,
@@ -138,7 +139,7 @@ func TestFilter(t *testing.T) {
 			},
 			output: []*backend.PodMetrics{
 				{
-					Pod: backend.Pod{Name: "pod1"},
+					NamespacedName: types.NamespacedName{Name: "pod1"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
@@ -163,7 +164,7 @@ func TestFilter(t *testing.T) {
 			// dropped.
 			input: []*backend.PodMetrics{
 				{
-					Pod: backend.Pod{Name: "pod1"},
+					NamespacedName: types.NamespacedName{Name: "pod1"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.9,
@@ -175,7 +176,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					Pod: backend.Pod{Name: "pod2"},
+					NamespacedName: types.NamespacedName{Name: "pod2"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.85,
@@ -187,7 +188,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 				{
-					Pod: backend.Pod{Name: "pod3"},
+					NamespacedName: types.NamespacedName{Name: "pod3"},
 					Metrics: backend.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.85,

--- a/pkg/ext-proc/server/runserver_test.go
+++ b/pkg/ext-proc/server/runserver_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRunnable(t *testing.T) {
 	// Make sure AsRunnable() does not use leader election.
-	runner := server.NewDefaultExtProcServerRunner().AsRunnable(logutil.NewTestLogger(), nil, nil)
+	runner := server.NewDefaultExtProcServerRunner().AsRunnable(logutil.NewTestLogger())
 	r, ok := runner.(manager.LeaderElectionRunnable)
 	if !ok {
 		t.Fatal("runner is not LeaderElectionRunnable")

--- a/pkg/ext-proc/test/utils.go
+++ b/pkg/ext-proc/test/utils.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -10,36 +11,50 @@ import (
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/handlers"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/scheduling"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/logging"
+	utiltesting "sigs.k8s.io/gateway-api-inference-extension/pkg/ext-proc/util/testing"
 )
 
 func StartExtProc(
-	logger logr.Logger,
+	ctx context.Context,
 	port int,
 	refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration,
 	pods []*backend.PodMetrics,
 	models map[string]*v1alpha1.InferenceModel,
 ) *grpc.Server {
-	ps := make(backend.PodSet)
-	pms := make(map[backend.Pod]*backend.PodMetrics)
+	logger := log.FromContext(ctx)
+	pms := make(map[types.NamespacedName]*backend.PodMetrics)
 	for _, pod := range pods {
-		ps[pod.Pod] = true
-		pms[pod.Pod] = pod
+		pms[pod.NamespacedName] = pod
 	}
 	pmc := &backend.FakePodMetricsClient{Res: pms}
-	pp := backend.NewProvider(pmc, backend.NewK8sDataStore(backend.WithPods(pods)))
-	if err := pp.Init(logger, refreshPodsInterval, refreshMetricsInterval, refreshPrometheusMetricsInterval); err != nil {
+	datastore := backend.NewDatastore()
+	for _, m := range models {
+		datastore.ModelSet(m)
+	}
+	for _, pm := range pods {
+		pod := utiltesting.MakePod(pm.NamespacedName.Name, pm.NamespacedName.Namespace).
+			ReadyCondition().
+			IP(pm.Address).
+			Obj()
+		datastore.PodAddIfNotExist(&pod)
+		datastore.PodUpdateMetricsIfExist(pm)
+	}
+	pp := backend.NewProvider(pmc, datastore)
+	if err := pp.Init(ctx, refreshMetricsInterval, refreshPrometheusMetricsInterval); err != nil {
 		logutil.Fatal(logger, err, "Failed to initialize")
 	}
-	return startExtProc(logger, port, pp, models)
+	return startExtProc(logger, port, datastore)
 }
 
 // startExtProc starts an extProc server with fake pods.
-func startExtProc(logger logr.Logger, port int, pp *backend.Provider, models map[string]*v1alpha1.InferenceModel) *grpc.Server {
+func startExtProc(logger logr.Logger, port int, datastore backend.Datastore) *grpc.Server {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		logutil.Fatal(logger, err, "Failed to listen", "port", port)
@@ -47,7 +62,7 @@ func startExtProc(logger logr.Logger, port int, pp *backend.Provider, models map
 
 	s := grpc.NewServer()
 
-	extProcPb.RegisterExternalProcessorServer(s, handlers.NewServer(pp, scheduling.NewScheduler(pp), "target-pod", &backend.FakeDataStore{Res: models}))
+	extProcPb.RegisterExternalProcessorServer(s, handlers.NewServer(scheduling.NewScheduler(datastore), "target-pod", datastore))
 
 	logger.Info("gRPC server starting", "port", port)
 	reflection.Register(s)
@@ -60,10 +75,10 @@ func startExtProc(logger logr.Logger, port int, pp *backend.Provider, models map
 	return s
 }
 
-func GenerateRequest(logger logr.Logger, model string) *extProcPb.ProcessingRequest {
+func GenerateRequest(logger logr.Logger, prompt, model string) *extProcPb.ProcessingRequest {
 	j := map[string]interface{}{
 		"model":       model,
-		"prompt":      "hello",
+		"prompt":      prompt,
 		"max_tokens":  100,
 		"temperature": 0,
 	}
@@ -80,11 +95,12 @@ func GenerateRequest(logger logr.Logger, model string) *extProcPb.ProcessingRequ
 	return req
 }
 
-func FakePod(index int) backend.Pod {
+func FakePodMetrics(index int, metrics backend.Metrics) *backend.PodMetrics {
 	address := fmt.Sprintf("address-%v", index)
-	pod := backend.Pod{
-		Name:    fmt.Sprintf("pod-%v", index),
-		Address: address,
+	pod := backend.PodMetrics{
+		NamespacedName: types.NamespacedName{Name: fmt.Sprintf("pod-%v", index)},
+		Address:        address,
+		Metrics:        metrics,
 	}
-	return pod
+	return &pod
 }

--- a/pkg/ext-proc/test/utils.go
+++ b/pkg/ext-proc/test/utils.go
@@ -44,7 +44,7 @@ func StartExtProc(
 			IP(pm.Address).
 			Obj()
 		datastore.PodUpdateOrAddIfNotExist(&pod)
-		datastore.PodUpdateMetricsIfExist(pm)
+		datastore.PodUpdateMetricsIfExist(pm.NamespacedName, &pm.Metrics)
 	}
 	pp := backend.NewProvider(pmc, datastore)
 	if err := pp.Init(ctx, refreshMetricsInterval, refreshPrometheusMetricsInterval); err != nil {

--- a/pkg/ext-proc/test/utils.go
+++ b/pkg/ext-proc/test/utils.go
@@ -43,7 +43,7 @@ func StartExtProc(
 			ReadyCondition().
 			IP(pm.Address).
 			Obj()
-		datastore.PodAddIfNotExist(&pod)
+		datastore.PodUpdateOrAddIfNotExist(&pod)
 		datastore.PodUpdateMetricsIfExist(pm)
 	}
 	pp := backend.NewProvider(pmc, datastore)
@@ -98,9 +98,11 @@ func GenerateRequest(logger logr.Logger, prompt, model string) *extProcPb.Proces
 func FakePodMetrics(index int, metrics backend.Metrics) *backend.PodMetrics {
 	address := fmt.Sprintf("address-%v", index)
 	pod := backend.PodMetrics{
-		NamespacedName: types.NamespacedName{Name: fmt.Sprintf("pod-%v", index)},
-		Address:        address,
-		Metrics:        metrics,
+		Pod: backend.Pod{
+			NamespacedName: types.NamespacedName{Name: fmt.Sprintf("pod-%v", index)},
+			Address:        address,
+		},
+		Metrics: metrics,
 	}
 	return &pod
 }

--- a/pkg/ext-proc/util/testing/wrappers.go
+++ b/pkg/ext-proc/util/testing/wrappers.go
@@ -1,0 +1,50 @@
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodWrapper wraps a Pod.
+type PodWrapper struct {
+	corev1.Pod
+}
+
+// MakePod creates a wrapper for a Pod.
+func MakePod(podName, ns string) *PodWrapper {
+	return &PodWrapper{
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: ns,
+			},
+			Spec:   corev1.PodSpec{},
+			Status: corev1.PodStatus{},
+		},
+	}
+}
+
+// Labels sets the pod labels.
+func (p *PodWrapper) Labels(labels map[string]string) *PodWrapper {
+	p.ObjectMeta.Labels = labels
+	return p
+}
+
+// SetReadyCondition sets a PodReay=true condition.
+func (p *PodWrapper) ReadyCondition() *PodWrapper {
+	p.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	}}
+	return p
+}
+
+func (p *PodWrapper) IP(ip string) *PodWrapper {
+	p.Status.PodIP = ip
+	return p
+}
+
+// Obj returns the wrapped Pod.
+func (p *PodWrapper) Obj() corev1.Pod {
+	return p.Pod
+}

--- a/pkg/manifests/ext_proc.yaml
+++ b/pkg/manifests/ext_proc.yaml
@@ -71,7 +71,7 @@ spec:
     spec:
       containers:
       - name: inference-gateway-ext-proc
-        image: us-central1-docker.pkg.dev/ahg-gke-dev/jobset2/epp:dfee85a
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
         imagePullPolicy: Always
         args:
         - -poolName

--- a/pkg/manifests/ext_proc.yaml
+++ b/pkg/manifests/ext_proc.yaml
@@ -71,7 +71,7 @@ spec:
     spec:
       containers:
       - name: inference-gateway-ext-proc
-        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+        image: us-central1-docker.pkg.dev/ahg-gke-dev/jobset2/epp:dfee85a
         imagePullPolicy: Always
         args:
         - -poolName

--- a/pkg/manifests/vllm/deployment.yaml
+++ b/pkg/manifests/vllm/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           - "8000"
           - "--enable-lora"
           - "--max-loras"
-          - "2"
+          - "4"
           - "--max-cpu-loras"
           - "12"
           - "--lora-modules"

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -490,7 +490,8 @@ func BeforeSuit(t *testing.T) func() {
 	}
 
 	assert.EventuallyWithT(t, func(t *assert.CollectT) {
-		synced := serverRunner.Datastore.PoolHasSynced() && serverRunner.Datastore.ModelGet("my-model") != nil
+		_, modelExist := serverRunner.Datastore.ModelGet("my-model")
+		synced := serverRunner.Datastore.PoolHasSynced() && modelExist
 		assert.True(t, synced, "Timeout waiting for the pool and models to sync")
 	}, 10*time.Second, 10*time.Millisecond)
 

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -380,7 +380,7 @@ func setUpHermeticServer(podMetrics []*backend.PodMetrics) (client extProcPb.Ext
 				IP(pm.Address).
 				Obj()
 			serverRunner.Datastore.PodUpdateOrAddIfNotExist(&pod)
-			serverRunner.Datastore.PodUpdateMetricsIfExist(pm)
+			serverRunner.Datastore.PodUpdateMetricsIfExist(pm.NamespacedName, &pm.Metrics)
 		}
 		serverRunner.Provider = backend.NewProvider(pmc, serverRunner.Datastore)
 		if err := serverRunner.AsRunnable(logger.WithName("ext-proc")).Start(serverCtx); err != nil {

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -379,7 +379,7 @@ func setUpHermeticServer(podMetrics []*backend.PodMetrics) (client extProcPb.Ext
 				ReadyCondition().
 				IP(pm.Address).
 				Obj()
-			serverRunner.Datastore.PodAddIfNotExist(&pod)
+			serverRunner.Datastore.PodUpdateOrAddIfNotExist(&pod)
 			serverRunner.Datastore.PodUpdateMetricsIfExist(pm)
 		}
 		serverRunner.Provider = backend.NewProvider(pmc, serverRunner.Datastore)


### PR DESCRIPTION
This PR removes the intermediate cache in provider, and consolidates all storage behind the datastore component. This limits what is now called provider into a pure probing controller. To validate the change, I tried to increase test coverage especially for the controllers, which uncovered a couple of bugs (I added comments pointing them out). 

The PR is long, but unfortunately there is no way around doing this refactor without such a significant change. The best way to approach this PR is to start by looking at the Datastore interface, which defines the contract for accessing all cached state related to the pool, the models and the pods. All accesses to the datastore are done only via this interface. The components that accesses the datastore are the controllers (pool, model and pod) and the provider (which as mentioned above is now in practice a probing controller). As a followup, I plan to move the datastore implementation into an internal pkg, and make only the interface public.

I think we are still lacking proper test coverage overall. As a next step we should prioritize migrating our integration tests to ginkgo, moreover as it is right now the integration tests setup is not properly testing things end-to-end (e.g., pods are being injected via a side channel on the datastore instead of creating them on the api-server and have the controllers populate the datastore).

I'm hoping this PR will allow us to improve the probing logic through a clearer separation of responsibilities. I think https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/223 is compatible with this direction with the exception of the extra cache it introduces.

Testing: in addition to increasing test coverage, I also ran integration tests and the e2e test. Also deployed it on a real cluster with increased log level and verified the probing logs while sending a constant stream of requests.

Fixes #346 #349 #310
