### PR TITLE
Bumps vLLM Simulator Tag

### DIFF
--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.0
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.1
         imagePullPolicy: Always
         args:
         - --model


### PR DESCRIPTION
Bumps the vllm-sim image to support multiarch (https://github.com/llm-d/llm-d-inference-sim/pull/44).