### PR TITLE
reduce log level in metrics logger not to trash the log

### DIFF
--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -142,16 +142,14 @@ func run() error {
 	}
 
 	poolNamespacedName := types.NamespacedName{
-		Namespace: *poolNamespace,
 		Name:      *poolName,
+		Namespace: *poolNamespace,
 	}
 	mgr, err := runserver.NewDefaultManager(poolNamespacedName, cfg)
 	if err != nil {
 		setupLog.Error(err, "Failed to create controller manager")
 		return err
 	}
-
-	ctx := ctrl.SetupSignalHandler()
 
 	// Set up mapper for metric scraping.
 	mapping, err := backendmetrics.NewMetricMapping(
@@ -167,14 +165,15 @@ func run() error {
 
 	pmf := backendmetrics.NewPodMetricsFactory(&backendmetrics.PodMetricsClientImpl{MetricMapping: mapping}, *refreshMetricsInterval)
 	// Setup runner.
+	ctx := ctrl.SetupSignalHandler()
+
 	datastore := datastore.NewDatastore(ctx, pmf)
 
 	serverRunner := &runserver.ExtProcServerRunner{
 		GrpcPort:                                 *grpcPort,
 		DestinationEndpointHintMetadataNamespace: *destinationEndpointHintMetadataNamespace,
 		DestinationEndpointHintKey:               *destinationEndpointHintKey,
-		PoolName:                                 *poolName,
-		PoolNamespace:                            *poolNamespace,
+		PoolNamespacedName:                       poolNamespacedName,
 		Datastore:                                datastore,
 		SecureServing:                            *secureServing,
 		CertPath:                                 *certPath,

--- a/pkg/epp/backend/metrics/logger.go
+++ b/pkg/epp/backend/metrics/logger.go
@@ -55,8 +55,8 @@ func StartMetricsLogger(ctx context.Context, datastore Datastore, refreshPrometh
 			case <-ctx.Done():
 				logger.V(logutil.DEFAULT).Info("Shutting down prometheus metrics thread")
 				return
-			case <-ticker.C: // Periodically flush prometheus metrics for inference pool
-				flushPrometheusMetricsOnce(logger, datastore)
+			case <-ticker.C: // Periodically refresh prometheus metrics for inference pool
+				refreshPrometheusMetrics(logger, datastore)
 			}
 		}
 	}()
@@ -86,11 +86,11 @@ func StartMetricsLogger(ctx context.Context, datastore Datastore, refreshPrometh
 	}
 }
 
-func flushPrometheusMetricsOnce(logger logr.Logger, datastore Datastore) {
+func refreshPrometheusMetrics(logger logr.Logger, datastore Datastore) {
 	pool, err := datastore.PoolGet()
 	if err != nil {
 		// No inference pool or not initialize.
-		logger.V(logutil.DEFAULT).Info("pool is not initialized, skipping flushing metrics")
+		logger.V(logutil.DEBUG).Info("Pool is not initialized, skipping refreshing metrics")
 		return
 	}
 
@@ -98,7 +98,7 @@ func flushPrometheusMetricsOnce(logger logr.Logger, datastore Datastore) {
 	var queueTotal int
 
 	podMetrics := datastore.PodGetAll()
-	logger.V(logutil.TRACE).Info("Flushing Prometheus Metrics", "ReadyPods", len(podMetrics))
+	logger.V(logutil.TRACE).Info("Refreshing Prometheus Metrics", "ReadyPods", len(podMetrics))
 	if len(podMetrics) == 0 {
 		return
 	}

--- a/pkg/epp/backend/metrics/logger.go
+++ b/pkg/epp/backend/metrics/logger.go
@@ -90,7 +90,7 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore Datastore) {
 	pool, err := datastore.PoolGet()
 	if err != nil {
 		// No inference pool or not initialize.
-		logger.V(logutil.DEBUG).Info("Pool is not initialized, skipping refreshing metrics")
+		logger.V(logutil.DEFAULT).Info("Pool is not initialized, skipping refreshing metrics")
 		return
 	}
 

--- a/pkg/epp/backend/metrics/logger.go
+++ b/pkg/epp/backend/metrics/logger.go
@@ -98,7 +98,7 @@ func flushPrometheusMetricsOnce(logger logr.Logger, datastore Datastore) {
 	var queueTotal int
 
 	podMetrics := datastore.PodGetAll()
-	logger.V(logutil.VERBOSE).Info("Flushing Prometheus Metrics", "ReadyPods", len(podMetrics))
+	logger.V(logutil.TRACE).Info("Flushing Prometheus Metrics", "ReadyPods", len(podMetrics))
 	if len(podMetrics) == 0 {
 		return
 	}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -43,8 +43,7 @@ type ExtProcServerRunner struct {
 	GrpcPort                                 int
 	DestinationEndpointHintMetadataNamespace string
 	DestinationEndpointHintKey               string
-	PoolName                                 string
-	PoolNamespace                            string
+	PoolNamespacedName                       types.NamespacedName
 	Datastore                                datastore.Datastore
 	SecureServing                            bool
 	CertPath                                 string
@@ -73,8 +72,7 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 		GrpcPort:                                 DefaultGrpcPort,
 		DestinationEndpointHintKey:               DefaultDestinationEndpointHintKey,
 		DestinationEndpointHintMetadataNamespace: DefaultDestinationEndpointHintMetadataNamespace,
-		PoolName:                                 DefaultPoolName,
-		PoolNamespace:                            DefaultPoolNamespace,
+		PoolNamespacedName:                       types.NamespacedName{Name: DefaultPoolName, Namespace: DefaultPoolNamespace},
 		SecureServing:                            DefaultSecureServing,
 		RefreshPrometheusMetricsInterval:         DefaultRefreshPrometheusMetricsInterval,
 		// Datastore can be assigned later.
@@ -93,13 +91,10 @@ func (r *ExtProcServerRunner) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	if err := (&controller.InferenceModelReconciler{
-		Datastore: r.Datastore,
-		Client:    mgr.GetClient(),
-		PoolNamespacedName: types.NamespacedName{
-			Name:      r.PoolName,
-			Namespace: r.PoolNamespace,
-		},
-		Record: mgr.GetEventRecorderFor("InferenceModel"),
+		Datastore:          r.Datastore,
+		Client:             mgr.GetClient(),
+		PoolNamespacedName: r.PoolNamespacedName,
+		Record:             mgr.GetEventRecorderFor("InferenceModel"),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed setting up InferenceModelReconciler: %w", err)
 	}

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -1348,7 +1348,7 @@ func BeforeSuite() func() {
 	serverRunner.TestPodMetricsClient = &backendmetrics.FakePodMetricsClient{}
 	pmf := backendmetrics.NewPodMetricsFactory(serverRunner.TestPodMetricsClient, 10*time.Millisecond)
 	// Adjust from defaults
-	serverRunner.PoolName = "vllm-llama3-8b-instruct-pool"
+	serverRunner.PoolNamespacedName = types.NamespacedName{Name: "vllm-llama3-8b-instruct-pool", Namespace: "default"}
 	serverRunner.Datastore = datastore.NewDatastore(context.Background(), pmf)
 	serverRunner.SecureServing = false
 


### PR DESCRIPTION
metrics logger is trashing the epp log. so instead of allowing a focused view of what changed, the epp log looks like this:
```
{"level":"Level(-3)","ts":"2025-04-17T21:04:48Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:04:53Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:04:58Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:03Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:08Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"info","ts":"2025-04-17T21:05:10Z","caller":"runnable/grpc.go:19","msg":"gRPC server starting","name":"ext-proc"}
{"level":"info","ts":"2025-04-17T21:05:10Z","caller":"runnable/grpc.go:28","msg":"gRPC server listening","name":"ext-proc","port":9002}
{"level":"Level(-3)","ts":"2025-04-17T21:05:13Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:18Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:23Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:28Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:33Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:38Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:43Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:48Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:53Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:05:58Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:03Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:08Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:13Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:18Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:23Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:28Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:33Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:38Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:43Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:48Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:53Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:06:58Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:03Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:08Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:13Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:18Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:23Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:28Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:33Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:38Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:43Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:48Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:53Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:07:58Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:03Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:08Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:13Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:18Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:23Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:28Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
{"level":"Level(-3)","ts":"2025-04-17T21:08:33Z","caller":"metrics/logger.go:101","msg":"Flushing Prometheus Metrics","ReadyPods":1}
```

since EPP default log level is 4, this PR reduces the log level of the metrics logger (only this specific message) to TRACE to reduce this noise in the log.

additionally, as a followup to previous PR, change in few more places to use NamespacedName instead of passing around name + namespace as separate args.