### PR TITLE
Refactor: Externalize Scheduler's saturation logic and criticality-based service differentiation

### DIFF
--- a/pkg/epp/saturationdetector/saturationdetector.go
+++ b/pkg/epp/saturationdetector/saturationdetector.go
@@ -32,7 +32,6 @@ package saturationdetector
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -45,10 +44,6 @@ const (
 	// loggerName is the name to use for loggers created by this package.
 	loggerName = "SaturationDetector"
 )
-
-// ErrNilDatastore indicates NewSaturationDetector was called with a nil
-// datastore.
-var ErrNilDatastore = errors.New("datastore cannot be nil")
 
 // Config holds the configuration for the SaturationDetector.
 type Config struct {
@@ -89,10 +84,7 @@ type Detector struct {
 // The datastore is expected to provide access to live/recently-updated pod
 // metrics.
 // The config provides the thresholds for determining saturation.
-func NewDetector(config *Config, datastore Datastore, logger logr.Logger) (*Detector, error) {
-	if datastore == nil {
-		return nil, ErrNilDatastore
-	}
+func NewDetector(config *Config, datastore Datastore, logger logr.Logger) *Detector {
 	logger.WithName(loggerName).V(logutil.DEFAULT).Info("Creating new SaturationDetector",
 		"queueDepthThreshold", config.QueueDepthThreshold,
 		"kvCacheUtilThreshold", config.KVCacheUtilThreshold,
@@ -101,7 +93,7 @@ func NewDetector(config *Config, datastore Datastore, logger logr.Logger) (*Dete
 	return &Detector{
 		datastore: datastore,
 		config:    config,
-	}, nil
+	}
 }
 
 // IsSaturated checks if the system is currently considered saturated.


### PR DESCRIPTION
This commit refactors the request processing pipeline, externalizing saturation detection and criticality-based service differentiation from the Scheduler. These responsibilities are now primarily managed by the RequestControl.Director.

This change is a preparatory step for the introduction of a new Flow Controller component, which will eventually absorb these admission control duties.

Diff base is: #808 (split out for easier reviewing)
Related to: #674

Key changes include:

- Introduced `PreDispatch` method to `RequestControl.Director`. It utilizes the `SaturationDetector` for admission control of non-critical requests and handles request criticality to determine if saturation checks are bypassed.
- The saturation detection logic for dropping non-critical requests is intentionally preserved within the `Director` at this stage. This allows the option to bypass the future Flow Controller component during its maturation, ensuring the existing saturation and sheddable request behavior can be maintained as a fallback.
- Updated `main.go` to instantiate the `SaturationDetector`, wiring it into the request handling flow.
- Updated  `director_test.go` to align with the new component responsibilities, adding additional coverage where necessary.

Missing from this PR:

- Simplifying the `Scheduler` to focus solely on preference-based filtering and pod selection for requests that have already been admitted by the `Director`.
- Removing the `SheddableRequestFilter` and the distinct critical/sheddable filter paths from the `Scheduler`'s internal logic so that the `Scheduler` only applies a single, unified preference filter chain to all incoming requests.

I did not include the above in this PR due to high activity in those files. I will send a followup PR to address that. In the meantime, the saturation check happens twice: once in the Director, and then another redundant time in the Scheduler. This is wasted compute, but has no affect on behavior.

This refactoring leads to a cleaner architecture, making the `Scheduler` a more focused component and centralizing initial admission control logic, while paving the way for the future Flow Controller.

This is aligned with the direction in `0683-epp-architecture-proposal` and is no-op in terms of EPP behavior.