### PR TITLE
Docs: Fixes Meeting Recording Link

### DIFF
--- a/site-src/contributing/index.md
+++ b/site-src/contributing/index.md
@@ -45,5 +45,4 @@ doc. Feel free to add topics for discussion at an upcoming meeting.
 
 All meetings are recorded and automatically uploaded to the [WG-Serving meetings
 YouTube
-playlist][https://www.youtube.com/playlist?list=PL69nYSiGNLP30qNanabU75ayPK7OPNAAS].
-
+playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP30qNanabU75ayPK7OPNAAS).


### PR DESCRIPTION
Fixes the meeting recording link so the text is properly rendered instead of:

![Screenshot 2025-06-06 at 10 32 46 AM](https://github.com/user-attachments/assets/8a5d5077-4f39-4e8d-8132-598f6d5dfd0a)
