### PR TITLE
docs: update Istio gateway name for consistency

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -164,7 +164,7 @@ This quickstart guide is intended for engineers familiar with k8s and model serv
       5. Label the gateway
 
          ```bash
-         kubectl label gateway llm-gateway istio.io/enable-inference-extproc=true
+         kubectl label gateway inference-gateway istio.io/enable-inference-extproc=true
          ```
 
          Confirm that the Gateway was assigned an IP address and reports a `Programmed=True` status:


### PR DESCRIPTION
Following the instruction ["Istio > 5. Label the gateway"](https://deploy-preview-898--gateway-api-inference-extension.netlify.app/guides/#__tabbed_3_2), I got the following error. This PR updates the Istio gateway name for consistency.

```
$ kubectl label gateway llm-gateway istio.io/enable-inference-extproc=true
Error from server (NotFound): gateways.gateway.networking.k8s.io "llm-gateway" not found
```