### PR TITLE
adding logging & support for better Client response 

### DIFF
--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -47,7 +47,6 @@ type ExtProcServerRunner struct {
 	Datastore                                datastore.Datastore
 	SecureServing                            bool
 	CertPath                                 string
-	UseStreaming                             bool
 	RefreshPrometheusMetricsInterval         time.Duration
 	Scheduler                                requestcontrol.Scheduler
 


### PR DESCRIPTION
When requests/responses are not valid json, EPP clobbered any body message. This should improve UX & useful messaging in the face of failures.