### PR TITLE
Fixes Adapter ConfigMap Name Refs

### DIFF
--- a/config/manifests/vllm/gpu-deployment.yaml
+++ b/config/manifests/vllm/gpu-deployment.yaml
@@ -235,12 +235,12 @@ spec:
           emptyDir: {}
         - name: config-volume
           configMap:
-            name: vllm-llama3-8b-adapters
+            name: vllm-llama3-8b-instruct-adapters
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vllm-llama3-8b-adapters
+  name: vllm-llama3-8b-instruct-adapters
 data:
   configmap.yaml: |
       vLLMLoRAConfig:

--- a/tools/dynamic-lora-sidecar/README.md
+++ b/tools/dynamic-lora-sidecar/README.md
@@ -83,7 +83,7 @@ In this example, both adapters will use `meta-llama/Llama-3.1-8B-Instruct` as th
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vllm-llama3-8b-adapters
+  name: vllm-llama3-8b-instruct-adapters
 data:
   configmap.yaml: |
       vLLMLoRAConfig:


### PR DESCRIPTION
Updates the adapter ConfigMap name since the [adapter rollout guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/adapter-rollout/) refers to the adapter confimap as `vllm-llama3-8b-instruct-adapters`.