### PR TITLE
Consistent validation for reference types

### DIFF
--- a/api/v1alpha2/inferencemodel_types.go
+++ b/api/v1alpha2/inferencemodel_types.go
@@ -106,25 +106,18 @@ type PoolObjectReference struct {
 	//
 	// +optional
 	// +kubebuilder:default="inference.networking.x-k8s.io"
-	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Group string `json:"group,omitempty"`
+	Group Group `json:"group,omitempty"`
 
 	// Kind is kind of the referent. For example "InferencePool".
 	//
 	// +optional
 	// +kubebuilder:default="InferencePool"
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-	Kind string `json:"kind,omitempty"`
+	Kind Kind `json:"kind,omitempty"`
 
 	// Name is the name of the referent.
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Required
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 }
 
 // Criticality defines how important it is to serve the model compared to other models.

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -90,11 +90,11 @@ type Extension struct {
 // ExtensionReference is a reference to the extension deployment.
 type ExtensionReference struct {
 	// Group is the group of the referent.
-	// When unspecified or empty string, core API group is inferred.
+	// The default value is "", representing the Core API group.
 	//
 	// +optional
 	// +kubebuilder:default=""
-	Group *string `json:"group,omitempty"`
+	Group *Group `json:"group,omitempty"`
 
 	// Kind is the Kubernetes resource kind of the referent. For example
 	// "Service".
@@ -109,20 +109,19 @@ type ExtensionReference struct {
 	//
 	// +optional
 	// +kubebuilder:default=Service
-	Kind *string `json:"kind,omitempty"`
+	Kind *Kind `json:"kind,omitempty"`
 
 	// Name is the name of the referent.
 	//
 	// +kubebuilder:validation:Required
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 
-	// The port number on the service running the extension. When unspecified, implementations SHOULD infer a
-	// default value of 9002 when the Kind is Service.
+	// The port number on the service running the extension. When unspecified,
+	// implementations SHOULD infer a default value of 9002 when the Kind is
+	// Service.
 	//
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
 	// +optional
-	PortNumber *int32 `json:"targetPortNumber,omitempty"`
+	PortNumber *PortNumber `json:"portNumber,omitempty"`
 }
 
 // ExtensionConnection encapsulates options that configures the connection to the extension.

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -146,47 +146,6 @@ const (
 	FailClose ExtensionFailureMode = "FailClose"
 )
 
-// LabelKey was originally copied from: https://github.com/kubernetes-sigs/gateway-api/blob/99a3934c6bc1ce0874f3a4c5f20cafd8977ffcb4/apis/v1/shared_types.go#L694-L731
-// Duplicated as to not take an unexpected dependency on gw's API.
-//
-// LabelKey is the key of a label. This is used for validation
-// of maps. This matches the Kubernetes "qualified name" validation that is used for labels.
-// Labels are case sensitive, so: my-label and My-Label are considered distinct.
-//
-// Valid values include:
-//
-// * example
-// * example.com
-// * example.com/path
-// * example.com/path.html
-//
-// Invalid values include:
-//
-// * example~ - "~" is an invalid character
-// * example.com. - can not start or end with "."
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$`
-type LabelKey string
-
-// LabelValue is the value of a label. This is used for validation
-// of maps. This matches the Kubernetes label validation rules:
-// * must be 63 characters or less (can be empty),
-// * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
-// * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
-//
-// Valid values include:
-//
-// * MyValue
-// * my.name
-// * 123-my-value
-//
-// +kubebuilder:validation:MinLength=0
-// +kubebuilder:validation:MaxLength=63
-// +kubebuilder:validation:Pattern=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`
-type LabelValue string
-
 // InferencePoolStatus defines the observed state of InferencePool
 type InferencePoolStatus struct {
 	// Parents is a list of parent resources (usually Gateways) that are

--- a/api/v1alpha2/shared_types.go
+++ b/api/v1alpha2/shared_types.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+// Group refers to a Kubernetes Group. It must either be an empty string or a
+// RFC 1123 subdomain.
+//
+// This validation is based off of the corresponding Kubernetes validation:
+// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
+//
+// Valid values include:
+//
+// * "" - empty string implies core Kubernetes API group
+// * "gateway.networking.k8s.io"
+// * "foo.example.com"
+//
+// Invalid values include:
+//
+// * "example.com/bar" - "/" is an invalid character
+//
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+type Group string
+
+// Kind refers to a Kubernetes Kind.
+//
+// Valid values include:
+//
+// * "Service"
+// * "HTTPRoute"
+//
+// Invalid values include:
+//
+// * "invalid/kind" - "/" is an invalid character
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=63
+// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
+type Kind string
+
+// ObjectName refers to the name of a Kubernetes object.
+// Object names can have a variety of forms, including RFC 1123 subdomains,
+// RFC 1123 labels, or RFC 1035 labels.
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+type ObjectName string
+
+// PortNumber defines a network port.
+//
+// +kubebuilder:validation:Minimum=1
+// +kubebuilder:validation:Maximum=65535
+type PortNumber int32

--- a/api/v1alpha2/shared_types.go
+++ b/api/v1alpha2/shared_types.go
@@ -65,3 +65,44 @@ type ObjectName string
 // +kubebuilder:validation:Minimum=1
 // +kubebuilder:validation:Maximum=65535
 type PortNumber int32
+
+// LabelKey was originally copied from: https://github.com/kubernetes-sigs/gateway-api/blob/99a3934c6bc1ce0874f3a4c5f20cafd8977ffcb4/apis/v1/shared_types.go#L694-L731
+// Duplicated as to not take an unexpected dependency on gw's API.
+//
+// LabelKey is the key of a label. This is used for validation
+// of maps. This matches the Kubernetes "qualified name" validation that is used for labels.
+// Labels are case sensitive, so: my-label and My-Label are considered distinct.
+//
+// Valid values include:
+//
+// * example
+// * example.com
+// * example.com/path
+// * example.com/path.html
+//
+// Invalid values include:
+//
+// * example~ - "~" is an invalid character
+// * example.com. - can not start or end with "."
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$`
+type LabelKey string
+
+// LabelValue is the value of a label. This is used for validation
+// of maps. This matches the Kubernetes label validation rules:
+// * must be 63 characters or less (can be empty),
+// * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+// * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+//
+// Valid values include:
+//
+// * MyValue
+// * my.name
+// * 123-my-value
+//
+// +kubebuilder:validation:MinLength=0
+// +kubebuilder:validation:MaxLength=63
+// +kubebuilder:validation:Pattern=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`
+type LabelValue string

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -87,17 +87,17 @@ func (in *ExtensionReference) DeepCopyInto(out *ExtensionReference) {
 	*out = *in
 	if in.Group != nil {
 		in, out := &in.Group, &out.Group
-		*out = new(string)
+		*out = new(Group)
 		**out = **in
 	}
 	if in.Kind != nil {
 		in, out := &in.Kind, &out.Kind
-		*out = new(string)
+		*out = new(Kind)
 		**out = **in
 	}
 	if in.PortNumber != nil {
 		in, out := &in.PortNumber, &out.PortNumber
-		*out = new(int32)
+		*out = new(PortNumber)
 		**out = **in
 	}
 }

--- a/client-go/applyconfiguration/api/v1alpha2/extension.go
+++ b/client-go/applyconfiguration/api/v1alpha2/extension.go
@@ -37,7 +37,7 @@ func Extension() *ExtensionApplyConfiguration {
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Group field is set to the value of the last call.
-func (b *ExtensionApplyConfiguration) WithGroup(value string) *ExtensionApplyConfiguration {
+func (b *ExtensionApplyConfiguration) WithGroup(value apiv1alpha2.Group) *ExtensionApplyConfiguration {
 	b.ExtensionReferenceApplyConfiguration.Group = &value
 	return b
 }
@@ -45,7 +45,7 @@ func (b *ExtensionApplyConfiguration) WithGroup(value string) *ExtensionApplyCon
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Kind field is set to the value of the last call.
-func (b *ExtensionApplyConfiguration) WithKind(value string) *ExtensionApplyConfiguration {
+func (b *ExtensionApplyConfiguration) WithKind(value apiv1alpha2.Kind) *ExtensionApplyConfiguration {
 	b.ExtensionReferenceApplyConfiguration.Kind = &value
 	return b
 }
@@ -53,7 +53,7 @@ func (b *ExtensionApplyConfiguration) WithKind(value string) *ExtensionApplyConf
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *ExtensionApplyConfiguration) WithName(value string) *ExtensionApplyConfiguration {
+func (b *ExtensionApplyConfiguration) WithName(value apiv1alpha2.ObjectName) *ExtensionApplyConfiguration {
 	b.ExtensionReferenceApplyConfiguration.Name = &value
 	return b
 }
@@ -61,7 +61,7 @@ func (b *ExtensionApplyConfiguration) WithName(value string) *ExtensionApplyConf
 // WithPortNumber sets the PortNumber field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the PortNumber field is set to the value of the last call.
-func (b *ExtensionApplyConfiguration) WithPortNumber(value int32) *ExtensionApplyConfiguration {
+func (b *ExtensionApplyConfiguration) WithPortNumber(value apiv1alpha2.PortNumber) *ExtensionApplyConfiguration {
 	b.ExtensionReferenceApplyConfiguration.PortNumber = &value
 	return b
 }

--- a/client-go/applyconfiguration/api/v1alpha2/extensionreference.go
+++ b/client-go/applyconfiguration/api/v1alpha2/extensionreference.go
@@ -17,13 +17,17 @@ limitations under the License.
 
 package v1alpha2
 
+import (
+	apiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+)
+
 // ExtensionReferenceApplyConfiguration represents a declarative configuration of the ExtensionReference type for use
 // with apply.
 type ExtensionReferenceApplyConfiguration struct {
-	Group      *string `json:"group,omitempty"`
-	Kind       *string `json:"kind,omitempty"`
-	Name       *string `json:"name,omitempty"`
-	PortNumber *int32  `json:"targetPortNumber,omitempty"`
+	Group      *apiv1alpha2.Group      `json:"group,omitempty"`
+	Kind       *apiv1alpha2.Kind       `json:"kind,omitempty"`
+	Name       *apiv1alpha2.ObjectName `json:"name,omitempty"`
+	PortNumber *apiv1alpha2.PortNumber `json:"portNumber,omitempty"`
 }
 
 // ExtensionReferenceApplyConfiguration constructs a declarative configuration of the ExtensionReference type for use with
@@ -35,7 +39,7 @@ func ExtensionReference() *ExtensionReferenceApplyConfiguration {
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Group field is set to the value of the last call.
-func (b *ExtensionReferenceApplyConfiguration) WithGroup(value string) *ExtensionReferenceApplyConfiguration {
+func (b *ExtensionReferenceApplyConfiguration) WithGroup(value apiv1alpha2.Group) *ExtensionReferenceApplyConfiguration {
 	b.Group = &value
 	return b
 }
@@ -43,7 +47,7 @@ func (b *ExtensionReferenceApplyConfiguration) WithGroup(value string) *Extensio
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Kind field is set to the value of the last call.
-func (b *ExtensionReferenceApplyConfiguration) WithKind(value string) *ExtensionReferenceApplyConfiguration {
+func (b *ExtensionReferenceApplyConfiguration) WithKind(value apiv1alpha2.Kind) *ExtensionReferenceApplyConfiguration {
 	b.Kind = &value
 	return b
 }
@@ -51,7 +55,7 @@ func (b *ExtensionReferenceApplyConfiguration) WithKind(value string) *Extension
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *ExtensionReferenceApplyConfiguration) WithName(value string) *ExtensionReferenceApplyConfiguration {
+func (b *ExtensionReferenceApplyConfiguration) WithName(value apiv1alpha2.ObjectName) *ExtensionReferenceApplyConfiguration {
 	b.Name = &value
 	return b
 }
@@ -59,7 +63,7 @@ func (b *ExtensionReferenceApplyConfiguration) WithName(value string) *Extension
 // WithPortNumber sets the PortNumber field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the PortNumber field is set to the value of the last call.
-func (b *ExtensionReferenceApplyConfiguration) WithPortNumber(value int32) *ExtensionReferenceApplyConfiguration {
+func (b *ExtensionReferenceApplyConfiguration) WithPortNumber(value apiv1alpha2.PortNumber) *ExtensionReferenceApplyConfiguration {
 	b.PortNumber = &value
 	return b
 }

--- a/client-go/applyconfiguration/api/v1alpha2/poolobjectreference.go
+++ b/client-go/applyconfiguration/api/v1alpha2/poolobjectreference.go
@@ -17,12 +17,16 @@ limitations under the License.
 
 package v1alpha2
 
+import (
+	apiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+)
+
 // PoolObjectReferenceApplyConfiguration represents a declarative configuration of the PoolObjectReference type for use
 // with apply.
 type PoolObjectReferenceApplyConfiguration struct {
-	Group *string `json:"group,omitempty"`
-	Kind  *string `json:"kind,omitempty"`
-	Name  *string `json:"name,omitempty"`
+	Group *apiv1alpha2.Group      `json:"group,omitempty"`
+	Kind  *apiv1alpha2.Kind       `json:"kind,omitempty"`
+	Name  *apiv1alpha2.ObjectName `json:"name,omitempty"`
 }
 
 // PoolObjectReferenceApplyConfiguration constructs a declarative configuration of the PoolObjectReference type for use with
@@ -34,7 +38,7 @@ func PoolObjectReference() *PoolObjectReferenceApplyConfiguration {
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Group field is set to the value of the last call.
-func (b *PoolObjectReferenceApplyConfiguration) WithGroup(value string) *PoolObjectReferenceApplyConfiguration {
+func (b *PoolObjectReferenceApplyConfiguration) WithGroup(value apiv1alpha2.Group) *PoolObjectReferenceApplyConfiguration {
 	b.Group = &value
 	return b
 }
@@ -42,7 +46,7 @@ func (b *PoolObjectReferenceApplyConfiguration) WithGroup(value string) *PoolObj
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Kind field is set to the value of the last call.
-func (b *PoolObjectReferenceApplyConfiguration) WithKind(value string) *PoolObjectReferenceApplyConfiguration {
+func (b *PoolObjectReferenceApplyConfiguration) WithKind(value apiv1alpha2.Kind) *PoolObjectReferenceApplyConfiguration {
 	b.Kind = &value
 	return b
 }
@@ -50,7 +54,7 @@ func (b *PoolObjectReferenceApplyConfiguration) WithKind(value string) *PoolObje
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *PoolObjectReferenceApplyConfiguration) WithName(value string) *PoolObjectReferenceApplyConfiguration {
+func (b *PoolObjectReferenceApplyConfiguration) WithName(value apiv1alpha2.ObjectName) *PoolObjectReferenceApplyConfiguration {
 	b.Name = &value
 	return b
 }

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
@@ -56,7 +56,9 @@ spec:
                     default: ""
                     description: |-
                       Group is the group of the referent.
-                      When unspecified or empty string, core API group is inferred.
+                      The default value is "", representing the Core API group.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     default: Service
@@ -71,14 +73,20 @@ spec:
                       terms of conformance. They also may not be safe to forward to (see
                       CVE-2021-25740 for more information). Implementations MUST NOT
                       support ExternalName Services.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
                     description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
                     type: string
-                  targetPortNumber:
+                  portNumber:
                     description: |-
-                      The port number on the service running the extension. When unspecified, implementations SHOULD infer a
-                      default value of 9002 when the Kind is Service.
+                      The port number on the service running the extension. When unspecified,
+                      implementations SHOULD infer a default value of 9002 when the Kind is
+                      Service.
                     format: int32
                     maximum: 65535
                     minimum: 1

--- a/pkg/epp/controller/inferencemodel_reconciler.go
+++ b/pkg/epp/controller/inferencemodel_reconciler.go
@@ -58,7 +58,7 @@ func (c *InferenceModelReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		notFound = true
 	}
 
-	if notFound || !infModel.DeletionTimestamp.IsZero() || infModel.Spec.PoolRef.Name != c.PoolNamespacedName.Name {
+	if notFound || !infModel.DeletionTimestamp.IsZero() || infModel.Spec.PoolRef.Name != v1alpha2.ObjectName(c.PoolNamespacedName.Name) {
 		// InferenceModel object got deleted or changed the referenced pool.
 		err := c.handleModelDeleted(ctx, req.NamespacedName)
 		return ctrl.Result{}, err
@@ -128,5 +128,5 @@ func (c *InferenceModelReconciler) SetupWithManager(ctx context.Context, mgr ctr
 }
 
 func (c *InferenceModelReconciler) eventPredicate(infModel *v1alpha2.InferenceModel) bool {
-	return (infModel.Spec.PoolRef.Name == c.PoolNamespacedName.Name) && (infModel.GetNamespace() == c.PoolNamespacedName.Namespace)
+	return (infModel.Spec.PoolRef.Name == v1alpha2.ObjectName(c.PoolNamespacedName.Name)) && (infModel.GetNamespace() == c.PoolNamespacedName.Namespace)
 }

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -184,7 +184,7 @@ func (ds *datastore) ModelResync(ctx context.Context, c client.Client, modelName
 	for i := range models.Items {
 		m := &models.Items[i]
 		if m.Spec.ModelName != modelName || // The index should filter those out, but just in case!
-			m.Spec.PoolRef.Name != ds.pool.Name || // We don't care about other pools, we could setup an index on this too!
+			m.Spec.PoolRef.Name != v1alpha2.ObjectName(ds.pool.Name) || // We don't care about other pools, we could setup an index on this too!
 			!m.DeletionTimestamp.IsZero() { // ignore objects marked for deletion
 			continue
 		}

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -110,7 +110,7 @@ func (m *InferenceModelWrapper) ModelName(modelName string) *InferenceModelWrapp
 }
 
 func (m *InferenceModelWrapper) PoolName(poolName string) *InferenceModelWrapper {
-	m.Spec.PoolRef = v1alpha2.PoolObjectReference{Name: poolName}
+	m.Spec.PoolRef = v1alpha2.PoolObjectReference{Name: v1alpha2.ObjectName(poolName)}
 	return m
 }
 

--- a/test/utils/wrappers.go
+++ b/test/utils/wrappers.go
@@ -58,9 +58,9 @@ func (m *InferenceModelWrapper) SetCriticality(level v1alpha2.Criticality) *Infe
 // for group/kind and name as the PoolObjectReference name.
 func (m *InferenceModelWrapper) SetPoolRef(name string) *InferenceModelWrapper {
 	ref := v1alpha2.PoolObjectReference{
-		Group: v1alpha2.GroupVersion.Group,
+		Group: v1alpha2.Group(v1alpha2.GroupVersion.Group),
 		Kind:  "inferencepools",
-		Name:  name,
+		Name:  v1alpha2.ObjectName(name),
 	}
 	m.Spec.PoolRef = ref
 	return m


### PR DESCRIPTION
Although we had most of this validation for the PoolObjectRef, we did not for the ExtensionRef. We also renamed the go field name from TargetPortNumber to PortNumber, but missed the corresponding json tag, this also fixes that.