### PR TITLE
Amend the endpoint picker protocol to support multiple fallback endpoints

### DIFF
--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -44,11 +44,23 @@ Constraints:
 - If the EPP did not communicate the server endpoint via these two methods, it MUST return an error as follows:
   -  [ImmediateResponse](https://github.com/envoyproxy/envoy/blob/f2023ef77bdb4abaf9feef963c9a0c291f55568f/api/envoy/service/ext_proc/v3/external_processor.proto#L195) with 503 (Serivce Unavailable) HTTP status code if there are no ready endpoints.
   -  [ImmediateResponse](https://github.com/envoyproxy/envoy/blob/f2023ef77bdb4abaf9feef963c9a0c291f55568f/api/envoy/service/ext_proc/v3/external_processor.proto#L195) with 429 (Too Many Requests) HTTP status code if the request should be dropped (e.g., a Sheddable request, and the servers under heavy load).
-- The EPP MUST not set two different values in the header and the inner response metadata value. 
+- The EPP MUST not set two different values in the header and the inner response metadata value.
 - Setting different value leads to unpredictable behavior because proxies aren't guaranteed to support both paths, and so this protocol does not define what takes precedence.
 
 ### Destination endpoint fallback
-A single fallback endpoint CAN be set using the key `x-gateway-destination-endpoint-fallback` in the same metadata namespace as one used for `x-gateway-destination-endpoint` as follows:
+
+For each HTTP request, if destination endpoint fallback is necessary or possible, the EPP CAN set the `x-gateway-destination-endpoint` HTTP header or metadata entry with multiple addresses in `<ip:port>,<ip:port>,...` format. Multiple addresses are separated by commas. The first valid endpoint in the addresses list will be used as the primary endpoint. And if retrying is happening, the proxy will try the endpoints after the selected endpoint in order.
+
+For example:
+```go
+dynamicMetadata: {
+  "envoy.lb" {
+     "x-gateway-destination-endpoint": "<ip:port>,<ip:port>,..."
+  }
+}
+```
+
+Single fallback endpoint also CAN be set using the key `x-gateway-destination-endpoint-fallback` in the same metadata namespace as one used for `x-gateway-destination-endpoint` as follows:
 
 ```go
 dynamicMetadata: {
@@ -58,7 +70,7 @@ dynamicMetadata: {
 }
 ```
 
-### Why envoy.lb namespace as a default? 
+### Why envoy.lb namespace as a default?
 The `envoy.lb` namespace is a predefined namespace. One common way to use the selected endpoint returned from the server, is [envoy subsets](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/subsets)  where host metadata for subset load balancing must be placed under `envoy.lb`. Note that this is not related to the subsetting feature discussed above, this is an enovy implementation detail.
 
 ## Matching An InferenceModel

--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -25,9 +25,9 @@ If the key `x-gateway-destination-endpoint-subset` is set, the EPP MUST only sel
 If the key `x-gateway-destination-endpoint-subset` is not set, then the EPP MUST select from the set defined by the `InferencePool` selector.
 
 ## Destination Endpoint
-For each HTTP request, the EPP MUST communicate to the proxy the picked model server endpoint via:
+For each HTTP request, the EPP MUST communicate to the proxy one or more selected model server endpoints via:
 
-1. Setting the `x-gateway-destination-endpoint` HTTP header to the selected endpoints.
+1. Setting the `x-gateway-destination-endpoint` HTTP header to one or more selected endpoints.
 
 2. Set an unstructured entry in the [dynamic_metadata](https://github.com/envoyproxy/go-control-plane/blob/c19bf63a811c90bf9e02f8e0dc1dcef94931ebb4/envoy/service/ext_proc/v3/external_processor.pb.go#L320) field of the ext-proc response. The metadata entry for the picked endpoints MUST be wrapped with an outer key (which represents the metadata namespace) with a default of `envoy.lb`.
 
@@ -48,19 +48,7 @@ dynamicMetadata: {
 }
 ```
 
-The value of the header or metadata entry MUST contains at least one endpoint in `<ip:port>` format or multiple endpoints in `<ip:port>,<ip:port>,...` format. Multiple endpoints are separated by commas. The first valid endpoint in the value will be used. And if retrying is happening, the proxy will try the endpoints after the previously selected endpoint in order.
-
-Optionally, The EPP also CAN set additional endpoints by the key `x-gateway-destination-endpoint-fallback` in the same metadata namespace as one used for `x-gateway-destination-endpoint` as follows:
-
-```go
-dynamicMetadata: {
-  "envoy.lb" {
-     "x-gateway-destination-endpoint-fallback": <ip:port>
-  }
-}
-```
-
-The endpoints specified in `x-gateway-destination-endpoint-fallback` MAY be tried after the endpoints specified in `x-gateway-destination-endpoint` if all the endpoints specified in `x-gateway-destination-endpoint` are unavailable.
+The value of the header or metadata entry MUST contain at least one endpoint in `<ip:port>` format or multiple endpoints in `<ip:port>,<ip:port>,...` format. Multiple endpoints are separated by commas. The first valid endpoint in the list will be used. And if retrying is happening, the proxy will try the endpoints after the previously selected endpoint in order.
 
 Constraints:
 - If the EPP did not communicate the server endpoint via these two methods, it MUST return an error as follows:

--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -50,7 +50,7 @@ dynamicMetadata: {
 
 The value of the header or metadata entry MUST contains at least one endpoint in `<ip:port>` format or multiple endpoints in `<ip:port>,<ip:port>,...` format. Multiple endpoints are separated by commas. The first valid endpoint in the value will be used. And if retrying is happening, the proxy will try the endpoints after the previously selected endpoint in order.
 
-The EPP also can set additional endpoints by the key `x-gateway-destination-endpoint-fallback` in the same metadata namespace as one used for `x-gateway-destination-endpoint` as follows:
+Optionally, The EPP also CAN set additional endpoints by the key `x-gateway-destination-endpoint-fallback` in the same metadata namespace as one used for `x-gateway-destination-endpoint` as follows:
 
 ```go
 dynamicMetadata: {

--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -48,7 +48,7 @@ dynamicMetadata: {
 }
 ```
 
-The value of the header or metadata entry MUST contain at least one endpoint in `<ip:port>` format or multiple endpoints in `<ip:port>,<ip:port>,...` format. Multiple endpoints are separated by commas. The first valid endpoint in the list will be used. And if retrying is happening, the proxy will try the endpoints after the previously selected endpoint in order.
+The value of the header or metadata entry MUST contain at least one endpoint in `<ip:port>` format or multiple endpoints in `<ip:port>,<ip:port>,...` format. Multiple endpoints are separated by commas. The first valid endpoint in the list will be used. If retry is configured, the proxy will go sequentially down the list until one valid endpoint is found.
 
 Constraints:
 - If the EPP did not communicate the server endpoint via these two methods, it MUST return an error as follows:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/414

1. This PR extend value format of `x-gateway-destination-endpoint` to support multiple endpoints.
2. The new format could support mutliple fallback endpoints.
3. **The new format is compatible with previous format becase the previous format could be treat a speical case of new format.**
4. This will simplify the proxy implementation. The proxy needn't to handle different endpoint sources.
5. This will simplify the EPP implementation because the EPP needn't to set different endpoint sources.
6. It's possible to specify the fallback endpoints by HTTP header now.