### PR TITLE
Changes to multi-model guide in documentation

### DIFF
--- a/site-src/guides/serve-multiple-genai-models.md
+++ b/site-src/guides/serve-multiple-genai-models.md
@@ -7,6 +7,9 @@ You can then route requests based on the model name (such as "chatbot" and "reco
 
 ## How
 The following diagram illustrates how Gateway API Inference Extension routes requests to different models based on the model name.
+The model name is extarcted by [Body-Based routing](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/bbr/README.md)
+ from the request body to the header. The header is then matched to dispatch
+ requests to different `InferencePool` (and their EPPs) instances.
 ![Serving multiple generative AI models](../images/serve-mul-gen-AI-models.png)
 
 This example illustrates a conceptual example regarding how to use the `HTTPRoute` object to route based on model name like “chatbot” or “recommender” to `InferencePool`.
@@ -63,7 +66,7 @@ curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
 3. Send a few requests to model "recommender" as follows:
 ```bash
 curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
-"model": "chatbot",
+"model": "recommender",
 "prompt": "Give me restaurant recommendations in Paris",
 "max_tokens": 100,
 "temperature": 0


### PR DESCRIPTION
- clarify the use of BBR upfront (and not only as comment in YAML), and dispatching to different InferencePool/EPP
- fix typo in sample inference requests - both requests were sent to same model