### PR TITLE
fixed typo in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ verify: vet fmt-verify manifests generate ci-lint verify-all
 
 # Run static analysis.
 .PHONY: verify-all
-verify:
+verify-all:
 	hack/verify-all.sh -v
 
 ##@ Build


### PR DESCRIPTION
This PR fixes a typo that was introduced in #880 which added `verify` target twice in Makefile.

