### PR TITLE
Bug fix: Initialize RequestReceivedTimestamp

### DIFF
--- a/pkg/epp/handlers/streamingserver.go
+++ b/pkg/epp/handlers/streamingserver.go
@@ -90,6 +90,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
+			reqCtx.RequestReceivedTimestamp = time.Now()
 			// Do nothing. Header info is handled in the HandleRequestBody func
 		case *extProcPb.ProcessingRequest_RequestBody:
 			loggerVerbose.Info("Incoming body chunk", "body", string(v.RequestBody.Body), "EoS", v.RequestBody.EndOfStream)


### PR DESCRIPTION
See the difference of the e2e request latency after this fix. Before the e2e latency was showing 1 hour (the max bucket)

![image](https://github.com/user-attachments/assets/0e03f249-55f4-47fd-b0db-690eab016e87)