### PR TITLE
Update EPP to expose metrics to represent inference models

### DIFF
--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -178,7 +178,10 @@ func run() error {
 	datastore := datastore.NewDatastore(ctx, pmf)
 
 	// --- Setup Metrics Server ---
-	customCollectors := []prometheus.Collector{collectors.NewInferencePoolMetricsCollector(datastore)}
+	customCollectors := []prometheus.Collector{
+		collectors.NewInferencePoolMetricsCollector(datastore),
+		collectors.NewInferenceModelMetricsCollector(datastore),
+	}
 	metrics.Register(customCollectors...)
 	metrics.RecordInferenceExtensionInfo()
 	// Register metrics handler.

--- a/pkg/epp/metrics/collectors/inference_model.go
+++ b/pkg/epp/metrics/collectors/inference_model.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
+	metricsutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/metrics"
+)
+
+var (
+	descInferenceModelReady = prometheus.NewDesc(
+		"inference_model_ready",
+		metricsutil.HelpMsgWithStability("Indicates which InferenceModels are ready to serve by the epp. Value 1 indicates the model is tracked and ready, 0 indicates not ready.", compbasemetrics.ALPHA),
+		[]string{
+			"pool_name",
+			"model_name",
+		}, nil,
+	)
+)
+
+type inferenceModelMetricsCollector struct {
+	ds datastore.Datastore
+}
+
+// Check if inferenceModelMetricsCollector implements necessary interface
+var _ prometheus.Collector = &inferenceModelMetricsCollector{}
+
+// NewInferenceModelMetricsCollector implements the prometheus.Collector interface and
+// exposes metrics about inference models tracked by the epp.
+func NewInferenceModelMetricsCollector(ds datastore.Datastore) prometheus.Collector {
+	return &inferenceModelMetricsCollector{
+		ds: ds,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (c *inferenceModelMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descInferenceModelReady
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *inferenceModelMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	pool, err := c.ds.PoolGet()
+	if err != nil {
+		// Pool not synced yet, no metrics to expose
+		return
+	}
+
+	models := c.ds.ModelGetAll()
+	if len(models) == 0 {
+		return
+	}
+
+	for _, model := range models {
+		// Each model tracked by the datastore is considered "ready to serve" by the epp
+		ch <- prometheus.MustNewConstMetric(
+			descInferenceModelReady,
+			prometheus.GaugeValue,
+			1.0, // Value 1 indicates the model is ready to serve by the epp
+			pool.Name,
+			model.Spec.ModelName,
+		)
+	}
+}

--- a/pkg/epp/metrics/collectors/inference_model_test.go
+++ b/pkg/epp/metrics/collectors/inference_model_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/component-base/metrics/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
+)
+
+func TestNoInferenceModelMetricsCollected(t *testing.T) {
+	pmf := backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, 0)
+	ds := datastore.NewDatastore(context.Background(), pmf)
+
+	collector := &inferenceModelMetricsCollector{
+		ds: ds,
+	}
+
+	if err := testutil.CollectAndCompare(collector, strings.NewReader(""), ""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInferenceModelMetricsCollected(t *testing.T) {
+	pmf := backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, 0)
+	ds := datastore.NewDatastore(context.Background(), pmf)
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	pool := &v1alpha2.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pool",
+		},
+		Spec: v1alpha2.InferencePoolSpec{
+			TargetPortNumber: 8000,
+		},
+	}
+	_ = ds.PoolSet(context.Background(), fakeClient, pool)
+
+	// Add multiple models
+	model1 := &v1alpha2.InferenceModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model-1",
+		},
+		Spec: v1alpha2.InferenceModelSpec{
+			ModelName: "llama-3-8b",
+			PoolRef: v1alpha2.PoolObjectReference{
+			},
+		},
+	}
+	ds.ModelSetIfOlder(model1)
+
+	model2 := &v1alpha2.InferenceModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model-2",
+		},
+		Spec: v1alpha2.InferenceModelSpec{
+			ModelName: "llama-3-70b",
+			PoolRef: v1alpha2.PoolObjectReference{
+				Name: "test-pool",
+			},
+		},
+	}
+	ds.ModelSetIfOlder(model2)
+
+	collector := &inferenceModelMetricsCollector{
+		ds: ds,
+	}
+
+	err := testutil.CollectAndCompare(collector, strings.NewReader(`
+		# HELP inference_model_ready [ALPHA] Indicates which InferenceModels are ready to serve by the epp. Value 1 indicates the model is tracked and ready, 0 indicates not ready.
+		# TYPE inference_model_ready gauge
+		inference_model_ready{model_name="llama-3-70b",pool_name="test-pool"} 1
+		inference_model_ready{model_name="llama-3-8b",pool_name="test-pool"} 1
+`), "inference_model_ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Resolve #598 

Update EPP to expose metrics to represent inference models. `inference_model_ready` is a binary metric with the pool_name and model_name labels.