### PR TITLE
deploy: Enable logging for GKE gateway by default

### DIFF
--- a/config/charts/inferencepool/templates/gke.yaml
+++ b/config/charts/inferencepool/templates/gke.yaml
@@ -33,6 +33,8 @@ spec:
     name: {{ .Release.Name }}
   default:
     timeoutSec: 300    # 5-minute timeout (adjust as needed)
+    logging:
+      enabled: true    # log all requests by default
 ---
 apiVersion: monitoring.googleapis.com/v1
 kind: ClusterPodMonitoring

--- a/config/manifests/gateway/gke/gcp-backend-policy.yaml
+++ b/config/manifests/gateway/gke/gcp-backend-policy.yaml
@@ -9,3 +9,5 @@ spec:
     name: vllm-llama3-8b-instruct
   default:
     timeoutSec: 300
+    logging:
+      enabled: true


### PR DESCRIPTION
Logging dramatically reduces initial friction debugging and relative
to the cost to serve is fairly minor (about 2-5% overhead). Enable
by default as consistent with our guides.