### PR TITLE
fixed log before picker

### DIFF
--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -196,7 +196,7 @@ func (s *Scheduler) runPickerPlugin(ctx *types.SchedulingContext, weightedScoreP
 		i++
 	}
 
-	loggerDebug.Info("Before running picker plugin", "pods", weightedScorePerPod)
+	loggerDebug.Info("Before running picker plugin", "pods weighted score", fmt.Sprint(weightedScorePerPod))
 	before := time.Now()
 	result := s.picker.Pick(ctx, scoredPods)
 	metrics.RecordSchedulerPluginProcessingLatency(plugins.PickerPluginType, s.picker.Name(), time.Since(before))


### PR DESCRIPTION
fix the 'unsupported type: map[types.Pod]float64"}' error at the end of the log line:
```
{"level":"Level(-4)","ts":"2025-05-15T16:43:38Z","caller":"scheduling/scheduler.go:199","msg":"Before running picker plugin","x-request-id":"...","request":"TargetModel: meta-llama/Llama-3.2-3B-Instruct, Critical: false, PromptLength: 388, Headers: map[...]","podsError":"json: unsupported type: map[types.Pod]float64"}
```