### PR TITLE
update algorithm parameters from env variables

### DIFF
--- a/pkg/epp/scheduling/filter.go
+++ b/pkg/epp/scheduling/filter.go
@@ -141,7 +141,7 @@ func leastQueuingFilterFunc(logger logr.Logger, req *LLMRequest, pods []backendm
 }
 
 func lowQueueingPodPredicate(_ *LLMRequest, pod backendmetrics.PodMetrics) bool {
-	return pod.GetMetrics().WaitingQueueSize < queueingThresholdLoRA
+	return pod.GetMetrics().WaitingQueueSize < config.QueueingThresholdLoRA
 }
 
 // leastKVCacheFilterFunc finds the max and min KV cache of all pods, divides the whole range
@@ -223,7 +223,7 @@ func loRASoftAffinityFilter(logger logr.Logger, req *LLMRequest, pods []backendm
 
 	// If both groups have pods, use probability to select which group to return
 	if len(filtered_affinity) > 0 && len(filtered_available) > 0 {
-		if randGen.Float64() < loraAffinityThreshold {
+		if randGen.Float64() < config.LoraAffinityThreshold {
 			return filtered_affinity, nil
 		}
 		return filtered_available, nil

--- a/pkg/epp/scheduling/filter_test.go
+++ b/pkg/epp/scheduling/filter_test.go
@@ -449,23 +449,11 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 
 	// Set a specific test value for this test
 	testThreshold := 0.75 // 75%
-	// Inline update of threshold value
-	func(newValue float64, logger logr.Logger) {
-		logger.V(logutil.DEFAULT).Info("Updating LoRA affinity threshold",
-			"oldValue", config.LoraAffinityThreshold,
-			"newValue", newValue)
-		config.LoraAffinityThreshold = newValue
-	}(testThreshold, logger)
+	config.LoraAffinityThreshold = testThreshold
 
 	// Ensure we restore the original threshold when test completes
 	defer func() {
-		// Inline update to restore original value
-		func(newValue float64, logger logr.Logger) {
-			logger.V(logutil.DEFAULT).Info("Updating LoRA affinity threshold",
-				"oldValue", config.LoraAffinityThreshold,
-				"newValue", newValue)
-			config.LoraAffinityThreshold = newValue
-		}(originalThreshold, logger)
+		config.LoraAffinityThreshold = originalThreshold
 	}()
 
 

--- a/pkg/epp/scheduling/filter_test.go
+++ b/pkg/epp/scheduling/filter_test.go
@@ -430,6 +430,15 @@ func TestFilterFunc(t *testing.T) {
 	}
 }
 
+// UpdateLoraAffinityThreshold updates the LoRA affinity threshold value
+// This is useful for testing or dynamic reconfiguration
+func UpdateLoraAffinityThreshold(newValue float64, logger logr.Logger) {
+	logger.V(logutil.DEFAULT).Info("Updating LoRA affinity threshold",
+		"oldValue", config.LoraAffinityThreshold,
+		"newValue", newValue)
+	config.LoraAffinityThreshold = newValue
+}
+
 // TestLoRASoftAffinityDistribution tests that the loRASoftAffinityFilter function
 // properly distributes requests according to the loraAffinityThreshold
 func TestLoRASoftAffinityDistribution(t *testing.T) {

--- a/pkg/epp/scheduling/filter_test.go
+++ b/pkg/epp/scheduling/filter_test.go
@@ -430,8 +430,6 @@ func TestFilterFunc(t *testing.T) {
 	}
 }
 
-
-
 // TestLoRASoftAffinityDistribution tests that the loRASoftAffinityFilter function
 // properly distributes requests according to the loraAffinityThreshold
 func TestLoRASoftAffinityDistribution(t *testing.T) {
@@ -455,7 +453,6 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 	defer func() {
 		config.LoraAffinityThreshold = originalThreshold
 	}()
-
 
 	// Create a test request and pods
 	req := &LLMRequest{

--- a/pkg/epp/scheduling/filter_test.go
+++ b/pkg/epp/scheduling/filter_test.go
@@ -430,14 +430,7 @@ func TestFilterFunc(t *testing.T) {
 	}
 }
 
-// UpdateLoraAffinityThreshold updates the LoRA affinity threshold value
-// This is useful for testing or dynamic reconfiguration
-func UpdateLoraAffinityThreshold(newValue float64, logger logr.Logger) {
-	logger.V(logutil.DEFAULT).Info("Updating LoRA affinity threshold",
-		"oldValue", config.LoraAffinityThreshold,
-		"newValue", newValue)
-	config.LoraAffinityThreshold = newValue
-}
+
 
 // TestLoRASoftAffinityDistribution tests that the loRASoftAffinityFilter function
 // properly distributes requests according to the loraAffinityThreshold
@@ -456,12 +449,25 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 
 	// Set a specific test value for this test
 	testThreshold := 0.75 // 75%
-	UpdateLoraAffinityThreshold(testThreshold, logger)
+	// Inline update of threshold value
+	func(newValue float64, logger logr.Logger) {
+		logger.V(logutil.DEFAULT).Info("Updating LoRA affinity threshold",
+			"oldValue", config.LoraAffinityThreshold,
+			"newValue", newValue)
+		config.LoraAffinityThreshold = newValue
+	}(testThreshold, logger)
 
 	// Ensure we restore the original threshold when test completes
 	defer func() {
-		UpdateLoraAffinityThreshold(originalThreshold, logger)
+		// Inline update to restore original value
+		func(newValue float64, logger logr.Logger) {
+			logger.V(logutil.DEFAULT).Info("Updating LoRA affinity threshold",
+				"oldValue", config.LoraAffinityThreshold,
+				"newValue", newValue)
+			config.LoraAffinityThreshold = newValue
+		}(originalThreshold, logger)
 	}()
+
 
 	// Create a test request and pods
 	req := &LLMRequest{

--- a/pkg/epp/scheduling/filter_test.go
+++ b/pkg/epp/scheduling/filter_test.go
@@ -442,6 +442,18 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 		tolerancePercent  = 5.0 // Allow 5% tolerance from expected distribution
 	)
 
+	// Save original config value to restore later
+	originalThreshold := config.LoraAffinityThreshold
+
+	// Set a specific test value for this test
+	testThreshold := 0.75 // 75%
+	UpdateLoraAffinityThreshold(testThreshold, logger)
+
+	// Ensure we restore the original threshold when test completes
+	defer func() {
+		UpdateLoraAffinityThreshold(originalThreshold, logger)
+	}()
+
 	// Create a test request and pods
 	req := &LLMRequest{
 		Model:               testAffinityModel,
@@ -472,9 +484,10 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 	affinityCount := 0
 	availableCount := 0
 
-	// Use the actual loraAffinityThreshold as defined in the original code
-	// This test should work with whatever value is set there
-	expectedAffinityPercent := loraAffinityThreshold * 100
+	// Use the test threshold value
+	expectedAffinityPercent := config.LoraAffinityThreshold * 100
+	expectedAvailabilityPercent := 100 - expectedAffinityPercent
+
 	for i := 0; i < numIterations; i++ {
 		result, err := loRASoftAffinityFilter(logger, req, toInterface(pods))
 		if err != nil {
@@ -502,11 +515,12 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 	affinityLowerBound := expectedAffinityPercent - tolerancePercent
 	affinityUpperBound := expectedAffinityPercent + tolerancePercent
 
-	availableLowerBound := actualAvailablePercent - tolerancePercent
-	availableUpperBound := actualAvailablePercent + tolerancePercent
+	availableLowerBound := expectedAvailabilityPercent - tolerancePercent
+	availableUpperBound := expectedAvailabilityPercent + tolerancePercent
 
 	t.Logf("Distribution results over %d iterations:", numIterations)
-	t.Logf("Expected affinity percent: %.2f%% (threshold: %.2f)", expectedAffinityPercent, loraAffinityThreshold)
+	t.Logf("Expected affinity percent: %.2f%% (threshold: %.2f)", expectedAffinityPercent, config.LoraAffinityThreshold)
+	t.Logf("Expected availability percent: %.2f%% (threshold: %.2f)", expectedAvailabilityPercent, config.LoraAffinityThreshold)
 	t.Logf("Actual affinity percent: %.2f%% (%d out of %d)", actualAffinityPercent, affinityCount, numIterations)
 	t.Logf("Actual available percent: %.2f%% (%d out of %d)", actualAvailablePercent, availableCount, numIterations)
 

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -26,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
+	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
-	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 )
 
 // Config holds all the configuration values for the scheduler
@@ -130,8 +130,6 @@ var (
 	}
 )
 
-
-
 func NewScheduler(datastore datastore.Datastore) *Scheduler {
 	return &Scheduler{
 		datastore: datastore,
@@ -150,7 +148,7 @@ func (s *Scheduler) Schedule(ctx context.Context, req *LLMRequest) (targetPod ba
 
 	podMetrics := s.datastore.PodGetAll()
 	logger.V(logutil.DEBUG).Info(fmt.Sprintf("Scheduling a request. Metrics: %+v", podMetrics))
-  
+
 	pods, err := s.filter.Filter(logger, req, podMetrics)
 	if err != nil || len(pods) == 0 {
 		return nil, fmt.Errorf("failed to apply filter, resulted %v pods, this should never happen: %w", len(pods), err)

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -39,7 +39,7 @@ type Config struct {
 	LoraAffinityThreshold  float64
 }
 
-var (
+const (
 	// Default values to use if environment variables are not set
 	defaultKVCacheThreshold       = 0.8
 	defaultQueueThresholdCritical = 5
@@ -59,11 +59,7 @@ func LoadConfig() Config {
 		LoraAffinityThreshold:  envutil.GetEnvFloat("LORA_AFFINITY_THRESHOLD", defaultLoraAffinityThreshold, baseLogger),
 	}
 
-	baseLogger.V(logutil.DEFAULT).Info("Scheduler configuration loaded",
-		"kvCacheThreshold", config.KVCacheThreshold,
-		"queueThresholdCritical", config.QueueThresholdCritical,
-		"queueingThresholdLoRA", config.QueueingThresholdLoRA,
-		"loraAffinityThreshold", config.LoraAffinityThreshold)
+	baseLogger.V(logutil.DEFAULT).Info("Scheduler configuration loaded", "config", config)
 
 	return config
 }
@@ -154,10 +150,7 @@ func (s *Scheduler) Schedule(ctx context.Context, req *LLMRequest) (targetPod ba
 
 	// Log current configuration values for debugging purposes.
 	logger.V(logutil.TRACE).Info("Scheduler configuration",
-		"KVCacheThreshold", config.KVCacheThreshold,
-		"QueueThresholdCritical", config.QueueThresholdCritical,
-		"QueueingThresholdLoRA", config.QueueingThresholdLoRA,
-		"LoraAffinityThreshold", config.LoraAffinityThreshold,
+		"config", config,
 	)
 
 	podMetrics := s.datastore.PodGetAll()

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -148,11 +148,6 @@ type Scheduler struct {
 func (s *Scheduler) Schedule(ctx context.Context, req *LLMRequest) (targetPod backendmetrics.PodMetrics, err error) {
 	logger := log.FromContext(ctx).WithValues("request", req)
 
-	// Log current configuration values for debugging purposes.
-	logger.V(logutil.TRACE).Info("Scheduler configuration",
-		"config", config,
-	)
-
 	podMetrics := s.datastore.PodGetAll()
 	logger.V(logutil.DEBUG).Info(fmt.Sprintf("Scheduling a request. Metrics: %+v", podMetrics))
   

--- a/pkg/epp/util/env/env.go
+++ b/pkg/epp/util/env/env.go
@@ -1,0 +1,51 @@
+package env
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+// getEnvFloat gets a float64 from an environment variable with a default value
+func GetEnvFloat(key string, defaultVal float64, logger logr.Logger) float64 {
+	val, exists := os.LookupEnv(key)
+	if !exists {
+		logger.V(logutil.VERBOSE).Info("Environment variable not set, using default value",
+			"key", key, "defaultValue", defaultVal)
+		return defaultVal
+	}
+
+	floatVal, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		logger.V(logutil.VERBOSE).Info("Failed to parse environment variable as float, using default value",
+			"key", key, "value", val, "error", err, "defaultValue", defaultVal)
+		return defaultVal
+	}
+
+	logger.V(logutil.VERBOSE).Info("Successfully loaded environment variable",
+		"key", key, "value", floatVal)
+	return floatVal
+}
+
+// getEnvInt gets an int from an environment variable with a default value
+func GetEnvInt(key string, defaultVal int, logger logr.Logger) int {
+	val, exists := os.LookupEnv(key)
+	if !exists {
+		logger.V(logutil.VERBOSE).Info("Environment variable not set, using default value",
+			"key", key, "defaultValue", defaultVal)
+		return defaultVal
+	}
+
+	intVal, err := strconv.Atoi(val)
+	if err != nil {
+		logger.V(logutil.VERBOSE).Info("Failed to parse environment variable as int, using default value",
+			"key", key, "value", val, "error", err, "defaultValue", defaultVal)
+		return defaultVal
+	}
+
+	logger.V(logutil.VERBOSE).Info("Successfully loaded environment variable",
+		"key", key, "value", intVal)
+	return intVal
+}

--- a/pkg/epp/util/env/env_test.go
+++ b/pkg/epp/util/env/env_test.go
@@ -1,0 +1,144 @@
+package env
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+func TestGetEnvFloat(t *testing.T) {
+	logger := testr.New(t)
+
+	tests := []struct {
+		name       string
+		key        string
+		value      string
+		defaultVal float64
+		expected   float64
+		setup      func()
+		teardown   func()
+	}{
+		{
+			name:       "env variable exists and is valid",
+			key:        "TEST_FLOAT",
+			value:      "123.456",
+			defaultVal: 0.0,
+			expected:   123.456,
+			setup: func() {
+				os.Setenv("TEST_FLOAT", "123.456")
+			},
+			teardown: func() {
+				os.Unsetenv("TEST_FLOAT")
+			},
+		},
+		{
+			name:       "env variable exists but is invalid",
+			key:        "TEST_FLOAT",
+			value:      "invalid",
+			defaultVal: 99.9,
+			expected:   99.9,
+			setup: func() {
+				os.Setenv("TEST_FLOAT", "invalid")
+			},
+			teardown: func() {
+				os.Unsetenv("TEST_FLOAT")
+			},
+		},
+		{
+			name:       "env variable does not exist",
+			key:        "TEST_FLOAT_MISSING",
+			defaultVal: 42.42,
+			expected:   42.42,
+			setup:      func() {},
+			teardown:   func() {},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			defer tc.teardown()
+
+			result := GetEnvFloat(tc.key, tc.defaultVal, logger.V(logutil.VERBOSE))
+			if result != tc.expected {
+				t.Errorf("GetEnvFloat(%s, %f) = %f, expected %f", tc.key, tc.defaultVal, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	logger := testr.New(t)
+
+	tests := []struct {
+		name       string
+		key        string
+		value      string
+		defaultVal int
+		expected   int
+		setup      func()
+		teardown   func()
+	}{
+		{
+			name:       "env variable exists and is valid",
+			key:        "TEST_INT",
+			value:      "123",
+			defaultVal: 0,
+			expected:   123,
+			setup: func() {
+				os.Setenv("TEST_INT", "123")
+			},
+			teardown: func() {
+				os.Unsetenv("TEST_INT")
+			},
+		},
+		{
+			name:       "env variable exists but is invalid",
+			key:        "TEST_INT",
+			value:      "invalid",
+			defaultVal: 99,
+			expected:   99,
+			setup: func() {
+				os.Setenv("TEST_INT", "invalid")
+			},
+			teardown: func() {
+				os.Unsetenv("TEST_INT")
+			},
+		},
+		{
+			name:       "env variable does not exist",
+			key:        "TEST_INT_MISSING",
+			defaultVal: 42,
+			expected:   42,
+			setup:      func() {},
+			teardown:   func() {},
+		},
+		{
+			name:       "env variable is empty string",
+			key:        "TEST_INT_EMPTY",
+			value:      "",
+			defaultVal: 77,
+			expected:   77,
+			setup: func() {
+				os.Setenv("TEST_INT_EMPTY", "")
+			},
+			teardown: func() {
+				os.Unsetenv("TEST_INT_EMPTY")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			defer tc.teardown()
+
+			result := GetEnvInt(tc.key, tc.defaultVal, logger.V(logutil.VERBOSE))
+			if result != tc.expected {
+				t.Errorf("GetEnvInt(%s, %d) = %d, expected %d", tc.key, tc.defaultVal, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a significant refactor to make scheduler configuration values dynamically configurable through environment variables. The changes include creating a new `Config` struct to hold configuration values, updating various functions to use these new configuration values, and adding utility functions to load configuration from environment variables.

Key changes include:

Configuration Management:
* Added `Config` struct to hold configuration values (`KVCacheThreshold`, `QueueThresholdCritical`, `QueueingThresholdLoRA`, `LoraAffinityThreshold`) and initialized it using environment variables (`pkg/epp/scheduling/scheduler.go`).
* Implemented utility functions `getEnvFloat` and `getEnvInt` to retrieve configuration values from environment variables with default fallbacks (`pkg/epp/scheduling/scheduler.go`).

Function Updates:
* Updated `leastQueuingFilterFunc` and `loRASoftAffinityFilter` to use the new configuration values (`pkg/epp/scheduling/filter.go`). [[1]](diffhunk://#diff-39a77c3f30c969fdb254c6c00de96eb242c30bb66489d56fc572b9e549c97363L144-R144) [[2]](diffhunk://#diff-39a77c3f30c969fdb254c6c00de96eb242c30bb66489d56fc572b9e549c97363L226-R226)

Testing Enhancements:
* Modified `TestLoRASoftAffinityDistribution` to set and restore configuration values for testing purposes (`pkg/epp/scheduling/filter_test.go`). [[1]](diffhunk://#diff-96eede232beb0e3f1b04523a8f9c3e5e4f8db91ec3037e3f96bc6344d9c18ff5R445-R456) [[2]](diffhunk://#diff-96eede232beb0e3f1b04523a8f9c3e5e4f8db91ec3037e3f96bc6344d9c18ff5L475-R490) [[3]](diffhunk://#diff-96eede232beb0e3f1b04523a8f9c3e5e4f8db91ec3037e3f96bc6344d9c18ff5L505-R523)

Scheduler Enhancements:
* Added logging of current configuration values in the `Schedule` method for better debugging (`pkg/epp/scheduling/scheduler.go`).
* Added `UpdateLoraAffinityThreshold` function to allow dynamic updates of the LoRA affinity threshold (`pkg/epp/scheduling/scheduler.go`).[Copilot is generating a summary...]

**tested with:**
        - name: KV_CACHE_THRESHOLD
          value: "0.9"
        - name: QUEUE_THRESHOLD_CRITICAL
          value: "10"
        - name: QUEUING_THRESHOLD_LORA
          value: "23"
        - name: LORA_AFFINITY_THRESHOLD
          value: "0.7"
 **logs printed:**
2025-03-26T20:44:36Z    LEVEL(-3)       scheduling/scheduler.go:206     Scheduler configuration {"request": {"Model":"meta-llama/Llama-2-7b-hf","TargetModels":null,"ResolvedTargetModel":"meta-llama/Llama-2-7b-hf","Critical":true}, "KVCacheThreshold": 0.9, "QueueThresholdCritical": 10, "QueueingThresholdLoRA": 23, "LoraAffinityThreshold": 0.7}
2025-03-26T20:44:36Z    LEVEL(-3)       scheduling/scheduler.go:214     Scheduling a request.