### PR TITLE
Fixing errors in new template & disabling the default blank template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,6 +1,6 @@
 ---
 name: Blank Issue
-about: ''
+about: Create a new issue from scratch
 title: ''
 labels: needs-triage
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This indirection allows us to apply labels on _all_ issues being created, making triage simpler.