### PR TITLE
Allow partial metric updates

### DIFF
--- a/pkg/epp/backend/metrics/metrics.go
+++ b/pkg/epp/backend/metrics/metrics.go
@@ -39,7 +39,8 @@ type PodMetricsClientImpl struct {
 	MetricMapping *MetricMapping
 }
 
-// FetchMetrics fetches metrics from a given pod.
+// FetchMetrics fetches metrics from a given pod, clones the existing metrics object and returns an
+// updated one.
 func (p *PodMetricsClientImpl) FetchMetrics(
 	ctx context.Context,
 	pod *Pod,

--- a/pkg/epp/backend/metrics/pod_metrics.go
+++ b/pkg/epp/backend/metrics/pod_metrics.go
@@ -116,16 +116,21 @@ func (pm *podMetrics) refreshMetrics() error {
 	updated, err := pm.pmc.FetchMetrics(ctx, pm.GetPod(), pm.GetMetrics(), pool.Spec.TargetPortNumber)
 	if err != nil {
 		pm.logger.V(logutil.TRACE).Info("Failed to refreshed metrics:", "err", err)
-		// As refresher is running in the background, it's possible that the pod is deleted but
-		// the refresh goroutine doesn't read the done channel yet. In this case, we just return nil.
-		// The refresher will be stopped after this interval.
-		return nil
 	}
-	updated.UpdateTime = time.Now()
+	// Optimistically update metrics even if there was an error.
+	// The FetchMetrics can return an error for the following reasons:
+	// 1. As refresher is running in the background, it's possible that the pod is deleted but
+	// the refresh goroutine doesn't read the done channel yet. In this case, the updated
+	// metrics object will be nil. And the refresher will soon be stopped.
+	// 2. The FetchMetrics call can partially fail. For example, due to one metric missing. In
+	// this case, the updated metrics object will have partial updates. A partial update is
+	// considered better than no updates.
+	if updated != nil {
+		updated.UpdateTime = time.Now()
+		pm.logger.V(logutil.TRACE).Info("Refreshed metrics", "updated", updated)
+		atomic.StorePointer(&pm.metrics, unsafe.Pointer(updated))
+	}
 
-	pm.logger.V(logutil.TRACE).Info("Refreshed metrics", "updated", updated)
-
-	atomic.StorePointer(&pm.metrics, unsafe.Pointer(updated))
 	return nil
 }
 


### PR DESCRIPTION
This PR allows partial metric updates even if the PodMetricsClient returns an error due to failure in processing a subset of the metrics. A partial update is considered better than no update.

A practical issue this fixes is that in vllm v1, if LoRA adapter is not enabled, the lora metrics won't even show up. Therefore the metrics won't get refreshed.

This also helps with any transient error in missing a metric.

Note1: For the LoRA metric, technically we can have a flag to indicate whether we can skip scraping it. That can be a separate followup.

Note2: There should be a separate "conformance test" effort to make sure the supported model server emit the metrics required by our protocol. The PodMetricsClient shouldn't be responsible for that. Therefore it's safe to optimistically allow partial updates.