### PR TITLE
Adding terminationGracePeriodSeconds to match vLLMs

### DIFF
--- a/config/charts/inferencepool/templates/epp-deployment.yaml
+++ b/config/charts/inferencepool/templates/epp-deployment.yaml
@@ -16,6 +16,8 @@ spec:
         {{- include "gateway-api-inference-extension.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "gateway-api-inference-extension.name" . }}
+      # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
+      terminationGracePeriodSeconds: 130
       containers:
       - name: epp
         image: {{ .Values.inferenceExtension.image.hub }}/{{ .Values.inferenceExtension.image.name }}:{{ .Values.inferenceExtension.image.tag }}

--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -42,6 +42,8 @@ spec:
       labels:
         app: vllm-llama3-8b-instruct-epp
     spec:
+      # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
+      terminationGracePeriodSeconds: 130
       containers:
       - name: epp
         image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main


### PR DESCRIPTION
Fixes #548 
Tested 3 scenarios:
- Scale up to 4 replicas
- Scale down to 1 replica
- Rollout restart a single replica

There are small dips in the metric, but the largest dip was on scale up, so I believe the QPS dip is due to imperfect metric read as instances come up/down
![image](https://github.com/user-attachments/assets/e0699718-affa-4802-aab6-7660b27019fb)
