### PR TITLE
Cleanup - organize scheduler plugin by their functionality instead of type

### DIFF
--- a/pkg/epp/scheduling/plugins/capacity/filter_test.go
+++ b/pkg/epp/scheduling/plugins/capacity/filter_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+)
+
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    *types.LLMRequest
+		filter plugins.Filter
+		input  []types.Pod
+		output []types.Pod
+	}{
+		{
+			name:   "SheddableCapacityFilter, sheddable request",
+			req:    &types.LLMRequest{Critical: false},
+			filter: &SheddableCapacityFilter{queueThreshold: 0, kvCacheThreshold: 0.8},
+			input: []types.Pod{
+				&types.PodMetrics{
+					// This pod should be returned.
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize:    0,
+						KVCacheUsagePercent: 0,
+					},
+				},
+				&types.PodMetrics{
+					// Queue is non zero, despite low kv cache, should not return.
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize:    1,
+						KVCacheUsagePercent: 0.3,
+					},
+				},
+				&types.PodMetrics{
+					// High kv cache despite zero queue, should not return
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize:    0,
+						KVCacheUsagePercent: 1.0,
+					},
+				},
+			},
+			output: []types.Pod{
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize:    0,
+						KVCacheUsagePercent: 0,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := types.NewSchedulingContext(context.Background(), test.req, nil, test.input)
+			got := test.filter.Filter(ctx, test.input)
+
+			if diff := cmp.Diff(test.output, got); diff != "" {
+				t.Errorf("Unexpected output (-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/epp/scheduling/plugins/capacity/sheddable_capacity_filter.go
+++ b/pkg/epp/scheduling/plugins/capacity/sheddable_capacity_filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filter
+package capacity
 
 import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/config"

--- a/pkg/epp/scheduling/plugins/kvcache/filter_test.go
+++ b/pkg/epp/scheduling/plugins/kvcache/filter_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+)
+
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    *types.LLMRequest
+		filter plugins.Filter
+		input  []types.Pod
+		output []types.Pod
+	}{
+
+		{
+			name:   "least kv cache empty input",
+			filter: NewLeastKVCacheFilter(),
+			input:  []types.Pod{},
+			output: []types.Pod{},
+		},
+		{
+			name:   "least kv cache",
+			filter: NewLeastKVCacheFilter(),
+			input: []types.Pod{
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						KVCacheUsagePercent: 0,
+					},
+				},
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						KVCacheUsagePercent: 0.3,
+					},
+				},
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						KVCacheUsagePercent: 1.0,
+					},
+				},
+			},
+			output: []types.Pod{
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						KVCacheUsagePercent: 0,
+					},
+				},
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						KVCacheUsagePercent: 0.3,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := types.NewSchedulingContext(context.Background(), test.req, nil, test.input)
+			got := test.filter.Filter(ctx, test.input)
+
+			if diff := cmp.Diff(test.output, got); diff != "" {
+				t.Errorf("Unexpected output (-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/epp/scheduling/plugins/kvcache/kvcache_scorer.go
+++ b/pkg/epp/scheduling/plugins/kvcache/kvcache_scorer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scorer
+package kvcache
 
 import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"

--- a/pkg/epp/scheduling/plugins/kvcache/kvcache_scorer_test.go
+++ b/pkg/epp/scheduling/plugins/kvcache/kvcache_scorer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scorer
+package kvcache
 
 import (
 	"context"

--- a/pkg/epp/scheduling/plugins/kvcache/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/plugins/kvcache/least_kvcache_filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filter
+package kvcache
 
 import (
 	"math"

--- a/pkg/epp/scheduling/plugins/lora/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/plugins/lora/lora_affinity_filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filter
+package lora
 
 import (
 	"math/rand"

--- a/pkg/epp/scheduling/plugins/queue/filter_test.go
+++ b/pkg/epp/scheduling/plugins/queue/filter_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+)
+
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    *types.LLMRequest
+		filter plugins.Filter
+		input  []types.Pod
+		output []types.Pod
+	}{
+		{
+			name:   "least queuing empty input",
+			filter: NewLeastQueueFilter(),
+			input:  []types.Pod{},
+			output: []types.Pod{},
+		},
+		{
+			name:   "least queuing",
+			filter: NewLeastQueueFilter(),
+			input: []types.Pod{
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize: 0,
+					},
+				},
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize: 3,
+					},
+				},
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize: 10,
+					},
+				},
+			},
+			output: []types.Pod{
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize: 0,
+					},
+				},
+				&types.PodMetrics{
+					MetricsState: &backendmetrics.MetricsState{
+						WaitingQueueSize: 3,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := types.NewSchedulingContext(context.Background(), test.req, nil, test.input)
+			got := test.filter.Filter(ctx, test.input)
+
+			if diff := cmp.Diff(test.output, got); diff != "" {
+				t.Errorf("Unexpected output (-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/epp/scheduling/plugins/queue/least_queue_filter.go
+++ b/pkg/epp/scheduling/plugins/queue/least_queue_filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filter
+package queue
 
 import (
 	"math"

--- a/pkg/epp/scheduling/plugins/queue/low_queue_filter.go
+++ b/pkg/epp/scheduling/plugins/queue/low_queue_filter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package filter
+package queue
 
 import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/config"

--- a/pkg/epp/scheduling/plugins/queue/queue_scorer.go
+++ b/pkg/epp/scheduling/plugins/queue/queue_scorer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scorer
+package queue
 
 import (
 	"math"

--- a/pkg/epp/scheduling/plugins/queue/queue_scorer_test.go
+++ b/pkg/epp/scheduling/plugins/queue/queue_scorer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scorer
+package queue
 
 import (
 	"context"


### PR DESCRIPTION
PURE REFACTOR. NO LOGIC CHANGE.

This was discussed in https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/801#issuecomment-2873425931

The new way of organizing the plugins avoids confusion as some plugins can implement multiple plugin types (extension points).

**Option 1: (Current)** A "hybrid" organization based on plugin type (if a plugin only implements one plugin interface) and plugin functionality (if it implements multiple pugin interfaces)

```
plugins/
|--filter/ (plugins that only implement the Filter interface)
|----lora_affinity.go
|----least_kv_cache.go
|--scorer/ (plugins that only implement the Score interface)
|----queue.go
|----kv_cache.gpo
|--picker/ 
|----random_picker.go
|----max_score_picker.go
|--prefix/ (prefix plugin implements multiple plugin interfaces)
|-----plugin.go
|-----indexer.go
```

** Option 2: (This PR)**  Organize based on the functionality of the plugin, not which interface it implements. 
```
plugins
|--queue/ (queue filter and scorers)
|----queue_scorer.go
|----least_queue_filter.go
|--lora/ (lora affinity filter)
|----lora_affinity.go
|--kvcache/ (kv cache related filter and scorers)
|----leat_kv_cache_filter.go
|----kv_cache_scorer.gpo
|--prefix/ (no change to existing structure)
|-----plugin.go
|-----indexer.go
|--filter-util/
|----decision_tree_filter.go
|--random_picker.go
|--max_score_picker.go
```

** Option 3: (An improved version of Option 1, credits to @nirrozenbaum ) **
```
plugins/
├── filter/(...filters that only implement the Filter interface...)
├── scorer/(...scorers that only implement the Scorer interface...)
└── multi/ (plugins that implement multiple interfaces)
└──── prefix/(... your prefix files...)
└──── MY_PLUGIN_THAT_IMPLEMENTS_MULTIPLE_INTERFACES
```
