### PR TITLE
Use dedicated namespace for e2e test code

### DIFF
--- a/config/manifests/vllm/cpu-deployment.yaml
+++ b/config/manifests/vllm/cpu-deployment.yaml
@@ -113,5 +113,8 @@ data:
         ensureExist:
           models:
           - base-model: Qwen/Qwen2.5-1.5B
-            id: food-review-1
+            id: food-review
+            source: SriSanth2345/Qwen-1.5B-Tweet-Generations
+          - base-model: Qwen/Qwen2.5-1.5B
+            id: cad-fabricator
             source: SriSanth2345/Qwen-1.5B-Tweet-Generations

--- a/test/e2e/epp/README.md
+++ b/test/e2e/epp/README.md
@@ -28,6 +28,13 @@ Follow these steps to run the end-to-end tests:
    export HF_TOKEN=<MY_HF_TOKEN>
    ```
 
+1. **(Optional): Set the test namespace**: By default, the e2e test creates resources in the `inf-ext-e2e` namespace.
+   If you would like to change this namespace, set the following environment variable:
+
+   ```sh
+   export E2E_NS=<MY_NS>
+   ```
+
 1. **Run the Tests**: Run the `test-e2e` target:
 
    ```sh

--- a/test/testdata/envoy.yaml
+++ b/test/testdata/envoy.yaml
@@ -100,7 +100,7 @@ data:
                           grpc_service:
                             envoy_grpc:
                               cluster_name: ext_proc
-                              authority: vllm-llama3-8b-instruct-epp.default:9002
+                              authority: vllm-llama3-8b-instruct-epp.$E2E_NS:9002
                             timeout: 10s
                           processing_mode:
                             request_header_mode: SEND
@@ -195,7 +195,7 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: vllm-llama3-8b-instruct-epp.default
+                          address: vllm-llama3-8b-instruct-epp.$E2E_NS
                           port_value: 9002
                     health_status: HEALTHY
                     load_balancing_weight: 1
@@ -225,7 +225,7 @@ spec:
         image: docker.io/envoyproxy/envoy:distroless-v1.33.2
         args:
           - "--service-cluster" 
-          - "default/inference-gateway"
+          - "$E2E_NS/inference-gateway"
           - "--service-node"
           - "$(ENVOY_POD_NAME)"
           - "--log-level"

--- a/test/testdata/inferencepool-e2e.yaml
+++ b/test/testdata/inferencepool-e2e.yaml
@@ -1,6 +1,3 @@
-# Note: If you change this file, please also change the file used for e2e tests!
-# 
-# https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/test/testdata/inferencepool-e2e.yaml
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
@@ -12,12 +9,13 @@ spec:
     app: vllm-llama3-8b-instruct
   extensionRef:
     name: vllm-llama3-8b-instruct-epp
+    namespace: $E2E_NS
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: vllm-llama3-8b-instruct-epp
-  namespace: default
+  namespace: $E2E_NS
 spec:
   selector:
     app: vllm-llama3-8b-instruct-epp
@@ -32,7 +30,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vllm-llama3-8b-instruct-epp
-  namespace: default
+  namespace: $E2E_NS
   labels:
     app: vllm-llama3-8b-instruct-epp
 spec:
@@ -54,6 +52,8 @@ spec:
         args:
         - -poolName
         - "vllm-llama3-8b-instruct"
+        - -poolNamespace
+        - "$E2E_NS"
         - -v
         - "4"
         - --zap-encoder
@@ -120,7 +120,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: default
+  namespace: $E2E_NS
 roleRef:
   kind: ClusterRole
   name: pod-read


### PR DESCRIPTION
Fixed #227 

/assign @danehans 

See results of E2E run below using the CPU-based vLLM:

```
rramkumar@rramkumar:~/gateway-api-inference-extension$ export E2E_MANIFEST_PATH=config/manifests/vllm/cpu-deployment.yaml
rramkumar@rramkumar:~/gateway-api-inference-extension$ export E2E_NS=foobar
rramkumar@rramkumar:~/gateway-api-inference-extension$ make test-e2e
MANIFEST_PATH=/usr/local/google/home/rramkumar/gateway-api-inference-extension/config/manifests/vllm/cpu-deployment.yaml go test ./test/e2e/epp/ -v -ginkgo.v
=== RUN   TestAPIs
Running Suite: End To End Test Suite - /usr/local/google/home/rramkumar/gateway-api-inference-extension/test/e2e/epp
====================================================================================================================
Random Seed: 1744127212

Will run 1 of 1 specs
------------------------------
[BeforeSuite] 
/usr/local/google/home/rramkumar/gateway-api-inference-extension/test/e2e/epp/e2e_suite_test.go:104
  STEP: Setting up the test suite @ 04/08/25 15:46:52.744
  STEP: Creating test infrastructure @ 04/08/25 15:46:52.746
  STEP: Creating e2e namespace: foobar @ 04/08/25 15:46:52.746
  STEP: Ensuring MANIFEST_PATH environment variable is set @ 04/08/25 15:46:53.222
  STEP: Ensuring the model server manifest points to an existing file @ 04/08/25 15:46:53.222
  STEP: Reading YAML file: /usr/local/google/home/rramkumar/gateway-api-inference-extension/config/manifests/vllm/cpu-deployment.yaml @ 04/08/25 15:46:53.222
  STEP: Creating CRD resource from manifest: ../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml @ 04/08/25 15:46:53.223
  STEP: Reading YAML file: ../../../config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml @ 04/08/25 15:46:53.223
  STEP: Decoded GVK: apiextensions.k8s.io/v1, Kind=CustomResourceDefinition @ 04/08/25 15:46:53.224
  STEP: Checking CRD inferencemodels.inference.networking.x-k8s.io status is: Established @ 04/08/25 15:46:53.468
  STEP: Creating CRD resource from manifest: ../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml @ 04/08/25 15:46:53.545
  STEP: Reading YAML file: ../../../config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml @ 04/08/25 15:46:53.545
  STEP: Decoded GVK: apiextensions.k8s.io/v1, Kind=CustomResourceDefinition @ 04/08/25 15:46:53.547
  STEP: Checking CRD inferencepools.inference.networking.x-k8s.io status is: Established @ 04/08/25 15:46:53.758
  STEP: Reading YAML file: ../../testdata/inferencepool-e2e.yaml @ 04/08/25 15:46:53.833
  STEP: Replacing placeholder namespace with E2E_NS environment variable @ 04/08/25 15:46:53.833
  STEP: Creating inference extension resources from manifest: ../../testdata/inferencepool-e2e.yaml @ 04/08/25 15:46:53.833
  STEP: Decoded GVK: inference.networking.x-k8s.io/v1alpha2, Kind=InferencePool @ 04/08/25 15:46:53.834
  STEP: Decoded GVK: /v1, Kind=Service @ 04/08/25 15:46:56.021
  STEP: Decoded GVK: apps/v1, Kind=Deployment @ 04/08/25 15:46:56.139
  STEP: Decoded GVK: rbac.authorization.k8s.io/v1, Kind=ClusterRole @ 04/08/25 15:46:56.249
  STEP: Decoded GVK: rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding @ 04/08/25 15:46:56.374
  STEP: Checking if deployment foobar/vllm-llama3-8b-instruct-epp status is: Available @ 04/08/25 15:46:56.825
  STEP: Creating client resources from manifest: ../../testdata/client.yaml @ 04/08/25 15:47:07.174
  STEP: Reading YAML file: ../../testdata/client.yaml @ 04/08/25 15:47:07.174
  STEP: Decoded GVK: /v1, Kind=Pod @ 04/08/25 15:47:07.175
  STEP: Checking pod foobar/curl status is: Ready @ 04/08/25 15:47:07.389
  STEP: Reading YAML file: ../../testdata/envoy.yaml @ 04/08/25 15:47:08.425
  STEP: Replacing placeholder namespace with E2E_NS environment variable @ 04/08/25 15:47:08.425
  STEP: Creating envoy proxy resources from manifest: ../../testdata/envoy.yaml @ 04/08/25 15:47:08.425
  STEP: Decoded GVK: /v1, Kind=ConfigMap @ 04/08/25 15:47:08.426
  STEP: Decoded GVK: apps/v1, Kind=Deployment @ 04/08/25 15:47:08.523
  STEP: Decoded GVK: /v1, Kind=Service @ 04/08/25 15:47:08.611
  STEP: Checking if deployment foobar/envoy status is: Available @ 04/08/25 15:47:08.96
  STEP: Creating model server resources from manifest: /usr/local/google/home/rramkumar/gateway-api-inference-extension/config/manifests/vllm/cpu-deployment.yaml @ 04/08/25 15:47:10.74
  STEP: Decoded GVK: apps/v1, Kind=Deployment @ 04/08/25 15:47:10.741
  STEP: Decoded GVK: /v1, Kind=ConfigMap @ 04/08/25 15:47:10.831
  STEP: Checking if deployment foobar/vllm-llama3-8b-instruct status is: Available @ 04/08/25 15:47:11.044
[BeforeSuite] PASSED [74.897 seconds]
------------------------------
InferencePool when The Inference Extension is running Should route traffic to target model servers
/usr/local/google/home/rramkumar/gateway-api-inference-extension/test/e2e/epp/e2e_test.go:47
  STEP: Waiting for the namespace to exist. @ 04/08/25 15:48:07.641
  STEP: Ensuring namespace exists: foobar @ 04/08/25 15:48:07.641
  STEP: Creating an InferenceModel resource @ 04/08/25 15:48:07.734
  STEP: Ensuring the InferenceModel resource exists in the namespace @ 04/08/25 15:48:07.845
  STEP: Verifying connectivity through the inference extension @ 04/08/25 15:48:07.944
  STEP: Deleting the InferenceModel test resource. @ 04/08/25 15:49:48.896
• [101.501 seconds]
------------------------------
[AfterSuite] 
/usr/local/google/home/rramkumar/gateway-api-inference-extension/test/e2e/epp/e2e_suite_test.go:138
  STEP: Performing global cleanup @ 04/08/25 15:49:49.142
[AfterSuite] PASSED [2.185 seconds]
------------------------------

Ran 1 of 1 Specs in 178.584 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (178.58s)
PASS
ok  	sigs.k8s.io/gateway-api-inference-extension/test/e2e/epp	178.659s
```