### PR TITLE
Introduce SaturationDetector component

### DIFF
--- a/pkg/epp/common/config/defaults.go
+++ b/pkg/epp/common/config/defaults.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config holds common configuration default values used across
+// different EPP components.
+package config
+
+const (
+	// DefaultKVCacheThreshold is the default KV cache utilization (0.0 to 1.0)
+	// threshold.
+	DefaultKVCacheThreshold = 0.8
+	// DefaultQueueThresholdCritical is the default backend waiting queue size
+	// threshold.
+	DefaultQueueThresholdCritical = 5
+)

--- a/pkg/epp/saturationdetector/config.go
+++ b/pkg/epp/saturationdetector/config.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package saturationdetector
+
+import (
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	commonconfig "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/common/config"
+	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
+)
+
+// Default configuration values
+const (
+	DefaultQueueDepthThreshold  = commonconfig.DefaultQueueThresholdCritical
+	DefaultKVCacheUtilThreshold = commonconfig.DefaultKVCacheThreshold
+	// DefaultMetricsStalenessThreshold defines how old metrics can be before they
+	// are considered stale.
+	// Given the pod metrics refresh interval is 50ms, a threshold slightly above
+	// that should be fine.
+	DefaultMetricsStalenessThreshold = 200 * time.Millisecond
+)
+
+// Environment variable names for SaturationDetector configuration
+const (
+	EnvSdQueueDepthThreshold       = "SD_QUEUE_DEPTH_THRESHOLD"
+	EnvSdKVCacheUtilThreshold      = "SD_KV_CACHE_UTIL_THRESHOLD"
+	EnvSdMetricsStalenessThreshold = "SD_METRICS_STALENESS_THRESHOLD"
+)
+
+// LoadConfigFromEnv loads SaturationDetector Config from environment
+// variables.
+func LoadConfigFromEnv() *Config {
+	// Use a default logger for initial configuration loading.
+	logger := log.Log.WithName("saturation-detector-config")
+
+	cfg := &Config{}
+
+	cfg.QueueDepthThreshold = envutil.GetEnvInt(EnvSdQueueDepthThreshold, DefaultQueueDepthThreshold, logger)
+	cfg.KVCacheUtilThreshold = envutil.GetEnvFloat(EnvSdKVCacheUtilThreshold, DefaultKVCacheUtilThreshold, logger)
+	cfg.MetricsStalenessThreshold = envutil.GetEnvDuration(EnvSdMetricsStalenessThreshold, DefaultMetricsStalenessThreshold, logger)
+
+	// NewDetector validates the config and assigns defaults.
+	logger.Info("SaturationDetector configuration loaded from env",
+		"config", fmt.Sprintf("%+v", cfg))
+	return cfg
+}

--- a/pkg/epp/saturationdetector/saturationdetector.go
+++ b/pkg/epp/saturationdetector/saturationdetector.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package saturationdetector implements a mechanism to determine if the
+// backend model servers are considered saturated based on observed metrics.
+//
+// The current implementation provides a global saturation signal (IsSaturated)
+// primarily based on backend queue depths and KV cache utilization, reflecting
+// the saturation signals previously used by the Scheduler before the
+// introduction of the FlowController. It fetches live metrics from the
+// provided Datastore.
+//
+// TODO: Explore more advanced saturation signals in the future, such as:
+//   - Latency-objective-based saturation.
+//   - Predictive saturation based on trends.
+//   - Hysteresis bands or other smoothing techniques to prevent rapid
+//     oscillations of the saturation signal.
+package saturationdetector
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+// clock allows mocking time in tests.
+type clock interface {
+	now() time.Time
+}
+
+// realClock provides the real time.
+type realClock struct{}
+
+func (c realClock) now() time.Time { return time.Now() }
+
+const (
+	// loggerName is the name to use for loggers created by this package.
+	loggerName = "SaturationDetector"
+)
+
+// ErrNilDatastore indicates NewSaturationDetector was called with a nil
+// datastore.
+var ErrNilDatastore = errors.New("datastore cannot be nil")
+
+// Config holds the configuration for the SaturationDetector.
+type Config struct {
+	// QueueDepthThreshold defines the backend waiting queue size above which a
+	// pod is considered to have insufficient capacity for new requests.
+	QueueDepthThreshold int
+	// KVCacheUtilThreshold defines the KV cache utilization (0.0 to 1.0) above
+	// which a pod is considered to have insufficient capacity.
+	KVCacheUtilThreshold float64
+	// MetricsStalenessThreshold defines how old a pod's metrics can be.
+	// If a pod's metrics are older than this, it might be excluded from
+	// "good capacity" considerations or treated as having no capacity for
+	// safety.
+	MetricsStalenessThreshold time.Duration
+}
+
+// Datastore provides an interface to access backend pod metrics.
+type Datastore interface {
+	PodGetAll() []backendmetrics.PodMetrics
+}
+
+// Detector determines system saturation based on metrics from the Datastore.
+//
+// The Detector currently holds a direct dependency on a Datastore interface.
+// This design choice was made to encapsulate the logic of fetching and
+// interpreting metrics for saturation, thereby simplifying the dependencies
+// for primary consumers like the FlowController--to be added soon--(which
+// would otherwise need to manage Datastore interactions itself).
+// This architectural decision may be revisited in the future if a more
+// decoupled approach (e.g., passing metrics directly to IsSaturated) proves
+// more beneficial.
+type Detector struct {
+	datastore Datastore
+	config    Config
+	clock     clock
+}
+
+// NewDetector creates a new SaturationDetector.
+// The datastore is expected to provide access to live/recently-updated pod
+// metrics.
+// The config provides the thresholds for determining saturation.
+func NewDetector(config Config, datastore Datastore, logger logr.Logger) (*Detector, error) {
+	if datastore == nil {
+		return nil, ErrNilDatastore
+	}
+	if config.MetricsStalenessThreshold <= 0 {
+		config.MetricsStalenessThreshold = DefaultMetricsStalenessThreshold
+	}
+	logger.WithName(loggerName).V(logutil.DEFAULT).Info("Creating new SaturationDetector",
+		"queueDepthThreshold", config.QueueDepthThreshold,
+		"kvCacheUtilThreshold", config.KVCacheUtilThreshold,
+		"metricsStalenessThreshold", config.MetricsStalenessThreshold.String())
+	return &Detector{
+		datastore: datastore,
+		config:    config,
+		clock:     realClock{},
+	}, nil
+}
+
+// IsSaturated checks if the system is currently considered saturated.
+// The system is saturated if NO pod currently has "good capacity".
+// "Good capacity" means:
+//  1. Metrics are fresh (not stale).
+//  2. WaitingQueueSize <= QueueDepthThreshold.
+//  3. KVCacheUsagePercent <= KVCacheUtilThreshold.
+//
+// If no pods are found in the datastore, the system is considered saturated
+// (no capacity).
+func (d *Detector) IsSaturated(ctx context.Context) bool {
+	logger := log.FromContext(ctx).WithName(loggerName)
+	allPodsMetrics := d.datastore.PodGetAll()
+	if len(allPodsMetrics) == 0 {
+		logger.V(logutil.VERBOSE).Info("No pods found in datastore; system is considered SATURATED (no capacity).")
+		// If there are no pods, there is no capacity to serve requests.
+		// Treat this as a saturated state to enable FlowController queuing.
+		return true
+	}
+
+	now := d.clock.now()
+	foundPodWithGoodCapacity := false
+	for _, podMetric := range allPodsMetrics {
+		metrics := podMetric.GetMetrics()
+		podNn := "unknown-pod"
+		if podMetric.GetPod() != nil {
+			podNn = podMetric.GetPod().NamespacedName.String()
+		}
+
+		if metrics == nil {
+			logger.V(logutil.VERBOSE).Info("Pod has nil metrics, skipping for saturation check",
+				"pod", podNn)
+			continue
+		}
+
+		// 1. Check for metric staleness
+		if now.Sub(metrics.UpdateTime) > d.config.MetricsStalenessThreshold {
+			logger.V(logutil.VERBOSE).Info("Pod metrics are stale, considered as not having good capacity",
+				"pod", podNn,
+				"updateTime", metrics.UpdateTime,
+				"stalenessThreshold", d.config.MetricsStalenessThreshold)
+			continue
+		}
+
+		// 2. Check queue depth
+		isQueueGood := metrics.WaitingQueueSize <= d.config.QueueDepthThreshold
+
+		// 3. Check KV cache utilization
+		isKVCacheGood := metrics.KVCacheUsagePercent <= d.config.KVCacheUtilThreshold
+
+		if isQueueGood && isKVCacheGood {
+			logger.V(logutil.VERBOSE).Info("Found pod with good capacity",
+				"pod", podNn,
+				"waitingQueue", metrics.WaitingQueueSize,
+				"queueThreshold", d.config.QueueDepthThreshold,
+				"kvCacheUtil", metrics.KVCacheUsagePercent,
+				"kvCacheThreshold", d.config.KVCacheUtilThreshold)
+			foundPodWithGoodCapacity = true
+			// Found at least one pod with good capacity, so system is NOT saturated.
+			break
+		}
+	}
+
+	if !foundPodWithGoodCapacity {
+		logger.V(logutil.VERBOSE).Info("No pods found with good capacity; system is considered SATURATED.")
+		return true
+	}
+
+	logger.V(logutil.VERBOSE).Info("System is considered NOT saturated (at least one pod has good capacity).")
+	return false
+}

--- a/pkg/epp/saturationdetector/saturationdetector_test.go
+++ b/pkg/epp/saturationdetector/saturationdetector_test.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package saturationdetector
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+)
+
+// --- Mock Implementations ---
+
+type mockDatastore struct {
+	pods []*backendmetrics.FakePodMetrics
+}
+
+// PodGetAll returns all pod metrics from the fake datastore.
+func (fds *mockDatastore) PodGetAll() []backendmetrics.PodMetrics {
+	pm := make([]backendmetrics.PodMetrics, 0, len(fds.pods))
+	for _, pod := range fds.pods {
+		pm = append(pm, pod)
+	}
+	return pm
+}
+
+// mockClock allows controlling time in tests.
+type mockClock struct {
+	mu   sync.RWMutex
+	time time.Time
+}
+
+func newMockClock(t time.Time) *mockClock {
+	return &mockClock{time: t}
+}
+
+func (c *mockClock) now() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.time
+}
+
+func newMockPodMetrics(name string, metrics *backendmetrics.MetricsState) *backendmetrics.FakePodMetrics {
+	return &backendmetrics.FakePodMetrics{
+		Pod: &backend.Pod{
+			NamespacedName: types.NamespacedName{Name: name, Namespace: "ns1"},
+		},
+		Metrics: metrics,
+	}
+}
+
+// --- Tests ---
+
+func TestNewDetector(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  Config
+		datastore               Datastore
+		expectError             error
+		expectedStalenessThresh time.Duration
+	}{
+		{
+			name: "Valid config",
+			config: Config{
+				QueueDepthThreshold:       10,
+				KVCacheUtilThreshold:      0.8,
+				MetricsStalenessThreshold: 100 * time.Millisecond,
+			},
+			datastore:               &mockDatastore{},
+			expectError:             nil,
+			expectedStalenessThresh: 100 * time.Millisecond,
+		},
+		{
+			name:                    "Nil datastore",
+			config:                  Config{},
+			datastore:               nil,
+			expectError:             ErrNilDatastore,
+			expectedStalenessThresh: DefaultMetricsStalenessThreshold, // Default will be set if error didn't occur first
+		},
+		{
+			name: "Zero staleness threshold uses default",
+			config: Config{
+				QueueDepthThreshold:       5,
+				KVCacheUtilThreshold:      0.9,
+				MetricsStalenessThreshold: 0, // Should use default
+			},
+			datastore:               &mockDatastore{},
+			expectError:             nil,
+			expectedStalenessThresh: DefaultMetricsStalenessThreshold,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector, err := NewDetector(tt.config, tt.datastore, logr.Discard())
+
+			if !errors.Is(err, tt.expectError) {
+				t.Errorf("NewDetector() error = %v, wantErr %v", err, tt.expectError)
+			}
+
+			if err == nil && detector != nil {
+				detector.clock = newMockClock(time.Now())
+				if detector.config.MetricsStalenessThreshold != tt.expectedStalenessThresh {
+					t.Errorf("NewDetector() MetricsStalenessThreshold = %v, want %v", detector.config.MetricsStalenessThreshold, tt.expectedStalenessThresh)
+				}
+				if detector.config.QueueDepthThreshold != tt.config.QueueDepthThreshold {
+					t.Errorf("NewDetector() QueueDepthThreshold = %d, want %d", detector.config.QueueDepthThreshold, tt.config.QueueDepthThreshold)
+				}
+				if detector.config.KVCacheUtilThreshold != tt.config.KVCacheUtilThreshold {
+					t.Errorf("NewDetector() KVCacheUtilThreshold = %f, want %f", detector.config.KVCacheUtilThreshold, tt.config.KVCacheUtilThreshold)
+				}
+			}
+		})
+	}
+}
+
+func TestDetector_IsSaturated(t *testing.T) {
+	baseTime := time.Now()
+	defaultConfig := Config{
+		QueueDepthThreshold:       5,
+		KVCacheUtilThreshold:      0.90,
+		MetricsStalenessThreshold: 100 * time.Millisecond,
+	}
+
+	tests := []struct {
+		name            string
+		config          Config
+		pods            []*backendmetrics.FakePodMetrics
+		expectedSaturat bool
+	}{
+		{
+			name:            "No pods in datastore",
+			config:          defaultConfig,
+			pods:            []*backendmetrics.FakePodMetrics{},
+			expectedSaturat: true, // No capacity = saturated
+		},
+		{
+			name:   "Single pod with good capacity",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    2,
+					KVCacheUsagePercent: 0.5,
+				}),
+			},
+			expectedSaturat: false,
+		},
+		{
+			name:   "Single pod with stale metrics",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime.Add(-200 * time.Millisecond), // Stale
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+			},
+			expectedSaturat: true,
+		},
+		{
+			name:   "Single pod with high queue depth",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    10, // Exceeds threshold 5
+					KVCacheUsagePercent: 0.1,
+				}),
+			},
+			expectedSaturat: true,
+		},
+		{
+			name:   "Single pod with high KV cache utilization",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.95, // Exceeds threshold 0.90
+				}),
+			},
+			expectedSaturat: true,
+		},
+		{
+			name:   "Single pod with nil metrics",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", nil),
+			},
+			expectedSaturat: true,
+		},
+		{
+			name:   "Multiple pods, all good capacity",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime.Add(-10 * time.Millisecond),
+					WaitingQueueSize:    0,
+					KVCacheUsagePercent: 0.2,
+				}),
+			},
+			expectedSaturat: false,
+		},
+		{
+			name:   "Multiple pods, one good, one bad (stale)",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime, // Good
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime.Add(-300 * time.Millisecond), // Stale
+					WaitingQueueSize:    0,
+					KVCacheUsagePercent: 0.2,
+				}),
+			},
+			expectedSaturat: false, // One good pod is enough
+		},
+		{
+			name:   "Multiple pods, one good, one bad (high queue)",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    15, // Bad queue
+					KVCacheUsagePercent: 0.2,
+				}),
+			},
+			expectedSaturat: false,
+		},
+		{
+			name:   "Multiple pods, all bad capacity",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime.Add(-200 * time.Millisecond), // Stale
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    20, // High queue
+					KVCacheUsagePercent: 0.2,
+				}),
+				newMockPodMetrics("pod3", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.99, // High KV
+				}),
+			},
+			expectedSaturat: true,
+		},
+		{
+			name:   "Queue depth exactly at threshold",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    defaultConfig.QueueDepthThreshold, // Exactly at threshold (good)
+					KVCacheUsagePercent: 0.1,
+				}),
+			},
+			expectedSaturat: false,
+		},
+		{
+			name:   "KV cache exactly at threshold",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime,
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: defaultConfig.KVCacheUtilThreshold, // Exactly at threshold (good)
+				}),
+			},
+			expectedSaturat: false,
+		},
+		{
+			name:   "Metrics age exactly at staleness threshold",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime.Add(-defaultConfig.MetricsStalenessThreshold), // Exactly at threshold (good)
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+			},
+			expectedSaturat: false,
+		},
+		{
+			name:   "Metrics age just over staleness threshold",
+			config: defaultConfig,
+			pods: []*backendmetrics.FakePodMetrics{
+				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
+					UpdateTime:          baseTime.Add(-defaultConfig.MetricsStalenessThreshold - time.Nanosecond), // Just over (stale)
+					WaitingQueueSize:    1,
+					KVCacheUsagePercent: 0.1,
+				}),
+			},
+			expectedSaturat: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDS := &mockDatastore{pods: tt.pods}
+
+			detector, err := NewDetector(tt.config, mockDS, logr.Discard())
+			if err != nil {
+				t.Fatalf("NewDetector() failed: %v", err)
+			}
+			detector.clock = newMockClock(baseTime)
+
+			if got := detector.IsSaturated(context.Background()); got != tt.expectedSaturat {
+				t.Errorf("IsSaturated() = %v, want %v", got, tt.expectedSaturat)
+			}
+		})
+	}
+}

--- a/pkg/epp/scheduling/config/config.go
+++ b/pkg/epp/scheduling/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	commonconfig "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/common/config"
 	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
@@ -31,11 +32,9 @@ type Config struct {
 }
 
 const (
-	// Default values to use if environment variables are not set
-	defaultKVCacheThreshold       = 0.8
-	defaultQueueThresholdCritical = 5
-	defaultQueueingThresholdLoRA  = 128
-	defaultLoraAffinityThreshold  = 0.999
+	// Default values for LoRA specific thresholds
+	defaultQueueingThresholdLoRA = 128
+	defaultLoraAffinityThreshold = 0.999
 )
 
 // LoadConfig loads configuration from environment variables
@@ -44,8 +43,8 @@ func LoadConfig() Config {
 	baseLogger := log.Log.WithName("scheduling-config")
 
 	config := Config{
-		KVCacheThreshold:       envutil.GetEnvFloat("KV_CACHE_THRESHOLD", defaultKVCacheThreshold, baseLogger),
-		QueueThresholdCritical: envutil.GetEnvInt("QUEUE_THRESHOLD_CRITICAL", defaultQueueThresholdCritical, baseLogger),
+		KVCacheThreshold:       envutil.GetEnvFloat("KV_CACHE_THRESHOLD", commonconfig.DefaultKVCacheThreshold, baseLogger),
+		QueueThresholdCritical: envutil.GetEnvInt("QUEUE_THRESHOLD_CRITICAL", commonconfig.DefaultQueueThresholdCritical, baseLogger),
 		QueueingThresholdLoRA:  envutil.GetEnvInt("QUEUING_THRESHOLD_LORA", defaultQueueingThresholdLoRA, baseLogger),
 		LoraAffinityThreshold:  envutil.GetEnvFloat("LORA_AFFINITY_THRESHOLD", defaultLoraAffinityThreshold, baseLogger),
 	}


### PR DESCRIPTION
This commit adds a new `SaturationDetector` component responsible for determining if backend model servers are saturated. It bases its decision on observed metrics like queue depth and KV cache utilization, using configurable thresholds.

To be submitted before #805 (split this change out for easier review).
Related  to: #674

It's initial implementation uses identical thresholds to the `HasCapacity` filter embedded in the default Scheduler filter chain for sheddable requests.

The detector is designed to be a self-contained unit that can be leveraged by other components for admission control and capacity assessment. This is the first step in a larger refactoring to externalize and centralize saturation detection logic.