### PR TITLE
bump vllm-cpu image to latest

### DIFF
--- a/config/manifests/vllm/cpu-deployment.yaml
+++ b/config/manifests/vllm/cpu-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: lora
-          image: "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.7.2" # formal images can be found in https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
+          image: "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.8.0" # formal images can be found in https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:


### PR DESCRIPTION
this PR bumps vllm-cpu image to the latest image that was published yesterday (after testing that it's working).
as of now, they do not have the tag "latest" and therefore it's needed to specify the version.

I'll work with vllm community on publishing latest tag on every release as part of their CI/CD and then we can update our image to use "latest" tag.

until that happens, need to bump the version by PR