### PR TITLE
Fixing default status on InferencePool

### DIFF
--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -168,13 +168,14 @@ type PoolStatus struct {
 	//
 	// Known condition types are:
 	//
-	// * "Ready"
+	// * "Accepted"
+	// * "ResolvedRefs"
 	//
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Ready", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
@@ -154,13 +154,14 @@ spec:
                         message: Waiting for controller
                         reason: Pending
                         status: Unknown
-                        type: Ready
+                        type: Accepted
                       description: |-
                         Conditions track the state of the InferencePool.
 
                         Known condition types are:
 
-                        * "Ready"
+                        * "Accepted"
+                        * "ResolvedRefs"
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.


### PR DESCRIPTION
Thanks to @nicolexin for finding this: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/446#pullrequestreview-2658642000

/cc @danehans @kfswain @ahg-g