### PR TITLE
refactor: Move scheduling parameter updates to main

### DIFF
--- a/pkg/epp/saturationdetector/config.go
+++ b/pkg/epp/saturationdetector/config.go
@@ -16,12 +16,9 @@ limitations under the License.
 package saturationdetector
 
 import (
-	"fmt"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	commonconfig "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/common/config"
-	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
 )
 
 // Default configuration values
@@ -34,37 +31,3 @@ const (
 	// that should be fine.
 	DefaultMetricsStalenessThreshold = 200 * time.Millisecond
 )
-
-// Environment variable names for SaturationDetector configuration
-const (
-	EnvSdQueueDepthThreshold       = "SD_QUEUE_DEPTH_THRESHOLD"
-	EnvSdKVCacheUtilThreshold      = "SD_KV_CACHE_UTIL_THRESHOLD"
-	EnvSdMetricsStalenessThreshold = "SD_METRICS_STALENESS_THRESHOLD"
-)
-
-// LoadConfigFromEnv loads SaturationDetector Config from environment variables.
-func LoadConfigFromEnv() *Config {
-	// Use a default logger for initial configuration loading.
-	logger := log.Log.WithName("saturation-detector-config")
-
-	cfg := &Config{}
-
-	cfg.QueueDepthThreshold = envutil.GetEnvInt(EnvSdQueueDepthThreshold, DefaultQueueDepthThreshold, logger)
-	if cfg.QueueDepthThreshold <= 0 {
-		cfg.QueueDepthThreshold = DefaultQueueDepthThreshold
-	}
-
-	cfg.KVCacheUtilThreshold = envutil.GetEnvFloat(EnvSdKVCacheUtilThreshold, DefaultKVCacheUtilThreshold, logger)
-	if cfg.KVCacheUtilThreshold <= 0 || cfg.KVCacheUtilThreshold >= 1 {
-		cfg.KVCacheUtilThreshold = DefaultKVCacheUtilThreshold
-	}
-
-	cfg.MetricsStalenessThreshold = envutil.GetEnvDuration(EnvSdMetricsStalenessThreshold, DefaultMetricsStalenessThreshold, logger)
-	if cfg.MetricsStalenessThreshold <= 0 {
-		cfg.MetricsStalenessThreshold = DefaultMetricsStalenessThreshold
-	}
-
-	// NewDetector validates the config and assigns defaults.
-	logger.Info("SaturationDetector configuration loaded from env", "config", fmt.Sprintf("%+v", cfg))
-	return cfg
-}

--- a/pkg/epp/saturationdetector/saturationdetector_test.go
+++ b/pkg/epp/saturationdetector/saturationdetector_test.go
@@ -18,9 +18,6 @@ package saturationdetector
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -77,40 +74,13 @@ func TestNewDetector(t *testing.T) {
 			expectedKVCacheUtilThreshold: 0.8,
 			expectedStalenessThreshold:   100 * time.Millisecond,
 		},
-		{
-			name: "invalid thresholds, fallback to default",
-			config: &Config{
-				QueueDepthThreshold:       -1,
-				KVCacheUtilThreshold:      -5,
-				MetricsStalenessThreshold: 0,
-			},
-			datastore:                    &mockDatastore{},
-			expectedQueueDepthThreshold:  DefaultQueueDepthThreshold,
-			expectedKVCacheUtilThreshold: DefaultKVCacheUtilThreshold,
-			expectedStalenessThreshold:   DefaultMetricsStalenessThreshold,
-		},
-		{
-			name: "kv cache threshold above range, fallback to default",
-			config: &Config{
-				QueueDepthThreshold:       10,
-				KVCacheUtilThreshold:      1.5,
-				MetricsStalenessThreshold: 100 * time.Millisecond,
-			},
-			datastore:                    &mockDatastore{},
-			expectedQueueDepthThreshold:  10,
-			expectedKVCacheUtilThreshold: DefaultKVCacheUtilThreshold,
-			expectedStalenessThreshold:   100 * time.Millisecond,
-		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// validate configuration values are loaded from env vars properly, including the use of default values when provided value is invalid.
-			os.Setenv(EnvSdQueueDepthThreshold, strconv.Itoa(test.config.QueueDepthThreshold))
-			os.Setenv(EnvSdKVCacheUtilThreshold, fmt.Sprintf("%v", test.config.KVCacheUtilThreshold))
-			os.Setenv(EnvSdMetricsStalenessThreshold, test.config.MetricsStalenessThreshold.String())
 
-			detector := NewDetector(LoadConfigFromEnv(), test.datastore, logr.Discard())
+			detector := NewDetector(test.config, test.datastore, logr.Discard())
 			if detector == nil {
 				t.Fatalf("NewDetector() returned nil detector for valid config")
 			}


### PR DESCRIPTION
**Fix:** #586

This PR refactors the handling of scheduling parameters by moving their update logic from environment variables to the main function within the scheduling package.