### PR TITLE
Update Makefile for BBR to ensure all proper tags are added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ bbr-image-build: ## Build the image using Docker Buildx.
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		$(PUSH) \
 		$(LOAD) \
-		.
+		$(BBR_IMAGE_BUILD_EXTRA_OPTS) ./
 
 .PHONY: bbr-image-push
 bbr-image-push: PUSH=--push ## Build the image and push it to $IMAGE_REPO.


### PR DESCRIPTION
Ran the `make bbr-image-build` command with `export EXTRA_TAG=main` as per cloudbuild.yaml and verified the generated image has the `main` tag.