### PR TITLE
Update e2e test config

### DIFF
--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -94,11 +94,11 @@ var _ = ginkgo.Describe("InferencePool", func() {
 func newInferenceModel(ns string) *v1alpha2.InferenceModel {
 	targets := []v1alpha2.TargetModel{
 		{
-			Name:   modelName + "-0",
+			Name:   modelName,
 			Weight: ptr.To(int32(50)),
 		},
 		{
-			Name:   modelName + "-1",
+			Name:   "cad-fabricator",
 			Weight: ptr.To(int32(50)),
 		},
 	}

--- a/test/testdata/envoy.yaml
+++ b/test/testdata/envoy.yaml
@@ -104,10 +104,11 @@ data:
                             timeout: 10s
                           processing_mode:
                             request_header_mode: SEND
-                            response_header_mode: SKIP
-                            request_body_mode: BUFFERED
-                            request_trailer_mode: SKIP
-                            response_trailer_mode: SKIP
+                            response_header_mode: SEND
+                            request_body_mode: FULL_DUPLEX_STREAMED
+                            response_body_mode: FULL_DUPLEX_STREAMED
+                            request_trailer_mode: SEND
+                            response_trailer_mode: SEND
                           message_timeout: 1000s
                         # Mark it as disabled if needed for troubleshooting:
                         # disabled: true
@@ -221,7 +222,7 @@ spec:
     spec:
       containers:
       - name: envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.32.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.33.2
         args:
           - "--service-cluster" 
           - "default/inference-gateway"


### PR DESCRIPTION
Moving to FULL DUPLEX STREAM as the default, and updating the base model + LoRA adapter caused the e2e tests to fall out of sync.

Fixes: #619 