### PR TITLE
Tag the main version of the helm chart with v0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,7 +25,6 @@ steps:
     args:
       - inferencepool-helm-chart-push
     env:
-    - GIT_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - GOTOOLCHAIN=auto
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36

--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -21,7 +21,7 @@ set -o pipefail
 DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
 
 EXTRA_TAG=${EXTRA_TAG:-$(git branch --show-current)} 
-GIT_TAG=${GIT_TAG:-$(git tag | sort | grep -v rc | tail -n1)-$(git describe --tags --dirty --always)}
+CHART_VERSION=${CHART_VERSION:-"v0"}
 
 STAGING_IMAGE_REGISTRY=${STAGING_IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images}
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-${STAGING_IMAGE_REGISTRY}/gateway-api-inference-extension}
@@ -32,9 +32,10 @@ HELM=${HELM:-./bin/helm}
 
 readonly semver_regex='^v([0-9]+)(\.[0-9]+){1,2}$'
 
-chart_version=${GIT_TAG}
+chart_version=${CHART_VERSION}
 if [[ ${EXTRA_TAG} =~ ${semver_regex} ]]
 then
+  # This is a release branch, use the release version
   ${YQ} -i '.inferenceExtension.image.tag=strenv(EXTRA_TAG)' config/charts/inferencepool/values.yaml
   chart_version=${EXTRA_TAG}
 fi


### PR DESCRIPTION
v0 indicates dev version in semver.

The problem is that `helm push` doesn't allow setting more than one tag on a published helm chart, and currently the charts we have in the staging repo are tagged with the git commit hash, which is not practical to use, see below:

![image](https://github.com/user-attachments/assets/252df498-1371-462f-9d05-08a47b6a1a13)

This PR tags the charts created from the main branch with v0 all the time (helm doesn't allow using version "main" like containers, and so using v0)


The dev epp version and chart would be installed as follows:

```
helm install vllm-llama-7b oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
--version v0 \
--set inferencePool.name=vllm-llama-7b \
--set inferencePool.selector.app=vllm-llama2-7b
```