### PR TITLE
Add the base model of the cpu vllm sample app to InferenceModel.yaml

### DIFF
--- a/config/manifests/inferencemodel.yaml
+++ b/config/manifests/inferencemodel.yaml
@@ -21,3 +21,14 @@ spec:
   criticality: Critical
   poolRef:
     name: my-pool
+
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceModel
+metadata:
+  name: inferencemodel-base-model-cpu
+spec:
+  modelName: Qwen/Qwen2.5-1.5B-Instruct
+  criticality: Critical
+  poolRef:
+    name: my-pool


### PR DESCRIPTION
A follow up on https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/479#issuecomment-2717028402

Note our user guide uses the tweet-summary LoRA adapter as an example. If users follow the user guide carefully, they should not see the base model. This is just to avoid surprises for first time user if they see the base model and try to make a request like they normally do with any model server startup guides.