### PR TITLE
feat(conformance): enable multiple endpoints in header based filter for EPP's conformance testing.

### DIFF
--- a/conformance/testing-epp/plugins/filter/filter_test.go
+++ b/conformance/testing-epp/plugins/filter/filter_test.go
@@ -79,6 +79,40 @@ func TestFilter(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "TestHeaderBasedFilter, multiple header endpoints set and multiple matches",
+			req:    &types.LLMRequest{Headers: map[string]string{headerTestEppEndPointSelectionKey: "test-endpoint3,test-endpoint2"}},
+			filter: &HeaderBasedTestingFilter{},
+			input: []types.Pod{
+				&types.PodMetrics{
+					Pod: &backend.Pod{
+						Address: "test-endpoint1",
+					},
+				},
+				&types.PodMetrics{
+					Pod: &backend.Pod{
+						Address: "test-endpoint2",
+					},
+				},
+				&types.PodMetrics{
+					Pod: &backend.Pod{
+						Address: "test-endpoint3",
+					},
+				},
+			},
+			output: []types.Pod{
+				&types.PodMetrics{
+					Pod: &backend.Pod{
+						Address: "test-endpoint3",
+					},
+				},
+				&types.PodMetrics{
+					Pod: &backend.Pod{
+						Address: "test-endpoint2",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This change enhances the `HeaderBasedTestingFilter` to parse multiple, comma-separated endpoints from the `test-epp-endpoint-selection` header. This will be used further in EPP conformance tests extending #961 .