### PR TITLE
Update GO version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/gateway-api-inference-extension
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.0
 
 require (
 	github.com/elastic/crd-ref-docs v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/gateway-api-inference-extension
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.2
+toolchain go1.24.2
 
 require (
 	github.com/elastic/crd-ref-docs v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/gateway-api-inference-extension
 
 go 1.24.0
 
-toolchain go1.24.0
-
 require (
 	github.com/elastic/crd-ref-docs v0.1.0
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4


### PR DESCRIPTION
Update GO version for certain functions that are not supported in `1.23` such as testing.Context to not block `make test` from running.