### PR TITLE
fix metric scrape port not updated when inference pool target port updated

### DIFF
--- a/pkg/epp/backend/fake.go
+++ b/pkg/epp/backend/fake.go
@@ -31,7 +31,7 @@ type FakePodMetricsClient struct {
 	Res map[types.NamespacedName]*datastore.PodMetrics
 }
 
-func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, existing *datastore.PodMetrics) (*datastore.PodMetrics, error) {
+func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, existing *datastore.PodMetrics, port int32) (*datastore.PodMetrics, error) {
 	if err, ok := f.Err[existing.NamespacedName]; ok {
 		return nil, err
 	}

--- a/pkg/epp/backend/provider.go
+++ b/pkg/epp/backend/provider.go
@@ -157,8 +157,6 @@ func (p *Provider) refreshMetricsOnce(logger logr.Logger) error {
 }
 
 func (p *Provider) flushPrometheusMetricsOnce(logger logr.Logger) {
-	logger.V(logutil.DEBUG).Info("Flushing Prometheus Metrics")
-
 	pool, _ := p.datastore.PoolGet()
 	if pool == nil {
 		// No inference pool or not initialize.
@@ -169,6 +167,7 @@ func (p *Provider) flushPrometheusMetricsOnce(logger logr.Logger) {
 	var queueTotal int
 
 	podMetrics := p.datastore.PodGetAll()
+	logger.V(logutil.VERBOSE).Info("Flushing Prometheus Metrics", "ReadyPods", len(podMetrics))
 	if len(podMetrics) == 0 {
 		return
 	}

--- a/pkg/epp/backend/provider.go
+++ b/pkg/epp/backend/provider.go
@@ -49,7 +49,7 @@ type Provider struct {
 }
 
 type PodMetricsClient interface {
-	FetchMetrics(ctx context.Context, existing *datastore.PodMetrics) (*datastore.PodMetrics, error)
+	FetchMetrics(ctx context.Context, existing *datastore.PodMetrics, port int32) (*datastore.PodMetrics, error)
 }
 
 func (p *Provider) Init(ctx context.Context, refreshMetricsInterval, refreshPrometheusMetricsInterval time.Duration) error {
@@ -121,7 +121,8 @@ func (p *Provider) refreshMetricsOnce(logger logr.Logger) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			updated, err := p.pmc.FetchMetrics(ctx, existing)
+			pool, _ := p.datastore.PoolGet()
+			updated, err := p.pmc.FetchMetrics(ctx, existing, pool.Spec.TargetPortNumber)
 			if err != nil {
 				errCh <- fmt.Errorf("failed to parse metrics from %s: %v", existing.NamespacedName, err)
 				return

--- a/pkg/epp/backend/provider_test.go
+++ b/pkg/epp/backend/provider_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
 )
 
@@ -66,6 +67,12 @@ var (
 				"foo1": 1,
 				"bar1": 1,
 			},
+		},
+	}
+
+	inferencePool = &v1alpha2.InferencePool{
+		Spec: v1alpha2.InferencePoolSpec{
+			TargetPortNumber: 8000,
 		},
 	}
 )
@@ -127,7 +134,7 @@ func TestProvider(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ds := datastore.NewFakeDatastore(test.storePods, nil, nil)
+			ds := datastore.NewFakeDatastore(test.storePods, nil, inferencePool)
 			p := NewProvider(test.pmc, ds)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/pkg/epp/backend/vllm/metrics.go
+++ b/pkg/epp/backend/vllm/metrics.go
@@ -55,13 +55,15 @@ type PodMetricsClientImpl struct{}
 func (p *PodMetricsClientImpl) FetchMetrics(
 	ctx context.Context,
 	existing *datastore.PodMetrics,
+	port int32,
 ) (*datastore.PodMetrics, error) {
 	logger := log.FromContext(ctx)
 	loggerDefault := logger.V(logutil.DEFAULT)
 
 	// Currently the metrics endpoint is hard-coded, which works with vLLM.
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16): Consume this from InferencePool config.
-	url := existing.BuildScrapeEndpoint()
+	url := existing.Address + ":" + strconv.Itoa(int(port))
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		loggerDefault.Error(err, "Failed create HTTP request", "method", http.MethodGet, "url", url)

--- a/pkg/epp/backend/vllm/metrics.go
+++ b/pkg/epp/backend/vllm/metrics.go
@@ -62,7 +62,7 @@ func (p *PodMetricsClientImpl) FetchMetrics(
 
 	// Currently the metrics endpoint is hard-coded, which works with vLLM.
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16): Consume this from InferencePool config.
-	url := existing.Address + ":" + strconv.Itoa(int(port))
+	url := existing.Address + ":" + strconv.Itoa(int(port)) + "/metrics"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/epp/backend/vllm/metrics.go
+++ b/pkg/epp/backend/vllm/metrics.go
@@ -62,7 +62,7 @@ func (p *PodMetricsClientImpl) FetchMetrics(
 
 	// Currently the metrics endpoint is hard-coded, which works with vLLM.
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16): Consume this from InferencePool config.
-	url := existing.Address + ":" + strconv.Itoa(int(port)) + "/metrics"
+	url := "http://" + existing.Address + ":" + strconv.Itoa(int(port)) + "/metrics"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -35,10 +35,10 @@ import (
 )
 
 var (
-	basePod1  = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}, Address: "address-1", ScrapePath: "/metrics", ScrapePort: 8000}}
-	basePod2  = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod2"}, Address: "address-2", ScrapePath: "/metrics", ScrapePort: 8000}}
-	basePod3  = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod3"}, Address: "address-3", ScrapePath: "/metrics", ScrapePort: 8000}}
-	basePod11 = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}, Address: "address-11", ScrapePath: "/metrics", ScrapePort: 8000}}
+	basePod1  = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}, Address: "address-1"}}
+	basePod2  = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod2"}, Address: "address-2"}}
+	basePod3  = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod3"}, Address: "address-3"}}
+	basePod11 = &datastore.PodMetrics{Pod: datastore.Pod{NamespacedName: types.NamespacedName{Name: "pod1"}, Address: "address-11"}}
 )
 
 func TestPodReconciler(t *testing.T) {

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -265,16 +265,13 @@ func (ds *datastore) PodDelete(namespacedName types.NamespacedName) {
 }
 
 func (ds *datastore) PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool {
-	pool, _ := ds.PoolGet()
 	new := &PodMetrics{
 		Pod: Pod{
 			NamespacedName: types.NamespacedName{
 				Name:      pod.Name,
 				Namespace: pod.Namespace,
 			},
-			Address:    pod.Status.PodIP,
-			ScrapePath: "/metrics",
-			ScrapePort: pool.Spec.TargetPortNumber,
+			Address: pod.Status.PodIP,
 		},
 		Metrics: Metrics{
 			ActiveModels: make(map[string]int),

--- a/pkg/epp/datastore/types.go
+++ b/pkg/epp/datastore/types.go
@@ -26,10 +26,6 @@ import (
 type Pod struct {
 	NamespacedName types.NamespacedName
 	Address        string
-
-	// metrics scrape options
-	ScrapePort int32
-	ScrapePath string
 }
 
 type Metrics struct {
@@ -61,11 +57,10 @@ func (pm *PodMetrics) Clone() *PodMetrics {
 		Pod: Pod{
 			NamespacedName: pm.NamespacedName,
 			Address:        pm.Address,
-			ScrapePort:     pm.ScrapePort,
-			ScrapePath:     pm.ScrapePath,
 		},
 		Metrics: Metrics{
 			ActiveModels:            cm,
+			MaxActiveModels:         pm.MaxActiveModels,
 			RunningQueueSize:        pm.RunningQueueSize,
 			WaitingQueueSize:        pm.WaitingQueueSize,
 			KVCacheUsagePercent:     pm.KVCacheUsagePercent,
@@ -73,8 +68,4 @@ func (pm *PodMetrics) Clone() *PodMetrics {
 		},
 	}
 	return clone
-}
-
-func (pm *PodMetrics) BuildScrapeEndpoint() string {
-	return fmt.Sprintf("http://%s:%d%s", pm.Address, pm.ScrapePort, pm.ScrapePath)
 }


### PR DESCRIPTION
Currently the scrape port is stored in `PodMetrics`, which should be updated when targetPortNumber of inferencePool changed.

Also, currently the datastore stores all `PodMetrics` and return a reference of it when we try to read which in my opinion is not safe. This may cause inconsistency if we try to read and directly modify it in a goroutine. I think we should always return a copy and let the datastore control all write actions.