### PR TITLE
[WIP] proposal - add readypods field to InferencePoolStatus

### DIFF
--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -26,6 +26,8 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Inference Pool",type=string,JSONPath=`.metadata.name`
+// +kubebuilder:printcolumn:name="ReadyPods",type=date,JSONPath=`.status.readyPods`
 // +genclient
 type InferencePool struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -157,6 +159,10 @@ type InferencePoolStatus struct {
 	//
 	// +kubebuilder:validation:MaxItems=32
 	Parents []PoolStatus `json:"parent,omitempty"`
+	//ReadyPods is the number of pods that are associated with the InferencePool and are ready
+	// to serve inference requests. A pod is considered ready if its Ready condition is set to
+	// "True" and it is not marked for deletion.
+	ReadyPods int `json:"readyPods,omitempty"`
 }
 
 // PoolStatus defines the observed state of InferencePool from a Gateway.

--- a/client-go/applyconfiguration/api/v1alpha2/inferencepoolstatus.go
+++ b/client-go/applyconfiguration/api/v1alpha2/inferencepoolstatus.go
@@ -20,7 +20,8 @@ package v1alpha2
 // InferencePoolStatusApplyConfiguration represents a declarative configuration of the InferencePoolStatus type for use
 // with apply.
 type InferencePoolStatusApplyConfiguration struct {
-	Parents []PoolStatusApplyConfiguration `json:"parent,omitempty"`
+	Parents   []PoolStatusApplyConfiguration `json:"parent,omitempty"`
+	ReadyPods *int                           `json:"readyPods,omitempty"`
 }
 
 // InferencePoolStatusApplyConfiguration constructs a declarative configuration of the InferencePoolStatus type for use with
@@ -39,5 +40,13 @@ func (b *InferencePoolStatusApplyConfiguration) WithParents(values ...*PoolStatu
 		}
 		b.Parents = append(b.Parents, *values[i])
 	}
+	return b
+}
+
+// WithReadyPods sets the ReadyPods field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ReadyPods field is set to the value of the last call.
+func (b *InferencePoolStatusApplyConfiguration) WithReadyPods(value int) *InferencePoolStatusApplyConfiguration {
+	b.ReadyPods = &value
 	return b
 }

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
@@ -14,7 +14,14 @@ spec:
     singular: inferencepool
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.name
+      name: Inference Pool
+      type: string
+    - jsonPath: .status.readyPods
+      name: ReadyPods
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: InferencePool is the Schema for the InferencePools API.
@@ -271,6 +278,12 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+              readyPods:
+                description: |-
+                  ReadyPods is the number of pods that are associated with the InferencePool and are ready
+                  to serve inference requests. A pod is considered ready if its Ready condition is set to
+                  "True" and it is not marked for deletion.
+                type: integer
             type: object
         type: object
     served: true


### PR DESCRIPTION
This PR suggests adding to InferencePool status field `ReadyPods` to reflect the number of pods that are associated with the pool and are ready to serve inference requests. 
A pod is considered ready if its Ready condition is set to "True" and it is not marked for deletion.