### PR TITLE
Tools: Fixes test-e2e.sh script

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -59,8 +59,8 @@ check_pod_ready() {
 # Try to get the Gateway's IP and the port from the listener named "llm-gw" if it exists.
 if check_resource_exists "gateway" "inference-gateway" "default"; then
     GATEWAY_IP=$(kubectl get gateway inference-gateway -n default -o jsonpath='{.status.addresses[0].value}')
-    # Use JSONPath to select the port from the listener with name "llm-gw"
-    GATEWAY_PORT=$(kubectl get gateway inference-gateway -n default -o jsonpath='{.spec.listeners[?(@.name=="llm-gw")].port}')
+    # Use JSONPath to select the port from the listener with name "http"
+    GATEWAY_PORT=$(kubectl get gateway inference-gateway -n default -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
 else
     GATEWAY_IP=""
     GATEWAY_PORT=""


### PR DESCRIPTION
Updates the `test-e2e.sh` script to use the correct Gateway listener ([xref](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/v0.3.0/config/manifests/gateway)).

Fixes #899 