### PR TITLE
Add inference_extension_info metric for project metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ COPY cmd ./cmd
 COPY pkg ./pkg
 COPY internal ./internal
 COPY api ./api
+COPY .git ./.git
 WORKDIR /src/cmd/epp
-RUN go build -o /epp
+RUN go build -buildvcs=true -o /epp
 
 ## Multistage deploy
 FROM ${BASE_IMAGE}

--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -247,6 +247,8 @@ func registerHealthServer(mgr manager.Manager, logger logr.Logger, ds datastore.
 func registerMetricsHandler(mgr manager.Manager, port int, cfg *rest.Config) error {
 	metrics.Register()
 
+	metrics.RecordInferenceExtensionInfo()
+
 	// Init HTTP server.
 	h, err := metricsHandlerWithAuthenticationAndAuthorization(cfg)
 	if err != nil {

--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -35,6 +35,8 @@ curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
 | inference_pool_average_kv_cache_utilization  | Gauge            | The average kv cache utilization for an inference server pool.    | `name`=&lt;inference-pool-name&gt;                                                 | ALPHA       |
 | inference_pool_average_queue_size            | Gauge            | The average number of requests pending in the model server queue. | `name`=&lt;inference-pool-name&gt;                                                 | ALPHA       |
 | inference_pool_ready_pods                    | Gauge            | The number of ready pods for an inference server pool.            | `name`=&lt;inference-pool-name&gt;                                                 | ALPHA       |
+| inference_extension_info                     | Gauge            | The general information of the current build.                     | `commit`=&lt;hash-of-the-build&gt;                                                 | ALPHA       |
+
 
 ## Scrape Metrics
 


### PR DESCRIPTION
Start with just commit, version information will be added in a follow-up change.

Verified:
```
# HELP inference_extension_info [ALPHA] General information of the current build of Inference Extension.
# TYPE inference_extension_info gauge
inference_extension_info{commit="60f8c57bb95b656a75d27564d5ff01c060bcdba5"} 1
```

Partially Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/579