### PR TITLE
Pin PyPI package versions in requirements.txt

### DIFF
--- a/tools/dynamic-lora-sidecar/requirements.txt
+++ b/tools/dynamic-lora-sidecar/requirements.txt
@@ -1,6 +1,6 @@
-aiohttp
-jsonschema
-pyyaml
-requests 
-watchfiles
-watchdog
+aiohttp==3.12.12
+jsonschema==4.24.0
+PyYAML==6.0.2
+requests==2.32.4
+watchfiles==1.0.5
+watchdog==6.0.0


### PR DESCRIPTION
Resolve https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/962.

Pin PyPI package versions in requirements.txt for the Dynamic LoRA syncer sidecar for build stability. I confirmed `pip freeze` with the updated requirements.txt returns the same result as `pip freeze` on `us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main`  like below

<details><summary>Details</summary>

```terminal
laborant@dev-machine:gateway-api-inference-extension$ vim tools/dynamic-lora-sidecar/requirements.txt 
laborant@dev-machine:gateway-api-inference-extension$ cd tools/dynamic-lora-sidecar
laborant@dev-machine:dynamic-lora-sidecar$ docker build -t dynamic-lora-sidecar:test .
[+] Building 11.9s (12/12) FINISHED                                                                                                                                                               docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                        0.0s
 => => transferring dockerfile: 518B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/python:3.10-slim-buster                                                                                                                                  0.6s
 => [internal] load .dockerignore                                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                           0.0s
 => => transferring context: 25.14kB                                                                                                                                                                        0.0s
 => [stage-1 1/7] FROM docker.io/library/python:3.10-slim-buster@sha256:37aa274c2d001f09b14828450d903c55f821c90f225fdfdd80c5180fcca77b3f                                                                    0.1s
 => => resolve docker.io/library/python:3.10-slim-buster@sha256:37aa274c2d001f09b14828450d903c55f821c90f225fdfdd80c5180fcca77b3f                                                                            0.0s
 => => sha256:37aa274c2d001f09b14828450d903c55f821c90f225fdfdd80c5180fcca77b3f 988B / 988B                                                                                                                  0.0s
 => => sha256:68f714f81d6522d6ad2156abee2535307c2be24a96781f4823c06422dfff3a2c 1.37kB / 1.37kB                                                                                                              0.0s
 => => sha256:93b9055430ce944e6316e724e814427c9ad63c3fb9d87577f7e8436b9aa594c3 6.84kB / 6.84kB                                                                                                              0.0s
 => [stage-1 2/7] WORKDIR /dynamic-lora-reconciler                                                                                                                                                          0.0s
 => [stage-1 3/7] RUN python3 -m venv /opt/venv                                                                                                                                                             3.7s
 => [stage-1 4/7] RUN pip install --upgrade pip                                                                                                                                                             2.0s
 => [stage-1 5/7] COPY requirements.txt .                                                                                                                                                                   0.0s 
 => [stage-1 6/7] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                        5.2s 
 => [stage-1 7/7] COPY sidecar/* ./                                                                                                                                                                         0.0s 
 => exporting to image                                                                                                                                                                                      0.3s 
 => => exporting layers                                                                                                                                                                                     0.3s 
 => => writing image sha256:501b73fda62c3d00b1f71e317aa75c74ab11031c2ed8e16ccbd1b76d717bee4f                                                                                                                0.0s 
 => => naming to docker.io/library/dynamic-lora-sidecar:test                                                                                                                                                0.0s 
laborant@dev-machine:dynamic-lora-sidecar$ docker run --rm dynamic-lora-sidecar:test pip freeze                                                                                                                  
aiohappyeyeballs==2.6.1
aiohttp==3.12.12
aiosignal==1.3.2
anyio==4.9.0
async-timeout==5.0.1
attrs==25.3.0
certifi==2025.4.26
charset-normalizer==3.4.2
exceptiongroup==1.3.0
frozenlist==1.7.0
idna==3.10
jsonschema==4.24.0
jsonschema-specifications==2025.4.1
multidict==6.4.4
propcache==0.3.2
PyYAML==6.0.2
referencing==0.36.2
requests==2.32.4
rpds-py==0.25.1
sniffio==1.3.1
typing_extensions==4.14.0
urllib3==2.4.0
watchdog==6.0.0
watchfiles==1.0.5
yarl==1.20.1
laborant@dev-machine:~$ docker run us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main pip freeze
aiohappyeyeballs==2.6.1
aiohttp==3.12.12
aiosignal==1.3.2
anyio==4.9.0
async-timeout==5.0.1
attrs==25.3.0
certifi==2025.4.26
charset-normalizer==3.4.2
exceptiongroup==1.3.0
frozenlist==1.7.0
idna==3.10
jsonschema==4.24.0
jsonschema-specifications==2025.4.1
multidict==6.4.4
propcache==0.3.2
PyYAML==6.0.2
referencing==0.36.2
requests==2.32.4
rpds-py==0.25.1
sniffio==1.3.1
typing_extensions==4.14.0
urllib3==2.4.0
watchdog==6.0.0
watchfiles==1.0.5
yarl==1.20.1
laborant@dev-machine:dynamic-lora-sidecar$ diff -u <(docker run us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main pip freeze) <(docker run --rm dynamic-lora-sidecar:test pip freeze)
laborant@dev-machine:dynamic-lora-sidecar$
```

</details> 