### PR TITLE
Request for adding Alibaba Cloud Container Service for Kubernetes (ACK) into implementations

### DIFF
--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -80,6 +80,9 @@ and provides optimized routing for serving generative AI workloads,
 including weighted traffic splitting, mirroring, advanced routing, etc. 
 See the docs for the [usage][ack-gie-usage].
 
+Progress towards supporting Gateway API Inference Extension is being tracked 
+by [this Issue](https://github.com/AliyunContainerService/ack-gateway-api/issues/1).
+
 [ack]:https://www.alibabacloud.com/help/en/ack
 [ack-gie]:https://www.alibabacloud.com/help/en/ack/product-overview/ack-gateway-with-inference-extension
 [ack-gie-usage]:https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/intelligent-routing-and-traffic-management-with-ack-gateway-inference-extension

--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -6,11 +6,13 @@ This project has several implementations that are planned or in progress:
 * [Kgateway][2]
 * [Google Kubernetes Engine][3]
 * [Istio][4]
+* [Alibaba Cloud Container Service for Kubernetes][5]
 
 [1]:#envoy-gateway
 [2]:#kgateway
 [3]:#google-kubernetes-engine
 [4]:#istio
+[5]:#alibaba-cloud-container-service-for-kubernetes
 
 ## Envoy AI Gateway
 
@@ -65,3 +67,19 @@ For service mesh users, Istio also fully supports east-west (including [GAMMA](h
 
 Gateway API Inference Extension support is being tracked by this [GitHub
 Issue](https://github.com/istio/istio/issues/55768).
+
+## Alibaba Cloud Container Service for Kubernetes
+
+[Alibaba Cloud Container Service for Kubernetes (ACK)](ack) is a managed Kubernetes platform 
+offered by Alibaba Cloud. The implementation of the Gateway API in ACK is through the 
+[ACK Gateway with Inference Extension](ack-gie) component, which introduces model-aware, 
+GPU-efficient load balancing for AI workloads beyond basic HTTP routing.
+
+The ACK Gateway with Inference Extension implements the Gateway API Inference Extension 
+and provides optimized routing for serving generative AI workloads, 
+including weighted traffic splitting, mirroring, advanced routing, etc. 
+See the docs for the [usage](ack-gie-usage).
+
+[ack]:https://www.alibabacloud.com/help/en/ack
+[ack-gie]:https://www.alibabacloud.com/help/en/ack/product-overview/ack-gateway-with-inference-extension
+[ack-gie-usage]:https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/intelligent-routing-and-traffic-management-with-ack-gateway-inference-extension

--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -70,15 +70,15 @@ Issue](https://github.com/istio/istio/issues/55768).
 
 ## Alibaba Cloud Container Service for Kubernetes
 
-[Alibaba Cloud Container Service for Kubernetes (ACK)](ack) is a managed Kubernetes platform 
+[Alibaba Cloud Container Service for Kubernetes (ACK)][ack] is a managed Kubernetes platform 
 offered by Alibaba Cloud. The implementation of the Gateway API in ACK is through the 
-[ACK Gateway with Inference Extension](ack-gie) component, which introduces model-aware, 
+[ACK Gateway with Inference Extension][ack-gie] component, which introduces model-aware, 
 GPU-efficient load balancing for AI workloads beyond basic HTTP routing.
 
 The ACK Gateway with Inference Extension implements the Gateway API Inference Extension 
 and provides optimized routing for serving generative AI workloads, 
 including weighted traffic splitting, mirroring, advanced routing, etc. 
-See the docs for the [usage](ack-gie-usage).
+See the docs for the [usage][ack-gie-usage].
 
 [ack]:https://www.alibabacloud.com/help/en/ack
 [ack-gie]:https://www.alibabacloud.com/help/en/ack/product-overview/ack-gateway-with-inference-extension


### PR DESCRIPTION
Hi maintainers,

Alibaba Cloud Container Service for Kubernetes (ACK)  has just released ACK Gateway with Inference Extension, which implements Gateway API inference extension. The component utilize InferencePool and InferenceModel API to help our customers optimize their routing solution for inference workloads (Please refer to [the usage doc](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/intelligent-routing-and-traffic-management-with-ack-gateway-inference-extension#6ab3e971bfp3v)).

We sincerely request that ACK Gateway with Inference Extension be added to the implementation list of Gateway API inference extensions, and we look forward to contributing the customers requirements of Alibaba Cloud to the community.
@kfswain @liu-cong