### PR TITLE
Fix the DestinationRule's referenced model service name

### DIFF
--- a/config/manifests/gateway/istio/destination-rule.yaml
+++ b/config/manifests/gateway/istio/destination-rule.yaml
@@ -3,7 +3,7 @@ kind: DestinationRule
 metadata:
   name: epp-insecure-tls
 spec:
-  host: vllm-llama2-7b-epp
+  host: vllm-llama3-8b-instruct
   trafficPolicy:
       tls:
         mode: SIMPLE


### PR DESCRIPTION
Expands on #615 to update the host for the model service being referenced in the quickstart