### PR TITLE
fix context canceled recv error handling

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -18,7 +18,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"io"
 	"time"
 
@@ -90,7 +89,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		}
 
 		req, recvErr := srv.Recv()
-		if recvErr == io.EOF || errors.Is(recvErr, context.Canceled) {
+		if recvErr == io.EOF || status.Code(recvErr) == codes.Canceled {
 			return nil
 		}
 		if recvErr != nil {


### PR DESCRIPTION
When I send a request without request body, will always come up with an error like:

```shell
2025-02-23T10:30:23+08:00	ERROR	handlers/server.go:99	Cannot receive stream request
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers.(*Server).Process
	/root/MyCOde/kuromesi.com/gateway-api-inference-extension/pkg/epp/handlers/server.go:99
github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3._ExternalProcessor_Process_Handler
	/root/go/pkg/mod/github.com/envoyproxy/go-control-plane/envoy@v1.32.4/service/ext_proc/v3/external_processor_grpc.pb.go:106
google.golang.org/grpc.(*Server).processStreamingRPC
	/root/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1690
google.golang.org/grpc.(*Server).handleStream
	/root/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1814
google.golang.org/grpc.(*Server).serveStreams.func2.1
	/root/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1030
```

When I tried to debug this error, I found that this error is grpc status context canceled error, and current condition fails to catch this error since this is not an context.Canceled error.

```go
if recvErr == io.EOF || errors.Is(recvErr, context.Canceled)
```

![image](https://github.com/user-attachments/assets/dc5b4d40-f5d9-4f38-b52c-f8ce2f54faa0)

So I rewrite the condition to make sure this error can be correctly handled.