### PR TITLE
move PostResponse plugins to requestcontrol instead of scheduler

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
@@ -79,7 +80,7 @@ type StreamingServer struct {
 // Specifically, there are fields related to the ext-proc protocol, and then fields related to the lifecycle of the request.
 // We should split these apart as this monolithic object exposes too much data to too many layers.
 type RequestContext struct {
-	TargetPod                 string
+	TargetPod                 *backend.Pod
 	TargetEndpoint            string
 	Model                     string
 	ResolvedTargetModel       string
@@ -92,6 +93,8 @@ type RequestContext struct {
 	ResponseStatusCode        string
 	RequestRunning            bool
 	Request                   *Request
+
+	SchedulingRequest *schedulingtypes.LLMRequest
 
 	RequestState         StreamRequestState
 	modelServerStreaming bool

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -202,6 +202,18 @@ var (
 		[]string{"plugin_type", "plugin_name"},
 	)
 
+	RequestControlPluginProcessingLatencies = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: InferenceExtension,
+			Name:      "request_control_plugin_duration_seconds",
+			Help:      metricsutil.HelpMsgWithStability("RequestControl plugin processing latency distribution in seconds for each plugin type and plugin name.", compbasemetrics.ALPHA),
+			Buckets: []float64{
+				0.0001, 0.0002, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1,
+			},
+		},
+		[]string{"plugin_type", "plugin_name"},
+	)
+
 	// Prefix indexer Metrics
 	PrefixCacheSize = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -263,6 +275,7 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(inferencePoolReadyPods)
 		metrics.Registry.MustRegister(SchedulerPluginProcessingLatencies)
 		metrics.Registry.MustRegister(SchedulerE2ELatency)
+		metrics.Registry.MustRegister(RequestControlPluginProcessingLatencies)
 		metrics.Registry.MustRegister(InferenceExtensionInfo)
 		metrics.Registry.MustRegister(PrefixCacheSize)
 		metrics.Registry.MustRegister(PrefixCacheHitRatio)
@@ -289,6 +302,7 @@ func Reset() {
 	inferencePoolReadyPods.Reset()
 	SchedulerPluginProcessingLatencies.Reset()
 	SchedulerE2ELatency.Reset()
+	RequestControlPluginProcessingLatencies.Reset()
 	InferenceExtensionInfo.Reset()
 	PrefixCacheSize.Reset()
 	PrefixCacheHitRatio.Reset()
@@ -398,6 +412,11 @@ func RecordSchedulerPluginProcessingLatency(pluginType, pluginName string, durat
 // RecordSchedulerE2ELatency records the end-to-end scheduling latency.
 func RecordSchedulerE2ELatency(duration time.Duration) {
 	SchedulerE2ELatency.WithLabelValues().Observe(duration.Seconds())
+}
+
+// RecordRequestControlPluginProcessingLatency records the processing latency for a request-control plugin.
+func RecordRequestControlPluginProcessingLatency(pluginType, pluginName string, duration time.Duration) {
+	RequestControlPluginProcessingLatencies.WithLabelValues(pluginType, pluginName).Observe(duration.Seconds())
 }
 
 // RecordPrefixCacheSize records the size of the prefix indexer in megabytes.

--- a/pkg/epp/plugins/plugins.go
+++ b/pkg/epp/plugins/plugins.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+// Plugin defines the interface for a plugin.
+// This interface should be embedded in all plugins across the code.
+type Plugin interface {
+	// Name returns the name of the plugin.
+	Name() string
+}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -266,6 +266,6 @@ func (d *Director) runPostResponsePlugins(ctx context.Context, request *scheduli
 		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.Name())
 		before := time.Now()
 		plugin.PostResponse(ctx, request, response, targetPod)
-		metrics.RecordSchedulerPluginProcessingLatency(PostResponsePluginType, plugin.Name(), time.Since(before))
+		metrics.RecordRequestControlPluginProcessingLatency(PostResponsePluginType, plugin.Name(), time.Since(before))
 	}
 }

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -30,6 +31,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -39,7 +41,6 @@ import (
 // Scheduler defines the interface required by the Director for scheduling.
 type Scheduler interface {
 	Schedule(ctx context.Context, b *schedulingtypes.LLMRequest) (result map[string]*schedulingtypes.Result, err error)
-	OnResponse(ctx context.Context, resp *schedulingtypes.LLMResponse, targetPodName string)
 }
 
 // SaturationDetector provides a signal indicating whether the backends are considered saturated.
@@ -47,16 +48,25 @@ type SaturationDetector interface {
 	IsSaturated(ctx context.Context) bool
 }
 
-// Director orchestrates the request handling flow, including scheduling.
-type Director struct {
-	datastore          datastore.Datastore
-	scheduler          Scheduler
-	saturationDetector SaturationDetector
+// NewDirector creates a new Director instance with all dependencies.
+// postResponsePlugins remains nil as this is an optional field that can be set using the "WithPostResponsePlugins" function.
+func NewDirector(datastore datastore.Datastore, scheduler Scheduler, saturationDetector SaturationDetector) *Director {
+	return &Director{datastore: datastore, scheduler: scheduler, saturationDetector: saturationDetector}
 }
 
-// NewDirector creates a new Director instance with all dependencies.
-func NewDirector(datastore datastore.Datastore, scheduler Scheduler, saturationDetector SaturationDetector) *Director {
-	return &Director{datastore, scheduler, saturationDetector}
+// Director orchestrates the request handling flow, including scheduling.
+type Director struct {
+	datastore           datastore.Datastore
+	scheduler           Scheduler
+	saturationDetector  SaturationDetector
+	postResponsePlugins []PostResponsePlugin
+}
+
+// WithPostResponsePlugins sets the given plugins as the PostResponse plugins.
+// If the Director has PostResponse plugins already, this call replaces the existing plugins with the given ones.
+func (d *Director) WithPostResponsePlugins(plugins ...PostResponsePlugin) *Director {
+	d.postResponsePlugins = plugins
+	return d
 }
 
 // HandleRequest orchestrates the request lifecycle:
@@ -104,7 +114,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	// Prepare LLMRequest (needed for both saturation detection and Scheduler)
-	llmReq := &schedulingtypes.LLMRequest{
+	reqCtx.SchedulingRequest = &schedulingtypes.LLMRequest{
 		TargetModel: reqCtx.ResolvedTargetModel,
 		RequestId:   reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
 		Critical:    requestCriticality == v1alpha2.Critical,
@@ -113,7 +123,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 	logger = logger.WithValues(
 		"model", reqCtx.Model,
-		"resolvedTargetModel", llmReq.TargetModel,
+		"resolvedTargetModel", reqCtx.ResolvedTargetModel,
 		"criticality", requestCriticality,
 	)
 	ctx = log.IntoContext(ctx, logger)
@@ -126,7 +136,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	// --- 3. Dispatch (Calls Scheduler) ---
-	results, dispatchErr := d.Dispatch(ctx, llmReq)
+	results, dispatchErr := d.Dispatch(ctx, reqCtx.SchedulingRequest)
 	if dispatchErr != nil {
 		return reqCtx, dispatchErr
 	}
@@ -193,22 +203,19 @@ func (d *Director) PostDispatch(ctx context.Context, reqCtx *handlers.RequestCon
 	endpoint := targetPod.Address + ":" + strconv.Itoa(int(pool.Spec.TargetPortNumber))
 	logger.V(logutil.DEFAULT).Info("Request handled", "model", reqCtx.Model, "targetModel", reqCtx.ResolvedTargetModel, "endpoint", targetPod)
 
-	reqCtx.TargetPod = targetPod.NamespacedName.String()
+	reqCtx.TargetPod = targetPod
 	reqCtx.TargetEndpoint = endpoint
 
 	return reqCtx, nil
 }
 
 func (d *Director) HandleResponse(ctx context.Context, reqCtx *handlers.RequestContext) (*handlers.RequestContext, error) {
-	logger := log.FromContext(ctx)
-
-	llmResp := &schedulingtypes.LLMResponse{
+	response := &Response{
 		RequestId: reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
 		Headers:   reqCtx.Response.Headers,
 	}
-	logger.V(logutil.DEBUG).Info("LLM response assembled", "response", llmResp)
 
-	d.scheduler.OnResponse(ctx, llmResp, reqCtx.TargetPod)
+	d.runPostResponsePlugins(ctx, reqCtx.SchedulingRequest, response, reqCtx.TargetPod)
 
 	return reqCtx, nil
 }
@@ -252,4 +259,13 @@ func RandomWeightedDraw(logger logr.Logger, model *v1alpha2.InferenceModel, seed
 		randomVal -= *model.Weight
 	}
 	return ""
+}
+
+func (d *Director) runPostResponsePlugins(ctx context.Context, request *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {
+	for _, plugin := range d.postResponsePlugins {
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.Name())
+		before := time.Now()
+		plugin.PostResponse(ctx, request, response, targetPod)
+		metrics.RecordSchedulerPluginProcessingLatency(PostResponsePluginType, plugin.Name(), time.Since(before))
+	}
 }

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
 
@@ -27,15 +28,9 @@ const (
 	PostResponsePluginType = "PostResponse"
 )
 
-// Plugin defines the interface for requestcontrol plugins.
-type Plugin interface {
-	// Name returns the name of the plugin.
-	Name() string
-}
-
 // PostResponse is called by the director after a successful response was sent.
 // The given pod argument is the pod that served the request.
 type PostResponsePlugin interface {
-	Plugin
+	plugins.Plugin
 	PostResponse(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)
 }

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -27,9 +27,15 @@ const (
 	PostResponsePluginType = "PostResponse"
 )
 
+// Plugin defines the interface for requestcontrol plugins.
+type Plugin interface {
+	// Name returns the name of the plugin.
+	Name() string
+}
+
 // PostResponse is called by the director after a successful response was sent.
 // The given pod argument is the pod that served the request.
 type PostResponsePlugin interface {
-	Name() string
+	Plugin
 	PostResponse(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)
 }

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestcontrol
+
+import (
+	"context"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+)
+
+const (
+	PostResponsePluginType = "PostResponse"
+)
+
+// PostResponse is called by the director after a successful response was sent.
+// The given pod argument is the pod that served the request.
+type PostResponsePlugin interface {
+	Name() string
+	PostResponse(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)
+}

--- a/pkg/epp/requestcontrol/types.go
+++ b/pkg/epp/requestcontrol/types.go
@@ -23,7 +23,7 @@ type Response struct {
 	// Headers is a map of the response headers. Nil during body processing
 	Headers map[string]string
 	// Body Is the body of the response or nil during header processing
-	Body map[string]string
+	Body string
 	// IsStreaming indicates whether or not the response is being streamed by the model
 	IsStreaming bool
 	// EndOfStream when true indicates that this invocation contains the last chunk of the response

--- a/pkg/epp/requestcontrol/types.go
+++ b/pkg/epp/requestcontrol/types.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package requestcontrol
 
-// LLMResponse contains information from the response received to be passed to plugins
+// Response contains information from the response received to be passed to PostResponse plugins
 type Response struct {
 	// RequestId is the Envoy generated Id for the request being processed
 	RequestId string

--- a/pkg/epp/requestcontrol/types.go
+++ b/pkg/epp/requestcontrol/types.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestcontrol
+
+// LLMResponse contains information from the response received to be passed to plugins
+type Response struct {
+	// RequestId is the Envoy generated Id for the request being processed
+	RequestId string
+	// Headers is a map of the response headers. Nil during body processing
+	Headers map[string]string
+	// Body Is the body of the response or nil during header processing
+	Body map[string]string
+	// IsStreaming indicates whether or not the response is being streamed by the model
+	IsStreaming bool
+	// EndOfStream when true indicates that this invocation contains the last chunk of the response
+	EndOfStream bool
+}

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
 
@@ -30,41 +31,34 @@ const (
 	PostCyclePluginType = "PostCycle"
 )
 
-// Plugin defines the interface for scheduler plugins, combining scoring, filtering,
-// and event handling capabilities.
-type Plugin interface {
-	// Name returns the name of the plugin.
-	Name() string
-}
-
 // ProfilePicker selects the SchedulingProfiles to run from a list of candidate profiles, while taking into consideration the request properties
 // and the previously executed SchedluderProfile cycles along with their results.
 type ProfilePicker interface {
-	Plugin
+	plugins.Plugin
 	Pick(request *types.LLMRequest, profiles map[string]*SchedulerProfile, executionResults map[string]*types.Result) map[string]*SchedulerProfile
 }
 
 // Filter defines the interface for filtering a list of pods based on context.
 type Filter interface {
-	Plugin
+	plugins.Plugin
 	Filter(ctx context.Context, request *types.LLMRequest, cycleState *types.CycleState, pods []types.Pod) []types.Pod
 }
 
 // Scorer defines the interface for scoring a list of pods based on context.
 // Scorers must score pods with a value within the range of [0,1] where 1 is the highest score.
 type Scorer interface {
-	Plugin
+	plugins.Plugin
 	Score(ctx context.Context, request *types.LLMRequest, cycleState *types.CycleState, pods []types.Pod) map[types.Pod]float64
 }
 
 // Picker picks the final pod(s) to send the request to.
 type Picker interface {
-	Plugin
+	plugins.Plugin
 	Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.Result
 }
 
 // PostCycle is called by the scheduler after it selects a targetPod for the request in the SchedulerProfile cycle.
 type PostCycle interface {
-	Plugin
+	plugins.Plugin
 	PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.Result)
 }

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -23,12 +23,11 @@ import (
 )
 
 const (
-	ProfilePickerType      = "ProfilePicker"
-	FilterPluginType       = "Filter"
-	ScorerPluginType       = "Scorer"
-	PickerPluginType       = "Picker"
-	PostCyclePluginType    = "PostCycle"
-	PostResponsePluginType = "PostResponse"
+	ProfilePickerType   = "ProfilePicker"
+	FilterPluginType    = "Filter"
+	ScorerPluginType    = "Scorer"
+	PickerPluginType    = "Picker"
+	PostCyclePluginType = "PostCycle"
 )
 
 // Plugin defines the interface for scheduler plugins, combining scoring, filtering,
@@ -68,11 +67,4 @@ type Picker interface {
 type PostCycle interface {
 	Plugin
 	PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.Result)
-}
-
-// PostResponse is called by the scheduler after a successful response was sent.
-// The given pod argument is the pod that served the request.
-type PostResponse interface {
-	Plugin
-	PostResponse(ctx context.Context, response *types.LLMResponse, targetPod types.Pod)
 }

--- a/pkg/epp/scheduling/framework/scheduler_profile.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile.go
@@ -31,21 +31,19 @@ import (
 // NewSchedulerProfile creates a new SchedulerProfile object and returns its pointer.
 func NewSchedulerProfile() *SchedulerProfile {
 	return &SchedulerProfile{
-		filters:             []Filter{},
-		scorers:             []*WeightedScorer{},
-		postCyclePlugins:    []PostCycle{},
-		PostResponsePlugins: []PostResponse{},
+		filters:          []Filter{},
+		scorers:          []*WeightedScorer{},
+		postCyclePlugins: []PostCycle{},
 		// picker remains nil since profile doesn't support multiple pickers
 	}
 }
 
 // SchedulerProfile provides a profile configuration for the scheduler which influence routing decisions.
 type SchedulerProfile struct {
-	filters             []Filter
-	scorers             []*WeightedScorer
-	picker              Picker
-	postCyclePlugins    []PostCycle
-	PostResponsePlugins []PostResponse // TODO this field should get out of the scheduler
+	filters          []Filter
+	scorers          []*WeightedScorer
+	picker           Picker
+	postCyclePlugins []PostCycle
 }
 
 // WithFilters sets the given filter plugins as the Filter plugins.
@@ -100,9 +98,6 @@ func (p *SchedulerProfile) AddPlugins(pluginObjects ...Plugin) error {
 		}
 		if postCyclePlugin, ok := plugin.(PostCycle); ok {
 			p.postCyclePlugins = append(p.postCyclePlugins, postCyclePlugin)
-		}
-		if postResponsePlugin, ok := plugin.(PostResponse); ok {
-			p.PostResponsePlugins = append(p.PostResponsePlugins, postResponsePlugin)
 		}
 	}
 	return nil

--- a/pkg/epp/scheduling/framework/scheduler_profile.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile.go
@@ -23,6 +23,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -79,7 +80,7 @@ func (p *SchedulerProfile) WithPostCyclePlugins(plugins ...PostCycle) *Scheduler
 // Special Case: In order to add a scorer, one must use the scorer.NewWeightedScorer function in order to provide a weight.
 // if a scorer implements more than one interface, supplying a WeightedScorer is sufficient. The function will take the internal
 // scorer object and register it to all interfaces it implements.
-func (p *SchedulerProfile) AddPlugins(pluginObjects ...Plugin) error {
+func (p *SchedulerProfile) AddPlugins(pluginObjects ...plugins.Plugin) error {
 	for _, plugin := range pluginObjects {
 		if weightedScorer, ok := plugin.(*WeightedScorer); ok {
 			p.scorers = append(p.scorers, weightedScorer)

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -135,35 +135,3 @@ func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest) (ma
 
 	return profileExecutionResults, nil
 }
-
-// OnResponse is invoked during the processing of a response from an inference pod. It will invoke
-// any defined plugins that process the response.
-func (s *Scheduler) OnResponse(ctx context.Context, response *types.LLMResponse, targetPodName string) {
-	// Snapshot pod metrics from the datastore to:
-	// 1. Reduce concurrent access to the datastore.
-	// 2. Ensure consistent data during the scheduling operation of a request.
-	pods := types.ToSchedulerPodMetrics(s.datastore.PodGetAll())
-	var targetPod types.Pod
-	for _, pod := range pods {
-		if pod.GetPod().NamespacedName.String() == targetPodName {
-			targetPod = pod
-			break
-		}
-	}
-
-	// WORKAROUND until PostResponse is out of Scheduler
-	profileExecutionResults := map[string]*types.Result{}
-	profiles := s.profilePicker.Pick(nil, s.profiles, profileExecutionResults) // all profiles
-	for _, profile := range profiles {
-		s.runPostResponsePlugins(ctx, response, targetPod, profile)
-	}
-}
-
-func (s *Scheduler) runPostResponsePlugins(ctx context.Context, response *types.LLMResponse, targetPod types.Pod, profile *framework.SchedulerProfile) {
-	for _, plugin := range profile.PostResponsePlugins {
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.Name())
-		before := time.Now()
-		plugin.PostResponse(ctx, response, targetPod)
-		metrics.RecordSchedulerPluginProcessingLatency(framework.PostResponsePluginType, plugin.Name(), time.Since(before))
-	}
-}

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -41,20 +41,6 @@ func (r *LLMRequest) String() string {
 	return fmt.Sprintf("TargetModel: %s, Critical: %t, PromptLength: %d, Headers: %v", r.TargetModel, r.Critical, len(r.Prompt), r.Headers)
 }
 
-// LLMResponse contains information from the response received to be passed to plugins
-type LLMResponse struct {
-	// RequestId is the Envoy generated Id for the request being processed
-	RequestId string
-	// Headers is a map of the response headers. Nil during body processing
-	Headers map[string]string
-	// Body Is the body of the response or nil during header processing
-	Body map[string]string
-	// IsStreaming indicates whether or not the response is being streamed by the model
-	IsStreaming bool
-	// EndOfStream when true indicates that this invocation contains the last chunk of the response
-	EndOfStream bool
-}
-
 type Pod interface {
 	GetPod() *backend.Pod
 	GetMetrics() *backendmetrics.MetricsState

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -48,7 +48,7 @@ type LLMResponse struct {
 	// Headers is a map of the response headers. Nil during body processing
 	Headers map[string]string
 	// Body Is the body of the response or nil during header processing
-	Body string
+	Body map[string]string
 	// IsStreaming indicates whether or not the response is being streamed by the model
 	IsStreaming bool
 	// EndOfStream when true indicates that this invocation contains the last chunk of the response

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -48,7 +48,7 @@ type ExtProcServerRunner struct {
 	SecureServing                            bool
 	CertPath                                 string
 	RefreshPrometheusMetricsInterval         time.Duration
-	Scheduler                                requestcontrol.Scheduler
+	Director                                 *requestcontrol.Director
 	SaturationDetector                       requestcontrol.SaturationDetector
 
 	// This should only be used in tests. We won't need this once we do not inject metrics in the tests.
@@ -141,12 +141,11 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 			srv = grpc.NewServer()
 		}
 
-		director := requestcontrol.NewDirector(r.Datastore, r.Scheduler, r.SaturationDetector)
 		extProcServer := handlers.NewStreamingServer(
 			r.DestinationEndpointHintMetadataNamespace,
 			r.DestinationEndpointHintKey,
 			r.Datastore,
-			director,
+			r.Director,
 		)
 		extProcPb.RegisterExternalProcessorServer(
 			srv,


### PR DESCRIPTION
This PR moves PostResponse plugins out of scheduler and into requestcontrol layer (more specifically into the director).

several code changes were done as part of this change:
- moved the creation of director to `main.go` in order to allow easy setup of plugins as we have with scheduler. a plugin should be able to register to both scheduler plugin and post response plugin in main.
- added PostResponsePlugins slice in director and added the `WithPostResponsePlugins` function to allow easy setup of the PostResponsePlugins.
- PostResponse plugin now gets both the request and the response - this is very useful in prefix plugin in order to be able to concat the prompt with the response and save in prefix cache.
- unit + integration tests were updated accordingly.
- example how to register PostResponsePlugins can be seen here: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/ce5bae2f47d8a6ab7d7fdaa1d988f2bde414ed26/pkg/epp/requestcontrol/director_test.go#L525

in a follow up PR, we should update the prefix plugin to use `PostResponse` instead of `PostCycle` extension point and then remove completely the PostCycle.