### PR TITLE
remove EndpointSlice from RBAC

### DIFF
--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -87,16 +87,13 @@ metadata:
   name: pod-read
 rules:
 - apiGroups: ["inference.networking.x-k8s.io"]
+  resources: ["inferencepools"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["inference.networking.x-k8s.io"]
   resources: ["inferencemodels"]
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["inference.networking.x-k8s.io"]
-  resources: ["inferencepools"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
   verbs: ["get", "watch", "list"]
 - apiGroups:
   - authentication.k8s.io

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -104,7 +104,7 @@ func (r *ExtProcServerRunner) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		Client:    mgr.GetClient(),
 		Record:    mgr.GetEventRecorderFor("pod"),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("failed setting up EndpointSliceReconciler: %v", err)
+		return fmt.Errorf("failed setting up PodReconciler: %v", err)
 	}
 	return nil
 }

--- a/test/testdata/inferencepool-e2e.yaml
+++ b/test/testdata/inferencepool-e2e.yaml
@@ -89,16 +89,13 @@ metadata:
   name: pod-read
 rules:
 - apiGroups: ["inference.networking.x-k8s.io"]
+  resources: ["inferencepools"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["inference.networking.x-k8s.io"]
   resources: ["inferencemodels"]
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["inference.networking.x-k8s.io"]
-  resources: ["inferencepools"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
   verbs: ["get", "watch", "list"]
 - apiGroups:
   - authentication.k8s.io


### PR DESCRIPTION
EndpointSlice was used in the past and not used anymore as far as I can tell.
this PR removes EndpointSlice from RBAC settings (least privilege principle).
let me know If I missed something and EndpointSlice is still used.  