### PR TITLE
Rename resources to be model server generic instead of referencing vLLM

### DIFF
--- a/config/manifests/gateway/gke/gcp-backend-policy.yaml
+++ b/config/manifests/gateway/gke/gcp-backend-policy.yaml
@@ -6,7 +6,7 @@ spec:
   targetRef:
     group: "inference.networking.x-k8s.io"
     kind: InferencePool
-    name: vllm-llama3-8b-instruct
+    name: llama3-8b-instruct
   default:
     timeoutSec: 300
     logging:

--- a/config/manifests/gateway/gke/healthcheck.yaml
+++ b/config/manifests/gateway/gke/healthcheck.yaml
@@ -7,7 +7,7 @@ spec:
   targetRef:
     group: "inference.networking.x-k8s.io"
     kind: InferencePool
-    name: vllm-llama3-8b-instruct
+    name: llama3-8b-instruct
   default:
     config:
       type: HTTP

--- a/config/manifests/gateway/gke/httproute.yaml
+++ b/config/manifests/gateway/gke/httproute.yaml
@@ -11,7 +11,7 @@ spec:
   - backendRefs:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
-      name: vllm-llama3-8b-instruct
+      name: llama3-8b-instruct
     matches:
     - path:
         type: PathPrefix

--- a/config/manifests/inferencemodel.yaml
+++ b/config/manifests/inferencemodel.yaml
@@ -6,7 +6,7 @@ spec:
   modelName: food-review
   criticality: Standard
   poolRef:
-    name: vllm-llama3-8b-instruct
+    name: llama3-8b-instruct
   targetModels:
   - name: food-review-1
     weight: 100
@@ -19,7 +19,7 @@ spec:
   modelName: meta-llama/Llama-3.1-8B-Instruct
   criticality: Critical
   poolRef:
-    name: vllm-llama3-8b-instruct
+    name: llama3-8b-instruct
 ---
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceModel
@@ -29,4 +29,4 @@ spec:
   modelName: Qwen/Qwen2.5-1.5B-Instruct
   criticality: Critical
   poolRef:
-    name: vllm-llama3-8b-instruct
+    name: llama3-8b-instruct

--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -5,22 +5,22 @@ apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
   labels:
-  name: vllm-llama3-8b-instruct
+  name: llama3-8b-instruct
 spec:
   targetPortNumber: 8000
   selector:
-    app: vllm-llama3-8b-instruct
+    app: vllm-llama3-8b-instruct # Change this to target a different Model Server Deployment
   extensionRef:
-    name: vllm-llama3-8b-instruct-epp
+    name: llama3-8b-instruct-epp
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: vllm-llama3-8b-instruct-epp
+  name: llama3-8b-instruct-epp
   namespace: default
 spec:
   selector:
-    app: vllm-llama3-8b-instruct-epp
+    app: llama3-8b-instruct-epp
   ports:
     - protocol: TCP
       port: 9002
@@ -31,19 +31,19 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-llama3-8b-instruct-epp
+  name: llama3-8b-instruct-epp
   namespace: default
   labels:
-    app: vllm-llama3-8b-instruct-epp
+    app: llama3-8b-instruct-epp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vllm-llama3-8b-instruct-epp
+      app: llama3-8b-instruct-epp
   template:
     metadata:
       labels:
-        app: vllm-llama3-8b-instruct-epp
+        app: llama3-8b-instruct-epp
     spec:
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
       terminationGracePeriodSeconds: 130
@@ -53,7 +53,7 @@ spec:
         imagePullPolicy: Always
         args:
         - -poolName
-        - "vllm-llama3-8b-instruct"
+        - "llama3-8b-instruct"
         - -v
         - "4"
         - --zap-encoder


### PR DESCRIPTION
Renames the InferencePool, Services, and Deployments to not have vLLM in the name in preparation for adding Triton support.