### PR TITLE
Add the base model to InferenceModel sample manifest

### DIFF
--- a/config/manifests/inferencemodel.yaml
+++ b/config/manifests/inferencemodel.yaml
@@ -10,3 +10,14 @@ spec:
   targetModels:
   - name: tweet-summary-1
     weight: 100
+
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceModel
+metadata:
+  name: inferencemodel-base-model
+spec:
+  modelName: meta-llama/Llama-2-7b-hf
+  criticality: Critical
+  poolRef:
+    name: my-pool


### PR DESCRIPTION
Without this the gateway will return 404, though WAI, this can often lead to confusion especially for the first time user that the base model is not supported.