### PR TITLE
Parse request x-request-id and expose it in contextual logger

### DIFF
--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/status"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
 
 func NewServer(streaming bool) *Server {
@@ -74,6 +75,11 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 				// If streaming and the body is not empty, then headers are handled when processing request body.
 				loggerVerbose.Info("Received headers, passing off header processing until body arrives...")
 			} else {
+				if requestId := requtil.ExtractRequestId(v); len(requestId) > 0 {
+					logger = logger.WithValues(requtil.RequestIdHeaderKey, requestId)
+					loggerVerbose = logger.V(logutil.VERBOSE)
+					ctx = log.IntoContext(ctx, logger)
+				}
 				responses, err = s.HandleRequestHeaders(req.GetRequestHeaders())
 			}
 		case *extProcPb.ProcessingRequest_RequestBody:

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -75,7 +75,7 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 				// If streaming and the body is not empty, then headers are handled when processing request body.
 				loggerVerbose.Info("Received headers, passing off header processing until body arrives...")
 			} else {
-				if requestId := requtil.ExtractRequestId(v); len(requestId) > 0 {
+				if requestId := requtil.ExtractHeaderValue(v, requtil.RequestIdHeaderKey); len(requestId) > 0 {
 					logger = logger.WithValues(requtil.RequestIdHeaderKey, requestId)
 					loggerVerbose = logger.V(logutil.VERBOSE)
 					ctx = log.IntoContext(ctx, logger)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -159,7 +159,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
-			if requestId := requtil.ExtractRequestId(v); len(requestId) > 0 {
+			if requestId := requtil.ExtractHeaderValue(v, requtil.RequestIdHeaderKey); len(requestId) > 0 {
 				logger = logger.WithValues(requtil.RequestIdHeaderKey, requestId)
 				loggerTrace = logger.V(logutil.TRACE)
 				ctx = log.IntoContext(ctx, logger)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -40,6 +40,7 @@ import (
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
 
 func NewStreamingServer(scheduler Scheduler, destinationEndpointHintMetadataNamespace, destinationEndpointHintKey string, datastore datastore.Datastore) *StreamingServer {
@@ -158,6 +159,11 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
+			if requestId := requtil.ExtractRequestId(v); len(requestId) > 0 {
+				logger = logger.WithValues(requtil.RequestIdHeaderKey, requestId)
+				loggerTrace = logger.V(logutil.TRACE)
+				ctx = log.IntoContext(ctx, logger)
+			}
 			err = s.HandleRequestHeaders(ctx, reqCtx, v)
 		case *extProcPb.ProcessingRequest_RequestBody:
 			loggerTrace.Info("Incoming body chunk", "EoS", v.RequestBody.EndOfStream)

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -10,10 +10,12 @@ const (
 	RequestIdHeaderKey = "x-request-id"
 )
 
-func ExtractRequestId(req *extProcPb.ProcessingRequest_RequestHeaders) string {
+func ExtractHeaderValue(req *extProcPb.ProcessingRequest_RequestHeaders, headerKey string) string {
+	// header key should be case insensitive
+	headerKeyInLower := strings.ToLower(headerKey)
 	if req != nil && req.RequestHeaders != nil && req.RequestHeaders.Headers != nil {
 		for _, headerKv := range req.RequestHeaders.Headers.Headers {
-			if strings.ToLower(headerKv.Key) == RequestIdHeaderKey {
+			if strings.ToLower(headerKv.Key) == headerKeyInLower {
 				return string(headerKv.RawValue)
 			}
 		}

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -1,0 +1,22 @@
+package request
+
+import (
+	"strings"
+
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+)
+
+const (
+	RequestIdHeaderKey = "x-request-id"
+)
+
+func ExtractRequestId(req *extProcPb.ProcessingRequest_RequestHeaders) string {
+	if req != nil && req.RequestHeaders != nil && req.RequestHeaders.Headers != nil {
+		for _, headerKv := range req.RequestHeaders.Headers.Headers {
+			if strings.ToLower(headerKv.Key) == RequestIdHeaderKey {
+				return string(headerKv.RawValue)
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Provide an util function to extract `x-request-id` from request when request headers are coming, and expose `x-request-id` in contextual loggers. This mechanism is adde to both EPP and BBR.
This resolves https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/556.