### PR TITLE
updated godoc on scheduler filters, pickers and prefix plugin

### DIFF
--- a/pkg/epp/scheduling/plugins/filter/decision_tree_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/decision_tree_filter.go
@@ -22,6 +22,9 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
+// compile-time type validation
+var _ plugins.Filter = &DecisionTreeFilter{}
+
 // DecisionTreeFilter applies current fitler, and then recursively applies next filters
 // depending success or failure of the current filter.
 // It can be used to construct a flow chart algorithm.

--- a/pkg/epp/scheduling/plugins/filter/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/least_kvcache_filter.go
@@ -26,7 +26,7 @@ import (
 // compile-time type validation
 var _ plugins.Filter = &LeastKVCacheFilter{}
 
-// NewLeastKVCacheFilter returns a new LeastKVCacheFilter.
+// NewLeastKVCacheFilter initializes a new LeastKVCacheFilter and returns its pointer.
 func NewLeastKVCacheFilter() *LeastKVCacheFilter {
 	return &LeastKVCacheFilter{}
 }

--- a/pkg/epp/scheduling/plugins/filter/least_queue_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/least_queue_filter.go
@@ -26,7 +26,7 @@ import (
 // compile-time type validation
 var _ plugins.Filter = &LeastQueueFilter{}
 
-// NewLeastQueueFilter returns a new LeastQueueFilter.
+// NewLeastQueueFilter initializes a new LeastQueueFilter and returns its pointer.
 func NewLeastQueueFilter() *LeastQueueFilter {
 	return &LeastQueueFilter{}
 }
@@ -35,8 +35,7 @@ func NewLeastQueueFilter() *LeastQueueFilter {
 // (max-min) by the number of pods, and finds the pods that fall into the first range.
 // The intuition is that if there are multiple pods that share similar queue size in the low range,
 // we should consider them all instead of the absolute minimum one. This worked better than picking
-// the least one as it gives more choices for the next filter, which on aggregate gave better
-// results.
+// the least one as it gives more choices for the next filter, which on aggregate gave better results.
 type LeastQueueFilter struct{}
 
 // Name returns the name of the filter.

--- a/pkg/epp/scheduling/plugins/filter/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/lora_affinity_filter.go
@@ -28,7 +28,7 @@ import (
 // compile-time type validation
 var _ plugins.Filter = &LoraAffinityFilter{}
 
-// NewLoraAffinityFilter returns a new LoraAffinityFilter.
+// NewLoraAffinityFilter initializes a new LoraAffinityFilter and returns its pointer.
 func NewLoraAffinityFilter() *LoraAffinityFilter {
 	return &LoraAffinityFilter{
 		loraAffinityThreshold: config.Conf.LoraAffinityThreshold,

--- a/pkg/epp/scheduling/plugins/filter/low_queue_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/low_queue_filter.go
@@ -25,7 +25,7 @@ import (
 // compile-time type validation
 var _ plugins.Filter = &LowQueueFilter{}
 
-// NewLowQueueFilter returns a new LowQueueFilter.
+// NewLowQueueFilter initializes a new LowQueueFilter and returns its pointer.
 func NewLowQueueFilter() *LowQueueFilter {
 	return &LowQueueFilter{
 		queueingThresholdLoRA: config.Conf.QueueingThresholdLoRA,

--- a/pkg/epp/scheduling/plugins/filter/sheddable_capacity_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/sheddable_capacity_filter.go
@@ -25,7 +25,7 @@ import (
 // compile-time type validation
 var _ plugins.Filter = &SheddableCapacityFilter{}
 
-// NewSheddableCapacityFilter returns a new SheddableCapacityFilter.
+// NewSheddableCapacityFilter initializes a new SheddableCapacityFilter and returns its pointer.
 func NewSheddableCapacityFilter() *SheddableCapacityFilter {
 	return &SheddableCapacityFilter{
 		queueThreshold:   config.Conf.QueueThresholdCritical,

--- a/pkg/epp/scheduling/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/plugins/picker/max_score_picker.go
@@ -24,11 +24,13 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
+// compile-time type validation
 var _ plugins.Picker = &MaxScorePicker{}
 
-func NewMaxScorePicker() plugins.Picker {
+// NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
+func NewMaxScorePicker() *MaxScorePicker {
 	return &MaxScorePicker{
-		random: &RandomPicker{},
+		random: NewRandomPicker(),
 	}
 }
 

--- a/pkg/epp/scheduling/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/plugins/picker/random_picker.go
@@ -25,15 +25,23 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
+// compile-time type validation
 var _ plugins.Picker = &RandomPicker{}
+
+// NewRandomPicker initializes a new RandomPicker and returns its pointer.
+func NewRandomPicker() *RandomPicker {
+	return &RandomPicker{}
+}
 
 // RandomPicker picks a random pod from the list of candidates.
 type RandomPicker struct{}
 
+// Name returns the name of the picker.
 func (p *RandomPicker) Name() string {
 	return "random"
 }
 
+// Pick selects a random pod from the list of candidates.
 func (p *RandomPicker) Pick(ctx *types.SchedulingContext, scoredPods []*types.ScoredPod) *types.Result {
 	ctx.Logger.V(logutil.DEBUG).Info(fmt.Sprintf("Selecting a random pod from %d candidates: %+v", len(scoredPods), scoredPods))
 	i := rand.Intn(len(scoredPods))


### PR DESCRIPTION
This PR updates godoc on all filters, pickers and prefix plugin (mutli-extension plugin).

there are few more places to add godoc but to avoid conflicts with other opened PR, this will be done in a follow up PR after the existing ones are merged.