### PR TITLE
e2e: Fixes 404 Not Found Error

### DIFF
--- a/test/e2e/epp/e2e_suite_test.go
+++ b/test/e2e/epp/e2e_suite_test.go
@@ -62,6 +62,8 @@ const (
 	modelServerName = "vllm-llama3-8b-instruct"
 	// modelName is the test model name.
 	modelName = "food-review"
+	// targetModelName is the target model name of the test model server.
+	targetModelName = modelName + "-1"
 	// envoyName is the name of the envoy proxy test resources.
 	envoyName = "envoy"
 	// envoyPort is the listener port number of the test envoy proxy.

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -96,12 +96,8 @@ var _ = ginkgo.Describe("InferencePool", func() {
 func newInferenceModel(ns string) *v1alpha2.InferenceModel {
 	targets := []v1alpha2.TargetModel{
 		{
-			Name:   modelName,
-			Weight: ptr.To(int32(50)),
-		},
-		{
-			Name:   "cad-fabricator",
-			Weight: ptr.To(int32(50)),
+			Name:   targetModelName,
+			Weight: ptr.To(int32(100)),
 		},
 	}
 	return testutils.MakeModelWrapper("inferencemodel-sample", ns).


### PR DESCRIPTION
Running `make test-e2e` results in:

```sh
  STEP: Verifying connectivity through the inference extension @ 05/07/25 08:09:31.18
  [FAILED] in [It] - /Users/solo-system-dhansen/go/src/sigs.k8s.io/gateway-api-inference-extension/test/e2e/epp/e2e_test.go:89 @ 05/07/25 08:12:31.183
  STEP: Deleting the InferenceModel test resource. @ 05/07/25 08:12:31.183
• [FAILED] [180.340 seconds]
InferencePool when The Inference Extension is running [It] Should route traffic to target model servers
/Users/solo-system-dhansen/go/src/sigs.k8s.io/gateway-api-inference-extension/test/e2e/epp/e2e_test.go:47

  [FAILED] Timed out after 180.001s.
  Expected success, but got an error:
      <*errors.errorString | 0x14000a84730>:
      did not get 200 OK: HTTP/1.1 404 Not Found
      date: Wed, 07 May 2025 15:12:26 GMT
      server: uvicorn
      content-type: application/json
      x-went-into-resp-headers: true
      transfer-encoding: chunked

      {"code":404,"message":"The model `cad-fabricator` does not exist.","object":"error","param":null,"type":"NotFoundError"}  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                       Dload  Upload   Total   Spent    Left  Speed
100   239    0   120  100   119  16982  16841 --:--:-- --:--:-- --:--:-- 39833

      {
          s: "did not get 200 OK: HTTP/1.1 404 Not Found\r\ndate: Wed, 07 May 2025 15:12:26 GMT\r\nserver: uvicorn\r\ncontent-type: application/json\r\nx-went-into-resp-headers: true\r\ntransfer-encoding: chunked\r\n\r\n{\"code\":404,\"message\":\"The model `cad-fabricator` does not exist.\",\"object\":\"error\",\"param\":null,\"type\":\"NotFoundError\"}  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   239    0   120  100   119  16982  16841 --:--:-- --:--:-- --:--:-- 39833\n",
      }
  In [It] at: /Users/solo-system-dhansen/go/src/sigs.k8s.io/gateway-api-inference-extension/test/e2e/epp/e2e_test.go:89 @ 05/07/25 08:12:31.183
...
```

`cad-fabricator` is an invalid target model name. Based on the `config/manifests/vllm/gpu-deployment.yaml` manifest, `food-review-1`is the only configured LoRA adapter.