### PR TITLE
fix: pass commit hash from the cloud build default variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM ${BUILDER_IMAGE} AS builder
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
+ARG COMMIT_SHA=unknown
 
 # Dependencies
 WORKDIR /src
@@ -19,9 +20,8 @@ COPY cmd ./cmd
 COPY pkg ./pkg
 COPY internal ./internal
 COPY api ./api
-COPY .git ./.git
 WORKDIR /src/cmd/epp
-RUN go build -buildvcs=true -o /epp
+RUN go build -ldflags="-X sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics.CommitSHA=${COMMIT_SHA}" -o /epp
 
 ## Multistage deploy
 FROM ${BASE_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+GIT_COMMIT_SHA ?= "$(shell git rev-parse HEAD 2>/dev/null)"
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
 PLATFORMS ?= linux/amd64
 DOCKER_BUILDX_CMD ?= docker buildx
@@ -175,6 +176,7 @@ image-build: ## Build the EPP image using Docker Buildx.
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--build-arg COMMIT_SHA=${GIT_COMMIT_SHA} \
 		$(PUSH) \
 		$(LOAD) \
 		$(IMAGE_BUILD_EXTRA_OPTS) ./

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
     - GIT_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
+    - GIT_COMMIT_SHA=$COMMIT_SHA
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
     entrypoint: make
     args:

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -18,7 +18,6 @@ package metrics
 
 import (
 	"context"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -37,7 +36,7 @@ const (
 
 var (
 	// The git hash of the latest commit in the build.
-	CommitHash string
+	CommitSHA string
 )
 
 var (
@@ -337,25 +336,7 @@ func RecordSchedulerPluginProcessingLatency(pluginType, pluginName string, durat
 }
 
 func RecordInferenceExtensionInfo() {
-	if CommitHash != "" {
-		InferenceExtensionInfo.WithLabelValues(CommitHash).Set(1)
+	if CommitSHA != "" {
+		InferenceExtensionInfo.WithLabelValues(CommitSHA).Set(1)
 	}
-}
-
-func init() {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
-	}
-
-	var Commit = func(i *debug.BuildInfo) string {
-		for _, setting := range i.Settings {
-			if setting.Key == "vcs.revision" {
-				return setting.Value
-			}
-		}
-		return ""
-	}(info)
-
-	CommitHash = Commit
 }


### PR DESCRIPTION
TESTED with both local run of:

- make image-push
- cloud-build-local command

```
jeffluoo@jeffluoo.c ~/dev/ai/gateway-api-inference-extension% cloud-build-local --config=cloudbuild.yaml \                 
                  --dryrun=false \
                  --push=false \
                  --substitutions=_IMAGE_TAG=latest \
                  .

2025/04/30 17:38:10 Warning: there are left over step containers from a previous build, cleaning them.
2025/04/30 17:38:10 Warning: a network is left over from a previous build, cleaning it.
2025/04/30 17:38:10 Warning: there are left over step volumes from a previous build, cleaning it.
2025/04/30 17:38:12 Warning: The server docker version installed (20.10.21) is different from the one used in GCB (19.03.8)
2025/04/30 17:38:12 Warning: The client docker version installed (20.10.21) is different from the one used in GCB (19.03.8)
2025/04/30 17:38:21 Build id = localbuild_a1552614-b48b-459d-9c09-d3045c9fe351
2025/04/30 17:38:21 status changed to "BUILD"
BUILD
Starting Step #0
Step #0: Already have image (with digest): gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
Step #0: go: go.mod requires go >= 1.24.0 (running go 1.22.5; GOTOOLCHAIN=local)
Step #0: /buildx-entrypoint build -t us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:0.0.0 \
Step #0:        --platform=linux/amd64 \
Step #0:        --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot \
Step #0:        --build-arg BUILDER_IMAGE=golang:1.24 \
Step #0:        --build-arg COMMIT_SHA= \
Step #0:        --push  \
Step #0:         \
Step #0:        -t us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main ./
Step #0: Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
Step #0: Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
Step #0: Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
Step #0: Setting /usr/bin/qemu-sparc-static as binfmt interpreter for sparc
Step #0: Setting /usr/bin/qemu-sparc32plus-static as binfmt interpreter for sparc32plus
Step #0: Setting /usr/bin/qemu-sparc64-static as binfmt interpreter for sparc64
Step #0: Setting /usr/bin/qemu-ppc-static as binfmt interpreter for ppc
Step #0: Setting /usr/bin/qemu-ppc64-static as binfmt interpreter for ppc64
Step #0: Setting /usr/bin/qemu-ppc64le-static as binfmt interpreter for ppc64le
Step #0: Setting /usr/bin/qemu-m68k-static as binfmt interpreter for m68k
Step #0: Setting /usr/bin/qemu-mips-static as binfmt interpreter for mips
Step #0: Setting /usr/bin/qemu-mipsel-static as binfmt interpreter for mipsel
Step #0: Setting /usr/bin/qemu-mipsn32-static as binfmt interpreter for mipsn32
Step #0: Setting /usr/bin/qemu-mipsn32el-static as binfmt interpreter for mipsn32el
Step #0: Setting /usr/bin/qemu-mips64-static as binfmt interpreter for mips64
Step #0: Setting /usr/bin/qemu-mips64el-static as binfmt interpreter for mips64el
Step #0: Setting /usr/bin/qemu-sh4-static as binfmt interpreter for sh4
Step #0: Setting /usr/bin/qemu-sh4eb-static as binfmt interpreter for sh4eb
Step #0: Setting /usr/bin/qemu-s390x-static as binfmt interpreter for s390x
Step #0: Setting /usr/bin/qemu-aarch64-static as binfmt interpreter for aarch64
Step #0: Setting /usr/bin/qemu-aarch64_be-static as binfmt interpreter for aarch64_be
Step #0: Setting /usr/bin/qemu-hppa-static as binfmt interpreter for hppa
Step #0: Setting /usr/bin/qemu-riscv32-static as binfmt interpreter for riscv32
Step #0: Setting /usr/bin/qemu-riscv64-static as binfmt interpreter for riscv64
Step #0: Setting /usr/bin/qemu-xtensa-static as binfmt interpreter for xtensa
Step #0: Setting /usr/bin/qemu-xtensaeb-static as binfmt interpreter for xtensaeb
Step #0: Setting /usr/bin/qemu-microblaze-static as binfmt interpreter for microblaze
Step #0: Setting /usr/bin/qemu-microblazeel-static as binfmt interpreter for microblazeel
Step #0: Setting /usr/bin/qemu-or1k-static as binfmt interpreter for or1k
Step #0: Setting /usr/bin/qemu-hexagon-static as binfmt interpreter for hexagon
Step #0: recursing_neumann
Step #0: #0 building with "recursing_neumann" instance using docker-container driver
Step #0: 
Step #0: #1 [internal] booting buildkit
Step #0: #1 pulling image moby/buildkit:buildx-stable-1
Step #0: #1 pulling image moby/buildkit:buildx-stable-1 0.5s done
Step #0: #1 creating container buildx_buildkit_recursing_neumann0
Step #0: #1 creating container buildx_buildkit_recursing_neumann0 1.0s done
Step #0: #1 DONE 1.6s
Step #0: 
Step #0: #2 [internal] load build definition from Dockerfile
Step #0: #2 transferring dockerfile: 800B done
Step #0: #2 DONE 0.1s
Step #0: 
Step #0: #3 [internal] load metadata for docker.io/library/golang:1.24
Step #0: #3 ...
Step #0: 
Step #0: #4 [internal] load metadata for gcr.io/distroless/static:nonroot
Step #0: #4 DONE 0.6s
Step #0: 
Step #0: #3 [internal] load metadata for docker.io/library/golang:1.24
Step #0: #3 DONE 0.9s
Step #0: 
Step #0: #5 [internal] load .dockerignore
Step #0: #5 transferring context: 160B done
Step #0: #5 DONE 0.0s
Step #0: 
Step #0: #6 [internal] load build context
Step #0: #6 DONE 0.0s
Step #0: 
Step #0: #7 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
Step #0: #7 resolve gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc 0.0s done
Step #0: #7 ...
Step #0: 
Step #0: #6 [internal] load build context
Step #0: #6 transferring context: 442.24kB 0.0s done
Step #0: #6 DONE 0.2s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 resolve docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e 0.0s done
Step #0: #8 DONE 0.4s
Step #0: 
Step #0: #7 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
Step #0: #7 sha256:9aee425378d2c16cd44177dc54a274b312897f5860a8e78fdfda555a0d79dd71 130.50kB / 130.50kB 0.2s done
Step #0: #7 sha256:da7816fa955ea24533c388143c78804c28682eef99b4ee3723b548c70148bba6 321B / 321B 0.2s done
Step #0: #7 sha256:4aa0ea1413d37a58615488592a0b827ea4b2e48fa5a77cf707d0e35f025e613f 385B / 385B 0.2s done
Step #0: #7 sha256:0bab15eea81d0fe6ab56ebf5fba14e02c4c1775a7f7436fbddd3505add4e18fa 93B / 93B 0.2s done
Step #0: #7 sha256:5664b15f108bf9436ce3312090a767300800edbbfd4511aa1a6d64357024d5dd 168B / 168B 0.2s done
Step #0: #7 sha256:3214acf345c0cc6bbdb56b698a41ccdefc624a09d6beb0d38b5de0b2303ecaf4 123B / 123B 0.2s done
Step #0: #7 sha256:7c12895b777bcaa8ccae0605b4de635b68fc32d60fa08f421dc3818bf55ee212 0B / 188B 0.2s
Step #0: #7 sha256:a62778643d563b511190663ef9a77c30d46d282facfdce4f3a7aecc03423c1f3 67B / 67B 0.2s done
Step #0: #7 sha256:4eff9a62d888790350b2481ff4a4f38f9c94b3674d26b2f2c85ca39cdef43fd9 547.59kB / 547.59kB 0.1s done
Step #0: #7 sha256:7c12895b777bcaa8ccae0605b4de635b68fc32d60fa08f421dc3818bf55ee212 188B / 188B 0.3s done
Step #0: #7 sha256:bfb59b82a9b65e47d485e53b3e815bca3b3e21a095bd0cb88ced9ac0b48062bf 13.36kB / 13.36kB 0.1s done
Step #0: #7 sha256:3d78e577de35c8bf231e34862a13cde36cd7b253b6a7af2158035251d2dc48c0 104.23kB / 104.23kB 0.1s done
Step #0: #7 extracting sha256:3d78e577de35c8bf231e34862a13cde36cd7b253b6a7af2158035251d2dc48c0 0.1s done
Step #0: #7 DONE 1.3s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B 0.1s done
Step #0: #8 sha256:3b1d58d3def14be9f0b0952450a1b36b47b8e3df75197d829797ed1325396349 126B / 126B 0.1s done
Step #0: #8 sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c 52.43MB / 78.94MB 0.8s
Step #0: #8 sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe 48.23MB / 92.35MB 0.8s
Step #0: #8 sha256:ca513cad200b13ead2c745498459eed58a6db3480e3ba6117f854da097262526 49.28MB / 64.39MB 0.8s
Step #0: #8 sha256:63964a8518f54dc31f8df89d7f06714c7a793aa1aa08a64ae3d7f4f4f30b4ac8 24.01MB / 24.01MB 0.6s done
Step #0: #8 sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c 59.77MB / 78.94MB 0.9s
Step #0: #8 sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe 62.91MB / 92.35MB 0.9s
Step #0: #8 sha256:ca513cad200b13ead2c745498459eed58a6db3480e3ba6117f854da097262526 59.20MB / 64.39MB 0.9s
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 6.29MB / 48.49MB 0.2s
Step #0: #8 sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c 66.76MB / 78.94MB 1.1s
Step #0: #8 sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe 71.30MB / 92.35MB 1.1s
Step #0: #8 sha256:ca513cad200b13ead2c745498459eed58a6db3480e3ba6117f854da097262526 64.39MB / 64.39MB 1.0s done
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 14.68MB / 48.49MB 0.3s
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 20.97MB / 48.49MB 0.5s
Step #0: #8 ...
Step #0: 
Step #0: #7 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
Step #0: #7 extracting sha256:bfb59b82a9b65e47d485e53b3e815bca3b3e21a095bd0cb88ced9ac0b48062bf 0.0s done
Step #0: #7 extracting sha256:4eff9a62d888790350b2481ff4a4f38f9c94b3674d26b2f2c85ca39cdef43fd9 0.4s done
Step #0: #7 DONE 1.8s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c 73.40MB / 78.94MB 1.2s
Step #0: #8 sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe 85.98MB / 92.35MB 1.2s
Step #0: #8 ...
Step #0: 
Step #0: #7 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
Step #0: #7 extracting sha256:a62778643d563b511190663ef9a77c30d46d282facfdce4f3a7aecc03423c1f3 0.0s done
Step #0: #7 extracting sha256:7c12895b777bcaa8ccae0605b4de635b68fc32d60fa08f421dc3818bf55ee212 0.0s done
Step #0: #7 extracting sha256:3214acf345c0cc6bbdb56b698a41ccdefc624a09d6beb0d38b5de0b2303ecaf4 0.0s done
Step #0: #7 DONE 1.9s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c 78.94MB / 78.94MB 1.4s done
Step #0: #8 sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe 92.35MB / 92.35MB 1.3s done
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 26.21MB / 48.49MB 0.6s
Step #0: #8 ...
Step #0: 
Step #0: #7 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
Step #0: #7 extracting sha256:5664b15f108bf9436ce3312090a767300800edbbfd4511aa1a6d64357024d5dd 0.0s done
Step #0: #7 extracting sha256:0bab15eea81d0fe6ab56ebf5fba14e02c4c1775a7f7436fbddd3505add4e18fa 0.0s done
Step #0: #7 extracting sha256:4aa0ea1413d37a58615488592a0b827ea4b2e48fa5a77cf707d0e35f025e613f 0.0s done
Step #0: #7 extracting sha256:da7816fa955ea24533c388143c78804c28682eef99b4ee3723b548c70148bba6 0.0s done
Step #0: #7 DONE 2.0s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 ...
Step #0: 
Step #0: #7 [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
Step #0: #7 extracting sha256:9aee425378d2c16cd44177dc54a274b312897f5860a8e78fdfda555a0d79dd71 0.0s done
Step #0: #7 DONE 2.0s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 30.41MB / 48.49MB 0.9s
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 34.60MB / 48.49MB 1.1s
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 40.89MB / 48.49MB 1.2s
Step #0: #8 sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 48.49MB / 48.49MB 1.3s done
Step #0: #8 extracting sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2
Step #0: #8 extracting sha256:cf05a52c02353f0b2b6f9be0549ac916c3fb1dc8d4bacd405eac7f28562ec9f2 2.4s done
Step #0: #8 DONE 4.9s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 extracting sha256:63964a8518f54dc31f8df89d7f06714c7a793aa1aa08a64ae3d7f4f4f30b4ac8
Step #0: #8 extracting sha256:63964a8518f54dc31f8df89d7f06714c7a793aa1aa08a64ae3d7f4f4f30b4ac8 0.7s done
Step #0: #8 DONE 5.6s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 extracting sha256:ca513cad200b13ead2c745498459eed58a6db3480e3ba6117f854da097262526
Step #0: #8 extracting sha256:ca513cad200b13ead2c745498459eed58a6db3480e3ba6117f854da097262526 3.3s done
Step #0: #8 DONE 8.9s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 extracting sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe
Step #0: #8 extracting sha256:e46f54697eb97b3e550e762b20a1596c1b90956cb126063b68e9ec4b6584fcfe 2.9s done
Step #0: #8 DONE 11.8s
Step #0: 
Step #0: #8 [builder  1/10] FROM docker.io/library/golang:1.24@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
Step #0: #8 extracting sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c
Step #0: #8 extracting sha256:f1d296901bdc593d88a0813bb00eef0974b68222cba6add046b831c086a1c68c 6.7s done
Step #0: #8 extracting sha256:3b1d58d3def14be9f0b0952450a1b36b47b8e3df75197d829797ed1325396349
Step #0: #8 extracting sha256:3b1d58d3def14be9f0b0952450a1b36b47b8e3df75197d829797ed1325396349 0.0s done
Step #0: #8 extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 0.0s done
Step #0: #8 DONE 18.6s
Step #0: 
Step #0: #9 [builder  2/10] WORKDIR /src
Step #0: #9 DONE 1.0s
Step #0: 
Step #0: #10 [builder  3/10] COPY go.mod go.sum ./
Step #0: #10 DONE 0.1s
Step #0: 
Step #0: #11 [builder  4/10] RUN go mod download
Step #0: #11 DONE 3.8s
Step #0: 
Step #0: #12 [builder  5/10] COPY cmd ./cmd
Step #0: #12 DONE 0.7s
Step #0: 
Step #0: #13 [builder  6/10] COPY pkg ./pkg
Step #0: #13 DONE 0.1s
Step #0: 
Step #0: #14 [builder  7/10] COPY internal ./internal
Step #0: #14 DONE 0.1s
Step #0: 
Step #0: #15 [builder  8/10] COPY api ./api
Step #0: #15 DONE 0.1s
Step #0: 
Step #0: #16 [builder  9/10] WORKDIR /src/cmd/epp
Step #0: #16 DONE 0.1s
Step #0: 
Step #0: #17 [builder 10/10] RUN go build -ldflags="-X sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics.CommitSHA=" -o /epp
^C
```

```
go build -ldflags="-X sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics.CommitSHA=
```
shows empty string becuase the variable will only be populated if is triggered from git according to https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions.
