### PR TITLE
Docs: Bumps Kgateway to v2.0.2

### DIFF
--- a/config/manifests/gateway/kgateway/httproute.yaml
+++ b/config/manifests/gateway/kgateway/httproute.yaml
@@ -12,7 +12,6 @@ spec:
     - group: inference.networking.x-k8s.io
       kind: InferencePool
       name: vllm-llama3-8b-instruct
-      port: 8000 # Remove when https://github.com/kgateway-dev/kgateway/issues/10987 is fixed.
     matches:
     - path:
         type: PathPrefix

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -200,7 +200,7 @@ This quickstart guide is intended for engineers familiar with k8s and model serv
       2. Set the Kgateway version and install the Kgateway CRDs.
 
          ```bash
-         KGTW_VERSION=v2.0.0
+         KGTW_VERSION=v2.0.2
          helm upgrade -i --create-namespace --namespace kgateway-system --version $KGTW_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
          ```
 


### PR DESCRIPTION
- Updates the getting started guide to use Kgateway v2.0.2.
- Removes the port specifier workaround in the example Kgateway httproute.