### PR TITLE
Setting zap to emit logs as JSON in the deployment.

### DIFF
--- a/config/manifests/inferencepool.yaml
+++ b/config/manifests/inferencepool.yaml
@@ -50,6 +50,8 @@ spec:
         - "vllm-llama2-7b"
         - -v
         - "4"
+        - --zap-encoder
+        - "json"
         - -grpcPort
         - "9002"
         - -grpcHealthPort


### PR DESCRIPTION
This is a small fix to default the zap logging output to json rather than console, allowing the log severity to be picked up by a logging tool. The default is `json` unless you have the `Development` flag set to true, which we do. 

Configuration of that flag can be done in a separate PR, this is just a quick patch fix.