### PR TITLE
Switch to gcr.io/distroless/static:nonroot base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile has specific requirement to put this ARG at the beginning:
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG BUILDER_IMAGE=golang:1.23-alpine
-ARG BASE_IMAGE=gcr.io/distroless/base-debian10
+ARG BUILDER_IMAGE=golang:1.23
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 ## Multistage build
 FROM ${BUILDER_IMAGE} AS builder

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ SYNCER_IMAGE_NAME := lora-syncer
 SYNCER_IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(SYNCER_IMAGE_NAME)
 SYNCER_IMAGE_TAG ?= $(SYNCER_IMAGE_REPO):$(GIT_TAG)
 
-BASE_IMAGE ?= gcr.io/distroless/base-debian10
-BUILDER_IMAGE ?= golang:1.23-alpine
+BASE_IMAGE ?= gcr.io/distroless/static:nonroot
+BUILDER_IMAGE ?= golang:1.23
 ifdef GO_VERSION
 BUILDER_IMAGE = golang:$(GO_VERSION)
 endif


### PR DESCRIPTION
This avoids loading unnecessary libraries that can be source of security vulnerabilities.

Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/344 