### PR TITLE
fix labels not cloned bug

### DIFF
--- a/pkg/epp/backend/metrics/pod_metrics.go
+++ b/pkg/epp/backend/metrics/pod_metrics.go
@@ -64,18 +64,22 @@ func (pm *podMetrics) GetMetrics() *Metrics {
 	return pm.metrics.Load()
 }
 
-func (pm *podMetrics) UpdatePod(in *corev1.Pod) {
-	pm.pod.Store(toInternalPod(in))
+func (pm *podMetrics) UpdatePod(pod *corev1.Pod) {
+	pm.pod.Store(toInternalPod(pod))
 }
 
-func toInternalPod(in *corev1.Pod) *backend.Pod {
+func toInternalPod(pod *corev1.Pod) *backend.Pod {
+	labels := make(map[string]string, len(pod.GetLabels()))
+	for key, value := range pod.GetLabels() {
+		labels[key] = value
+	}
 	return &backend.Pod{
 		NamespacedName: types.NamespacedName{
-			Name:      in.Name,
-			Namespace: in.Namespace,
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
 		},
-		Address: in.Status.PodIP,
-		Labels:  in.Labels,
+		Address: pod.Status.PodIP,
+		Labels:  labels,
 	}
 }
 

--- a/pkg/epp/backend/pod.go
+++ b/pkg/epp/backend/pod.go
@@ -36,12 +36,16 @@ func (p *Pod) Clone() *Pod {
 	if p == nil {
 		return nil
 	}
+	clonedLabels := make(map[string]string, len(p.Labels))
+	for key, value := range p.Labels {
+		clonedLabels[key] = value
+	}
 	return &Pod{
 		NamespacedName: types.NamespacedName{
 			Name:      p.NamespacedName.Name,
 			Namespace: p.NamespacedName.Namespace,
 		},
 		Address: p.Address,
-		Labels:  p.Labels,
+		Labels:  clonedLabels,
 	}
 }

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -96,7 +96,7 @@ func TestSchedule(t *testing.T) {
 			wantRes: &types.Result{
 				TargetPod: &types.ScoredPod{
 					Pod: &types.PodMetrics{
-						Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+						Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}, Labels: make(map[string]string)},
 						Metrics: &backendmetrics.Metrics{
 							WaitingQueueSize:    3,
 							KVCacheUsagePercent: 0.1,
@@ -159,7 +159,7 @@ func TestSchedule(t *testing.T) {
 			wantRes: &types.Result{
 				TargetPod: &types.ScoredPod{
 					Pod: &types.PodMetrics{
-						Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+						Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}, Labels: make(map[string]string)},
 						Metrics: &backendmetrics.Metrics{
 							WaitingQueueSize:    0,
 							KVCacheUsagePercent: 0.2,
@@ -370,7 +370,7 @@ func TestSchedulePlugins(t *testing.T) {
 
 			// Validate output
 			wantPod := &types.PodMetrics{
-				Pod: &backend.Pod{NamespacedName: test.wantTargetPod},
+				Pod: &backend.Pod{NamespacedName: test.wantTargetPod, Labels: make(map[string]string)},
 			}
 			wantRes := &types.Result{TargetPod: wantPod}
 			if diff := cmp.Diff(wantRes, got); diff != "" {


### PR DESCRIPTION
this PR fix a bug in cloning the pod's labels.
the bug was that labels value is assigned from one map to another.
this copies a pointer to the map (both vars are sharing the map), two problems with that:
1. if the map will change due to pod labels change and reconcile event at the same time a plugin access that map with no locking mechanism, it may cause issues (read & write in parallel to labels map without sync).
2. pod's labels may change during the scheduling cycle which is no good cause it may cause inconsistencies in the scheduler plugins.

this PR clones the labels to fix it.  