### PR TITLE
[WIP] feat(conformance): Add HTTPRoute port validation tests for InferencePool backends

### DIFF
--- a/conformance/tests/basic/inferencepool_httproute_port_validation.go
+++ b/conformance/tests/basic/inferencepool_httproute_port_validation.go
@@ -49,11 +49,10 @@ var InferencePoolHTTPRoutePortValidation = suite.ConformanceTest{
 	},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		const (
-			appBackendNamespace = "gateway-conformance-app-backend"
-			infraNamespace      = "gateway-conformance-infra"
-			gatewayName         = "conformance-gateway"
-			poolName            = "target-pool-port-validation"
-			// backendDeploymentName should be the metadata.name of the Deployment in the YAML.
+			appBackendNamespace   = "gateway-conformance-app-backend"
+			infraNamespace        = "gateway-conformance-infra"
+			gatewayName           = "conformance-gateway"
+			poolName              = "target-pool-port-validation"
 			backendDeploymentName = "infra-backend-deployment-port-test"
 		)
 
@@ -77,7 +76,7 @@ var InferencePoolHTTPRoutePortValidation = suite.ConformanceTest{
 				gatewayAddr,
 				hostname,
 				path,
-				backendDeploymentName, // Use the correct Deployment name here
+				backendDeploymentName,
 				appBackendNamespace,
 			)
 		})
@@ -97,7 +96,7 @@ var InferencePoolHTTPRoutePortValidation = suite.ConformanceTest{
 				gatewayAddr,
 				hostname,
 				path,
-				backendDeploymentName, // Use the correct Deployment name here
+				backendDeploymentName,
 				appBackendNamespace,
 			)
 		})

--- a/conformance/tests/basic/inferencepool_httproute_port_validation.go
+++ b/conformance/tests/basic/inferencepool_httproute_port_validation.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"net/http"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+
+	gwapihttp "sigs.k8s.io/gateway-api/conformance/utils/http"
+
+	// Local project imports
+	"sigs.k8s.io/gateway-api-inference-extension/conformance/tests"
+	k8sutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/kubernetes"
+	trafficutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/traffic"
+)
+
+func init() {
+	tests.ConformanceTests = append(tests.ConformanceTests, InferencePoolHTTPRoutePortValidation)
+}
+
+var InferencePoolHTTPRoutePortValidation = suite.ConformanceTest{
+	ShortName:   "InferencePoolHTTPRoutePortValidation",
+	Description: "Validates HTTPRoute backendRef port configurations (unspecified, matching, non-matching) when referencing an InferencePool, and checks resulting status conditions.",
+	Manifests:   []string{"tests/basic/inferencepool_httproute_port_validation.yaml"},
+	Features: []features.FeatureName{
+		features.FeatureName("SupportInferencePool"),
+		features.SupportGateway,
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		const (
+			appBackendNamespace = "gateway-conformance-app-backend"
+			infraNamespace      = "gateway-conformance-infra"
+			gatewayName         = "conformance-gateway"
+			poolName            = "target-pool-port-validation"
+			// backendDeploymentName should be the metadata.name of the Deployment in the YAML.
+			backendDeploymentName = "infra-backend-deployment-port-test"
+		)
+
+		gatewayNN := types.NamespacedName{Name: gatewayName, Namespace: infraNamespace}
+		poolNN := types.NamespacedName{Name: poolName, Namespace: appBackendNamespace}
+
+		gatewayAddr := k8sutils.GetGatewayEndpoint(t, s.Client, s.TimeoutConfig, gatewayNN)
+
+		t.Run("Scenario 1: HTTPRoute backendRef to InferencePool with Port Unspecified", func(t *testing.T) {
+			routeNN := types.NamespacedName{Name: "httproute-pool-port-unspecified", Namespace: appBackendNamespace}
+			hostname := "port-unspecified.example.com"
+			path := "/test-port-unspecified"
+
+			k8sutils.HTTPRouteMustBeAcceptedAndResolved(t, s.Client, s.TimeoutConfig, routeNN, gatewayNN)
+			k8sutils.InferencePoolMustBeAcceptedByParent(t, s.Client, poolNN)
+
+			trafficutils.MakeRequestAndExpectSuccess(
+				t,
+				s.RoundTripper,
+				s.TimeoutConfig,
+				gatewayAddr,
+				hostname,
+				path,
+				backendDeploymentName, // Use the correct Deployment name here
+				appBackendNamespace,
+			)
+		})
+
+		t.Run("Scenario 2: HTTPRoute backendRef to InferencePool with Port Specified and Matching", func(t *testing.T) {
+			routeNN := types.NamespacedName{Name: "httproute-pool-port-matching", Namespace: appBackendNamespace}
+			hostname := "port-matching.example.com"
+			path := "/test-port-matching"
+
+			k8sutils.HTTPRouteMustBeAcceptedAndResolved(t, s.Client, s.TimeoutConfig, routeNN, gatewayNN)
+			k8sutils.InferencePoolMustBeAcceptedByParent(t, s.Client, poolNN)
+
+			trafficutils.MakeRequestAndExpectSuccess(
+				t,
+				s.RoundTripper,
+				s.TimeoutConfig,
+				gatewayAddr,
+				hostname,
+				path,
+				backendDeploymentName, // Use the correct Deployment name here
+				appBackendNamespace,
+			)
+		})
+
+		t.Run("Scenario 3: HTTPRoute backendRef to InferencePool with Port Specified and Non-Matching", func(t *testing.T) {
+			routeNN := types.NamespacedName{Name: "httproute-pool-port-non-matching", Namespace: appBackendNamespace}
+			hostname := "port-non-matching.example.com"
+			path := "/test-port-non-matching"
+
+			acceptedCondition := metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(gatewayv1.RouteReasonAccepted),
+			}
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, gatewayNN, acceptedCondition)
+
+			resolvedRefsCondition := metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.RouteReasonBackendNotFound),
+			}
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, gatewayNN, resolvedRefsCondition)
+			k8sutils.InferencePoolMustBeAcceptedByParent(t, s.Client, poolNN)
+
+			expectedResponse := trafficutils.BuildExpectedHTTPResponse(
+				hostname,
+				path,
+				http.StatusServiceUnavailable,
+				"",
+				"",
+			)
+			gwapihttp.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gatewayAddr, expectedResponse)
+
+			t.Logf("Successfully verified HTTPRoute %s has conditions: Accepted=True and ResolvedRefs=False (Reason: %s) for Gateway %s due to port mismatch",
+				routeNN.String(), resolvedRefsCondition.Reason, gatewayNN.String())
+		})
+	},
+}

--- a/conformance/tests/basic/inferencepool_httproute_port_validation.yaml
+++ b/conformance/tests/basic/inferencepool_httproute_port_validation.yaml
@@ -1,0 +1,148 @@
+# conformance/tests/basic/inferencepool_httproute_port_validation.yaml
+
+# --- Backend Deployment (reusing standard echoserver) ---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infra-backend-deployment-port-test
+  namespace: gateway-conformance-app-backend
+  labels:
+    app: infra-backend-port-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infra-backend-port-test
+  template:
+    metadata:
+      labels:
+        app: infra-backend-port-test
+    spec:
+      containers:
+      - name: echoserver
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        ports:
+        - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 2
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+---
+# --- Backend Service ---
+# Service for the infra-backend-deployment-port-test.
+apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend-svc-port-test
+  namespace: gateway-conformance-app-backend
+spec:
+  selector:
+    app: infra-backend-port-test
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000
+---
+# --- InferencePool Definition ---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: target-pool-port-validation
+  namespace: gateway-conformance-app-backend
+spec:
+  selector:
+    app: "infra-backend-port-test"
+  targetPortNumber: 3000
+  extensionRef:
+    name: target-pool-port-validation-epp
+---
+# --- HTTPRoute Scenario 1: Port Unspecified ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-pool-port-unspecified
+  namespace: gateway-conformance-app-backend
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: conformance-gateway
+    namespace: gateway-conformance-infra
+    sectionName: http
+  hostnames:
+  - "port-unspecified.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: target-pool-port-validation
+      # Port is intentionally unspecified here
+    matches:
+    - path:
+        type: PathPrefix
+        value: /test-port-unspecified
+---
+# --- HTTPRoute Scenario 2: Port Matching ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-pool-port-matching
+  namespace: gateway-conformance-app-backend
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: conformance-gateway
+    namespace: gateway-conformance-infra
+    sectionName: http
+  hostnames:
+  - "port-matching.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: target-pool-port-validation
+      port: 3000 # Port matches InferencePool's targetPortNumber
+    matches:
+    - path:
+        type: PathPrefix
+        value: /test-port-matching
+---
+# --- HTTPRoute Scenario 3: Port Non-Matching ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-pool-port-non-matching
+  namespace: gateway-conformance-app-backend
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: conformance-gateway
+    namespace: gateway-conformance-infra
+    sectionName: http
+  hostnames:
+  - "port-non-matching.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: target-pool-port-validation
+      port: 8888 # Port does NOT match InferencePool's targetPortNumber
+    matches:
+    - path:
+        type: PathPrefix
+        value: /test-port-non-matching

--- a/conformance/tests/basic/inferencepool_resolvedrefs_condition.go
+++ b/conformance/tests/basic/inferencepool_resolvedrefs_condition.go
@@ -110,8 +110,8 @@ var InferencePoolParentStatus = suite.ConformanceTest{
 			t.Logf("Deleting HTTPRoute %s", httpRoutePrimaryNN.String())
 			require.NoError(t, s.Client.Delete(context.TODO(), httpRoutePrimary), "failed to delete httproute-for-primary-gw")
 
-			t.Logf("Waiting for %v for Gateway conditions to update after deleting HTTPRoute %s", inferenceTimeoutConfig.HTTPRouteDeletionReconciliationTimeout, httpRoutePrimaryNN.String()) //
-			time.Sleep(inferenceTimeoutConfig.HTTPRouteDeletionReconciliationTimeout)                                                                                                         //
+			t.Logf("Waiting for %v for Gateway conditions to update after deleting HTTPRoute %s", inferenceTimeoutConfig.HTTPRouteDeletionReconciliationTimeout, httpRoutePrimaryNN.String())
+			time.Sleep(inferenceTimeoutConfig.HTTPRouteDeletionReconciliationTimeout)
 
 			k8sutils.InferencePoolMustBeAcceptedByParent(t, s.Client, poolNN)
 			t.Logf("InferencePool %s still has parent status Accepted:True as expected with one reference remaining.", poolNN.String())

--- a/conformance/utils/traffic/traffic.go
+++ b/conformance/utils/traffic/traffic.go
@@ -1,4 +1,18 @@
-// Add these functions to conformance/utils/traffic/traffic.go
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package traffic
 


### PR DESCRIPTION
When I'm running the InferencePoolHTTPRoutePortValidation test, specifically Scenario 3 (which tests an HTTPRoute with a mismatched port in its backendRef to an InferencePool):

I set up an HTTPRoute to reference a valid InferencePool. However, the port I specify in the HTTPRoute's backendRef (e.g., 8888) deliberately does not match the InferencePool's actual listening port (targetPortNumber, e.g., 3000).

My test expects that due to this port mismatch, the Gateway controller would set the HTTPRoute's ResolvedRefs condition to Status: False (likely with a Reason like BackendNotFound or similar, indicating an invalid reference).

However, what I'm observing with the current implementation controller is that the HTTPRoute's ResolvedRefs condition is actually being set to Status: True with Reason: ResolvedRefs. 

This seems to mean the controller considers the reference valid despite the port discrepancy. Is my expectation in point 2 (that ResolvedRefs should be False) correct for this scenario?


Adds new conformance tests (`InferencePoolHTTPRoutePortValidation`) to verify `HTTPRoute.spec.rules.backendRefs.port` behavior with `InferencePool` backends. Covers scenarios for unspecified, matching, and non-matching ports.

Addresses #886.

``` 
go test -v ./conformance -args -debug     -gateway-class istio     -cleanup-base-resources=false     -run-test InferencePoolHTTPRoutePortValidation
=== RUN   TestConformance
...
    conformance.go:68: Skipping InferencePoolResolvedRefsCondition: test explicitly skipped
--- FAIL: TestConformance (66.51s)
    --- SKIP: TestConformance/HTTPRouteInvalidInferencePoolRef (0.00s)
    --- SKIP: TestConformance/InferencePoolAccepted (0.00s)
    --- FAIL: TestConformance/InferencePoolHTTPRoutePortValidation (62.59s)
        --- PASS: TestConformance/InferencePoolHTTPRoutePortValidation/Scenario_1:_HTTPRoute_backendRef_to_InferencePool_with_Port_Unspecified (0.37s)
        --- PASS: TestConformance/InferencePoolHTTPRoutePortValidation/Scenario_2:_HTTPRoute_backendRef_to_InferencePool_with_Port_Specified_and_Matching (0.35s)
        --- FAIL: TestConformance/InferencePoolHTTPRoutePortValidation/Scenario_3:_HTTPRoute_backendRef_to_InferencePool_with_Port_Specified_and_Non-Matching (60.04s)
    --- SKIP: TestConformance/InferencePoolResolvedRefsCondition (0.00s)
FAIL
FAIL    sigs.k8s.io/gateway-api-inference-extension/conformance 66.716s
FAIL


```