### PR TITLE
filter irrelevant pods in pod controller

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -150,6 +150,9 @@ func (ds *datastore) PoolHasSynced() bool {
 func (ds *datastore) PoolLabelsMatch(podLabels map[string]string) bool {
 	ds.poolAndModelsMu.RLock()
 	defer ds.poolAndModelsMu.RUnlock()
+	if ds.pool == nil {
+		return false
+	}
 	poolSelector := selectorFromInferencePoolSelector(ds.pool.Spec.Selector)
 	podSet := labels.Set(podLabels)
 	return poolSelector.Matches(podSet)


### PR DESCRIPTION
Pod controller only need to care about pods that related to inferencepool. So we can prevent these irrelevant pods enter in queue.