### PR TITLE
add max score picker

### DIFF
--- a/pkg/epp/scheduling/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/plugins/picker/max_score_picker.go
@@ -1,0 +1,55 @@
+package picker
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+// MaxScorePicker picks the pod with the maximum score from the list of
+// candidates.
+type MaxScorePicker struct{}
+
+var _ plugins.Picker = &MaxScorePicker{}
+
+// Name returns the name of the picker.
+func (msp *MaxScorePicker) Name() string {
+	return "max_score"
+}
+
+// Pick selects the pod with the maximum score from the list of candidates.
+func (msp *MaxScorePicker) Pick(ctx *types.SchedulingContext, scoredPods []*types.ScoredPod) *types.Result {
+	debugLogger := ctx.Logger.V(logutil.DEBUG).WithName("max-score-picker")
+	debugLogger.Info(fmt.Sprintf("Selecting the pod with the max score from %d candidates: %+v",
+		len(scoredPods), scoredPods))
+
+	winners := make([]*types.ScoredPod, 0)
+
+	maxScore := 0.0
+	for _, pod := range scoredPods {
+		score := pod.Score
+		if score > maxScore {
+			maxScore = score
+			winners = []*types.ScoredPod{pod}
+		} else if score == maxScore {
+			winners = append(winners, pod)
+		}
+	}
+
+	if len(winners) == 0 {
+		return nil
+	}
+
+	if len(winners) > 1 {
+		debugLogger.Info(fmt.Sprintf("Multiple pods have the same max score (%f): %+v",
+			maxScore, winners))
+
+		randomPicker := RandomPicker{}
+		return randomPicker.Pick(ctx, winners)
+	}
+
+	debugLogger.Info(fmt.Sprintf("Selected pod with max score (%f): %+v", maxScore, winners[0]))
+	return &types.Result{TargetPod: winners[0]}
+}

--- a/pkg/epp/scheduling/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/plugins/picker/random_picker.go
@@ -37,5 +37,5 @@ func (rp *RandomPicker) Name() string {
 func (rp *RandomPicker) Pick(ctx *types.SchedulingContext, scoredPods []*types.ScoredPod) *types.Result {
 	ctx.Logger.V(logutil.DEBUG).Info(fmt.Sprintf("Selecting a random pod from %d candidates: %+v", len(scoredPods), scoredPods))
 	i := rand.Intn(len(scoredPods))
-	return &types.Result{TargetPod: scoredPods[i].Pod}
+	return &types.Result{TargetPod: scoredPods[i]}
 }

--- a/pkg/epp/scheduling/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/plugins/picker/random_picker.go
@@ -30,11 +30,11 @@ var _ plugins.Picker = &RandomPicker{}
 // RandomPicker picks a random pod from the list of candidates.
 type RandomPicker struct{}
 
-func (rp *RandomPicker) Name() string {
+func (p *RandomPicker) Name() string {
 	return "random"
 }
 
-func (rp *RandomPicker) Pick(ctx *types.SchedulingContext, scoredPods []*types.ScoredPod) *types.Result {
+func (p *RandomPicker) Pick(ctx *types.SchedulingContext, scoredPods []*types.ScoredPod) *types.Result {
 	ctx.Logger.V(logutil.DEBUG).Info(fmt.Sprintf("Selecting a random pod from %d candidates: %+v", len(scoredPods), scoredPods))
 	i := rand.Intn(len(scoredPods))
 	return &types.Result{TargetPod: scoredPods[i]}

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -93,17 +93,19 @@ func TestSchedule(t *testing.T) {
 				},
 			},
 			wantRes: &types.Result{
-				TargetPod: &types.PodMetrics{
-					Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					Metrics: &backendmetrics.Metrics{
-						WaitingQueueSize:    3,
-						KVCacheUsagePercent: 0.1,
-						MaxActiveModels:     2,
-						ActiveModels: map[string]int{
-							"foo":      1,
-							"critical": 1,
+				TargetPod: &types.ScoredPod{
+					Pod: &types.PodMetrics{
+						Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+						Metrics: &backendmetrics.Metrics{
+							WaitingQueueSize:    3,
+							KVCacheUsagePercent: 0.1,
+							MaxActiveModels:     2,
+							ActiveModels: map[string]int{
+								"foo":      1,
+								"critical": 1,
+							},
+							WaitingModels: map[string]int{},
 						},
-						WaitingModels: map[string]int{},
 					},
 				},
 			},
@@ -154,17 +156,19 @@ func TestSchedule(t *testing.T) {
 				},
 			},
 			wantRes: &types.Result{
-				TargetPod: &types.PodMetrics{
-					Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					Metrics: &backendmetrics.Metrics{
-						WaitingQueueSize:    0,
-						KVCacheUsagePercent: 0.2,
-						MaxActiveModels:     2,
-						ActiveModels: map[string]int{
-							"foo": 1,
-							"bar": 1,
+				TargetPod: &types.ScoredPod{
+					Pod: &types.PodMetrics{
+						Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+						Metrics: &backendmetrics.Metrics{
+							WaitingQueueSize:    0,
+							KVCacheUsagePercent: 0.2,
+							MaxActiveModels:     2,
+							ActiveModels: map[string]int{
+								"foo": 1,
+								"bar": 1,
+							},
+							WaitingModels: map[string]int{},
 						},
-						WaitingModels: map[string]int{},
 					},
 				},
 			},
@@ -505,7 +509,7 @@ func findPods(ctx *types.SchedulingContext, names ...k8stypes.NamespacedName) []
 func getPodScore(scoredPods []*types.ScoredPod, selectedPod types.Pod) float64 {
 	finalScore := 0.0
 	for _, scoredPod := range scoredPods {
-		if scoredPod.Pod.GetPod().NamespacedName.String() == selectedPod.GetPod().NamespacedName.String() {
+		if scoredPod.GetPod().NamespacedName.String() == selectedPod.GetPod().NamespacedName.String() {
 			finalScore = scoredPod.Score
 			break
 		}

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -47,7 +47,7 @@ type Pod interface {
 }
 
 type ScoredPod struct {
-	Pod   Pod
+	Pod
 	Score float64
 }
 


### PR DESCRIPTION
This PR adds max score picker functionality.
if there is more than one pod with the highest score, it choses randomly between those pods.

additionally, the PR embeds Pod interface in the ScoredPod as suggested by @liu-cong in code review of previous PR.