### PR TITLE
remove the PreCycle plugin from scheduler

### DIFF
--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -572,11 +572,6 @@ func TestSchedulerPluginProcessingLatencies(t *testing.T) {
 			name: "multiple plugins",
 			latencies: []pluginLatency{
 				{
-					pluginType: "PreSchedule",
-					pluginName: "PluginA",
-					duration:   100 * time.Millisecond,
-				},
-				{
 					pluginType: "PostSchedule",
 					pluginName: "PluginB",
 					duration:   200 * time.Millisecond,

--- a/pkg/epp/metrics/testdata/scheduler_plugin_processing_latencies_metric
+++ b/pkg/epp/metrics/testdata/scheduler_plugin_processing_latencies_metric
@@ -1,18 +1,5 @@
 # HELP inference_extension_scheduler_plugin_duration_seconds [ALPHA] Scheduler plugin processing latency distribution in seconds for each plugin type and plugin name.
 # TYPE inference_extension_scheduler_plugin_duration_seconds histogram
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.0001"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.0002"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.0005"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.001"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.002"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.005"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.01"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.02"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.05"} 0
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="0.1"} 1
-inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginA",plugin_type="PreSchedule",le="+Inf"} 1
-inference_extension_scheduler_plugin_duration_seconds_sum{plugin_name="PluginA",plugin_type="PreSchedule"} 0.1
-inference_extension_scheduler_plugin_duration_seconds_count{plugin_name="PluginA",plugin_type="PreSchedule"} 1
 inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginB",plugin_type="PostSchedule",le="0.0001"} 0
 inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginB",plugin_type="PostSchedule",le="0.0002"} 0
 inference_extension_scheduler_plugin_duration_seconds_bucket{plugin_name="PluginB",plugin_type="PostSchedule",le="0.0005"} 0

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	ProfilePickerType      = "ProfilePicker"
-	PreCyclePluginType     = "PreCycle"
 	FilterPluginType       = "Filter"
 	ScorerPluginType       = "Scorer"
 	PickerPluginType       = "Picker"
@@ -42,13 +41,6 @@ type Plugin interface {
 type ProfilePicker interface {
 	Plugin
 	Pick(request *types.LLMRequest, profiles map[string]*SchedulerProfile, executionResults map[string]*types.Result) map[string]*SchedulerProfile
-}
-
-// PreCycle is called when the scheduler receives a new request and invokes a SchedulerProfile cycle.
-// It can be used for various initialization work.
-type PreCycle interface {
-	Plugin
-	PreCycle(ctx *types.SchedulingContext)
 }
 
 // Filter defines the interface for filtering a list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -114,7 +114,6 @@ func (s *schedulingContextState) Clone() types.StateData {
 }
 
 // compile-time type assertion
-var _ framework.PreCycle = &Plugin{}
 var _ framework.Scorer = &Plugin{}
 var _ framework.PostCycle = &Plugin{}
 
@@ -130,18 +129,6 @@ func New(config Config) *Plugin {
 // Name returns the name of the plugin.
 func (m *Plugin) Name() string {
 	return "prefix-cache"
-}
-
-// PreCycle initializes the prefix plugin state for the current scheduling cycle.
-func (m *Plugin) PreCycle(ctx *types.SchedulingContext) {
-	hashes := hashPrompt(ctx, m.HashBlockSize, m.MaxPrefixBlocksToMatch)
-	state := &schedulingContextState{
-		PrefixHashes:       hashes,
-		PrefixCacheServers: m.matchLongestPrefix(ctx, hashes, DefaultNumServersToMatch),
-	}
-
-	ctx.CycleState.Write(types.StateKey(m.Name()), state)
-	ctx.Logger.V(logutil.TRACE).Info(fmt.Sprintf("PreCycle, cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
 }
 
 // PostCycle records in the plugin cache the result of the scheduling selection.
@@ -160,13 +147,20 @@ func (m *Plugin) PostCycle(ctx *types.SchedulingContext, res *types.Result) {
 
 // Score returns the scoring result for the given list of pods based on context.
 func (m *Plugin) Score(ctx *types.SchedulingContext, pods []types.Pod) map[types.Pod]float64 {
-	scores := make(map[types.Pod]float64, len(pods))
-
-	state, err := m.getPrefixState(ctx.CycleState)
-	if err != nil {
-		ctx.Logger.Error(err, "failed to read prefix plugin cycle state")
-		return scores
+	// pre score step, hashing prompt and find longest prefix match.
+	hashes := hashPrompt(ctx, m.HashBlockSize, m.MaxPrefixBlocksToMatch)
+	numServers := DefaultNumServersToMatch
+	if numServers > len(pods) {
+		numServers = len(pods)
 	}
+	state := &schedulingContextState{
+		PrefixHashes:       hashes,
+		PrefixCacheServers: m.matchLongestPrefix(ctx, hashes, numServers),
+	}
+	ctx.CycleState.Write(types.StateKey(m.Name()), state)
+	ctx.Logger.V(logutil.TRACE).Info(fmt.Sprintf("cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
+	// calculate the scores of pods
+	scores := make(map[types.Pod]float64, len(pods))
 
 	total := len(state.PrefixHashes)
 	podScoreFunc := func(pod types.Pod) float64 {
@@ -185,9 +179,6 @@ func (m *Plugin) Score(ctx *types.SchedulingContext, pods []types.Pod) map[types
 
 // matchLongestPrefix returns a map of servers and length of prefix that each server caches.
 func (m *Plugin) matchLongestPrefix(ctx *types.SchedulingContext, hashes []BlockHash, numServers int) map[ServerID]int {
-	if numServers > len(ctx.PodsSnapshot) {
-		numServers = len(ctx.PodsSnapshot)
-	}
 	res := make(map[ServerID]int)
 	// Use a greedy strategy to search from the longest prefix.
 	// NOTE: It's possible to further optimize this with a binary search.

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -28,7 +28,8 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaaaa",
 	}
 	ctx := types.NewSchedulingContext(context.Background(), req1, nil, pods)
-	plugin.PreCycle(ctx)
+	// Updated to use the new Score method signature
+	scores := plugin.Score(ctx, pods)
 	state, err := plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
@@ -36,9 +37,6 @@ func TestPrefixPlugin(t *testing.T) {
 	// Total hashes = 2 (the first one is for the model)
 	assert.Equal(t, 2, len(state.PrefixHashes), "number of hashes is incorrect")
 	assert.Equal(t, 0, len(state.PrefixCacheServers), "there shouldn't be any cached servers")
-
-	// Updated to use the new Score method signature
-	scores := plugin.Score(ctx, pods)
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
@@ -52,7 +50,8 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "bbbbbb",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req2, nil, pods)
-	plugin.PreCycle(ctx)
+	// Updated to use the new Score method signature
+	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
@@ -60,9 +59,6 @@ func TestPrefixPlugin(t *testing.T) {
 	// Total hashes = 2 (the first one is for the model)
 	assert.Equal(t, 2, len(state.PrefixHashes), "number of hashes is incorrect")
 	assert.Equal(t, 0, len(state.PrefixCacheServers), "there shouldn't be any cached servers")
-
-	// Updated to use the new Score method signature
-	scores = plugin.Score(ctx, pods)
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
@@ -75,7 +71,8 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaabbbb",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req3, nil, pods)
-	plugin.PreCycle(ctx)
+	// Updated to use the new Score method signature
+	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
@@ -83,9 +80,6 @@ func TestPrefixPlugin(t *testing.T) {
 	// Total hashes = 3 (the first one is for the model)
 	assert.Equal(t, 3, len(state.PrefixHashes), "number of hashes is incorrect")
 	assert.Equal(t, 1, len(state.PrefixCacheServers), "pod1 should have cached the aaaa prefix")
-
-	// Updated to use the new Score method signature
-	scores = plugin.Score(ctx, pods)
 	assert.Equal(t, float64(2)/float64(3), scores[pod1], "score should be 2/3 - the model and the first prefix block match")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
@@ -97,7 +91,8 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaabbbb",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req4, nil, pods)
-	plugin.PreCycle(ctx)
+	// Updated to use the new Score method signature
+	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
@@ -105,9 +100,6 @@ func TestPrefixPlugin(t *testing.T) {
 	// Total hashes = 3 (the first one is for the model)
 	assert.Equal(t, 3, len(state.PrefixHashes), "number of hashes is incorrect")
 	assert.Equal(t, 0, len(state.PrefixCacheServers), "pod1 should have cached the aaaa prefix")
-
-	// Updated to use the new Score method signature
-	scores = plugin.Score(ctx, pods)
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
@@ -119,7 +111,8 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaabbbbcccc",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req5, nil, pods)
-	plugin.PreCycle(ctx)
+	// Updated to use the new Score method signature
+	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
 	t.Logf("Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
@@ -127,9 +120,6 @@ func TestPrefixPlugin(t *testing.T) {
 	// Total hashes = 4 (the first one is for the model)
 	assert.Equal(t, 4, len(state.PrefixHashes), "number of hashes is incorrect")
 	assert.Equal(t, 1, len(state.PrefixCacheServers), "pod1 should have cached the aaaa prefix")
-
-	// Updated to use the new Score method signature
-	scores = plugin.Score(ctx, pods)
 	assert.Equal(t, 0.75, scores[pod1], "score should be 0.75 - the model and the first 2 prefix blocks match")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -28,7 +28,6 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaaaa",
 	}
 	ctx := types.NewSchedulingContext(context.Background(), req1, nil, pods)
-	// Updated to use the new Score method signature
 	scores := plugin.Score(ctx, pods)
 	state, err := plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
@@ -50,7 +49,6 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "bbbbbb",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req2, nil, pods)
-	// Updated to use the new Score method signature
 	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
@@ -71,7 +69,6 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaabbbb",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req3, nil, pods)
-	// Updated to use the new Score method signature
 	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
@@ -91,7 +88,6 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaabbbb",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req4, nil, pods)
-	// Updated to use the new Score method signature
 	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)
@@ -111,7 +107,6 @@ func TestPrefixPlugin(t *testing.T) {
 		Prompt:      "aaaabbbbcccc",
 	}
 	ctx = types.NewSchedulingContext(context.Background(), req5, nil, pods)
-	// Updated to use the new Score method signature
 	scores = plugin.Score(ctx, pods)
 	state, err = plugin.getPrefixState(ctx.CycleState)
 	assert.NoError(t, err)


### PR DESCRIPTION
as discussed in scheduler design latest discussions, the plan is to completely remove the Pre/Post Cycle (previously called Pre/Post Schedule) from Scheduler. atm the only plugin that uses both is Prefix.
This PR completely removes `PreCycle` plugin from the scheduler.

As a side effect, this PR also fixes the following bug:

before this PR, the logic that calculated hashes in Prefix plugin `PreCycle` could have been buggy, since pods that have the longest prefix may be filtered out in the filter phase.

This PR is fixing this problem by calculating longest prefix only for the pods that passed the filtering phase.

cc: @ahg-g @kfswain @liu-cong 