### PR TITLE
scheduler restructuring

### DIFF
--- a/pkg/epp/backend/metrics/pod_metrics.go
+++ b/pkg/epp/backend/metrics/pod_metrics.go
@@ -41,9 +41,8 @@ type podMetrics struct {
 	ds       Datastore
 	interval time.Duration
 
-	parentCtx context.Context
-	once      sync.Once // ensure the StartRefreshLoop is only called once.
-	done      chan struct{}
+	once sync.Once // ensure the StartRefreshLoop is only called once.
+	done chan struct{}
 
 	logger logr.Logger
 }
@@ -79,8 +78,8 @@ func toInternalPod(in *corev1.Pod) *Pod {
 }
 
 // start starts a goroutine exactly once to periodically update metrics. The goroutine will be
-// stopped either when stop() is called, or the parentCtx is cancelled.
-func (pm *podMetrics) startRefreshLoop() {
+// stopped either when stop() is called, or the given ctx is cancelled.
+func (pm *podMetrics) startRefreshLoop(ctx context.Context) {
 	pm.once.Do(func() {
 		go func() {
 			pm.logger.V(logutil.DEFAULT).Info("Starting refresher", "pod", pm.GetPod())
@@ -90,7 +89,7 @@ func (pm *podMetrics) startRefreshLoop() {
 				select {
 				case <-pm.done:
 					return
-				case <-pm.parentCtx.Done():
+				case <-ctx.Done():
 					return
 				case <-ticker.C: // refresh metrics periodically
 					if err := pm.refreshMetrics(); err != nil {

--- a/pkg/epp/backend/metrics/types.go
+++ b/pkg/epp/backend/metrics/types.go
@@ -43,18 +43,17 @@ type PodMetricsFactory struct {
 func (f *PodMetricsFactory) NewPodMetrics(parentCtx context.Context, in *corev1.Pod, ds Datastore) PodMetrics {
 	pod := toInternalPod(in)
 	pm := &podMetrics{
-		pmc:       f.pmc,
-		ds:        ds,
-		interval:  f.refreshMetricsInterval,
-		parentCtx: parentCtx,
-		once:      sync.Once{},
-		done:      make(chan struct{}),
-		logger:    log.FromContext(parentCtx).WithValues("pod", pod.NamespacedName),
+		pmc:      f.pmc,
+		ds:       ds,
+		interval: f.refreshMetricsInterval,
+		once:     sync.Once{},
+		done:     make(chan struct{}),
+		logger:   log.FromContext(parentCtx).WithValues("pod", pod.NamespacedName),
 	}
 	pm.pod.Store(pod)
 	pm.metrics.Store(newMetrics())
 
-	pm.startRefreshLoop()
+	pm.startRefreshLoop(parentCtx)
 	return pm
 }
 

--- a/pkg/epp/scheduling/plugins/noop.go
+++ b/pkg/epp/scheduling/plugins/noop.go
@@ -27,12 +27,16 @@ type NoopPlugin struct{}
 
 func (p *NoopPlugin) Name() string { return "NoopPlugin" }
 
-func (p *NoopPlugin) Score(ctx *types.Context, pod types.Pod) (float64, error) { return 0.0, nil }
+func (p *NoopPlugin) PreSchedule(ctx *types.SchedulingContext) {}
 
-func (p *NoopPlugin) Filter(ctx *types.Context, pods []types.Pod) ([]types.Pod, error) {
+func (p *NoopPlugin) Filter(ctx *types.SchedulingContext, pods []types.Pod) ([]types.Pod, error) {
 	return pods, nil
 }
 
-func (p *NoopPlugin) PreSchedule(ctx *types.Context) {}
+func (p *NoopPlugin) Score(ctx *types.SchedulingContext, pod types.Pod) (float64, error) {
+	return 0.0, nil
+}
 
-func (p *NoopPlugin) PostSchedule(ctx *types.Context, res *types.Result) {}
+func (p *NoopPlugin) PostSchedule(ctx *types.SchedulingContext, res *types.Result) {}
+
+func (p *NoopPlugin) PostResponse(ctx *types.SchedulingContext, pod types.Pod) {}

--- a/pkg/epp/scheduling/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/plugins/picker/random_picker.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package plugins
+package picker
 
 import (
 	"fmt"
@@ -30,8 +30,8 @@ func (rp *RandomPicker) Name() string {
 	return "random"
 }
 
-func (rp *RandomPicker) Pick(ctx *types.Context, pods []types.Pod) (*types.Result, error) {
+func (rp *RandomPicker) Pick(ctx *types.SchedulingContext, pods []types.Pod) *types.Result {
 	ctx.Logger.V(logutil.DEBUG).Info(fmt.Sprintf("Selecting a random pod from %d candidates: %+v", len(pods), pods))
 	i := rand.Intn(len(pods))
-	return &types.Result{TargetPod: pods[i]}, nil
+	return &types.Result{TargetPod: pods[i]}
 }

--- a/pkg/epp/scheduling/plugins/plugins.go
+++ b/pkg/epp/scheduling/plugins/plugins.go
@@ -14,27 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package types
+package plugins
 
 import (
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
 
 const (
 	PreSchedulerPluginType = "PreSchedule"
-	PostSchedulePluginType = "PostSchedule"
 	FilterPluginType       = "Filter"
 	ScorerPluginType       = "Scorer"
+	PostSchedulePluginType = "PostSchedule"
 	PickerPluginType       = "Picker"
+	PostResponsePluginType = "PostResponse"
 )
-
-type Pod interface {
-	GetPod() *backendmetrics.Pod
-	GetMetrics() *backendmetrics.Metrics
-	SetScore(float64)
-	Score() float64
-	String() string
-}
 
 // Plugin defines the interface for scheduler plugins, combining scoring, filtering,
 // and event handling capabilities.
@@ -47,29 +40,36 @@ type Plugin interface {
 // initialization work.
 type PreSchedule interface {
 	Plugin
-	PreSchedule(ctx *Context)
-}
-
-// PostSchedule is called by the scheduler after it selects a targetPod for the request.
-type PostSchedule interface {
-	Plugin
-	PostSchedule(ctx *Context, res *Result)
+	PreSchedule(ctx *types.SchedulingContext)
 }
 
 // Filter defines the interface for filtering a list of pods based on context.
 type Filter interface {
 	Plugin
-	Filter(ctx *Context, pods []Pod) ([]Pod, error)
+	Filter(ctx *types.SchedulingContext, pods []types.Pod) []types.Pod
 }
 
 // Scorer defines the interface for scoring pods based on context.
 type Scorer interface {
 	Plugin
-	Score(ctx *Context, pod Pod) (float64, error)
+	Score(ctx *types.SchedulingContext, pod types.Pod) float64
+}
+
+// PostSchedule is called by the scheduler after it selects a targetPod for the request.
+type PostSchedule interface {
+	Plugin
+	PostSchedule(ctx *types.SchedulingContext, res *types.Result)
 }
 
 // Picker picks the final pod(s) to send the request to.
 type Picker interface {
 	Plugin
-	Pick(ctx *Context, pods []Pod) (*Result, error)
+	Pick(ctx *types.SchedulingContext, pods []types.Pod) *types.Result
+}
+
+// PostResponse is called by the scheduler after a successful response was sent.
+// The given pod argument is the pod that served the request.
+type PostResponse interface {
+	Plugin
+	PostResponse(ctx *types.SchedulingContext, pod types.Pod)
 }

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -18,12 +18,12 @@ package scheduling
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics" // Import config for thresholds
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
 
@@ -247,30 +247,22 @@ func TestSchedulePlugins(t *testing.T) {
 		ScoreRes:  0.8,
 		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
 	}
-	tpFilterErr := &TestPlugin{
-		NameRes:   "filter err",
-		FilterErr: errors.New("filter error"),
-	}
-	tpScorerErr := &TestPlugin{
-		NameRes:  "score err",
-		ScoreErr: errors.New("score err"),
+	tp_filterAll := &TestPlugin{
+		NameRes:   "filter all",
+		FilterRes: []k8stypes.NamespacedName{},
 	}
 	pickerPlugin := &TestPlugin{
 		NameRes: "picker",
 		PickRes: k8stypes.NamespacedName{Name: "pod1"},
 	}
-	pickerErr := &TestPlugin{
-		NameRes: "picker err",
-		PickErr: errors.New("picker err"),
-	}
 
 	tests := []struct {
 		name                string
-		preSchedulePlugins  []types.PreSchedule
-		postSchedulePlugins []types.PostSchedule
-		filters             []types.Filter
-		scorers             []types.Scorer
-		picker              types.Picker
+		preSchedulePlugins  []plugins.PreSchedule
+		filters             []plugins.Filter
+		scorers             []plugins.Scorer
+		postSchedulePlugins []plugins.PostSchedule
+		picker              plugins.Picker
 		input               []*backendmetrics.FakePodMetrics
 		wantTargetPod       k8stypes.NamespacedName
 		targetPodScore      float64
@@ -280,10 +272,10 @@ func TestSchedulePlugins(t *testing.T) {
 	}{
 		{
 			name:                "all plugins executed successfully",
-			preSchedulePlugins:  []types.PreSchedule{tp1, tp2},
-			postSchedulePlugins: []types.PostSchedule{tp1, tp2},
-			filters:             []types.Filter{tp1, tp2},
-			scorers:             []types.Scorer{tp1, tp2},
+			preSchedulePlugins:  []plugins.PreSchedule{tp1, tp2},
+			filters:             []plugins.Filter{tp1, tp2},
+			scorers:             []plugins.Scorer{tp1, tp2},
+			postSchedulePlugins: []plugins.PostSchedule{tp1, tp2},
 			picker:              pickerPlugin,
 			input: []*backendmetrics.FakePodMetrics{
 				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
@@ -296,46 +288,19 @@ func TestSchedulePlugins(t *testing.T) {
 			err:            false,
 		},
 		{
-			name:                "filter error",
-			preSchedulePlugins:  []types.PreSchedule{tp1, tp2},
-			postSchedulePlugins: []types.PostSchedule{tp1, tp2},
-			filters:             []types.Filter{tp1, tpFilterErr},
-			scorers:             []types.Scorer{tp1, tp2},
+			name:                "filter all",
+			preSchedulePlugins:  []plugins.PreSchedule{tp1, tp2},
+			filters:             []plugins.Filter{tp1, tp_filterAll},
+			scorers:             []plugins.Scorer{tp1, tp2},
+			postSchedulePlugins: []plugins.PostSchedule{tp1, tp2},
 			picker:              pickerPlugin,
 			input: []*backendmetrics.FakePodMetrics{
 				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
 				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}},
 				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}},
 			},
-			err: true,
-		},
-		{
-			name:                "scorer error",
-			preSchedulePlugins:  []types.PreSchedule{tp1, tp2},
-			postSchedulePlugins: []types.PostSchedule{tp1, tp2},
-			filters:             []types.Filter{tp1, tp2},
-			scorers:             []types.Scorer{tp1, tpScorerErr},
-			picker:              pickerPlugin,
-			input: []*backendmetrics.FakePodMetrics{
-				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
-				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}},
-				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}},
-			},
-			err: true,
-		},
-		{
-			name:                "picker error",
-			preSchedulePlugins:  []types.PreSchedule{tp1, tp2},
-			postSchedulePlugins: []types.PostSchedule{tp1, tp2},
-			filters:             []types.Filter{tp1, tp2},
-			scorers:             []types.Scorer{tp1, tp2},
-			picker:              pickerErr,
-			input: []*backendmetrics.FakePodMetrics{
-				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
-				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}},
-				{Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}},
-			},
-			err: true,
+			numPodsToScore: 0,
+			err:            true, // no available pods to server after filter all
 		},
 	}
 
@@ -343,26 +308,26 @@ func TestSchedulePlugins(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Reset all plugins before each new test case.
 			for _, plugin := range test.preSchedulePlugins {
-				plugin.(*TestPlugin).Reset()
+				plugin.(*TestPlugin).reset()
 			}
 			for _, plugin := range test.postSchedulePlugins {
-				plugin.(*TestPlugin).Reset()
+				plugin.(*TestPlugin).reset()
 			}
 			for _, plugin := range test.filters {
-				plugin.(*TestPlugin).Reset()
+				plugin.(*TestPlugin).reset()
 			}
 			for _, plugin := range test.scorers {
-				plugin.(*TestPlugin).Reset()
+				plugin.(*TestPlugin).reset()
 			}
-			test.picker.(*TestPlugin).Reset()
+			test.picker.(*TestPlugin).reset()
 
 			// Initialize the scheduler
 			scheduler := &Scheduler{
 				datastore:           &fakeDataStore{pods: test.input},
 				preSchedulePlugins:  test.preSchedulePlugins,
-				postSchedulePlugins: test.postSchedulePlugins,
 				filters:             test.filters,
 				scorers:             test.scorers,
+				postSchedulePlugins: test.postSchedulePlugins,
 				picker:              test.picker,
 			}
 
@@ -397,13 +362,6 @@ func TestSchedulePlugins(t *testing.T) {
 				}
 			}
 
-			for _, plugin := range test.postSchedulePlugins {
-				tp, _ := plugin.(*TestPlugin)
-				if tp.PostScheduleCallCount != 1 {
-					t.Errorf("Plugin %s PostSchedule() called %d times, expected 1", tp.NameRes, tp.PostScheduleCallCount)
-				}
-			}
-
 			for _, plugin := range test.filters {
 				tp, _ := plugin.(*TestPlugin)
 				if tp.FilterCallCount != 1 {
@@ -415,6 +373,13 @@ func TestSchedulePlugins(t *testing.T) {
 				tp, _ := plugin.(*TestPlugin)
 				if tp.ScoreCallCount != test.numPodsToScore {
 					t.Errorf("Plugin %s Score() called %d times, expected 1", tp.NameRes, tp.ScoreCallCount)
+				}
+			}
+
+			for _, plugin := range test.postSchedulePlugins {
+				tp, _ := plugin.(*TestPlugin)
+				if tp.PostScheduleCallCount != 1 {
+					t.Errorf("Plugin %s PostSchedule() called %d times, expected 1", tp.NameRes, tp.PostScheduleCallCount)
 				}
 			}
 
@@ -444,55 +409,49 @@ type TestPlugin struct {
 	NameRes               string
 	ScoreCallCount        int
 	ScoreRes              float64
-	ScoreErr              error
 	FilterCallCount       int
 	FilterRes             []k8stypes.NamespacedName
-	FilterErr             error
 	PreScheduleCallCount  int
 	PostScheduleCallCount int
 	PickCallCount         int
 	PickRes               k8stypes.NamespacedName
-	PickErr               error
 }
 
 func (tp *TestPlugin) Name() string { return tp.NameRes }
 
-func (tp *TestPlugin) Score(ctx *types.Context, pod types.Pod) (float64, error) {
-	tp.ScoreCallCount++
-	return tp.ScoreRes, tp.ScoreErr
-}
-
-func (tp *TestPlugin) Filter(ctx *types.Context, pods []types.Pod) ([]types.Pod, error) {
-	tp.FilterCallCount++
-	return findPods(ctx, tp.FilterRes...), tp.FilterErr
-}
-
-func (tp *TestPlugin) PreSchedule(ctx *types.Context) {
+func (tp *TestPlugin) PreSchedule(ctx *types.SchedulingContext) {
 	tp.PreScheduleCallCount++
 }
 
-func (tp *TestPlugin) PostSchedule(ctx *types.Context, res *types.Result) {
+func (tp *TestPlugin) Filter(ctx *types.SchedulingContext, pods []types.Pod) []types.Pod {
+	tp.FilterCallCount++
+	return findPods(ctx, tp.FilterRes...)
+}
+
+func (tp *TestPlugin) Score(ctx *types.SchedulingContext, pod types.Pod) float64 {
+	tp.ScoreCallCount++
+	return tp.ScoreRes
+}
+
+func (tp *TestPlugin) PostSchedule(ctx *types.SchedulingContext, res *types.Result) {
 	tp.PostScheduleCallCount++
 }
 
-func (tp *TestPlugin) Pick(ctx *types.Context, pods []types.Pod) (*types.Result, error) {
+func (tp *TestPlugin) Pick(ctx *types.SchedulingContext, pods []types.Pod) *types.Result {
 	tp.PickCallCount++
-	if tp.PickErr != nil {
-		return nil, tp.PickErr
-	}
 	pod := findPods(ctx, tp.PickRes)[0]
-	return &types.Result{TargetPod: pod}, nil
+	return &types.Result{TargetPod: pod}
 }
 
-func (tp *TestPlugin) Reset() {
+func (tp *TestPlugin) reset() {
 	tp.PreScheduleCallCount = 0
-	tp.PostScheduleCallCount = 0
 	tp.FilterCallCount = 0
 	tp.ScoreCallCount = 0
+	tp.PostScheduleCallCount = 0
 	tp.PickCallCount = 0
 }
 
-func findPods(ctx *types.Context, names ...k8stypes.NamespacedName) []types.Pod {
+func findPods(ctx *types.SchedulingContext, names ...k8stypes.NamespacedName) []types.Pod {
 	res := []types.Pod{}
 	for _, pod := range ctx.PodsSnapshot {
 		for _, name := range names {

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -40,8 +40,16 @@ func (r *LLMRequest) String() string {
 	return fmt.Sprintf("Model: %s, TargetModels: %v, ResolvedTargetModel: %s, Critical: %t, PromptLength: %v", r.Model, r.TargetModels, r.ResolvedTargetModel, r.Critical, len(r.Prompt))
 }
 
-// Context holds contextual information during a scheduling operation.
-type Context struct {
+type Pod interface {
+	GetPod() *backendmetrics.Pod
+	GetMetrics() *backendmetrics.Metrics
+	SetScore(float64)
+	Score() float64
+	String() string
+}
+
+// SchedulingContext holds contextual information during a scheduling operation.
+type SchedulingContext struct {
 	context.Context
 	Logger       logr.Logger
 	Req          *LLMRequest
@@ -77,9 +85,9 @@ type PodMetrics struct {
 	*backendmetrics.Metrics
 }
 
-func NewContext(ctx context.Context, req *LLMRequest, pods []Pod) *Context {
+func NewSchedulingContext(ctx context.Context, req *LLMRequest, pods []Pod) *SchedulingContext {
 	logger := log.FromContext(ctx).WithValues("request", req)
-	return &Context{
+	return &SchedulingContext{
 		Context:      ctx,
 		Logger:       logger,
 		Req:          req,


### PR DESCRIPTION
This PR does a restructuring of the scheduler existing code. for example moving plugins interfaces from `scheduling/types/interfaces.go` to `/scheduling/plugins/plugins.go`. no code changes in this aspect of restructuring.

additionally, it adds some small changes, like the removal of return error from filter, scorer and picker interfaces since it was never used. tests were updated accordingly.