### PR TITLE
added scheduler plugins interfaces to initialize scheduler refactoring

### DIFF
--- a/pkg/epp/backend/metrics/pod_metrics.go
+++ b/pkg/epp/backend/metrics/pod_metrics.go
@@ -78,7 +78,7 @@ func toInternalPod(in *corev1.Pod) *Pod {
 }
 
 // start starts a goroutine exactly once to periodically update metrics. The goroutine will be
-// stopped either when stop() is called, or the parentCtx is cancelled.
+// stopped either when stop() is called, or the given ctx is cancelled.
 func (pm *podMetrics) startRefreshLoop(ctx context.Context) {
 	pm.once.Do(func() {
 		go func() {

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -65,7 +65,7 @@ type StreamingServer struct {
 }
 
 type Scheduler interface {
-	Schedule(ctx context.Context, b *schedulingtypes.LLMRequest) (targetPod schedulingtypes.Pod, err error)
+	Schedule(ctx context.Context, b *schedulingtypes.LLMRequest) (result *schedulingtypes.Result, err error)
 }
 
 // RequestContext stores context information during the life time of an HTTP request.

--- a/pkg/epp/scheduling/plugins/plugins.go
+++ b/pkg/epp/scheduling/plugins/plugins.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+)
+
+// Plugin defines the interface for scheduler plugins, combining scoring, filtering,
+// and event handling capabilities.
+type Plugin interface {
+	// Name returns the name of the plugin.
+	Name() string
+}
+
+// PreSchedule is called when the scheduler receives a new request. It can be used for various
+// initialization work.
+type PreSchedule interface {
+	Plugin
+	PreSchedule(ctx *types.SchedulingContext)
+}
+
+// PostSchedule is called by the scheduler after it selects a targetPod for the request.
+type PostSchedule interface {
+	Plugin
+	PostSchedule(ctx *types.SchedulingContext, res *types.Result)
+}
+
+// Filter defines the interface for filtering a list of pods based on context.
+type Filter interface {
+	Plugin
+	Filter(ctx *types.SchedulingContext, pods []types.Pod) []types.Pod
+}
+
+// Scorer defines the interface for scoring pods based on context.
+type Scorer interface {
+	Plugin
+	Score(ctx *types.SchedulingContext, pod types.Pod) (float64, error)
+}

--- a/pkg/epp/scheduling/plugins/plugins.go
+++ b/pkg/epp/scheduling/plugins/plugins.go
@@ -34,12 +34,6 @@ type PreSchedule interface {
 	PreSchedule(ctx *types.SchedulingContext)
 }
 
-// PostSchedule is called by the scheduler after it selects a targetPod for the request.
-type PostSchedule interface {
-	Plugin
-	PostSchedule(ctx *types.SchedulingContext, res *types.Result)
-}
-
 // Filter defines the interface for filtering a list of pods based on context.
 type Filter interface {
 	Plugin
@@ -50,4 +44,17 @@ type Filter interface {
 type Scorer interface {
 	Plugin
 	Score(ctx *types.SchedulingContext, pod types.Pod) (float64, error)
+}
+
+// PostSchedule is called by the scheduler after it selects a targetPod for the request.
+type PostSchedule interface {
+	Plugin
+	PostSchedule(ctx *types.SchedulingContext, res *types.Result)
+}
+
+// PostResponse is called by the scheduler after a successful response was sent.
+// The given pod argument is the pod that served the request.
+type PostResponse interface {
+	Plugin
+	PostResponse(ctx *types.SchedulingContext, pod types.Pod)
 }

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -31,7 +31,7 @@ func TestSchedule(t *testing.T) {
 		name   string
 		req    *types.LLMRequest
 		input  []*backendmetrics.FakePodMetrics
-		output types.Pod
+		output *types.Result
 		err    bool
 	}{
 		{
@@ -80,17 +80,19 @@ func TestSchedule(t *testing.T) {
 					},
 				},
 			},
-			output: &types.PodMetrics{
-				Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-				Metrics: &backendmetrics.Metrics{
-					WaitingQueueSize:    3,
-					KVCacheUsagePercent: 0.1,
-					MaxActiveModels:     2,
-					ActiveModels: map[string]int{
-						"foo":      1,
-						"critical": 1,
+			output: &types.Result{
+				TargetPod: &types.PodMetrics{
+					Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+					Metrics: &backendmetrics.Metrics{
+						WaitingQueueSize:    3,
+						KVCacheUsagePercent: 0.1,
+						MaxActiveModels:     2,
+						ActiveModels: map[string]int{
+							"foo":      1,
+							"critical": 1,
+						},
+						WaitingModels: map[string]int{},
 					},
-					WaitingModels: map[string]int{},
 				},
 			},
 		},
@@ -139,17 +141,19 @@ func TestSchedule(t *testing.T) {
 					},
 				},
 			},
-			output: &types.PodMetrics{
-				Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-				Metrics: &backendmetrics.Metrics{
-					WaitingQueueSize:    0,
-					KVCacheUsagePercent: 0.2,
-					MaxActiveModels:     2,
-					ActiveModels: map[string]int{
-						"foo": 1,
-						"bar": 1,
+			output: &types.Result{
+				TargetPod: &types.PodMetrics{
+					Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+					Metrics: &backendmetrics.Metrics{
+						WaitingQueueSize:    0,
+						KVCacheUsagePercent: 0.2,
+						MaxActiveModels:     2,
+						ActiveModels: map[string]int{
+							"foo": 1,
+							"bar": 1,
+						},
+						WaitingModels: map[string]int{},
 					},
-					WaitingModels: map[string]int{},
 				},
 			},
 		},
@@ -212,7 +216,8 @@ func TestSchedule(t *testing.T) {
 				t.Errorf("Unexpected error, got %v, want %v", err, test.err)
 			}
 
-			if diff := cmp.Diff(test.output, got); diff != "" {
+			opt := cmp.AllowUnexported(types.PodMetrics{})
+			if diff := cmp.Diff(test.output, got, opt); diff != "" {
 				t.Errorf("Unexpected output (-want +got): %v", diff)
 			}
 		})


### PR DESCRIPTION
after several maintainers reviewed @liu-cong PR #677, it was decided to break down that PR into smaller PRs to allow easier reviews and refactoring. 

This PR is a first out of a series of PRs that will result in the scheduler refactoring according to the description in #677.
Current PR defines the scheduler new plugins interfaces and does the minimal changes to adapt the existing code to use the new Filter interface.

In a follow up PR, the scheduler will be updated to use these interfaces in  its `Schedule` function.