### PR TITLE
generalize scheduling cycle state concept

### DIFF
--- a/pkg/epp/scheduling/plugins/prefix/plugin.go
+++ b/pkg/epp/scheduling/plugins/prefix/plugin.go
@@ -95,9 +95,7 @@ type SchedulingContextState struct {
 
 func (s *SchedulingContextState) Clone() types.StateData {
 	prefixHashes := make([]BlockHash, len(s.PrefixHashes))
-	for i, hash := range s.PrefixHashes {
-		prefixHashes[i] = hash
-	}
+	copy(prefixHashes, s.PrefixHashes)
 	prefixCacheServers := make(map[ServerID]int, len(s.PrefixCacheServers))
 	for key, value := range s.PrefixCacheServers {
 		prefixCacheServers[key] = value

--- a/pkg/epp/scheduling/plugins/prefix/plugin.go
+++ b/pkg/epp/scheduling/plugins/prefix/plugin.go
@@ -78,6 +78,13 @@ type Indexer interface {
 	Add(hashes []BlockHash, server ServerID)
 }
 
+// BlockHash is a hash of the block of request body.
+type BlockHash uint64
+
+type ServerID k8stypes.NamespacedName
+
+var _ types.SchedulingStateData = &SchedulingContextState{}
+
 // This is the state of this plugin to be used during a scheduling cycle.
 type SchedulingContextState struct {
 	// PrefixHashes is a list of prefix hashes of the request prompt broken into blocks.
@@ -86,10 +93,21 @@ type SchedulingContextState struct {
 	PrefixCacheServers map[ServerID]int
 }
 
-// BlockHash is a hash of the block of request body.
-type BlockHash uint64
+func (s *SchedulingContextState) Clone() types.SchedulingStateData {
+	prefixHashes := make([]BlockHash, len(s.PrefixHashes))
+	for i, hash := range s.PrefixHashes {
+		prefixHashes[i] = hash
+	}
+	prefixCacheServers := make(map[ServerID]int, len(s.PrefixCacheServers))
+	for key, value := range s.PrefixCacheServers {
+		prefixCacheServers[key] = value
+	}
 
-type ServerID k8stypes.NamespacedName
+	return &SchedulingContextState{
+		PrefixHashes:       prefixHashes,
+		PrefixCacheServers: prefixCacheServers,
+	}
+}
 
 func (s ServerID) String() string {
 	return k8stypes.NamespacedName(s).String()
@@ -109,18 +127,23 @@ func (m *Plugin) Name() string {
 
 func (m *Plugin) PreSchedule(ctx *types.SchedulingContext) {
 	hashes := hashPrompt(ctx, m.HashBlockSize, m.MaxPrefixBlocksToMatch)
-	state := SchedulingContextState{
+	state := &SchedulingContextState{
 		PrefixHashes:       hashes,
 		PrefixCacheServers: m.matchLongestPrefix(ctx, hashes, DefaultNumServersToMatch),
 	}
-	ctx.SetPluginState(types.PluginName(m.Name()), state)
+
+	ctx.CycleState.Write(types.StateKey(m.Name()), state)
 	ctx.Logger.V(logutil.DEBUG).Info(fmt.Sprintf("PreSchedule, cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
 }
 
 // If a request was routed to a server, record it in the cache:
 func (m *Plugin) PostSchedule(ctx *types.SchedulingContext, res *types.Result) {
 	targetPod := res.TargetPod.GetPod()
-	state := ctx.GetPluginState(types.PluginName(m.Name())).(SchedulingContextState)
+	state, err := m.getPrefixState(ctx.CycleState)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to read prefix plugin cycle state")
+		return
+	}
 	m.indexer.Add(state.PrefixHashes, ServerID(targetPod.NamespacedName))
 	total := len(state.PrefixHashes)
 	matchLen := state.PrefixCacheServers[ServerID(targetPod.NamespacedName)]
@@ -128,7 +151,14 @@ func (m *Plugin) PostSchedule(ctx *types.SchedulingContext, res *types.Result) {
 }
 
 func (m *Plugin) Score(ctx *types.SchedulingContext, pods []types.Pod) map[types.Pod]float64 {
-	state := ctx.GetPluginState(types.PluginName(m.Name())).(SchedulingContextState)
+	scores := make(map[types.Pod]float64, len(pods))
+
+	state, err := m.getPrefixState(ctx.CycleState)
+	if err != nil {
+		ctx.Logger.Error(err, "failed to read prefix plugin cycle state")
+		return scores
+	}
+
 	total := len(state.PrefixHashes)
 	podScoreFunc := func(pod types.Pod) float64 {
 		if total == 0 {
@@ -138,7 +168,6 @@ func (m *Plugin) Score(ctx *types.SchedulingContext, pods []types.Pod) map[types
 		return float64(matchLen) / float64(total)
 	}
 
-	scores := make(map[types.Pod]float64, len(pods))
 	for _, pod := range pods {
 		scores[pod] = podScoreFunc(pod)
 	}
@@ -168,6 +197,21 @@ func (m *Plugin) matchLongestPrefix(ctx *types.SchedulingContext, hashes []Block
 		}
 	}
 	return res
+}
+
+func (m *Plugin) getPrefixState(cycleState *types.SchedulingCycleState) (*SchedulingContextState, error) {
+	prefixStateKey := types.StateKey(m.Name())
+	state, err := cycleState.Read(prefixStateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading %q from CycleState: %w", prefixStateKey, err)
+	}
+
+	prefixSchedulingState, ok := state.(*SchedulingContextState)
+	if !ok {
+		return nil, fmt.Errorf("invalid Prefix state, got type %T", state)
+	}
+
+	return prefixSchedulingState, nil
 }
 
 // hashPrompt divides the prompt into blocks and calculate the prefix cache for each block.

--- a/pkg/epp/scheduling/plugins/prefix/plugin.go
+++ b/pkg/epp/scheduling/plugins/prefix/plugin.go
@@ -83,7 +83,7 @@ type BlockHash uint64
 
 type ServerID k8stypes.NamespacedName
 
-var _ types.SchedulingStateData = &SchedulingContextState{}
+var _ types.StateData = &SchedulingContextState{}
 
 // This is the state of this plugin to be used during a scheduling cycle.
 type SchedulingContextState struct {
@@ -93,7 +93,7 @@ type SchedulingContextState struct {
 	PrefixCacheServers map[ServerID]int
 }
 
-func (s *SchedulingContextState) Clone() types.SchedulingStateData {
+func (s *SchedulingContextState) Clone() types.StateData {
 	prefixHashes := make([]BlockHash, len(s.PrefixHashes))
 	for i, hash := range s.PrefixHashes {
 		prefixHashes[i] = hash
@@ -199,7 +199,7 @@ func (m *Plugin) matchLongestPrefix(ctx *types.SchedulingContext, hashes []Block
 	return res
 }
 
-func (m *Plugin) getPrefixState(cycleState *types.SchedulingCycleState) (*SchedulingContextState, error) {
+func (m *Plugin) getPrefixState(cycleState *types.CycleState) (*SchedulingContextState, error) {
 	prefixStateKey := types.StateKey(m.Name())
 	state, err := cycleState.Read(prefixStateKey)
 	if err != nil {

--- a/pkg/epp/scheduling/plugins/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/plugins/prefix/plugin_test.go
@@ -30,7 +30,8 @@ func TestPrefixPlugin(t *testing.T) {
 	}
 	ctx := types.NewSchedulingContext(context.Background(), req1, pods)
 	plugin.PreSchedule(ctx)
-	state := ctx.GetPluginState(types.PluginName(plugin.Name())).(SchedulingContextState)
+	state, err := plugin.getPrefixState(ctx.CycleState)
+	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
 	// Input size is 6, hash block size is 4, the last 2 characters are ignored.
 	// Total hashes = 2 (the first one is for the model)
@@ -54,7 +55,8 @@ func TestPrefixPlugin(t *testing.T) {
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req2, pods)
 	plugin.PreSchedule(ctx)
-	state = ctx.GetPluginState(types.PluginName(plugin.Name())).(SchedulingContextState)
+	state, err = plugin.getPrefixState(ctx.CycleState)
+	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
 	// Input size is 6, hash block size is 4, the last 2 characters are ignored.
 	// Total hashes = 2 (the first one is for the model)
@@ -77,7 +79,8 @@ func TestPrefixPlugin(t *testing.T) {
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req3, pods)
 	plugin.PreSchedule(ctx)
-	state = ctx.GetPluginState(types.PluginName(plugin.Name())).(SchedulingContextState)
+	state, err = plugin.getPrefixState(ctx.CycleState)
+	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
 	// Input size is 8, hash block size is 4, so 2 hashes will be calculated.
 	// Total hashes = 3 (the first one is for the model)
@@ -99,7 +102,8 @@ func TestPrefixPlugin(t *testing.T) {
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req4, pods)
 	plugin.PreSchedule(ctx)
-	state = ctx.GetPluginState(types.PluginName(plugin.Name())).(SchedulingContextState)
+	state, err = plugin.getPrefixState(ctx.CycleState)
+	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
 	// Input size is 8, hash block size is 4, so 2 hashes will be calculated.
 	// Total hashes = 3 (the first one is for the model)
@@ -121,7 +125,8 @@ func TestPrefixPlugin(t *testing.T) {
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req5, pods)
 	plugin.PreSchedule(ctx)
-	state = ctx.GetPluginState(types.PluginName(plugin.Name())).(SchedulingContextState)
+	state, err = plugin.getPrefixState(ctx.CycleState)
+	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
 	// Input size is 12, hash block size is 4, so 3 hashes will be calculated.
 	// Total hashes = 4 (the first one is for the model)

--- a/pkg/epp/scheduling/types/cycle_state.go
+++ b/pkg/epp/scheduling/types/cycle_state.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	// ErrNotFound is the not found error message.
+	ErrNotFound = errors.New("not found")
+)
+
+// StateData is a generic type for arbitrary data stored in CycleState.
+type StateData interface {
+	// Clone is an interface to make a copy of StateData.
+	Clone() StateData
+}
+
+// StateKey is the type of keys stored in CycleState.
+type StateKey string
+
+// NewCycleState initializes a new CycleState and returns its pointer.
+func NewCycleState() *CycleState {
+	return &CycleState{}
+}
+
+// CycleState provides a mechanism for plugins to store and retrieve arbitrary data.
+// StateData stored by one plugin can be read, altered, or deleted by another plugin.
+// CycleState does not provide any data protection, as all plugins are assumed to be
+// trusted.
+// Note: CycleState uses a sync.Map to back the storage, because it is thread safe. It's aimed to optimize for the "write once and read many times" scenarios.
+type CycleState struct {
+	// key: StateKey, value: StateData
+	storage sync.Map
+}
+
+// Clone creates a copy of CycleState and returns its pointer. Clone returns
+// nil if the context being cloned is nil.
+func (c *CycleState) Clone() *CycleState {
+	if c == nil {
+		return nil
+	}
+	copy := NewCycleState()
+	// Safe copy storage in case of overwriting.
+	c.storage.Range(func(k, v interface{}) bool {
+		copy.storage.Store(k, v.(StateData).Clone())
+		return true
+	})
+
+	return copy
+}
+
+// Read retrieves data with the given "key" from CycleState. If the key is not
+// present, ErrNotFound is returned.
+//
+// See CycleState for notes on concurrency.
+func (c *CycleState) Read(key StateKey) (StateData, error) {
+	if v, ok := c.storage.Load(key); ok {
+		return v.(StateData), nil
+	}
+	return nil, ErrNotFound
+}
+
+// Write stores the given "val" in CycleState with the given "key".
+//
+// See CycleState for notes on concurrency.
+func (c *CycleState) Write(key StateKey, val StateData) {
+	c.storage.Store(key, val)
+}
+
+// Delete deletes data with the given key from CycleState.
+//
+// See CycleState for notes on concurrency.
+func (c *CycleState) Delete(key StateKey) {
+	c.storage.Delete(key)
+}

--- a/pkg/epp/scheduling/types/scheduling_context.go
+++ b/pkg/epp/scheduling/types/scheduling_context.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func NewSchedulingContext(ctx context.Context, req *LLMRequest, pods []Pod) *SchedulingContext {
+	logger := log.FromContext(ctx).WithValues("request", req)
+	return &SchedulingContext{
+		Context:      ctx,
+		Logger:       logger,
+		Req:          req,
+		PodsSnapshot: pods,
+		CycleState:   NewCycleState(),
+	}
+}
+
+// SchedulingContext holds contextual information during a scheduling operation.
+type SchedulingContext struct {
+	context.Context
+	Logger       logr.Logger
+	Req          *LLMRequest
+	PodsSnapshot []Pod
+	// CycleState can be used by plugins to store state during a scheduling cycle, to communicate
+	// between different extension points.
+	CycleState *CycleState
+}


### PR DESCRIPTION
this PR aims to generalize scheduling CycleState inspired by the kube-scheduler framework CycleState.
the idea here is that the CycleState doesn't not necessarily map data from plugin name to its relevant state. 
it could be more generalized structures, for example adding headers field that can be consumed by the `schedule` caller.

additionally, it switches to using sync.map and interface similar to kube-scheduler. 
as of today, all scheduler plugins are running sequentially, but this can be easily changed to run plugins of the same type in parallel (e.g., each scorer is independent so it's possible to run all scorers in parallel to optimize response time).

This is part of a series of PRs that generalize scheduler and allow its extensibility in an easy and intuitive way. 