### PR TITLE
Fixing try it out curl

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -260,7 +260,7 @@ This quickstart guide is intended for engineers familiar with k8s and model serv
    PORT=80
 
    curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
-   "model": "food-review-1",
+   "model": "food-review",
    "prompt": "Write as if you were a critic: San Francisco",
    "max_tokens": 100,
    "temperature": 0


### PR DESCRIPTION
Issue link - https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/907

As mentioned in the issue, the quickstart guide currently has separate tabs to test GPU and CPU-based deployment options, but both deployment options should use the same model name.

After fix the try it out section has only 1 curl that can be used. Also the tab sections have been removed.