### PR TITLE
reduce log level of "prefix cached servers" to TRACE

### DIFF
--- a/pkg/epp/scheduling/plugins/prefix/plugin.go
+++ b/pkg/epp/scheduling/plugins/prefix/plugin.go
@@ -186,7 +186,7 @@ func (m *Plugin) matchLongestPrefix(ctx *types.SchedulingContext, hashes []Block
 		hash := hashes[i]
 		cachedServers := m.indexer.Get(hash)
 		if len(cachedServers) > 0 {
-			ctx.Logger.V(logutil.DEBUG).Info("Found cached servers", "cachedServers", cachedServers, "total # blocks", len(hashes), "longest prefix", i)
+			ctx.Logger.V(logutil.TRACE).Info("Found cached servers", "cachedServers", cachedServers, "total # blocks", len(hashes), "longest prefix", i)
 			for server := range cachedServers {
 				// Update servers with their longest prefix match.
 				// If we already found this server with longer prefix match, don't update it.

--- a/pkg/epp/scheduling/plugins/prefix/plugin.go
+++ b/pkg/epp/scheduling/plugins/prefix/plugin.go
@@ -119,6 +119,7 @@ func New(config Config) *Plugin {
 	return m
 }
 
+// Name returns the name of the plugin.
 func (m *Plugin) Name() string {
 	return "prefix-cache"
 }
@@ -131,7 +132,7 @@ func (m *Plugin) PreSchedule(ctx *types.SchedulingContext) {
 	}
 
 	ctx.CycleState.Write(types.StateKey(m.Name()), state)
-	ctx.Logger.V(logutil.DEBUG).Info(fmt.Sprintf("PreSchedule, cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
+	ctx.Logger.V(logutil.TRACE).Info(fmt.Sprintf("PreSchedule, cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
 }
 
 // If a request was routed to a server, record it in the cache:
@@ -148,6 +149,7 @@ func (m *Plugin) PostSchedule(ctx *types.SchedulingContext, res *types.Result) {
 	metrics.RecordPrefixCacheMatch(matchLen*m.HashBlockSize, total*m.HashBlockSize)
 }
 
+// Score returns the scoring result for the given list of pods based on context.
 func (m *Plugin) Score(ctx *types.SchedulingContext, pods []types.Pod) map[types.Pod]float64 {
 	scores := make(map[types.Pod]float64, len(pods))
 


### PR DESCRIPTION
default log level of epp is 4, having this log in debug level bombs the log with this line.

when running scheduler with prefix plugin enabled the log includes multiple lines of `found cached servers`.
this is running for every prefix and every server that includes that prefix.
the below log is a small part of a SINGLE REQUEST log:
```
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"scheduling/scheduler.go:139","msg":"Running pre-schedule plugin","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","plugin":"prefix-cache"}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":91}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":90}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":89}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":88}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":87}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":86}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":85}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":84}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":83}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":82}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":81}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":80}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":79}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":78}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":77}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":76}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":75}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":74}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":73}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":72}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":71}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":70}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":69}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":68}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":67}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":66}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":65}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":64}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":63}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":62}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":61}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":60}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":59}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":58}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":57}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":56}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":55}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":54}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":53}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":52}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":51}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":50}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":49}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":48}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":47}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":46}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":45}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":44}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-id":"97307923-8d96-4eaf-840d-3cb1c735f465","request":"TargetModel: meta-llama/Llama-3.1-70B-Instruct, Critical: true, PromptLength: 6803, Headers: map[:authority:inference-gateway :method:POST :path:/v1/chat/completions :scheme:http accept:application/json accept-encoding:gzip, deflate authorization:Bearer EMPTY content-length:7028 content-type:application/json user-agent:AsyncOpenAI/Python 1.77.0 x-envoy-external-address:10.129.2.64 x-forwarded-for:10.129.2.64 x-forwarded-proto:http x-request-id:97307923-8d96-4eaf-840d-3cb1c735f465 x-stainless-arch:x64 x-stainless-async:async:asyncio x-stainless-lang:python x-stainless-os:Linux x-stainless-package-version:1.77.0 x-stainless-read-timeout:600 x-stainless-retry-count:0 x-stainless-runtime:CPython x-stainless-runtime-version:3.12.10]","cachedServersError":"json: unsupported type: map[prefix.ServerID]bool","total # blocks":107,"longest prefix":43}
{"level":"Level(-4)","ts":"2025-05-15T18:30:36Z","caller":"prefix/plugin.go:187","msg":"Found cached servers","x-request-........

...
...
...
```