### PR TITLE
Adding deprecation notice of BUFFERED mode on patch policy.

### DIFF
--- a/config/manifests/gateway/patch_policy.yaml
+++ b/config/manifests/gateway/patch_policy.yaml
@@ -55,6 +55,9 @@ spec:
         path: "/virtual_hosts/0/routes/0/route/cluster"
         value: original_destination_cluster
 # Comment the below to disable full duplex streaming
+# NOTE: As of https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/552
+# FULL_DUPLEX_STREAMED is the primary supported protocol for ext-proc. The buffered variant is no longer
+# being actively developed, may be missing features/fixes, and will soon be removed.
     - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
       name: "default/inference-gateway/llm-gw"
       operation:


### PR DESCRIPTION
Adding disclaimer to location where user would disable FULL_DUPLEX to indicate that Buffered communication between EPP <-> Proxy is no longer the default behavior

cc: @ahg-g 