### PR TITLE
embed dynamic metadata under envoy.lb namespace to support subsets

### DIFF
--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -116,6 +116,12 @@ func (s *Server) HandleRequestBody(
 	reqCtx.TargetPod = targetPod.NamespacedName.String()
 	reqCtx.TargetEndpoint = endpoint
 
+	emittedDynamicMetadata, _ := structpb.NewStruct(map[string]interface{}{
+		"envoy.lb": map[string]interface{}{
+			s.targetEndpointKey: endpoint,
+		},
+	})
+
 	headers := []*configPb.HeaderValueOption{
 		{
 			Header: &configPb.HeaderValue{
@@ -155,15 +161,7 @@ func (s *Server) HandleRequestBody(
 				},
 			},
 		},
-		DynamicMetadata: &structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				s.targetEndpointKey: {
-					Kind: &structpb.Value_StringValue{
-						StringValue: endpoint,
-					},
-				},
-			},
-		},
+		DynamicMetadata: emittedDynamicMetadata,
 	}
 	return resp, nil
 }


### PR DESCRIPTION
With envoy implementations, one way to use the selected endpoints from the endpoint picker is using [envoy subsets](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/subsets). 

This is how it works:
1. have envoy cluster with subsets_selector for the model pods.
2. Instead of using the header with original_dst cluster (which does not support fallbacks), the ext_proc server dynamically set the metadata under enovy.lb namespace which lets you do subset load balancing.

Note: envoy.lb is a predefined namespace and the metadata has to be within it for subsetting to work. 

This may be considered a breaking change - so let me know if you want to leave the higher level metadata (not under envoy.lb) in addition. 

Will fix the tests if the direction is agreed
