### PR TITLE
Fix InferenceModel deletion logic

### DIFF
--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -149,6 +149,8 @@ func run() error {
 		return err
 	}
 
+	ctx := ctrl.SetupSignalHandler()
+
 	// Setup runner.
 	datastore := datastore.NewDatastore()
 	provider := backend.NewProvider(&vllm.PodMetricsClientImpl{}, datastore)
@@ -165,7 +167,7 @@ func run() error {
 		CertPath:                                 *certPath,
 		Provider:                                 provider,
 	}
-	if err := serverRunner.SetupWithManager(mgr); err != nil {
+	if err := serverRunner.SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "Failed to setup ext-proc controllers")
 		return err
 	}
@@ -188,7 +190,7 @@ func run() error {
 
 	// Start the manager. This blocks until a signal is received.
 	setupLog.Info("Controller manager starting")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "Error starting controller manager")
 		return err
 	}

--- a/pkg/epp/controller/inferencemodel_reconciler.go
+++ b/pkg/epp/controller/inferencemodel_reconciler.go
@@ -18,8 +18,8 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,6 +34,10 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
+const (
+	modelNameKey = "spec.modelName"
+)
+
 type InferenceModelReconciler struct {
 	client.Client
 	Scheme             *runtime.Scheme
@@ -43,44 +47,103 @@ type InferenceModelReconciler struct {
 }
 
 func (c *InferenceModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	loggerDefault := logger.V(logutil.DEFAULT)
-	loggerDefault.Info("Reconciling InferenceModel", "name", req.NamespacedName)
-
-	infModel := &v1alpha2.InferenceModel{}
-	if err := c.Get(ctx, req.NamespacedName, infModel); err != nil {
-		if errors.IsNotFound(err) {
-			loggerDefault.Info("InferenceModel not found. Removing from datastore since object must be deleted", "name", req.NamespacedName)
-			c.Datastore.ModelDelete(infModel.Spec.ModelName)
-			return ctrl.Result{}, nil
-		}
-		loggerDefault.Error(err, "Unable to get InferenceModel", "name", req.NamespacedName)
-		return ctrl.Result{}, err
-	} else if !infModel.DeletionTimestamp.IsZero() {
-		loggerDefault.Info("InferenceModel is marked for deletion. Removing from datastore", "name", req.NamespacedName)
-		c.Datastore.ModelDelete(infModel.Spec.ModelName)
+	if req.Namespace != c.PoolNamespacedName.Namespace {
 		return ctrl.Result{}, nil
 	}
+	logger := log.FromContext(ctx).V(logutil.DEFAULT).WithValues("inferenceModel", req.Name)
+	ctx = ctrl.LoggerInto(ctx, logger)
 
-	c.updateDatastore(logger, infModel)
+	logger.Info("Reconciling InferenceModel")
+
+	infModel := &v1alpha2.InferenceModel{}
+	notFound := false
+	if err := c.Get(ctx, req.NamespacedName, infModel); err != nil {
+		if !errors.IsNotFound(err) {
+			logger.Error(err, "Unable to get InferenceModel")
+			return ctrl.Result{}, err
+		}
+		notFound = true
+	}
+
+	if notFound || !infModel.DeletionTimestamp.IsZero() || infModel.Spec.PoolRef.Name != c.PoolNamespacedName.Name {
+		// InferenceModel object got deleted or changed the referenced pool.
+		err := c.handleModelDeleted(ctx, req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+
+	// Add or update if the InferenceModel instance has a creation timestamp older than the existing entry of the model.
+	logger = logger.WithValues("poolRef", infModel.Spec.PoolRef).WithValues("modelName", infModel.Spec.ModelName)
+	if !c.Datastore.ModelSetIfOlder(infModel) {
+		logger.Info("Skipping InferenceModel, existing instance has older creation timestamp")
+
+	}
+	logger.Info("Added/Updated InferenceModel")
+
 	return ctrl.Result{}, nil
 }
 
-func (c *InferenceModelReconciler) updateDatastore(logger logr.Logger, infModel *v1alpha2.InferenceModel) {
-	loggerDefault := logger.V(logutil.DEFAULT)
+func (c *InferenceModelReconciler) handleModelDeleted(ctx context.Context, req types.NamespacedName) error {
+	logger := log.FromContext(ctx)
 
-	if infModel.Spec.PoolRef.Name == c.PoolNamespacedName.Name {
-		loggerDefault.Info("Updating datastore", "poolRef", infModel.Spec.PoolRef, "serverPoolName", c.PoolNamespacedName)
-		loggerDefault.Info("Adding/Updating InferenceModel", "modelName", infModel.Spec.ModelName)
-		c.Datastore.ModelSet(infModel)
-		return
+	// We will lookup the modelName associated with this object to search for
+	// other instance referencing the same ModelName if exist to store the oldest in
+	// its place. This ensures that the InferenceModel with the oldest creation
+	// timestamp is active.
+	existing, exists := c.Datastore.ModelGetByObjName(req)
+	if !exists {
+		// No entry exists in the first place, nothing to do.
+		return nil
 	}
-	loggerDefault.Info("Removing/Not adding InferenceModel", "modelName", infModel.Spec.ModelName)
-	// If we get here. The model is not relevant to this pool, remove.
-	c.Datastore.ModelDelete(infModel.Spec.ModelName)
+	// Delete the internal object, it may be replaced with another version below.
+	c.Datastore.ModelDelete(req)
+	logger.Info("InferenceModel removed from datastore", "poolRef", existing.Spec.PoolRef, "modelName", existing.Spec.ModelName)
+
+	// List all InferenceModels with a matching ModelName.
+	var models v1alpha2.InferenceModelList
+	if err := c.List(ctx, &models, client.MatchingFields{modelNameKey: existing.Spec.ModelName}, client.InNamespace(c.PoolNamespacedName.Namespace)); err != nil {
+		return fmt.Errorf("listing models that match the modelName %s: %w", existing.Spec.ModelName, err)
+	}
+	if len(models.Items) == 0 {
+		// No other instances of InferenceModels with this ModelName exists.
+		return nil
+	}
+
+	var oldest *v1alpha2.InferenceModel
+	for i := range models.Items {
+		m := &models.Items[i]
+		if m.Spec.ModelName != existing.Spec.ModelName || // The index should filter those out, but just in case!
+			m.Spec.PoolRef.Name != c.PoolNamespacedName.Name || // We don't care about other pools, we could setup an index on this too!
+			m.Name == existing.Name { // We don't care about the same object, it could be in the list if it was only marked for deletion, but not yet deleted.
+			continue
+		}
+		if oldest == nil || m.ObjectMeta.CreationTimestamp.Before(&oldest.ObjectMeta.CreationTimestamp) {
+			oldest = m
+		}
+	}
+	if oldest != nil && c.Datastore.ModelSetIfOlder(oldest) {
+		logger.Info("InferenceModel replaced.",
+			"poolRef", oldest.Spec.PoolRef,
+			"modelName", oldest.Spec.ModelName,
+			"newInferenceModel", types.NamespacedName{Name: oldest.Name, Namespace: oldest.Namespace})
+	}
+
+	return nil
 }
 
-func (c *InferenceModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func indexInferenceModelsByModelName(obj client.Object) []string {
+	m, ok := obj.(*v1alpha2.InferenceModel)
+	if !ok {
+		return nil
+	}
+	return []string{m.Spec.ModelName}
+}
+
+func (c *InferenceModelReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	// Create an index on ModelName for InferenceModel objects.
+	indexer := mgr.GetFieldIndexer()
+	if err := indexer.IndexField(ctx, &v1alpha2.InferenceModel{}, modelNameKey, indexInferenceModelsByModelName); err != nil {
+		return fmt.Errorf("setting index on ModelName for InferenceModel: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha2.InferenceModel{}).
 		WithEventFilter(predicate.Funcs{

--- a/pkg/epp/controller/inferencemodel_reconciler.go
+++ b/pkg/epp/controller/inferencemodel_reconciler.go
@@ -92,6 +92,7 @@ func (c *InferenceModelReconciler) handleModelDeleted(ctx context.Context, req t
 	}
 	logger.Info("InferenceModel removed from datastore", "poolRef", existing.Spec.PoolRef, "modelName", existing.Spec.ModelName)
 
+	// TODO(#409): replace this backfill logic with one that is based on InferenceModel Ready conditions once those are set by an external controller.
 	updated, err := c.Datastore.ModelResync(ctx, c.Client, existing.Spec.ModelName)
 	if err != nil {
 		return err

--- a/pkg/epp/controller/inferencemodel_reconciler.go
+++ b/pkg/epp/controller/inferencemodel_reconciler.go
@@ -85,17 +85,15 @@ func (c *InferenceModelReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (c *InferenceModelReconciler) handleModelDeleted(ctx context.Context, req types.NamespacedName) error {
 	logger := log.FromContext(ctx)
 
-	// We will lookup the modelName associated with this object to search for
-	// other instance referencing the same ModelName if exist to store the oldest in
+	// We will lookup and delete the modelName associated with this object, and search for
+	// other instances referencing the same modelName if exist, and store the oldest in
 	// its place. This ensures that the InferenceModel with the oldest creation
 	// timestamp is active.
-	existing, exists := c.Datastore.ModelGetByObjName(req)
+	existing, exists := c.Datastore.ModelDelete(req)
 	if !exists {
 		// No entry exists in the first place, nothing to do.
 		return nil
 	}
-	// Delete the internal object, it may be replaced with another version below.
-	c.Datastore.ModelDelete(req)
 	logger.Info("InferenceModel removed from datastore", "poolRef", existing.Spec.PoolRef, "modelName", existing.Spec.ModelName)
 
 	// List all InferenceModels with a matching ModelName.

--- a/pkg/epp/controller/inferencemodel_reconciler_test.go
+++ b/pkg/epp/controller/inferencemodel_reconciler_test.go
@@ -18,302 +18,219 @@ package controller
 
 import (
 	"context"
-	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+	utiltest "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
 )
 
 var (
-	infModel1 = &v1alpha2.InferenceModel{
-		Spec: v1alpha2.InferenceModelSpec{
-			ModelName: "fake model1",
-			PoolRef:   v1alpha2.PoolObjectReference{Name: "test-pool"},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-service",
-		},
-	}
-	infModel1Modified = &v1alpha2.InferenceModel{
-		Spec: v1alpha2.InferenceModelSpec{
-			ModelName: "fake model1",
-			PoolRef:   v1alpha2.PoolObjectReference{Name: "test-poolio"},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-service",
-		},
-	}
-	infModel2 = &v1alpha2.InferenceModel{
-		Spec: v1alpha2.InferenceModelSpec{
-			ModelName: "fake model",
-			PoolRef:   v1alpha2.PoolObjectReference{Name: "test-pool"},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-service-2",
-		},
-	}
+	pool      = utiltest.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
+	infModel1 = utiltest.MakeInferenceModel("model1").
+			Namespace(pool.Namespace).
+			ModelName("fake model1").
+			Criticality(v1alpha2.Standard).
+			CreationTimestamp(metav1.Unix(1000, 0)).
+			PoolName(pool.Name).ObjRef()
+	infModel1Pool2 = utiltest.MakeInferenceModel(infModel1.Name).
+			Namespace(infModel1.Namespace).
+			ModelName(infModel1.Spec.ModelName).
+			Criticality(*infModel1.Spec.Criticality).
+			CreationTimestamp(metav1.Unix(1001, 0)).
+			PoolName("test-pool2").ObjRef()
+	infModel1NS2 = utiltest.MakeInferenceModel(infModel1.Name).
+			Namespace("ns2").
+			ModelName(infModel1.Spec.ModelName).
+			Criticality(*infModel1.Spec.Criticality).
+			CreationTimestamp(metav1.Unix(1002, 0)).
+			PoolName(pool.Name).ObjRef()
+	infModel1Critical = utiltest.MakeInferenceModel(infModel1.Name).
+				Namespace(infModel1.Namespace).
+				ModelName(infModel1.Spec.ModelName).
+				Criticality(v1alpha2.Critical).
+				CreationTimestamp(metav1.Unix(1003, 0)).
+				PoolName(pool.Name).ObjRef()
+	infModel1Deleted = utiltest.MakeInferenceModel(infModel1.Name).
+				Namespace(infModel1.Namespace).
+				ModelName(infModel1.Spec.ModelName).
+				CreationTimestamp(metav1.Unix(1004, 0)).
+				DeletionTimestamp().
+				PoolName(pool.Name).ObjRef()
+	// Same ModelName, different object with newer creation timestamp
+	infModel1Newer = utiltest.MakeInferenceModel("model1-newer").
+			Namespace(pool.Namespace).
+			ModelName("fake model1").
+			Criticality(v1alpha2.Standard).
+			CreationTimestamp(metav1.Unix(1005, 0)).
+			PoolName(pool.Name).ObjRef()
+	// Same ModelName, different object with older creation timestamp
+	infModel1Older = utiltest.MakeInferenceModel("model1-older").
+			Namespace(pool.Namespace).
+			ModelName("fake model1").
+			Criticality(v1alpha2.Standard).
+			CreationTimestamp(metav1.Unix(999, 0)).
+			PoolName(pool.Name).ObjRef()
+
+	infModel2 = utiltest.MakeInferenceModel("model2").
+			Namespace(pool.Namespace).
+			ModelName("fake model2").
+			CreationTimestamp(metav1.Unix(1000, 0)).
+			PoolName(pool.Name).ObjRef()
+	infModel2NS2 = utiltest.MakeInferenceModel(infModel2.Name).
+			Namespace("ns2").
+			ModelName(infModel2.Spec.ModelName).
+			CreationTimestamp(metav1.Unix(1000, 0)).
+			PoolName(pool.Name).ObjRef()
 )
 
-func TestUpdateDatastore_InferenceModelReconciler(t *testing.T) {
-	logger := logutil.NewTestLogger()
-
+func TestInferenceModelReconciler(t *testing.T) {
 	tests := []struct {
-		name                string
-		datastore           datastore.Datastore
-		incomingService     *v1alpha2.InferenceModel
-		wantInferenceModels *sync.Map
+		name              string
+		modelsInStore     []*v1alpha2.InferenceModel
+		modelsInAPIServer []*v1alpha2.InferenceModel
+		model             *v1alpha2.InferenceModel
+		incomingReq       *types.NamespacedName
+		wantModels        []*v1alpha2.InferenceModel
+		wantResult        ctrl.Result
 	}{
 		{
-			name: "No Services registered; valid, new service incoming.",
-			datastore: datastore.NewFakeDatastore(nil, nil, &v1alpha2.InferencePool{
-				Spec: v1alpha2.InferencePoolSpec{
-					Selector: map[v1alpha2.LabelKey]v1alpha2.LabelValue{"app": "vllm"},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test-pool",
-					ResourceVersion: "Old and boring",
-				},
-			}),
-
-			incomingService:     infModel1,
-			wantInferenceModels: populateServiceMap(infModel1),
+			name:       "Empty store, add new model",
+			model:      infModel1,
+			wantModels: []*v1alpha2.InferenceModel{infModel1},
 		},
 		{
-			name: "Removing existing service.",
-			datastore: datastore.NewFakeDatastore(nil, populateServiceMap(infModel1), &v1alpha2.InferencePool{
-				Spec: v1alpha2.InferencePoolSpec{
-					Selector: map[v1alpha2.LabelKey]v1alpha2.LabelValue{"app": "vllm"},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test-pool",
-					ResourceVersion: "Old and boring",
-				},
-			}),
-			incomingService:     infModel1Modified,
-			wantInferenceModels: populateServiceMap(),
+			name:          "Existing model changed pools",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel1Pool2,
+			wantModels:    []*v1alpha2.InferenceModel{},
 		},
 		{
-			name: "Unrelated service, do nothing.",
-			datastore: datastore.NewFakeDatastore(nil, populateServiceMap(infModel1), &v1alpha2.InferencePool{
-				Spec: v1alpha2.InferencePoolSpec{
-					Selector: map[v1alpha2.LabelKey]v1alpha2.LabelValue{"app": "vllm"},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test-pool",
-					ResourceVersion: "Old and boring",
-				},
-			}),
-			incomingService: &v1alpha2.InferenceModel{
-				Spec: v1alpha2.InferenceModelSpec{
-					ModelName: "fake model",
-					PoolRef:   v1alpha2.PoolObjectReference{Name: "test-poolio"},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "unrelated-service",
-				},
-			},
-			wantInferenceModels: populateServiceMap(infModel1),
+			name:          "Not found, delete existing model",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			incomingReq:   &types.NamespacedName{Name: infModel1.Name, Namespace: infModel1.Namespace},
+			wantModels:    []*v1alpha2.InferenceModel{},
 		},
 		{
-			name: "Add to existing",
-			datastore: datastore.NewFakeDatastore(nil, populateServiceMap(infModel1), &v1alpha2.InferencePool{
-				Spec: v1alpha2.InferencePoolSpec{
-					Selector: map[v1alpha2.LabelKey]v1alpha2.LabelValue{"app": "vllm"},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test-pool",
-					ResourceVersion: "Old and boring",
-				},
-			}),
-			incomingService:     infModel2,
-			wantInferenceModels: populateServiceMap(infModel1, infModel2),
+			name:          "Deletion timestamp set, delete existing model",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel1Deleted,
+			wantModels:    []*v1alpha2.InferenceModel{},
+		},
+		{
+			name:          "Model referencing a different pool, different pool name but same namespace",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel1NS2,
+			wantModels:    []*v1alpha2.InferenceModel{infModel1},
+		},
+		{
+			name:          "Model referencing a different pool, same pool name but different namespace",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel2NS2,
+			wantModels:    []*v1alpha2.InferenceModel{infModel1},
+		},
+		{
+			name:              "Existing model changed pools, replaced with another",
+			modelsInStore:     []*v1alpha2.InferenceModel{infModel1},
+			model:             infModel1Pool2,
+			modelsInAPIServer: []*v1alpha2.InferenceModel{infModel1Newer},
+			wantModels:        []*v1alpha2.InferenceModel{infModel1Newer},
+		},
+		{
+			name:              "Not found, delete existing model, replaced with another",
+			modelsInStore:     []*v1alpha2.InferenceModel{infModel1},
+			incomingReq:       &types.NamespacedName{Name: infModel1.Name, Namespace: infModel1.Namespace},
+			modelsInAPIServer: []*v1alpha2.InferenceModel{infModel1Newer},
+			wantModels:        []*v1alpha2.InferenceModel{infModel1Newer},
+		},
+		{
+			name:              "Deletion timestamp set, delete existing model, replaced with another",
+			modelsInStore:     []*v1alpha2.InferenceModel{infModel1},
+			model:             infModel1Deleted,
+			modelsInAPIServer: []*v1alpha2.InferenceModel{infModel1Newer},
+			wantModels:        []*v1alpha2.InferenceModel{infModel1Newer},
+		},
+		{
+			name:          "Older instance of the model observed",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel1Older,
+			wantModels:    []*v1alpha2.InferenceModel{infModel1Older},
+		},
+		{
+			name:          "Model changed criticality",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel1Critical,
+			wantModels:    []*v1alpha2.InferenceModel{infModel1Critical},
+		},
+		{
+			name:          "Model not found, no matching existing model to delete",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			incomingReq:   &types.NamespacedName{Name: "non-existent-model", Namespace: pool.Namespace},
+			wantModels:    []*v1alpha2.InferenceModel{infModel1},
+		},
+		{
+			name:          "Add to existing",
+			modelsInStore: []*v1alpha2.InferenceModel{infModel1},
+			model:         infModel2,
+			wantModels:    []*v1alpha2.InferenceModel{infModel1, infModel2},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pool, err := test.datastore.PoolGet()
-			if err != nil {
-				t.Fatalf("failed to get pool: %v", err)
+			// Create a fake client with no InferenceModel objects.
+			scheme := runtime.NewScheme()
+			_ = v1alpha2.AddToScheme(scheme)
+			initObjs := []client.Object{}
+			if test.model != nil {
+				initObjs = append(initObjs, test.model)
 			}
-			reconciler := &InferenceModelReconciler{
-				Datastore:          test.datastore,
-				PoolNamespacedName: types.NamespacedName{Name: pool.Name},
+			for _, m := range test.modelsInAPIServer {
+				initObjs = append(initObjs, m)
 			}
-			reconciler.updateDatastore(logger, test.incomingService)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(initObjs...).
+				WithIndex(&v1alpha2.InferenceModel{}, modelNameKey, indexInferenceModelsByModelName).
+				Build()
 
-			test.wantInferenceModels.Range(func(k, v any) bool {
-				_, exist := test.datastore.ModelGet(k.(string))
-				if !exist {
-					t.Fatalf("failed to get model %s", k)
-				}
-				return true
-			})
+			datastore := datastore.NewFakeDatastore(nil, test.modelsInStore, pool)
+			reconciler := &InferenceModelReconciler{
+				Client:             fakeClient,
+				Scheme:             scheme,
+				Record:             record.NewFakeRecorder(10),
+				Datastore:          datastore,
+				PoolNamespacedName: types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace},
+			}
+			if test.incomingReq == nil {
+				test.incomingReq = &types.NamespacedName{Name: test.model.Name, Namespace: test.model.Namespace}
+			}
+
+			// Call Reconcile.
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: *test.incomingReq})
+			if err != nil {
+				t.Fatalf("expected no error when resource is not found, got %v", err)
+			}
+
+			if diff := cmp.Diff(result, test.wantResult); diff != "" {
+				t.Errorf("Unexpected result diff (+got/-want): %s", diff)
+			}
+
+			if len(test.wantModels) != len(datastore.ModelGetAll()) {
+				t.Errorf("Unexpected; want: %d, got:%d", len(test.wantModels), len(datastore.ModelGetAll()))
+			}
+
+			if diff := diffStore(datastore, diffStoreParams{wantPool: pool, wantModels: test.wantModels}); diff != "" {
+				t.Errorf("Unexpected diff (+got/-want): %s", diff)
+			}
+
 		})
 	}
-}
-
-func TestReconcile_ResourceNotFound(t *testing.T) {
-	// Set up the scheme.
-	scheme := runtime.NewScheme()
-	_ = v1alpha2.AddToScheme(scheme)
-
-	// Create a fake client with no InferenceModel objects.
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	// Create a minimal datastore.
-	datastore := datastore.NewFakeDatastore(nil, nil, &v1alpha2.InferencePool{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
-	})
-
-	// Create the reconciler.
-	reconciler := &InferenceModelReconciler{
-		Client:             fakeClient,
-		Scheme:             scheme,
-		Record:             record.NewFakeRecorder(10),
-		Datastore:          datastore,
-		PoolNamespacedName: types.NamespacedName{Name: "test-pool"},
-	}
-
-	// Create a request for a non-existent resource.
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "non-existent-model", Namespace: "default"}}
-
-	// Call Reconcile.
-	result, err := reconciler.Reconcile(context.Background(), req)
-	if err != nil {
-		t.Fatalf("expected no error when resource is not found, got %v", err)
-	}
-
-	// Check that no requeue is requested.
-	if result.Requeue || result.RequeueAfter != 0 {
-		t.Errorf("expected no requeue, got %+v", result)
-	}
-}
-
-func TestReconcile_ModelMarkedForDeletion(t *testing.T) {
-	// Set up the scheme.
-	scheme := runtime.NewScheme()
-	_ = v1alpha2.AddToScheme(scheme)
-
-	// Create an InferenceModel object.
-	now := metav1.Now()
-	existingModel := &v1alpha2.InferenceModel{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "existing-model",
-			Namespace:         "default",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{"finalizer"},
-		},
-		Spec: v1alpha2.InferenceModelSpec{
-			ModelName: "fake-model",
-			PoolRef:   v1alpha2.PoolObjectReference{Name: "test-pool"},
-		},
-	}
-
-	// Create a fake client with the existing model.
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingModel).Build()
-
-	// Create a minimal datastore.
-	datastore := datastore.NewFakeDatastore(nil, nil, &v1alpha2.InferencePool{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
-	})
-
-	// Create the reconciler.
-	reconciler := &InferenceModelReconciler{
-		Client:             fakeClient,
-		Scheme:             scheme,
-		Record:             record.NewFakeRecorder(10),
-		Datastore:          datastore,
-		PoolNamespacedName: types.NamespacedName{Name: "test-pool", Namespace: "default"},
-	}
-
-	// Create a request for the existing resource.
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "existing-model", Namespace: "default"}}
-
-	// Call Reconcile.
-	result, err := reconciler.Reconcile(context.Background(), req)
-	if err != nil {
-		t.Fatalf("expected no error when resource exists, got %v", err)
-	}
-
-	// Check that no requeue is requested.
-	if result.Requeue || result.RequeueAfter != 0 {
-		t.Errorf("expected no requeue, got %+v", result)
-	}
-
-	// Verify that the datastore was not updated.
-	if _, exist := datastore.ModelGet(existingModel.Spec.ModelName); exist {
-		t.Errorf("expected datastore to not contain model %q", existingModel.Spec.ModelName)
-	}
-}
-
-func TestReconcile_ResourceExists(t *testing.T) {
-	// Set up the scheme.
-	scheme := runtime.NewScheme()
-	_ = v1alpha2.AddToScheme(scheme)
-
-	// Create an InferenceModel object.
-	existingModel := &v1alpha2.InferenceModel{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "existing-model",
-			Namespace: "default",
-		},
-		Spec: v1alpha2.InferenceModelSpec{
-			ModelName: "fake-model",
-			PoolRef:   v1alpha2.PoolObjectReference{Name: "test-pool"},
-		},
-	}
-
-	// Create a fake client with the existing model.
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingModel).Build()
-
-	// Create a minimal datastore.
-	datastore := datastore.NewFakeDatastore(nil, nil, &v1alpha2.InferencePool{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
-	})
-
-	// Create the reconciler.
-	reconciler := &InferenceModelReconciler{
-		Client:             fakeClient,
-		Scheme:             scheme,
-		Record:             record.NewFakeRecorder(10),
-		Datastore:          datastore,
-		PoolNamespacedName: types.NamespacedName{Name: "test-pool", Namespace: "default"},
-	}
-
-	// Create a request for the existing resource.
-	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "existing-model", Namespace: "default"}}
-
-	// Call Reconcile.
-	result, err := reconciler.Reconcile(context.Background(), req)
-	if err != nil {
-		t.Fatalf("expected no error when resource exists, got %v", err)
-	}
-
-	// Check that no requeue is requested.
-	if result.Requeue || result.RequeueAfter != 0 {
-		t.Errorf("expected no requeue, got %+v", result)
-	}
-
-	// Verify that the datastore was updated.
-	if _, exist := datastore.ModelGet(existingModel.Spec.ModelName); !exist {
-		t.Errorf("expected datastore to contain model %q", existingModel.Spec.ModelName)
-	}
-}
-
-func populateServiceMap(services ...*v1alpha2.InferenceModel) *sync.Map {
-	returnVal := &sync.Map{}
-
-	for _, service := range services {
-		returnVal.Store(service.Spec.ModelName, service)
-	}
-	return returnVal
 }

--- a/pkg/epp/controller/inferencemodel_reconciler_test.go
+++ b/pkg/epp/controller/inferencemodel_reconciler_test.go
@@ -198,7 +198,7 @@ func TestInferenceModelReconciler(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(initObjs...).
-				WithIndex(&v1alpha2.InferenceModel{}, modelNameKey, indexInferenceModelsByModelName).
+				WithIndex(&v1alpha2.InferenceModel{}, datastore.ModelNameIndexKey, indexInferenceModelsByModelName).
 				Build()
 
 			datastore := datastore.NewFakeDatastore(nil, test.modelsInStore, pool)

--- a/pkg/epp/controller/pod_reconciler.go
+++ b/pkg/epp/controller/pod_reconciler.go
@@ -75,7 +75,7 @@ func (c *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (c *PodReconciler) updateDatastore(logger logr.Logger, pod *corev1.Pod) {
 	namespacedName := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 	if !pod.DeletionTimestamp.IsZero() || !c.Datastore.PoolLabelsMatch(pod.Labels) || !podIsReady(pod) {
-		logger.V(logutil.DEFAULT).Info("Pod removed or not added", "name", namespacedName)
+		logger.V(logutil.DEBUG).Info("Pod removed or not added", "name", namespacedName)
 		c.Datastore.PodDelete(namespacedName)
 	} else {
 		if c.Datastore.PodUpdateOrAddIfNotExist(pod) {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -19,47 +19,173 @@ package datastore
 import (
 	"testing"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+	testutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
 )
 
-func TestHasSynced(t *testing.T) {
+func TestPool(t *testing.T) {
+	pool1Selector := map[string]string{"app": "vllm_v1"}
+	pool1 := testutil.MakeInferencePool("pool1").
+		Namespace("default").
+		Selector(pool1Selector).ObjRef()
 	tests := []struct {
-		name          string
-		inferencePool *v1alpha2.InferencePool
-		hasSynced     bool
+		name            string
+		inferencePool   *v1alpha2.InferencePool
+		labels          map[string]string
+		wantSynced      bool
+		wantPool        *v1alpha2.InferencePool
+		wantErr         error
+		wantLabelsMatch bool
 	}{
 		{
-			name: "Ready when InferencePool exists in data store",
-			inferencePool: &v1alpha2.InferencePool{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test-pool",
-					Namespace: "default",
-				},
-			},
-			hasSynced: true,
+			name:            "Ready when InferencePool exists in data store",
+			inferencePool:   pool1,
+			labels:          pool1Selector,
+			wantSynced:      true,
+			wantPool:        pool1,
+			wantLabelsMatch: true,
 		},
 		{
-			name:          "Not ready when InferencePool is nil in data store",
-			inferencePool: nil,
-			hasSynced:     false,
+			name:            "Labels not matched",
+			inferencePool:   pool1,
+			labels:          map[string]string{"app": "vllm_v2"},
+			wantSynced:      true,
+			wantPool:        pool1,
+			wantLabelsMatch: false,
+		},
+		{
+			name:       "Not ready when InferencePool is nil in data store",
+			wantErr:    errPoolNotSynced,
+			wantSynced: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			datastore := NewDatastore()
-			// Set the inference pool
-			if tt.inferencePool != nil {
-				datastore.PoolSet(tt.inferencePool)
+			datastore.PoolSet(tt.inferencePool)
+			gotPool, gotErr := datastore.PoolGet()
+			if diff := cmp.Diff(tt.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error diff (+got/-want): %s", diff)
 			}
-			// Check if the data store has been initialized
-			hasSynced := datastore.PoolHasSynced()
-			if hasSynced != tt.hasSynced {
-				t.Errorf("IsInitialized() = %v, want %v", hasSynced, tt.hasSynced)
+			if diff := cmp.Diff(tt.wantPool, gotPool); diff != "" {
+				t.Errorf("Unexpected pool diff (+got/-want): %s", diff)
+			}
+			gotSynced := datastore.PoolHasSynced()
+			if diff := cmp.Diff(tt.wantSynced, gotSynced); diff != "" {
+				t.Errorf("Unexpected synced diff (+got/-want): %s", diff)
+			}
+			if tt.labels != nil {
+				gotLabelsMatch := datastore.PoolLabelsMatch(tt.labels)
+				if diff := cmp.Diff(tt.wantLabelsMatch, gotLabelsMatch); diff != "" {
+					t.Errorf("Unexpected labels match diff (+got/-want): %s", diff)
+				}
 			}
 		})
 	}
+}
+
+func TestModel(t *testing.T) {
+	chatModel := "chat"
+	tsModel := "tweet-summary"
+	model1ts := testutil.MakeInferenceModel("model1").
+		CreationTimestamp(metav1.Unix(1000, 0)).
+		ModelName(tsModel).ObjRef()
+	// Same model name as model1ts, different object name.
+	model2ts := testutil.MakeInferenceModel("model2").
+		CreationTimestamp(metav1.Unix(1001, 0)).
+		ModelName(tsModel).ObjRef()
+	// Same model name as model1ts, newer timestamp
+	model1tsNewer := testutil.MakeInferenceModel("model1").
+		CreationTimestamp(metav1.Unix(1002, 0)).
+		Criticality(v1alpha2.Critical).
+		ModelName(tsModel).ObjRef()
+	model2tsNewer := testutil.MakeInferenceModel("model2").
+		CreationTimestamp(metav1.Unix(1003, 0)).
+		ModelName(tsModel).ObjRef()
+	// Same object name as model2ts, different model name.
+	model2chat := testutil.MakeInferenceModel(model2ts.Name).
+		CreationTimestamp(metav1.Unix(1005, 0)).
+		ModelName(chatModel).ObjRef()
+
+	ds := NewDatastore()
+	dsImpl := ds.(*datastore)
+
+	// Step 1: add model1 with tweet-summary as modelName.
+	ds.ModelSetIfOlder(model1ts)
+	if diff := diffModelMaps(dsImpl, []*v1alpha2.InferenceModel{model1ts}); diff != "" {
+		t.Errorf("Unexpected models diff: %s", diff)
+	}
+
+	// Step 2: set model1 with the same modelName, but with criticality set and newer creation timestamp, should update.
+	ds.ModelSetIfOlder(model1tsNewer)
+	if diff := diffModelMaps(dsImpl, []*v1alpha2.InferenceModel{model1tsNewer}); diff != "" {
+		t.Errorf("Unexpected models diff: %s", diff)
+	}
+
+	// Step 3: set model2 with the same modelName, but newer creation timestamp, should not update.
+	ds.ModelSetIfOlder(model2tsNewer)
+	if diff := diffModelMaps(dsImpl, []*v1alpha2.InferenceModel{model1tsNewer}); diff != "" {
+		t.Errorf("Unexpected models diff: %s", diff)
+	}
+
+	// Step 4: set model2 with the same modelName, but older creation timestamp, should update.
+	ds.ModelSetIfOlder(model2ts)
+	if diff := diffModelMaps(dsImpl, []*v1alpha2.InferenceModel{model2ts}); diff != "" {
+		t.Errorf("Unexpected models diff: %s", diff)
+	}
+
+	// Step 5: set model2 updated with a new modelName, should update modelName.
+	ds.ModelSetIfOlder(model2chat)
+	if diff := diffModelMaps(dsImpl, []*v1alpha2.InferenceModel{model2chat}); diff != "" {
+		t.Errorf("Unexpected models diff: %s", diff)
+	}
+
+	// Step 6: set model1 with the tweet-summary modelName, both models should exist.
+	ds.ModelSetIfOlder(model1ts)
+	if diff := diffModelMaps(dsImpl, []*v1alpha2.InferenceModel{model2chat, model1ts}); diff != "" {
+		t.Errorf("Unexpected models diff: %s", diff)
+	}
+
+	// Step 7: getting the models by model name, chat -> model2; tweet-summary -> model1
+	gotChat, exists := ds.ModelGetByModelName(chatModel)
+	if !exists {
+		t.Error("Chat model should exist!")
+	}
+	if diff := cmp.Diff(model2chat, gotChat); diff != "" {
+		t.Errorf("Unexpected chat model diff: %s", diff)
+	}
+	gotSummary, exists := ds.ModelGetByModelName(tsModel)
+	if !exists {
+		t.Error("Summary model should exist!")
+	}
+	if diff := cmp.Diff(model1ts, gotSummary); diff != "" {
+		t.Errorf("Unexpected summary model diff: %s", diff)
+	}
+
+	// Step 6: delete model1, summary model should not exist.
+	ds.ModelDelete(types.NamespacedName{Name: model1ts.Name, Namespace: model1ts.Namespace})
+	_, exists = ds.ModelGetByModelName(tsModel)
+	if exists {
+		t.Error("Summary model should not exist!")
+	}
+
+}
+
+func diffModelMaps(ds *datastore, want []*v1alpha2.InferenceModel) string {
+	byObjName := ds.ModelGetAll()
+	byModelName := []*v1alpha2.InferenceModel{}
+	for _, v := range ds.modelsByModelName {
+		byModelName = append(byModelName, v)
+	}
+	if diff := testutil.DiffModelLists(byObjName, byModelName); diff != "" {
+		return "Inconsistent maps diff: " + diff
+	}
+	return testutil.DiffModelLists(want, byObjName)
 }
 
 func TestRandomWeightedDraw(t *testing.T) {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -155,15 +155,6 @@ func TestModel(t *testing.T) {
 			wantModels:   []*v1alpha2.InferenceModel{model2ts},
 		},
 		{
-			name:           "Set model2 updated with a new modelName, should update modelName",
-			existingModels: []*v1alpha2.InferenceModel{model2ts},
-			op: func(ds Datastore) bool {
-				return ds.ModelSetIfOlder(model2chat)
-			},
-			wantOpResult: true,
-			wantModels:   []*v1alpha2.InferenceModel{model2chat},
-		},
-		{
 			name:           "Set model1 with the tweet-summary modelName, both models should exist",
 			existingModels: []*v1alpha2.InferenceModel{model2chat},
 			op: func(ds Datastore) bool {

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -64,7 +64,7 @@ func (s *Server) HandleRequestBody(
 	// NOTE: The nil checking for the modelObject means that we DO allow passthrough currently.
 	// This might be a security risk in the future where adapters not registered in the InferenceModel
 	// are able to be requested by using their distinct name.
-	modelObj, exist := s.datastore.ModelGetByModelName(model)
+	modelObj, exist := s.datastore.ModelGet(model)
 	if !exist {
 		return nil, errutil.Error{Code: errutil.BadConfiguration, Msg: fmt.Sprintf("error finding a model object in InferenceModel for input %v", model)}
 	}

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -64,7 +64,7 @@ func (s *Server) HandleRequestBody(
 	// NOTE: The nil checking for the modelObject means that we DO allow passthrough currently.
 	// This might be a security risk in the future where adapters not registered in the InferenceModel
 	// are able to be requested by using their distinct name.
-	modelObj, exist := s.datastore.ModelGet(model)
+	modelObj, exist := s.datastore.ModelGetByModelName(model)
 	if !exist {
 		return nil, errutil.Error{Code: errutil.BadConfiguration, Msg: fmt.Sprintf("error finding a model object in InferenceModel for input %v", model)}
 	}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -85,7 +85,7 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 }
 
 // SetupWithManager sets up the runner with the given manager.
-func (r *ExtProcServerRunner) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ExtProcServerRunner) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	// Create the controllers and register them with the manager
 	if err := (&controller.InferencePoolReconciler{
 		Datastore: r.Datastore,
@@ -109,7 +109,7 @@ func (r *ExtProcServerRunner) SetupWithManager(mgr ctrl.Manager) error {
 			Namespace: r.PoolNamespace,
 		},
 		Record: mgr.GetEventRecorderFor("InferenceModel"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed setting up InferenceModelReconciler: %w", err)
 	}
 

--- a/pkg/epp/test/utils.go
+++ b/pkg/epp/test/utils.go
@@ -53,14 +53,15 @@ func StartExtProc(
 	pmc := &backend.FakePodMetricsClient{Res: pms}
 	datastore := datastore.NewDatastore()
 	for _, m := range models {
-		datastore.ModelSet(m)
+		datastore.ModelSetIfOlder(m)
 	}
 	for _, pm := range pods {
-		pod := utiltesting.MakePod(pm.NamespacedName.Name, pm.NamespacedName.Namespace).
+		pod := utiltesting.MakePod(pm.NamespacedName.Name).
+			Namespace(pm.NamespacedName.Namespace).
 			ReadyCondition().
 			IP(pm.Address).
-			Obj()
-		datastore.PodUpdateOrAddIfNotExist(&pod)
+			ObjRef()
+		datastore.PodUpdateOrAddIfNotExist(pod)
 		datastore.PodUpdateMetricsIfExist(pm.NamespacedName, &pm.Metrics)
 	}
 	pp := backend.NewProvider(pmc, datastore)

--- a/pkg/epp/util/testing/diff.go
+++ b/pkg/epp/util/testing/diff.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+)
+
+func DiffModelLists(want, got []*v1alpha2.InferenceModel) string {
+	return cmp.Diff(want, got, cmpopts.SortSlices(func(a, b *v1alpha2.InferenceModel) bool { return a.Name < b.Name }))
+}

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -19,6 +19,7 @@ package testing
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 )
 
 // PodWrapper wraps a Pod.
@@ -27,17 +28,21 @@ type PodWrapper struct {
 }
 
 // MakePod creates a wrapper for a Pod.
-func MakePod(podName, ns string) *PodWrapper {
+func MakePod(podName string) *PodWrapper {
 	return &PodWrapper{
 		corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      podName,
-				Namespace: ns,
+				Name: podName,
 			},
 			Spec:   corev1.PodSpec{},
 			Status: corev1.PodStatus{},
 		},
 	}
+}
+
+func (p *PodWrapper) Namespace(ns string) *PodWrapper {
+	p.ObjectMeta.Namespace = ns
+	return p
 }
 
 // Labels sets the pod labels.
@@ -60,7 +65,109 @@ func (p *PodWrapper) IP(ip string) *PodWrapper {
 	return p
 }
 
+func (p *PodWrapper) DeletionTimestamp() *PodWrapper {
+	now := metav1.Now()
+	p.ObjectMeta.DeletionTimestamp = &now
+	p.ObjectMeta.Finalizers = []string{"finalizer"}
+	return p
+}
+
 // Obj returns the wrapped Pod.
-func (p *PodWrapper) Obj() corev1.Pod {
-	return p.Pod
+func (p *PodWrapper) ObjRef() *corev1.Pod {
+	return &p.Pod
+}
+
+// InferenceModelWrapper wraps an InferenceModel.
+type InferenceModelWrapper struct {
+	v1alpha2.InferenceModel
+}
+
+// MakeInferenceModel creates a wrapper for a InferenceModel.
+func MakeInferenceModel(name string) *InferenceModelWrapper {
+	return &InferenceModelWrapper{
+		v1alpha2.InferenceModel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1alpha2.InferenceModelSpec{},
+		},
+	}
+}
+
+func (m *InferenceModelWrapper) Namespace(ns string) *InferenceModelWrapper {
+	m.ObjectMeta.Namespace = ns
+	return m
+}
+
+// Obj returns the wrapped InferenceModel.
+func (m *InferenceModelWrapper) ObjRef() *v1alpha2.InferenceModel {
+	return &m.InferenceModel
+}
+
+func (m *InferenceModelWrapper) ModelName(modelName string) *InferenceModelWrapper {
+	m.Spec.ModelName = modelName
+	return m
+}
+
+func (m *InferenceModelWrapper) PoolName(poolName string) *InferenceModelWrapper {
+	m.Spec.PoolRef = v1alpha2.PoolObjectReference{Name: poolName}
+	return m
+}
+
+func (m *InferenceModelWrapper) Criticality(criticality v1alpha2.Criticality) *InferenceModelWrapper {
+	m.Spec.Criticality = &criticality
+	return m
+}
+
+func (m *InferenceModelWrapper) DeletionTimestamp() *InferenceModelWrapper {
+	now := metav1.Now()
+	m.ObjectMeta.DeletionTimestamp = &now
+	m.ObjectMeta.Finalizers = []string{"finalizer"}
+	return m
+}
+
+func (m *InferenceModelWrapper) CreationTimestamp(t metav1.Time) *InferenceModelWrapper {
+	m.ObjectMeta.CreationTimestamp = t
+	return m
+}
+
+// InferencePoolWrapper wraps an InferencePool.
+type InferencePoolWrapper struct {
+	v1alpha2.InferencePool
+}
+
+// MakeInferencePool creates a wrapper for a InferencePool.
+func MakeInferencePool(name string) *InferencePoolWrapper {
+	return &InferencePoolWrapper{
+		v1alpha2.InferencePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1alpha2.InferencePoolSpec{},
+		},
+	}
+}
+
+func (m *InferencePoolWrapper) Namespace(ns string) *InferencePoolWrapper {
+	m.ObjectMeta.Namespace = ns
+	return m
+}
+
+func (m *InferencePoolWrapper) Selector(selector map[string]string) *InferencePoolWrapper {
+	s := make(map[v1alpha2.LabelKey]v1alpha2.LabelValue)
+	for k, v := range selector {
+		s[v1alpha2.LabelKey(k)] = v1alpha2.LabelValue(v)
+	}
+	m.Spec.Selector = s
+	return m
+}
+
+func (m *InferencePoolWrapper) TargetPortNumber(p int32) *InferencePoolWrapper {
+	m.Spec.TargetPortNumber = p
+	return m
+}
+
+// Obj returns the wrapped InferencePool.
+func (m *InferencePoolWrapper) ObjRef() *v1alpha2.InferencePool {
+	return &m.InferencePool
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -245,11 +245,6 @@ func createModelServer(k8sClient client.Client, secretPath, deployPath string) {
 
 	// Wait for the deployment to be available.
 	testutils.DeploymentAvailable(ctx, k8sClient, deploy, modelReadyTimeout, interval)
-
-	// Wait for the service to exist.
-	testutils.EventuallyExists(ctx, func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Namespace: nsName, Name: modelServerName}, &corev1.Service{})
-	}, existsTimeout, interval)
 }
 
 // createEnvoy creates the envoy proxy resources used for testing from the given filePath.

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -476,7 +476,7 @@ func BeforeSuit(t *testing.T) func() {
 	}
 
 	assert.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, modelExist := serverRunner.Datastore.ModelGetByModelName("my-model")
+		_, modelExist := serverRunner.Datastore.ModelGet("my-model")
 		synced := serverRunner.Datastore.PoolHasSynced() && modelExist
 		assert.True(t, synced, "Timeout waiting for the pool and models to sync")
 	}, 10*time.Second, 10*time.Millisecond)

--- a/test/integration/hermetic_test.go
+++ b/test/integration/hermetic_test.go
@@ -360,11 +360,12 @@ func setUpHermeticServer(podMetrics []*datastore.PodMetrics) (client extProcPb.E
 	go func() {
 		serverRunner.Datastore.PodDeleteAll()
 		for _, pm := range podMetrics {
-			pod := utiltesting.MakePod(pm.NamespacedName.Name, pm.NamespacedName.Namespace).
+			pod := utiltesting.MakePod(pm.NamespacedName.Name).
+				Namespace(pm.NamespacedName.Namespace).
 				ReadyCondition().
 				IP(pm.Address).
-				Obj()
-			serverRunner.Datastore.PodUpdateOrAddIfNotExist(&pod)
+				ObjRef()
+			serverRunner.Datastore.PodUpdateOrAddIfNotExist(pod)
 			serverRunner.Datastore.PodUpdateMetricsIfExist(pm.NamespacedName, &pm.Metrics)
 		}
 		serverRunner.Provider = backend.NewProvider(pmc, serverRunner.Datastore)
@@ -429,7 +430,7 @@ func BeforeSuit(t *testing.T) func() {
 	serverRunner.Datastore = datastore.NewDatastore()
 	serverRunner.SecureServing = false
 
-	if err := serverRunner.SetupWithManager(mgr); err != nil {
+	if err := serverRunner.SetupWithManager(context.Background(), mgr); err != nil {
 		logutil.Fatal(logger, err, "Failed to setup server runner")
 	}
 
@@ -475,7 +476,7 @@ func BeforeSuit(t *testing.T) func() {
 	}
 
 	assert.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, modelExist := serverRunner.Datastore.ModelGet("my-model")
+		_, modelExist := serverRunner.Datastore.ModelGetByModelName("my-model")
 		synced := serverRunner.Datastore.PoolHasSynced() && modelExist
 		assert.True(t, synced, "Timeout waiting for the pool and models to sync")
 	}, 10*time.Second, 10*time.Millisecond)


### PR DESCRIPTION
Currently the logic tracks the models by Spec.ModelName, since this is not guaranteed to be unique within the cluster, we could run into two issues:

1) If the model name changes on the same InferenceModel object, we don't delete the original model entry in the datastore. 
2) We don't enforce the semantics that the modelName with the oldest creation timestamp is retained. While the api is assuming that this is enforced by another controller via the Ready condition, we don't have this controller yet, and so currently the behavior is unpredictable depending on InferenceModel events order.

To address the above, the PR makes changes to both the InferenceModel reconciler and the Model APIs in the datastore to ensure thread safe updates of the entries. In the store, the sync.Map was replaced with two maps to track the InferenceModel entries by both ModelName and InferenceModel object NamespacedName. This is needed to properly handle deletions when the object doesn't exist anymore (could be handled in other ways, but this seemed like a reasonable approach).

The PR increases the datastore pkg unit test coverage the Pool and Model APIs. We still need to followup with adding unit test coverage to the pods APIs, which is currently non-existent.

Note that I started this PR to increase test coverage for the reconcilers to address #356 and #353, and so you will see refactoring to the tests in the other controllers as well.

Part of #353 #391 
Fixes #394
Fixes #356 
Fixes #328