### PR TITLE
Docs: Quickstart Fixes

### DIFF
--- a/config/manifests/gateway/httproute-with-timeout.yaml
+++ b/config/manifests/gateway/httproute-with-timeout.yaml
@@ -11,7 +11,7 @@ spec:
   - backendRefs:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
-      name: vllm-llama2-7b
+      name: vllm-llama3-8b-instruct
     matches:
     - path:
         type: PathPrefix

--- a/config/manifests/gateway/httproute.yaml
+++ b/config/manifests/gateway/httproute.yaml
@@ -11,7 +11,7 @@ spec:
   - backendRefs:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
-      name: vllm-llama2-7b
+      name: vllm-llama3-8b-instruct
     matches:
     - path:
         type: PathPrefix

--- a/config/manifests/inferencemodel.yaml
+++ b/config/manifests/inferencemodel.yaml
@@ -8,7 +8,7 @@ spec:
   poolRef:
     name: vllm-llama3-8b-instruct
   targetModels:
-  - name: food-review-1
+  - name: food-review
     weight: 100
 
 ---


### PR DESCRIPTION
1. The InferencePool name referenced by the quick start guide (`https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/inferencepool-resources.yaml`) is no longer `vllm-llama2-7b`:

```
apiVersion: inference.networking.x-k8s.io/v1alpha2
kind: InferencePool
metadata:
  labels:
  name: vllm-llama3-8b-instruct
spec:
  targetPortNumber: 8000
  selector:
    app: vllm-llama3-8b-instruct
  extensionRef:
    name: vllm-llama3-8b-instruct-epp
```

2. The `food-review-1` model does not exist. Updates the `food-review` example InferenceModel to use the correct target model name:

```
$ kubextl exec deploy/vllm-llama3-8b-instruct -- curl 127.0.0.1:8000/v1/models | jq .
...
    {
      "id": "food-review",
      "object": "model",
...
```