### PR TITLE
Update dynamic-lora-sidecar to expose metrics to track loaded adapters

### DIFF
--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -4,22 +4,31 @@ This guide describes the current state of exposed metrics and how to scrape them
 
 ## Requirements
 
-To have response metrics, ensure the body mode is set to `Buffered` or `Streamed` (this should be the default behavior for all implementations).
+=== "EPP"
 
-If you want to include usage metrics for vLLM model server streaming request, send the request with `include_usage`:
+      To have response metrics, ensure the body mode is set to `Buffered` or `Streamed` (this should be the default behavior for all implementations).
 
-```
-curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
-"model": "food-review",
-"prompt": "whats your fav movie?",
-"max_tokens": 10,
-"temperature": 0,
-"stream": true,
-"stream_options": {"include_usage": "true"}
-}'
-```
+      If you want to include usage metrics for vLLM model server streaming request, send the request with `include_usage`:
+
+      ```
+      curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
+      "model": "food-review",
+      "prompt": "whats your fav movie?",
+      "max_tokens": 10,
+      "temperature": 0,
+      "stream": true,
+      "stream_options": {"include_usage": "true"}
+      }'
+      ```
+
+=== "Dynamic LORA Adapter Sidecar"
+
+      To have response metrics, ensure the vLLM model server is configured with the dynamic LoRA adapter as a sidecar container and a ConfigMap to configure which models to load/unload. See [this doc](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/tools/dynamic-lora-sidecar#example-configuration) for an example.
+
 
 ## Exposed metrics
+
+### EPP
 
 | **Metric name**                              | **Metric Type**  | <div style="width:200px">**Description**</div>  | <div style="width:250px">**Labels**</div>                                          | **Status**  |
 |:---------------------------------------------|:-----------------|:------------------------------------------------------------------|:-----------------------------------------------------------------------------------|:------------|
@@ -38,10 +47,19 @@ curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
 | inference_pool_ready_pods                    | Gauge            | The number of ready pods for an inference server pool.            | `name`=&lt;inference-pool-name&gt;                                                 | ALPHA       |
 | inference_extension_info                     | Gauge            | The general information of the current build.                     | `commit`=&lt;hash-of-the-build&gt; <br> `build_ref`=&lt;ref-to-the-build&gt;        | ALPHA       |
 
+### Dynamic LORA Adapter Sidecar
+
+| **Metric name**            | **Metric Type**  | <div style="width:200px">**Description**</div>   | <div style="width:250px">**Labels**</div> | **Status**  |
+|:---------------------------|:-----------------|:-------------------------------------------------|:------------------------------------------|:------------|
+| lora_syncer_adapter_status | Gauge            | Status of LoRA adapters (1=loaded, 0=not_loaded) | `adapter_name`=&lt;adapter_id&gt;         | ALPHA       |
 
 ## Scrape Metrics
 
-Metrics endpoint is exposed at port 9090 by default. To scrape metrics, the client needs a ClusterRole with the following rule:
+The metrics endpoints are exposed on different ports by default:
+- EPP exposes the metrics endpoint at port 9090
+- Dynamic LoRA adapter sidecar exposes the metrics endpoint at port 8080
+
+To scrape metrics, the client needs a ClusterRole with the following rule:
 `nonResourceURLs: "/metrics", verbs: get`.
 
 Here is one example if the client needs to mound the secret to act as the service account
@@ -86,7 +104,9 @@ metadata:
     kubernetes.io/service-account.name: inference-gateway-sa-metrics-reader
 type: kubernetes.io/service-account-token
 ```
-Then, you can curl the 9090 port like following
+
+Then, you can curl the appropriate port as follows. For EPP (port 9090),
+
 ```
 TOKEN=$(kubectl -n default get secret inference-gateway-sa-metrics-reader-secret  -o jsonpath='{.secrets[0].name}' -o jsonpath='{.data.token}' | base64 --decode)
 

--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -106,12 +106,12 @@ metadata:
 type: kubernetes.io/service-account-token
 ```
 
-Then, you can curl the appropriate port as follows. For EPP (port 9090),
+Then, you can curl the appropriate port as follows. For EPP (port 9090)
 
 ```
 TOKEN=$(kubectl -n default get secret inference-gateway-sa-metrics-reader-secret  -o jsonpath='{.secrets[0].name}' -o jsonpath='{.data.token}' | base64 --decode)
 
-kubectl -n default port-forward inference-gateway-ext-proc-pod-name  9090:9090
+kubectl -n default port-forward inference-gateway-ext-proc-pod-name  9090
 
 curl -H "Authorization: Bearer $TOKEN" localhost:9090/metrics
 ```

--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -21,7 +21,7 @@ This guide describes the current state of exposed metrics and how to scrape them
       }'
       ```
 
-=== "Dynamic LORA Adapter Sidecar"
+=== "Dynamic LoRA Adapter Sidecar"
 
       To have response metrics, ensure the vLLM model server is configured with the dynamic LoRA adapter as a sidecar container and a ConfigMap to configure which models to load/unload. See [this doc](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/tools/dynamic-lora-sidecar#example-configuration) for an example.
 
@@ -47,15 +47,16 @@ This guide describes the current state of exposed metrics and how to scrape them
 | inference_pool_ready_pods                    | Gauge            | The number of ready pods for an inference server pool.            | `name`=&lt;inference-pool-name&gt;                                                 | ALPHA       |
 | inference_extension_info                     | Gauge            | The general information of the current build.                     | `commit`=&lt;hash-of-the-build&gt; <br> `build_ref`=&lt;ref-to-the-build&gt;        | ALPHA       |
 
-### Dynamic LORA Adapter Sidecar
+### Dynamic LoRA Adapter Sidecar
 
 | **Metric name**            | **Metric Type**  | <div style="width:200px">**Description**</div>   | <div style="width:250px">**Labels**</div> | **Status**  |
 |:---------------------------|:-----------------|:-------------------------------------------------|:------------------------------------------|:------------|
-| lora_syncer_adapter_status | Gauge            | Status of LoRA adapters (1=loaded, 0=not_loaded) | `adapter_name`=&lt;adapter_id&gt;         | ALPHA       |
+| lora_syncer_adapter_status | Gauge            | Status of LoRA adapters (1=loaded, 0=not_loaded) | `adapter_name`=&lt;adapter-id&gt;         | ALPHA       |
 
 ## Scrape Metrics
 
 The metrics endpoints are exposed on different ports by default:
+
 - EPP exposes the metrics endpoint at port 9090
 - Dynamic LoRA adapter sidecar exposes the metrics endpoint at port 8080
 
@@ -110,7 +111,7 @@ Then, you can curl the appropriate port as follows. For EPP (port 9090),
 ```
 TOKEN=$(kubectl -n default get secret inference-gateway-sa-metrics-reader-secret  -o jsonpath='{.secrets[0].name}' -o jsonpath='{.data.token}' | base64 --decode)
 
-kubectl -n default port-forward inference-gateway-ext-proc-pod-name  9090
+kubectl -n default port-forward inference-gateway-ext-proc-pod-name  9090:9090
 
 curl -H "Authorization: Bearer $TOKEN" localhost:9090/metrics
 ```

--- a/tools/dynamic-lora-sidecar/README.md
+++ b/tools/dynamic-lora-sidecar/README.md
@@ -121,6 +121,9 @@ spec:
       - name: reconciler
         image: your-image:tag
         command: ["python", "sidecar.py", "--health-check-timeout", "600", "--health-check-interval", "5", "--reconcile-trigger", "10"] #optional if overriding default values
+        ports:
+        - containerPort: 8080
+          name: metrics
         volumeMounts:
         - name: config-volume
           mountPath: /config

--- a/tools/dynamic-lora-sidecar/deployment.yaml
+++ b/tools/dynamic-lora-sidecar/deployment.yaml
@@ -69,7 +69,10 @@ spec:
           image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main
           restartPolicy: Always
           imagePullPolicy: Always
-          env: 
+          ports:
+          - containerPort: 8080
+            name: metrics
+          env:
             - name: DYNAMIC_LORA_ROLLOUT_CONFIG
               value: "/config/configmap.yaml"
           volumeMounts: # DO NOT USE subPath

--- a/tools/dynamic-lora-sidecar/requirements.txt
+++ b/tools/dynamic-lora-sidecar/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.12.12
 jsonschema==4.24.0
+prometheus_client==0.22.1
 PyYAML==6.0.2
 requests==2.32.4
 watchfiles==1.0.5


### PR DESCRIPTION
Resolves https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/600

Update dynamic-lora-sidecar to expose metrics to track loaded adapters. `lora_syncer_adapter_status`  is a binary metric with the adapter_name label. I confirmed sidecar.py ran  an HTTP server with the port 8080 that returned metrics.

<details><summary>curl http://localhost:8080/metrics</summary>

* Run sidecar.py

```
(venv) laborant@dev-machine:sidecar$ pwd
/home/laborant/gateway-api-inference-extension/tools/dynamic-lora-sidecar/sidecar
(venv) laborant@dev-machine:sidecar$ uv run --with-requirements ../requirements.txt python sidecar.py --config ../configmap.yaml
2025-06-13 04:59:09 - INFO - sidecar.py:118 -  Settings initialized: health check timeout=300s, interval=2s, reconcile trigger=5s
2025-06-13 04:59:09 - INFO - sidecar.py:332 -  Starting metrics server on port 8080
2025-06-13 04:59:09 - INFO - sidecar.py:335 -  Running initial reconcile for config map ../configmap.yaml
2025-06-13 04:59:09 - INFO - sidecar.py:281 -  reconciling model server localhost:8000 with config stored at ../configmap.yaml
```

* Run curl

```
laborant@dev-machine:~$ curl http://localhost:8080/metrics
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 1473.0
python_gc_objects_collected_total{generation="1"} 168.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 76.0
python_gc_collections_total{generation="1"} 6.0
python_gc_collections_total{generation="2"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="12",patchlevel="3",version="3.12.3"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.99852032e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 4.1213952e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.74979074849e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.5700000000000001
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 9.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP lora_syncer_adapter_status Status of LoRA adapters (1=loaded, 0=not_loaded)
# TYPE lora_syncer_adapter_status gauge
```

</details> 

<details><summary>pytest</summary>

```
(venv) laborant@dev-machine:sidecar$ uv run --with-requirements ../requirements.txt --with pytest pytest .
==================================================================== test session starts =====================================================================
platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.6.0
rootdir: /home/laborant/gateway-api-inference-extension/tools/dynamic-lora-sidecar/sidecar
plugins: anyio-4.9.0
collected 6 items                                                                                                                                            

test_sidecar.py ......                                                                                                                                 [100%]

===================================================================== 6 passed in 0.26s ======================================================================
```

</details> 