### PR TITLE
minor changes in few places

### DIFF
--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -4,7 +4,6 @@
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
-  labels:
   name: vllm-llama3-8b-instruct
 spec:
   targetPortNumber: 8000

--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -54,6 +54,8 @@ spec:
         args:
         - -poolName
         - "vllm-llama3-8b-instruct"
+        - "-poolNamespace"
+        - "default"
         - -v
         - "4"
         - --zap-encoder

--- a/pkg/epp/controller/inferencepool_reconciler.go
+++ b/pkg/epp/controller/inferencepool_reconciler.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,9 +35,8 @@ import (
 // will have the proper controller that will create/manage objects on behalf of the server pool.
 type InferencePoolReconciler struct {
 	client.Client
-	Record             record.EventRecorder
-	PoolNamespacedName types.NamespacedName
-	Datastore          datastore.Datastore
+	Record    record.EventRecorder
+	Datastore datastore.Datastore
 }
 
 func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/epp/controller/inferencepool_reconciler_test.go
+++ b/pkg/epp/controller/inferencepool_reconciler_test.go
@@ -96,7 +96,7 @@ func TestInferencePoolReconciler(t *testing.T) {
 
 	pmf := backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, time.Second)
 	datastore := datastore.NewDatastore(ctx, pmf)
-	inferencePoolReconciler := &InferencePoolReconciler{PoolNamespacedName: namespacedName, Client: fakeClient, Datastore: datastore}
+	inferencePoolReconciler := &InferencePoolReconciler{Client: fakeClient, Datastore: datastore}
 
 	// Step 1: Inception, only ready pods matching pool1 are added to the store.
 	if _, err := inferencePoolReconciler.Reconcile(ctx, req); err != nil {

--- a/pkg/epp/server/controller_manager.go
+++ b/pkg/epp/server/controller_manager.go
@@ -39,8 +39,8 @@ func init() {
 	utilruntime.Must(v1alpha2.Install(scheme))
 }
 
-// DefaultManagerOptions returns the default options used to create the manager.
-func DefaultManagerOptions(namespace, name string) ctrl.Options {
+// defaultManagerOptions returns the default options used to create the manager.
+func defaultManagerOptions(namespace string, name string) ctrl.Options {
 	return ctrl.Options{
 		Scheme: scheme,
 		Cache: cache.Options{
@@ -71,7 +71,7 @@ func DefaultManagerOptions(namespace, name string) ctrl.Options {
 
 // NewDefaultManager creates a new controller manager with default configuration.
 func NewDefaultManager(namespace, name string, restConfig *rest.Config) (ctrl.Manager, error) {
-	manager, err := ctrl.NewManager(restConfig, DefaultManagerOptions(namespace, name))
+	manager, err := ctrl.NewManager(restConfig, defaultManagerOptions(namespace, name))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller manager: %v", err)
 	}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -87,11 +87,7 @@ func (r *ExtProcServerRunner) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	if err := (&controller.InferencePoolReconciler{
 		Datastore: r.Datastore,
 		Client:    mgr.GetClient(),
-		PoolNamespacedName: types.NamespacedName{
-			Name:      r.PoolName,
-			Namespace: r.PoolNamespace,
-		},
-		Record: mgr.GetEventRecorderFor("InferencePool"),
+		Record:    mgr.GetEventRecorderFor("InferencePool"),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("failed setting up InferencePoolReconciler: %w", err)
 	}

--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -5,10 +5,12 @@ This project has several implementations that are planned or in progress:
 * [Envoy AI Gateway][1]
 * [Kgateway][2]
 * [Google Kubernetes Engine][3]
+* [Istio][4]
 
 [1]:#envoy-gateway
 [2]:#kgateway
 [3]:#google-kubernetes-engine
+[4]:#istio
 
 ## Envoy AI Gateway
 


### PR DESCRIPTION
this PR handles few minor things:
- in the epp yaml the namespace flag is not set. in cmd/main it DOES have a default value set for using `default` namespace. having said that, I tried few days ago to follow the getting started guide while deploying to another namespace. overall it went fine, but it took me a while to recall this flag has to be set. in our docs and examples we assume using default namespace, but when users deploy GIE in their envs, this is unlikely. I think poolNamespace flag should be passed explicitly to allow relatively easy way to change the used namespace (I don't expect a newcomer who tries following the getting started guide to get into code and understand they need to add this flag).
- remove PoolNamespacedName from InfPool Reconciler, it's not in use since we added the server side filtering.
- add Istio to gateways.md headers (it was missing from the list)