### PR TITLE
Docs: Updates getting started guide for kgateway

### DIFF
--- a/config/manifests/gateway/kgateway/resources.yaml
+++ b/config/manifests/gateway/kgateway/resources.yaml
@@ -1,0 +1,40 @@
+# Requires Kgateway 2.0.0 or greater.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: inference-gateway
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+    - name: llm-gw
+      protocol: HTTP
+      port: 8081
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: inference-gateway
+    sectionName: llm-gw
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: vllm-llama2-7b
+      port: 8000
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      backendRequest: 24h
+      request: 24h


### PR DESCRIPTION
- Uses tabs to separate implementations.
- Moves Envoy Gateway-specific content to Envoy Gateway tab.
- Adds a Kgateway tab with instructions for using Kgateway as an Inference Gateway.