### PR TITLE
scheduler redesign continuation

### DIFF
--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/multi/prefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/picker"
-	profilepicker "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/profile-picker"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/profile"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/scorer"
 	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/server"
 	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
@@ -222,7 +222,7 @@ func run() error {
 			}
 		}
 
-		schedulerConfig := scheduling.NewSchedulerConfig(profilepicker.NewAllProfilesPicker(), map[string]*framework.SchedulerProfile{"schedulerv2": schedulerProfile})
+		schedulerConfig := scheduling.NewSchedulerConfig(profile.NewSingleProfileHandler(), map[string]*framework.SchedulerProfile{"schedulerv2": schedulerProfile})
 		scheduler = scheduling.NewSchedulerWithConfig(datastore, schedulerConfig)
 	}
 

--- a/conformance/testing-epp/scheduler.go
+++ b/conformance/testing-epp/scheduler.go
@@ -21,14 +21,17 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/picker"
-	profilepicker "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/profile-picker"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/profile"
 )
 
 // NewReqHeaderBasedScheduler creates a scheduler for conformance tests that selects
 // an endpoint based on the "test-epp-endpoint-selection" request header. If the
 // header is missing or the specified endpoint doesn't exist, no endpoint is returned.
 func NewReqHeaderBasedScheduler(datastore scheduling.Datastore) *scheduling.Scheduler {
-	predicatableSchedulerProfile := framework.NewSchedulerProfile().WithFilters(filter.NewHeaderBasedTestingFilter()).WithPicker(picker.NewMaxScorePicker())
+	predicatableSchedulerProfile := framework.NewSchedulerProfile().
+		WithFilters(filter.NewHeaderBasedTestingFilter()).
+		WithPicker(picker.NewMaxScorePicker())
+
 	return scheduling.NewSchedulerWithConfig(datastore, scheduling.NewSchedulerConfig(
-		profilepicker.NewAllProfilesPicker(), map[string]*framework.SchedulerProfile{"req-header-based-profile": predicatableSchedulerProfile}))
+		profile.NewSingleProfileHandler(), map[string]*framework.SchedulerProfile{"req-header-based-profile": predicatableSchedulerProfile}))
 }

--- a/conformance/testing-epp/sheduler_test.go
+++ b/conformance/testing-epp/sheduler_test.go
@@ -33,7 +33,7 @@ func TestSchedule(t *testing.T) {
 		name    string
 		input   []*backendmetrics.FakePodMetrics
 		req     *types.LLMRequest
-		wantRes map[string]*types.Result
+		wantRes *types.SchedulingResult
 		err     bool
 	}{
 		{
@@ -79,17 +79,20 @@ func TestSchedule(t *testing.T) {
 				Headers:   map[string]string{"test-epp-endpoint-selection": "matched-endpoint"},
 				RequestId: uuid.NewString(),
 			},
-			wantRes: map[string]*types.Result{
-				"req-header-based-profile": {
-					TargetPod: &types.ScoredPod{
-						Pod: &types.PodMetrics{
-							Pod: &backend.Pod{
-								Address: "matched-endpoint",
-								Labels:  map[string]string{},
+			wantRes: &types.SchedulingResult{
+				ProfileResults: map[string]*types.ProfileRunResult{
+					"req-header-based-profile": {
+						TargetPod: &types.ScoredPod{
+							Pod: &types.PodMetrics{
+								Pod: &backend.Pod{
+									Address: "matched-endpoint",
+									Labels:  map[string]string{},
+								},
 							},
 						},
 					},
 				},
+				PrimaryProfileName: "req-header-based-profile",
 			},
 		},
 	}

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -54,11 +54,11 @@ func (m *mockSaturationDetector) IsSaturated(_ context.Context) bool {
 }
 
 type mockScheduler struct {
-	scheduleResults map[string]*schedulingtypes.Result
+	scheduleResults *schedulingtypes.SchedulingResult
 	scheduleErr     error
 }
 
-func (m *mockScheduler) Schedule(ctx context.Context, req *schedulingtypes.LLMRequest) (map[string]*schedulingtypes.Result, error) {
+func (m *mockScheduler) Schedule(ctx context.Context, req *schedulingtypes.LLMRequest) (*schedulingtypes.SchedulingResult, error) {
 	return m.scheduleResults, m.scheduleErr
 }
 
@@ -126,17 +126,20 @@ func TestDirector_HandleRequest(t *testing.T) {
 	}
 	ds.PodUpdateOrAddIfNotExist(testPod)
 
-	defaultSuccessfulScheduleResults := map[string]*schedulingtypes.Result{
-		"testProfile": {
-			TargetPod: &schedulingtypes.ScoredPod{
-				Pod: &schedulingtypes.PodMetrics{
-					Pod: &backend.Pod{
-						Address:        "192.168.1.100",
-						NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"},
+	defaultSuccessfulScheduleResults := &schedulingtypes.SchedulingResult{
+		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
+			"testProfile": {
+				TargetPod: &schedulingtypes.ScoredPod{
+					Pod: &schedulingtypes.PodMetrics{
+						Pod: &backend.Pod{
+							Address:        "192.168.1.100",
+							NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"},
+						},
 					},
 				},
 			},
 		},
+		PrimaryProfileName: "testProfile",
 	}
 
 	tests := []struct {

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -33,17 +33,14 @@ const (
 )
 
 // ProfileHandler defines the extension points for handling multi SchedulerProfile instances.
-// More specifically, this interface defines the 'PickProfiles' and 'ProcessProfilesResults'
-// extension points.
-
-// ProfileHandler
+// More specifically, this interface defines the 'Pick' and 'ProcessResults' extension points.
 type ProfileHandler interface {
 	plugins.Plugin
 	// Pick selects the SchedulingProfiles to run from a list of candidate profiles, while taking into consideration the request properties
 	// and the previously executed SchedluderProfile cycles along with their results.
 	Pick(ctx context.Context, request *types.LLMRequest, profiles map[string]*SchedulerProfile, profileResults map[string]*types.ProfileRunResult) map[string]*SchedulerProfile
 
-	// ProcessResults handles the outcome of each profile run.
+	// ProcessResults handles the outcome of the profile runs after all profiles ran succuessfully.
 	// It may aggregate results, log test profile outputs, or apply custom logic. It specifies in the SchedulingResult the
 	// key of the primary profile that should be used to get the request selected destination.
 	ProcessResults(ctx context.Context, request *types.LLMRequest, profileResults map[string]*types.ProfileRunResult) *types.SchedulingResult

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -24,18 +24,29 @@ import (
 )
 
 const (
-	ProfilePickerType   = "ProfilePicker"
-	FilterPluginType    = "Filter"
-	ScorerPluginType    = "Scorer"
-	PickerPluginType    = "Picker"
-	PostCyclePluginType = "PostCycle"
+	ProfilePickerType          = "ProfilePicker"
+	FilterPluginType           = "Filter"
+	ScorerPluginType           = "Scorer"
+	PickerPluginType           = "Picker"
+	PostCyclePluginType        = "PostCycle"
+	ProcessProfilesResultsType = "ProcessProfilesResults"
 )
 
-// ProfilePicker selects the SchedulingProfiles to run from a list of candidate profiles, while taking into consideration the request properties
-// and the previously executed SchedluderProfile cycles along with their results.
-type ProfilePicker interface {
+// ProfileHandler defines the extension points for handling multi SchedulerProfile instances.
+// More specifically, this interface defines the 'PickProfiles' and 'ProcessProfilesResults'
+// extension points.
+
+// ProfileHandler
+type ProfileHandler interface {
 	plugins.Plugin
-	Pick(ctx context.Context, request *types.LLMRequest, profiles map[string]*SchedulerProfile, executionResults map[string]*types.Result) map[string]*SchedulerProfile
+	// Pick selects the SchedulingProfiles to run from a list of candidate profiles, while taking into consideration the request properties
+	// and the previously executed SchedluderProfile cycles along with their results.
+	Pick(ctx context.Context, request *types.LLMRequest, profiles map[string]*SchedulerProfile, profileResults map[string]*types.ProfileRunResult) map[string]*SchedulerProfile
+
+	// ProcessResults handles the outcome of each profile run.
+	// It may aggregate results, log test profile outputs, or apply custom logic. It specifies in the SchedulingResult the
+	// key of the primary profile that should be used to get the request selected destination.
+	ProcessResults(ctx context.Context, request *types.LLMRequest, profileResults map[string]*types.ProfileRunResult) *types.SchedulingResult
 }
 
 // Filter defines the interface for filtering a list of pods based on context.
@@ -54,11 +65,12 @@ type Scorer interface {
 // Picker picks the final pod(s) to send the request to.
 type Picker interface {
 	plugins.Plugin
-	Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.Result
+	Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.ProfileRunResult
 }
 
 // PostCycle is called by the scheduler after it selects a targetPod for the request in the SchedulerProfile cycle.
+// DEPRECATED - do not use PostCycle. this is in the process of deprecation.
 type PostCycle interface {
 	plugins.Plugin
-	PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.Result)
+	PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.ProfileRunResult)
 }

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -167,7 +167,7 @@ func (m *Plugin) Score(ctx context.Context, request *types.LLMRequest, cycleStat
 }
 
 // PostCycle records in the plugin cache the result of the scheduling selection.
-func (m *Plugin) PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.Result) {
+func (m *Plugin) PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.ProfileRunResult) {
 	targetPod := res.TargetPod.GetPod()
 	state, err := m.getPrefixState(cycleState)
 	if err != nil {

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -56,7 +56,7 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
 	// Simulate pod1 was picked.
-	plugin.PostCycle(context.Background(), cycleState1, &types.Result{TargetPod: pod1})
+	plugin.PostCycle(context.Background(), cycleState1, &types.ProfileRunResult{TargetPod: pod1})
 
 	// Second request doesn't share any prefix with first one. It should be added to the cache but
 	// the pod score should be 0.
@@ -77,7 +77,7 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
 	// Simulate pod2 was picked.
-	plugin.PostCycle(context.Background(), cycleState2, &types.Result{TargetPod: pod2})
+	plugin.PostCycle(context.Background(), cycleState2, &types.ProfileRunResult{TargetPod: pod2})
 
 	// Third request shares partial prefix with first one.
 	req3 := &types.LLMRequest{
@@ -96,7 +96,7 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(2)/float64(3), scores[pod1], "score should be 2/3 - the model and the first prefix block match")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	plugin.PostCycle(context.Background(), cycleState3, &types.Result{TargetPod: pod1})
+	plugin.PostCycle(context.Background(), cycleState3, &types.ProfileRunResult{TargetPod: pod1})
 
 	// 4th request is same as req3 except the model is different, still no match.
 	req4 := &types.LLMRequest{
@@ -115,7 +115,7 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	plugin.PostCycle(context.Background(), cycleState4, &types.Result{TargetPod: pod1})
+	plugin.PostCycle(context.Background(), cycleState4, &types.ProfileRunResult{TargetPod: pod1})
 
 	// 5th request shares partial prefix with 3rd one.
 	req5 := &types.LLMRequest{
@@ -134,5 +134,5 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, 0.75, scores[pod1], "score should be 0.75 - the model and the first 2 prefix blocks match")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	plugin.PostCycle(context.Background(), cycleState5, &types.Result{TargetPod: pod1})
+	plugin.PostCycle(context.Background(), cycleState5, &types.ProfileRunResult{TargetPod: pod1})
 }

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -47,7 +47,7 @@ func (p *MaxScorePicker) Name() string {
 }
 
 // Pick selects the pod with the maximum score from the list of candidates.
-func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.Result {
+func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.ProfileRunResult {
 	log.FromContext(ctx).V(logutil.DEBUG).Info(fmt.Sprintf("Selecting a pod with the max score from %d candidates: %+v", len(scoredPods), scoredPods))
 
 	highestScorePods := []*types.ScoredPod{}
@@ -65,5 +65,5 @@ func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *types.CycleState,
 		return p.random.Pick(ctx, cycleState, highestScorePods) // pick randomly from the highest score pods
 	}
 
-	return &types.Result{TargetPod: highestScorePods[0]}
+	return &types.ProfileRunResult{TargetPod: highestScorePods[0]}
 }

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -44,8 +44,8 @@ func (p *RandomPicker) Name() string {
 }
 
 // Pick selects a random pod from the list of candidates.
-func (p *RandomPicker) Pick(ctx context.Context, _ *types.CycleState, scoredPods []*types.ScoredPod) *types.Result {
+func (p *RandomPicker) Pick(ctx context.Context, _ *types.CycleState, scoredPods []*types.ScoredPod) *types.ProfileRunResult {
 	log.FromContext(ctx).V(logutil.DEBUG).Info(fmt.Sprintf("Selecting a random pod from %d candidates: %+v", len(scoredPods), scoredPods))
 	i := rand.Intn(len(scoredPods))
-	return &types.Result{TargetPod: scoredPods[i]}
+	return &types.ProfileRunResult{TargetPod: scoredPods[i]}
 }

--- a/pkg/epp/scheduling/framework/scheduler_profile.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile.go
@@ -106,7 +106,7 @@ func (p *SchedulerProfile) AddPlugins(pluginObjects ...plugins.Plugin) error {
 
 // RunCycle runs a SchedulerProfile cycle. In other words, it invokes all the SchedulerProfile plugins in this
 // order - Filters, Scorers, Picker, PostCyclePlugins. After completing all, it returns the result.
-func (p *SchedulerProfile) Run(ctx context.Context, request *types.LLMRequest, cycleState *types.CycleState, podsSnapshot []types.Pod) (*types.Result, error) {
+func (p *SchedulerProfile) Run(ctx context.Context, request *types.LLMRequest, cycleState *types.CycleState, podsSnapshot []types.Pod) (*types.ProfileRunResult, error) {
 	pods := p.runFilterPlugins(ctx, request, cycleState, podsSnapshot)
 	if len(pods) == 0 {
 		return nil, errutil.Error{Code: errutil.Internal, Msg: "no pods available for the given request"}
@@ -165,7 +165,7 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *types.
 	return weightedScorePerPod
 }
 
-func (p *SchedulerProfile) runPickerPlugin(ctx context.Context, cycleState *types.CycleState, weightedScorePerPod map[types.Pod]float64) *types.Result {
+func (p *SchedulerProfile) runPickerPlugin(ctx context.Context, cycleState *types.CycleState, weightedScorePerPod map[types.Pod]float64) *types.ProfileRunResult {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	scoredPods := make([]*types.ScoredPod, len(weightedScorePerPod))
 	i := 0
@@ -183,7 +183,7 @@ func (p *SchedulerProfile) runPickerPlugin(ctx context.Context, cycleState *type
 	return result
 }
 
-func (p *SchedulerProfile) runPostCyclePlugins(ctx context.Context, cycleState *types.CycleState, result *types.Result) {
+func (p *SchedulerProfile) runPostCyclePlugins(ctx context.Context, cycleState *types.CycleState, result *types.ProfileRunResult) {
 	for _, plugin := range p.postCyclePlugins {
 		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-cycle plugin", "plugin", plugin.Name())
 		before := time.Now()

--- a/pkg/epp/scheduling/framework/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile_test.go
@@ -144,7 +144,7 @@ func TestSchedulePlugins(t *testing.T) {
 			wantPod := &types.PodMetrics{
 				Pod: &backend.Pod{NamespacedName: test.wantTargetPod, Labels: make(map[string]string)},
 			}
-			wantRes := &types.Result{
+			wantRes := &types.ProfileRunResult{
 				TargetPod: wantPod,
 			}
 
@@ -226,7 +226,7 @@ func (tp *testPlugin) Score(_ context.Context, _ *types.LLMRequest, _ *types.Cyc
 	return scoredPods
 }
 
-func (tp *testPlugin) Pick(_ context.Context, _ *types.CycleState, scoredPods []*types.ScoredPod) *types.Result {
+func (tp *testPlugin) Pick(_ context.Context, _ *types.CycleState, scoredPods []*types.ScoredPod) *types.ProfileRunResult {
 	tp.PickCallCount++
 	tp.NumOfPickerCandidates = len(scoredPods)
 
@@ -238,10 +238,10 @@ func (tp *testPlugin) Pick(_ context.Context, _ *types.CycleState, scoredPods []
 		}
 	}
 
-	return &types.Result{TargetPod: winnerPod}
+	return &types.ProfileRunResult{TargetPod: winnerPod}
 }
 
-func (tp *testPlugin) PostCycle(_ context.Context, _ *types.CycleState, res *types.Result) {
+func (tp *testPlugin) PostCycle(_ context.Context, _ *types.CycleState, res *types.ProfileRunResult) {
 	tp.PostScheduleCallCount++
 }
 

--- a/pkg/epp/scheduling/scheduler_config.go
+++ b/pkg/epp/scheduling/scheduler_config.go
@@ -19,15 +19,15 @@ package scheduling
 import "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
 
 // NewSchedulerConfig creates a new SchedulerConfig object and returns its pointer.
-func NewSchedulerConfig(profilePicker framework.ProfilePicker, profiles map[string]*framework.SchedulerProfile) *SchedulerConfig {
+func NewSchedulerConfig(profilePicker framework.ProfileHandler, profiles map[string]*framework.SchedulerProfile) *SchedulerConfig {
 	return &SchedulerConfig{
-		profilePicker: profilePicker,
-		profiles:      profiles,
+		profileHandler: profilePicker,
+		profiles:       profiles,
 	}
 }
 
 // SchedulerConfig provides a configuration for the scheduler which influence routing decisions.
 type SchedulerConfig struct {
-	profilePicker framework.ProfilePicker
-	profiles      map[string]*framework.SchedulerProfile
+	profileHandler framework.ProfileHandler
+	profiles       map[string]*framework.SchedulerProfile
 }

--- a/pkg/epp/scheduling/scheduler_config.go
+++ b/pkg/epp/scheduling/scheduler_config.go
@@ -19,9 +19,9 @@ package scheduling
 import "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
 
 // NewSchedulerConfig creates a new SchedulerConfig object and returns its pointer.
-func NewSchedulerConfig(profilePicker framework.ProfileHandler, profiles map[string]*framework.SchedulerProfile) *SchedulerConfig {
+func NewSchedulerConfig(profileHandler framework.ProfileHandler, profiles map[string]*framework.SchedulerProfile) *SchedulerConfig {
 	return &SchedulerConfig{
-		profileHandler: profilePicker,
+		profileHandler: profileHandler,
 		profiles:       profiles,
 	}
 }

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -34,7 +34,7 @@ func TestSchedule(t *testing.T) {
 		name    string
 		req     *types.LLMRequest
 		input   []*backendmetrics.FakePodMetrics
-		wantRes map[string]*types.Result
+		wantRes *types.SchedulingResult
 		err     bool
 	}{
 		{
@@ -92,24 +92,27 @@ func TestSchedule(t *testing.T) {
 					},
 				},
 			},
-			wantRes: map[string]*types.Result{
-				"default": {
-					TargetPod: &types.ScoredPod{
-						Pod: &types.PodMetrics{
-							Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}, Labels: make(map[string]string)},
-							MetricsState: &backendmetrics.MetricsState{
-								WaitingQueueSize:    3,
-								KVCacheUsagePercent: 0.1,
-								MaxActiveModels:     2,
-								ActiveModels: map[string]int{
-									"foo":      1,
-									"critical": 1,
+			wantRes: &types.SchedulingResult{
+				ProfileResults: map[string]*types.ProfileRunResult{
+					"default": {
+						TargetPod: &types.ScoredPod{
+							Pod: &types.PodMetrics{
+								Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}, Labels: make(map[string]string)},
+								MetricsState: &backendmetrics.MetricsState{
+									WaitingQueueSize:    3,
+									KVCacheUsagePercent: 0.1,
+									MaxActiveModels:     2,
+									ActiveModels: map[string]int{
+										"foo":      1,
+										"critical": 1,
+									},
+									WaitingModels: map[string]int{},
 								},
-								WaitingModels: map[string]int{},
 							},
 						},
 					},
 				},
+				PrimaryProfileName: "default",
 			},
 		},
 	}

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -78,7 +78,13 @@ func ToSchedulerPodMetrics(pods []backendmetrics.PodMetrics) []Pod {
 	return pm
 }
 
-// Result captures the scheduler result.
-type Result struct {
+// ProfileRunResult captures the profile run result.
+type ProfileRunResult struct {
 	TargetPod Pod
+}
+
+// SchedulingResult captures the result of the scheduling cycle.
+type SchedulingResult struct {
+	ProfileResults     map[string]*ProfileRunResult
+	PrimaryProfileName string
 }


### PR DESCRIPTION
following agreements made on #905, 
this PR implements another step towards the end goal of the scheduler new design. main changes include:
- rename of the profile handling plugin to ProfileHandler and add the ProcessProfilesResults extension point (function called ProcessResults in ProfileHandler interface, as agreed in the design discussion).
- add SchedulingResult which includes the map of the profile runs results and the key of the primary profile that is used in the director code to set the destination header (in the future it can be changed to use a `PreRequest` plugin).
- add the ProcessResults call in the scheduler request flow.
- create CycleState per request and not per profile.
- add a DEPRECATED comment on `PostCycle`. once PostResponse is used in prefix plugin, we should remove PostCycle.
- updated all tests according to the above changes.