### PR TITLE
renamed Metrics to MetricsState and move to a separate file

### DIFF
--- a/pkg/epp/backend/metrics/fake.go
+++ b/pkg/epp/backend/metrics/fake.go
@@ -31,7 +31,7 @@ import (
 // FakePodMetrics is an implementation of PodMetrics that doesn't run the async refresh loop.
 type FakePodMetrics struct {
 	Pod     *backend.Pod
-	Metrics *Metrics
+	Metrics *MetricsState
 }
 
 func (fpm *FakePodMetrics) String() string {
@@ -41,7 +41,7 @@ func (fpm *FakePodMetrics) String() string {
 func (fpm *FakePodMetrics) GetPod() *backend.Pod {
 	return fpm.Pod
 }
-func (fpm *FakePodMetrics) GetMetrics() *Metrics {
+func (fpm *FakePodMetrics) GetMetrics() *MetricsState {
 	return fpm.Metrics
 }
 func (fpm *FakePodMetrics) UpdatePod(pod *corev1.Pod) {
@@ -53,10 +53,10 @@ type FakePodMetricsClient struct {
 	errMu sync.RWMutex
 	Err   map[types.NamespacedName]error
 	resMu sync.RWMutex
-	Res   map[types.NamespacedName]*Metrics
+	Res   map[types.NamespacedName]*MetricsState
 }
 
-func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, pod *backend.Pod, existing *Metrics, port int32) (*Metrics, error) {
+func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, pod *backend.Pod, existing *MetricsState, port int32) (*MetricsState, error) {
 	f.errMu.RLock()
 	err, ok := f.Err[pod.NamespacedName]
 	f.errMu.RUnlock()
@@ -73,7 +73,7 @@ func (f *FakePodMetricsClient) FetchMetrics(ctx context.Context, pod *backend.Po
 	return res.Clone(), nil
 }
 
-func (f *FakePodMetricsClient) SetRes(new map[types.NamespacedName]*Metrics) {
+func (f *FakePodMetricsClient) SetRes(new map[types.NamespacedName]*MetricsState) {
 	f.resMu.Lock()
 	defer f.resMu.Unlock()
 	f.Res = new

--- a/pkg/epp/backend/metrics/metrics.go
+++ b/pkg/epp/backend/metrics/metrics.go
@@ -41,7 +41,7 @@ type PodMetricsClientImpl struct {
 }
 
 // FetchMetrics fetches metrics from a given pod, clones the existing metrics object and returns an updated one.
-func (p *PodMetricsClientImpl) FetchMetrics(ctx context.Context, pod *backend.Pod, existing *Metrics, port int32) (*Metrics, error) {
+func (p *PodMetricsClientImpl) FetchMetrics(ctx context.Context, pod *backend.Pod, existing *MetricsState, port int32) (*MetricsState, error) {
 	// Currently the metrics endpoint is hard-coded, which works with vLLM.
 	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/16): Consume this from InferencePool config.
 	url := "http://" + pod.Address + ":" + strconv.Itoa(int(port)) + "/metrics"
@@ -73,8 +73,8 @@ func (p *PodMetricsClientImpl) FetchMetrics(ctx context.Context, pod *backend.Po
 // promToPodMetrics updates internal pod metrics with scraped Prometheus metrics.
 func (p *PodMetricsClientImpl) promToPodMetrics(
 	metricFamilies map[string]*dto.MetricFamily,
-	existing *Metrics,
-) (*Metrics, error) {
+	existing *MetricsState,
+) (*MetricsState, error) {
 	var errs error
 	updated := existing.Clone()
 

--- a/pkg/epp/backend/metrics/metrics_state.go
+++ b/pkg/epp/backend/metrics/metrics_state.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"time"
+)
+
+// newMetricsState initializes a new MetricsState and returns its pointer.
+func newMetricsState() *MetricsState {
+	return &MetricsState{
+		ActiveModels:  make(map[string]int),
+		WaitingModels: make(map[string]int),
+	}
+}
+
+// MetricsState holds the latest state of the metrics that were scraped from a pod.
+type MetricsState struct {
+	// ActiveModels is a set of models(including LoRA adapters) that are currently cached to GPU.
+	ActiveModels  map[string]int
+	WaitingModels map[string]int
+	// MaxActiveModels is the maximum number of models that can be loaded to GPU.
+	MaxActiveModels         int
+	RunningQueueSize        int
+	WaitingQueueSize        int
+	KVCacheUsagePercent     float64
+	KvCacheMaxTokenCapacity int
+
+	// UpdateTime record the last time when the metrics were updated.
+	UpdateTime time.Time
+}
+
+// String returns a string with all MetricState information
+func (s *MetricsState) String() string {
+	if s == nil {
+		return ""
+	}
+	return fmt.Sprintf("%+v", *s)
+}
+
+// Clone creates a copy of MetricsState and returns its pointer.
+// Clone returns nil if the object being cloned is nil.
+func (s *MetricsState) Clone() *MetricsState {
+	if s == nil {
+		return nil
+	}
+	activeModels := make(map[string]int, len(s.ActiveModels))
+	for key, value := range s.ActiveModels {
+		activeModels[key] = value
+	}
+	waitingModels := make(map[string]int, len(s.WaitingModels))
+	for key, value := range s.WaitingModels {
+		waitingModels[key] = value
+	}
+	return &MetricsState{
+		ActiveModels:            activeModels,
+		WaitingModels:           waitingModels,
+		MaxActiveModels:         s.MaxActiveModels,
+		RunningQueueSize:        s.RunningQueueSize,
+		WaitingQueueSize:        s.WaitingQueueSize,
+		KVCacheUsagePercent:     s.KVCacheUsagePercent,
+		KvCacheMaxTokenCapacity: s.KvCacheMaxTokenCapacity,
+		UpdateTime:              s.UpdateTime,
+	}
+}

--- a/pkg/epp/backend/metrics/metrics_test.go
+++ b/pkg/epp/backend/metrics/metrics_test.go
@@ -377,8 +377,8 @@ func TestPromToPodMetrics(t *testing.T) {
 		name            string
 		metricFamilies  map[string]*dto.MetricFamily
 		mapping         *MetricMapping
-		existingMetrics *Metrics
-		expectedMetrics *Metrics
+		existingMetrics *MetricsState
+		expectedMetrics *MetricsState
 		expectedErr     error // Count of expected errors
 	}{
 		{
@@ -401,8 +401,8 @@ func TestPromToPodMetrics(t *testing.T) {
 				KVCacheUtilization:  &MetricSpec{MetricName: "vllm_usage"},
 				LoraRequestInfo:     &MetricSpec{MetricName: "vllm:lora_requests_info"},
 			},
-			existingMetrics: &Metrics{},
-			expectedMetrics: &Metrics{
+			existingMetrics: &MetricsState{},
+			expectedMetrics: &MetricsState{
 				WaitingQueueSize:    7,
 				KVCacheUsagePercent: 0.8,
 				ActiveModels:        map[string]int{"lora1": 0, "lora2": 0},
@@ -418,8 +418,8 @@ func TestPromToPodMetrics(t *testing.T) {
 				KVCacheUtilization:  &MetricSpec{MetricName: "vllm_usage"},
 				LoraRequestInfo:     &MetricSpec{MetricName: "vllm:lora_requests_info"},
 			},
-			existingMetrics: &Metrics{ActiveModels: map[string]int{}, WaitingModels: map[string]int{}},
-			expectedMetrics: &Metrics{ActiveModels: map[string]int{}, WaitingModels: map[string]int{}},
+			existingMetrics: &MetricsState{ActiveModels: map[string]int{}, WaitingModels: map[string]int{}},
+			expectedMetrics: &MetricsState{ActiveModels: map[string]int{}, WaitingModels: map[string]int{}},
 			expectedErr:     multierr.Combine(errors.New("metric family \"vllm_waiting\" not found"), errors.New("metric family \"vllm_usage\" not found"), errors.New("metric family \"vllm:lora_requests_info\" not found")),
 		},
 		{
@@ -437,8 +437,8 @@ func TestPromToPodMetrics(t *testing.T) {
 				KVCacheUtilization:  &MetricSpec{MetricName: "vllm_usage"},
 				LoraRequestInfo:     &MetricSpec{MetricName: "vllm:lora_requests_info"},
 			},
-			existingMetrics: &Metrics{},
-			expectedMetrics: &Metrics{
+			existingMetrics: &MetricsState{},
+			expectedMetrics: &MetricsState{
 				WaitingQueueSize:    0,
 				KVCacheUsagePercent: 0.8,
 				ActiveModels:        map[string]int{"lora1": 0, "lora2": 0},
@@ -457,8 +457,8 @@ func TestPromToPodMetrics(t *testing.T) {
 			mapping: &MetricMapping{
 				LoraRequestInfo: &MetricSpec{MetricName: "vllm:lora_requests_info"},
 			},
-			existingMetrics: &Metrics{},
-			expectedMetrics: &Metrics{
+			existingMetrics: &MetricsState{},
+			expectedMetrics: &MetricsState{
 				ActiveModels:    map[string]int{"lora1": 0},
 				WaitingModels:   map[string]int{},
 				MaxActiveModels: 0, // Should still default to 0.
@@ -494,7 +494,7 @@ func TestFetchMetrics(t *testing.T) {
 			Name:      "pod",
 		},
 	}
-	existing := &Metrics{}
+	existing := &MetricsState{}
 	p := &PodMetricsClientImpl{} // No MetricMapping needed for this basic test
 
 	_, err := p.FetchMetrics(ctx, pod, existing, 9999) // Use a port that's unlikely to be in use.

--- a/pkg/epp/backend/metrics/pod_metrics.go
+++ b/pkg/epp/backend/metrics/pod_metrics.go
@@ -37,7 +37,7 @@ const (
 
 type podMetrics struct {
 	pod      atomic.Pointer[backend.Pod]
-	metrics  atomic.Pointer[Metrics]
+	metrics  atomic.Pointer[MetricsState]
 	pmc      PodMetricsClient
 	ds       Datastore
 	interval time.Duration
@@ -49,7 +49,7 @@ type podMetrics struct {
 }
 
 type PodMetricsClient interface {
-	FetchMetrics(ctx context.Context, pod *backend.Pod, existing *Metrics, port int32) (*Metrics, error)
+	FetchMetrics(ctx context.Context, pod *backend.Pod, existing *MetricsState, port int32) (*MetricsState, error)
 }
 
 func (pm *podMetrics) String() string {
@@ -60,7 +60,7 @@ func (pm *podMetrics) GetPod() *backend.Pod {
 	return pm.pod.Load()
 }
 
-func (pm *podMetrics) GetMetrics() *Metrics {
+func (pm *podMetrics) GetMetrics() *MetricsState {
 	return pm.metrics.Load()
 }
 

--- a/pkg/epp/backend/metrics/pod_metrics_test.go
+++ b/pkg/epp/backend/metrics/pod_metrics_test.go
@@ -36,7 +36,7 @@ var (
 			Namespace: "default",
 		},
 	}
-	initial = &Metrics{
+	initial = &MetricsState{
 		WaitingQueueSize:    0,
 		KVCacheUsagePercent: 0.2,
 		MaxActiveModels:     2,
@@ -46,7 +46,7 @@ var (
 		},
 		WaitingModels: map[string]int{},
 	}
-	updated = &Metrics{
+	updated = &MetricsState{
 		WaitingQueueSize:    9999,
 		KVCacheUsagePercent: 0.99,
 		MaxActiveModels:     99,
@@ -69,16 +69,16 @@ func TestMetricsRefresh(t *testing.T) {
 	namespacedName := types.NamespacedName{Name: pod1.Name, Namespace: pod1.Namespace}
 	// Use SetRes to simulate an update of metrics from the pod.
 	// Verify that the metrics are updated.
-	pmc.SetRes(map[types.NamespacedName]*Metrics{namespacedName: initial})
+	pmc.SetRes(map[types.NamespacedName]*MetricsState{namespacedName: initial})
 	condition := func(collect *assert.CollectT) {
-		assert.True(collect, cmp.Equal(pm.GetMetrics(), initial, cmpopts.IgnoreFields(Metrics{}, "UpdateTime")))
+		assert.True(collect, cmp.Equal(pm.GetMetrics(), initial, cmpopts.IgnoreFields(MetricsState{}, "UpdateTime")))
 	}
 	assert.EventuallyWithT(t, condition, time.Second, time.Millisecond)
 
 	// Stop the loop, and simulate metric update again, this time the PodMetrics won't get the
 	// new update.
 	pm.StopRefreshLoop()
-	pmc.SetRes(map[types.NamespacedName]*Metrics{namespacedName: updated})
+	pmc.SetRes(map[types.NamespacedName]*MetricsState{namespacedName: updated})
 	// Still expect the same condition (no metrics update).
 	assert.EventuallyWithT(t, condition, time.Second, time.Millisecond)
 }

--- a/pkg/epp/metrics/collectors/inference_pool_test.go
+++ b/pkg/epp/metrics/collectors/inference_pool_test.go
@@ -40,7 +40,7 @@ var (
 		},
 	}
 	pod1NamespacedName = types.NamespacedName{Name: pod1.Name, Namespace: pod1.Namespace}
-	pod1Metrics        = &backendmetrics.Metrics{
+	pod1Metrics        = &backendmetrics.MetricsState{
 		WaitingQueueSize:    100,
 		KVCacheUsagePercent: 0.2,
 		MaxActiveModels:     2,
@@ -62,7 +62,7 @@ func TestNoMetricsCollected(t *testing.T) {
 
 func TestMetricsCollected(t *testing.T) {
 	pmc := &backendmetrics.FakePodMetricsClient{
-		Res: map[types.NamespacedName]*backendmetrics.Metrics{
+		Res: map[types.NamespacedName]*backendmetrics.MetricsState{
 			pod1NamespacedName: pod1Metrics,
 		},
 	}

--- a/pkg/epp/scheduling/plugins/filter/filter_test.go
+++ b/pkg/epp/scheduling/plugins/filter/filter_test.go
@@ -64,29 +64,29 @@ func TestFilter(t *testing.T) {
 			filter: NewLeastQueueFilter(),
 			input: []types.Pod{
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize: 0,
 					},
 				},
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize: 3,
 					},
 				},
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize: 10,
 					},
 				},
 			},
 			output: []types.Pod{
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize: 0,
 					},
 				},
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize: 3,
 					},
 				},
@@ -103,29 +103,29 @@ func TestFilter(t *testing.T) {
 			filter: NewLeastKVCacheFilter(),
 			input: []types.Pod{
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						KVCacheUsagePercent: 0,
 					},
 				},
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						KVCacheUsagePercent: 0.3,
 					},
 				},
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						KVCacheUsagePercent: 1.0,
 					},
 				},
 			},
 			output: []types.Pod{
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						KVCacheUsagePercent: 0,
 					},
 				},
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						KVCacheUsagePercent: 0.3,
 					},
 				},
@@ -138,21 +138,21 @@ func TestFilter(t *testing.T) {
 			input: []types.Pod{
 				&types.PodMetrics{
 					// This pod should be returned.
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0,
 					},
 				},
 				&types.PodMetrics{
 					// Queue is non zero, despite low kv cache, should not return.
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize:    1,
 						KVCacheUsagePercent: 0.3,
 					},
 				},
 				&types.PodMetrics{
 					// High kv cache despite zero queue, should not return
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 1.0,
 					},
@@ -160,7 +160,7 @@ func TestFilter(t *testing.T) {
 			},
 			output: []types.Pod{
 				&types.PodMetrics{
-					Metrics: &backendmetrics.Metrics{
+					MetricsState: &backendmetrics.MetricsState{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0,
 					},
@@ -213,7 +213,7 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 	pods := []types.Pod{
 		&types.PodMetrics{
 			Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "affinity-pod"}},
-			Metrics: &backendmetrics.Metrics{
+			MetricsState: &backendmetrics.MetricsState{
 				MaxActiveModels: 2,
 				ActiveModels: map[string]int{
 					testAffinityModel: 1,
@@ -222,7 +222,7 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 		},
 		&types.PodMetrics{
 			Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "available-pod"}},
-			Metrics: &backendmetrics.Metrics{
+			MetricsState: &backendmetrics.MetricsState{
 				MaxActiveModels: 2,
 				ActiveModels:    map[string]int{},
 			},

--- a/pkg/epp/scheduling/plugins/scorer/kvcache_test.go
+++ b/pkg/epp/scheduling/plugins/scorer/kvcache_test.go
@@ -35,9 +35,9 @@ func TestKvCacheScorer(t *testing.T) {
 		{
 			name: "Different KV cache utilization",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.8}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.5}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.8}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.0}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 0.2, // Highest KV cache usage (0.8) gets lowest score (1-0.8=0.2)
@@ -48,8 +48,8 @@ func TestKvCacheScorer(t *testing.T) {
 		{
 			name: "Same KV cache utilization",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.6}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.6}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.6}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.6}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 0.4, // Both get same score (1-0.6=0.4)
@@ -59,8 +59,8 @@ func TestKvCacheScorer(t *testing.T) {
 		{
 			name: "Zero KV cache utilization",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.0}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.0}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 1.0, // No KV cache usage gets highest score
@@ -70,8 +70,8 @@ func TestKvCacheScorer(t *testing.T) {
 		{
 			name: "Full KV cache utilization",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 1.0}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 1.0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.5}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 0.0, // Full KV cache (1.0) gets lowest score (1-1=0)

--- a/pkg/epp/scheduling/plugins/scorer/queue_test.go
+++ b/pkg/epp/scheduling/plugins/scorer/queue_test.go
@@ -35,9 +35,9 @@ func TestQueueScorer(t *testing.T) {
 		{
 			name: "Different queue sizes",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 10}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 5}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 10}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 5}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 0}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 0.0, // Longest queue (10) gets lowest score
@@ -48,8 +48,8 @@ func TestQueueScorer(t *testing.T) {
 		{
 			name: "Same queue sizes",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 5}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 5}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 5}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 5}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 1.0, // When all pods have the same queue size, they get the same neutral score
@@ -59,8 +59,8 @@ func TestQueueScorer(t *testing.T) {
 		{
 			name: "Zero queue sizes",
 			pods: []types.Pod{
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 0}},
-				&types.PodMetrics{Pod: &backend.Pod{}, Metrics: &backendmetrics.Metrics{WaitingQueueSize: 0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 0}},
+				&types.PodMetrics{Pod: &backend.Pod{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 0}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 1.0,

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -60,7 +60,7 @@ func TestSchedule(t *testing.T) {
 			input: []*backendmetrics.FakePodMetrics{
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
 						MaxActiveModels:     2,
@@ -72,7 +72,7 @@ func TestSchedule(t *testing.T) {
 				},
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
 						MaxActiveModels:     2,
@@ -84,7 +84,7 @@ func TestSchedule(t *testing.T) {
 				},
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.2,
 						MaxActiveModels:     2,
@@ -98,7 +98,7 @@ func TestSchedule(t *testing.T) {
 				TargetPod: &types.ScoredPod{
 					Pod: &types.PodMetrics{
 						Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}, Labels: make(map[string]string)},
-						Metrics: &backendmetrics.Metrics{
+						MetricsState: &backendmetrics.MetricsState{
 							WaitingQueueSize:    3,
 							KVCacheUsagePercent: 0.1,
 							MaxActiveModels:     2,
@@ -123,7 +123,7 @@ func TestSchedule(t *testing.T) {
 			input: []*backendmetrics.FakePodMetrics{
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
 						MaxActiveModels:     2,
@@ -135,7 +135,7 @@ func TestSchedule(t *testing.T) {
 				},
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.1,
 						MaxActiveModels:     2,
@@ -147,7 +147,7 @@ func TestSchedule(t *testing.T) {
 				},
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.2,
 						MaxActiveModels:     2,
@@ -161,7 +161,7 @@ func TestSchedule(t *testing.T) {
 				TargetPod: &types.ScoredPod{
 					Pod: &types.PodMetrics{
 						Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}, Labels: make(map[string]string)},
-						Metrics: &backendmetrics.Metrics{
+						MetricsState: &backendmetrics.MetricsState{
 							WaitingQueueSize:    0,
 							KVCacheUsagePercent: 0.2,
 							MaxActiveModels:     2,
@@ -187,7 +187,7 @@ func TestSchedule(t *testing.T) {
 			input: []*backendmetrics.FakePodMetrics{
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.9,
 						MaxActiveModels:     2,
@@ -199,7 +199,7 @@ func TestSchedule(t *testing.T) {
 				},
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    3,
 						KVCacheUsagePercent: 0.85,
 						MaxActiveModels:     2,
@@ -211,7 +211,7 @@ func TestSchedule(t *testing.T) {
 				},
 				{
 					Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
-					Metrics: &backendmetrics.Metrics{
+					Metrics: &backendmetrics.MetricsState{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.85,
 						MaxActiveModels:     2,

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -57,7 +57,7 @@ type LLMResponse struct {
 
 type Pod interface {
 	GetPod() *backend.Pod
-	GetMetrics() *backendmetrics.Metrics
+	GetMetrics() *backendmetrics.MetricsState
 	String() string
 }
 
@@ -77,19 +77,19 @@ func (pm *PodMetrics) GetPod() *backend.Pod {
 	return pm.Pod
 }
 
-func (pm *PodMetrics) GetMetrics() *backendmetrics.Metrics {
-	return pm.Metrics
+func (pm *PodMetrics) GetMetrics() *backendmetrics.MetricsState {
+	return pm.MetricsState
 }
 
 type PodMetrics struct {
 	*backend.Pod
-	*backendmetrics.Metrics
+	*backendmetrics.MetricsState
 }
 
 func ToSchedulerPodMetrics(pods []backendmetrics.PodMetrics) []Pod {
 	pm := make([]Pod, 0, len(pods))
 	for _, pod := range pods {
-		pm = append(pm, &PodMetrics{Pod: pod.GetPod().Clone(), Metrics: pod.GetMetrics().Clone()})
+		pm = append(pm, &PodMetrics{Pod: pod.GetPod().Clone(), MetricsState: pod.GetMetrics().Clone()})
 	}
 	return pm
 }


### PR DESCRIPTION
This PR renames the struct `Metrics` (under backend/metrics) to `MetricsState` and move it to a separate file (extracted from `types.go`).

currently in the repo there are many different places that uses the terminology 'metrics', which makes it confusing to a newcomer to understand where do we define what metrics we collect, and where is the metrics latest state.
This PR aims to solve this issue, as the changed struct holds the state of the scraped metrics from a pod (the values may change every scraping internal).

Additionally, not only this change improves readability of current code, it's also a first PR out of a bigger change. 
on follow up PRs, the concept of ServerState (a general purpose interface) will be introduced and is representing a state of data that is collected/scraped from a pod (this is part of data layer and extensible pod scrapers).
MetricsState will the first use of that interface once the interface is introduced.

**This PR has NO LOGIC CHANGE**.