### PR TITLE
docs: Escape templating syntax in metrics.md to avoid Jinja2 conflicts

### DIFF
--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -112,8 +112,8 @@ alert: HighInferenceRequestLatencyP99
 expr: histogram_quantile(0.99, rate(inference_model_request_duration_seconds_bucket[5m])) > 10.0 # Adjust threshold as needed (e.g., 10.0 seconds)
 for: 5m
 annotations:
-  title: 'High latency (P99) for model {{ $labels.model_name }}'
-  description: 'The 99th percentile request duration for model {{ $labels.model_name }} and target model {{ $labels.target_model_name }} has been consistently above 10.0 seconds for 5 minutes.'
+  title: 'High latency (P99) for model {{ "{{" }} $labels.model_name {{ "}}" }}'
+  description: 'The 99th percentile request duration for model {{ "{{" }} $labels.model_name {{ "}}" }} and target model {{ "{{" }} $labels.target_model_name {{ "}}" }} has been consistently above 10.0 seconds for 5 minutes.'
 labels:
   severity: 'warning'
 ```
@@ -125,8 +125,8 @@ alert: HighInferenceErrorRate
 expr: sum by (model_name) (rate(inference_model_request_error_total[5m])) / sum by (model_name) (rate(inference_model_request_total[5m])) > 0.05 # Adjust threshold as needed (e.g., 5% error rate)
 for: 5m
 annotations:
-  title: 'High error rate for model {{ $labels.model_name }}'
-  description: 'The error rate for model {{ $labels.model_name }} and target model {{ $labels.target_model_name }} has been consistently above 5% for 5 minutes.'
+  title: 'High error rate for model {{ "{{" }} $labels.model_name {{ "}}" }}'
+  description: 'The error rate for model {{ "{{" }} $labels.model_name {{ "}}" }} and target model {{ "{{" }} $labels.target_model_name {{ "}}" }} has been consistently above 5% for 5 minutes.'
 labels:
   severity: 'critical'
   impact: 'availability'
@@ -139,8 +139,8 @@ alert: HighInferencePoolAvgQueueSize
 expr: inference_pool_average_queue_size > 50 # Adjust threshold based on expected queue size
 for: 5m
 annotations:
-  title: 'High average queue size for inference pool {{ $labels.name }}'
-  description: 'The average number of requests pending in the queue for inference pool {{ $labels.name }} has been consistently above 50 for 5 minutes.'
+  title: 'High average queue size for inference pool {{ "{{" }} $labels.name {{ "}}" }}'
+  description: 'The average number of requests pending in the queue for inference pool {{ "{{" }} $labels.name {{ "}}" }} has been consistently above 50 for 5 minutes.'
 labels:
   severity: 'critical'
   impact: 'performance'
@@ -153,8 +153,8 @@ alert: HighInferencePoolAvgKVCacheUtilization
 expr: inference_pool_average_kv_cache_utilization > 0.9 # 90% utilization
 for: 5m
 annotations:
-  title: 'High KV cache utilization for inference pool {{ $labels.name }}'
-  description: 'The average KV cache utilization for inference pool {{ $labels.name }} has been consistently above 90% for 5 minutes, indicating potential resource exhaustion.'
+  title: 'High KV cache utilization for inference pool {{ "{{" }} $labels.name {{ "}}" }}'
+  description: 'The average KV cache utilization for inference pool {{ "{{" }} $labels.name {{ "}}" }} has been consistently above 90% for 5 minutes, indicating potential resource exhaustion.'
 labels:
   severity: 'critical'
   impact: 'resource_exhaustion'


### PR DESCRIPTION
Escaped `{{ $labels.* }}` expressions in metrics.md using `{{ "{{" }}` syntax to prevent Jinja2 from rendering them during site build. 
Fixes markdown build errors with mkdocs-macros.

fixes: #955
