### PR TITLE
Docs: Bumps Kgateway to v2.0.0

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -201,7 +201,7 @@ This quickstart guide is intended for engineers familiar with k8s and model serv
       2. Set the Kgateway version and install the Kgateway CRDs.
 
          ```bash
-         KGTW_VERSION=v2.0.0-rc.2
+         KGTW_VERSION=v2.0.0
          helm upgrade -i --create-namespace --namespace kgateway-system --version $KGTW_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
          ```
 


### PR DESCRIPTION
Bumps Kgateway to v2.0.0 in the quickstart guide.