### PR TITLE
fix bbr dockerfile that was broken in PR #664

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ bbr-image-local-load: bbr-image-local-build
 
 .PHONY: bbr-image-build
 bbr-image-build: ## Build the image using Docker Buildx.
-	$(IMAGE_BUILD_CMD) -f body-based-routing.Dockerfile -t $(BBR_IMAGE_TAG) \
+	$(IMAGE_BUILD_CMD) -f bbr.Dockerfile -t $(BBR_IMAGE_TAG) \
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \

--- a/bbr.Dockerfile
+++ b/bbr.Dockerfile
@@ -19,12 +19,12 @@ COPY cmd ./cmd
 COPY pkg ./pkg
 COPY internal ./internal
 WORKDIR /src/cmd/bbr
-RUN go build -o /body-based-routing
+RUN go build -o /bbr
 
 ## Multistage deploy
 FROM ${BASE_IMAGE}
 
 WORKDIR /
-COPY --from=builder /body-based-routing /body-based-routing
+COPY --from=builder /bbr /bbr
 
-ENTRYPOINT ["/body-based-routing"]
+ENTRYPOINT ["/bbr"]

--- a/body-based-routing.Dockerfile
+++ b/body-based-routing.Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 COPY cmd ./cmd
 COPY pkg ./pkg
 COPY internal ./internal
-WORKDIR /src/cmd/body-based-routing
+WORKDIR /src/cmd/bbr
 RUN go build -o /body-based-routing
 
 ## Multistage deploy


### PR DESCRIPTION
bbr dir was changed, but dockerfile wasn't updated accordingly.
since PR #664 was merged, all merged PRs are failing in `post-inference-extension-push-images` 