### PR TITLE
refactor(conformance): move some common resources to shared place and add EPP service to tests needed.

### DIFF
--- a/conformance/resources/manifests/manifests.yaml
+++ b/conformance/resources/manifests/manifests.yaml
@@ -21,15 +21,6 @@ metadata:
   labels:
     gateway-conformance: backend
 ---
-# Namespace for simple web server backends. This is expected by
-# the upstream conformance suite's Setup method.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: gateway-conformance-web-backend
-  labels:
-    gateway-conformance: web-backend
----
 # A basic Gateway resource that allows HTTPRoutes from the same namespace.
 # Tests can use this as a parent reference for routes that target InferencePools.
 apiVersion: gateway.networking.k8s.io/v1
@@ -70,3 +61,84 @@ spec:
     allowedRoutes:
       namespaces:
         from: All
+
+### The following defines the essential resources for the gateway conformance test.
+### All resources are created in the 'gateway-conformance-app-backend' namespace.
+---
+# Deploys a mock backend service to act as a model server.
+#
+# For conformance testing, a simple echo server is sufficient. The goal is to
+# verify that requests are successfully routed to a backend, not to validate
+# the content of the server's response. In a real-world use case, this would
+# be replaced by the actual model-serving application.
+#
+# The Pods created by this Deployment are selected by the InferencePool resource.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-backend-primary-model-server-deployment
+  namespace: gateway-conformance-app-backend
+  labels:
+    app: app-backend-primary-model-server
+spec:
+  selector:
+    matchLabels:
+      app: app-backend-primary-model-server
+  template:
+    metadata:
+      labels:
+        app: app-backend-primary-model-server
+    spec:
+      containers:
+      - name: echoserver
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        ports:
+        - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 2
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+---
+# --- Required Role and RoleBinding for Conformance Test for EPP ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: inference-model-reader
+  namespace: gateway-conformance-app-backend
+rules:
+- apiGroups: ["inference.networking.x-k8s.io"]
+  resources: ["inferencemodels", "inferencepools"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: epp-to-inference-model-reader
+  namespace: gateway-conformance-app-backend
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: gateway-conformance-app-backend
+roleRef:
+  kind: Role
+  name: inference-model-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/conformance/tests/basic/inferencepool_accepted.yaml
+++ b/conformance/tests/basic/inferencepool_accepted.yaml
@@ -3,43 +3,6 @@
 # InferencePool and HTTPRoute resources, which the InferencePoolAccepted
 # test will use to verify that the controller recognizes and accepts the resource.
 
-# --- Minimal Backend Deployment (using agnhost echo server) ---
-# This Deployment provides Pods for the InferencePool to select.
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: infra-backend-v1-deployment
-  namespace: gateway-conformance-app-backend
-  labels:
-    app: infra-backend-v1
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: infra-backend-v1
-  template:
-    metadata:
-      labels:
-        app: infra-backend-v1
-    spec:
-      containers:
-      - name: agnhost-echo
-        image: k8s.gcr.io/e2e-test-images/agnhost:2.39
-        args:
-        - serve-hostname
-        - --http-port=8080
-        ports:
-        - name: http
-          containerPort: 8080
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          failureThreshold: 2
-
----
 # --- InferencePool Definition ---
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
@@ -53,7 +16,7 @@ spec:
   # --- Selector (Required) ---
   # Selects the Pods belonging to this pool.
   selector:
-    app: "infra-backend-v1"
+    app: "app-backend-primary-model-server"
 
   # --- Target Port (Required) ---
   # The port the model server container (agnhost in this case) listens on.
@@ -64,8 +27,83 @@ spec:
   extensionRef:
     # group: "" # Optional
     # kind: Service # Optional
-    name: infra-backend-v1-epp
-
+    name: app-endpoint-picker-svc
+---
+# --- Conformance EPP service Definition ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-endpoint-picker-svc
+  namespace: gateway-conformance-app-backend
+spec:
+  selector:
+    app: app-backend-epp
+  ports:
+    - protocol: TCP
+      port: 9002
+      targetPort: 9002
+      appProtocol: http2
+  type: ClusterIP
+---
+# --- Conformance EPP Deployment ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-endpoint-picker
+  namespace: gateway-conformance-app-backend
+  labels:
+    app: app-backend-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-backend-epp
+  template:
+    metadata:
+      labels:
+        app: app-backend-epp
+    spec:
+      # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
+      terminationGracePeriodSeconds: 130
+      containers:
+      - name: epp
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+        imagePullPolicy: Always
+        args:
+        - -poolName
+        - "inferencepool-basic-accepted"
+        - -poolNamespace
+        - "gateway-conformance-app-backend"
+        - -v
+        - "4"
+        - --zap-encoder
+        - "json"
+        - -grpcPort
+        - "9002"
+        - -grpcHealthPort
+        - "9003"
+        env:
+        - name: USE_STREAMING
+          value: "true"
+        - name: ENABLE_REQ_HEADER_BASED_SCHEDULER_FOR_TESTING # Used for conformance test.
+          value: "true"
+        ports:
+        - containerPort: 9002
+        - containerPort: 9003
+        - name: metrics
+          containerPort: 9090
+        livenessProbe:
+          grpc:
+            port: 9003
+            service: inference-extension
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          grpc:
+            port: 9003
+            service: inference-extension
+          initialDelaySeconds: 5
+          periodSeconds: 10
 ---
 # --- HTTPRoute Definition ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/conformance/tests/basic/inferencepool_resolvedrefs_condition.go
+++ b/conformance/tests/basic/inferencepool_resolvedrefs_condition.go
@@ -59,7 +59,7 @@ var InferencePoolParentStatus = suite.ConformanceTest{
 			pathPrimaryGw              = "/primary-gateway-test"
 			hostnameSecondaryGw        = "secondary.example.com"
 			pathSecondaryGw            = "/secondary-gateway-test"
-			backendServicePodName      = "infra-backend-deployment"
+			backendServicePodName      = "app-backend-primary-model-server"
 		)
 
 		poolNN := types.NamespacedName{Name: poolName, Namespace: appBackendNamespace}

--- a/conformance/tests/basic/inferencepool_resolvedrefs_condition.yaml
+++ b/conformance/tests/basic/inferencepool_resolvedrefs_condition.yaml
@@ -3,67 +3,6 @@
 # This manifest defines the initial resources for the
 # inferencepool_resolvedrefs_condition.go conformance test.
 
-# --- Backend Deployment (using standard Gateway API echoserver) ---
-# This Deployment provides Pods for the InferencePool to select.
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: infra-backend-deployment
-  namespace: gateway-conformance-app-backend
-  labels:
-    app: infra-backend
-spec:
-  selector:
-    matchLabels:
-      app: infra-backend
-  template:
-    metadata:
-      labels:
-        app: infra-backend
-    spec:
-      containers:
-      - name: echoserver
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
-        ports:
-        - containerPort: 3000
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 3000
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          failureThreshold: 2
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
----
-# --- Backend Service ---
-# Service for the infra-backend-deployment.
-apiVersion: v1
-kind: Service
-metadata:
-  name: infra-backend-svc
-  namespace: gateway-conformance-app-backend
-spec:
-  selector:
-    app: infra-backend
-  ports:
-  - name: http
-    port: 3000
-    targetPort: 3000
-  - name: epp
-    port: 9002
-    targetPort: 9002
 ---
 # --- InferencePool Definition ---
 apiVersion: inference.networking.x-k8s.io/v1alpha2
@@ -73,10 +12,86 @@ metadata:
   namespace: gateway-conformance-app-backend
 spec:
   selector:
-    app: "infra-backend"
+    app: "app-backend-primary-model-server"
   targetPortNumber: 3000
   extensionRef:
-    name: infra-backend-svc
+    name: app-endpoint-picker-svc
+---
+# --- Conformance EPP service Definition ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-endpoint-picker-svc
+  namespace: gateway-conformance-app-backend
+spec:
+  selector:
+    app: app-backend-epp
+  ports:
+    - protocol: TCP
+      port: 9002
+      targetPort: 9002
+      appProtocol: http2
+  type: ClusterIP
+---
+# --- Conformance EPP Deployment ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-endpoint-picker
+  namespace: gateway-conformance-app-backend
+  labels:
+    app: app-backend-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-backend-epp
+  template:
+    metadata:
+      labels:
+        app: app-backend-epp
+    spec:
+      # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
+      terminationGracePeriodSeconds: 130
+      containers:
+      - name: epp
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+        imagePullPolicy: Always
+        args:
+        - -poolName
+        - "multi-gateway-pool"
+        - -poolNamespace
+        - "gateway-conformance-app-backend"
+        - -v
+        - "4"
+        - --zap-encoder
+        - "json"
+        - -grpcPort
+        - "9002"
+        - -grpcHealthPort
+        - "9003"
+        env:
+        - name: USE_STREAMING
+          value: "true"
+        - name: ENABLE_REQ_HEADER_BASED_SCHEDULER_FOR_TESTING # Used for conformance test.
+          value: "true"
+        ports:
+        - containerPort: 9002
+        - containerPort: 9003
+        - name: metrics
+          containerPort: 9090
+        livenessProbe:
+          grpc:
+            port: 9003
+            service: inference-extension
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          grpc:
+            port: 9003
+            service: inference-extension
+          initialDelaySeconds: 5
+          periodSeconds: 10
 ---
 # --- HTTPRoute for Primary Gateway (conformance-gateway) ---
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
Basic refactor, the common resources is 
1. the mock model server
2. RBAC

Tested against istio:

```
go test -v ./conformance -args -debug -gateway-class istio -cleanup-base-resources=false

=== NAME  TestConformance/InferencePoolResolvedRefsCondition
    inferencepool_resolvedrefs_condition.go:160: InferencePoolResolvedRefsCondition test completed.
    apply.go:283: 2025-06-13T18:54:06.737348221Z: Deleting httproute-for-secondary-gw HTTPRoute
    apply.go:283: 2025-06-13T18:54:06.756555547Z: Deleting httproute-for-primary-gw HTTPRoute
    apply.go:283: 2025-06-13T18:54:06.773621102Z: Deleting app-endpoint-picker Deployment
    apply.go:283: 2025-06-13T18:54:06.815087012Z: Deleting app-endpoint-picker-svc Service
    apply.go:283: 2025-06-13T18:54:06.931322441Z: Deleting multi-gateway-pool InferencePool
--- PASS: TestConformance (45.67s)
    --- PASS: TestConformance/HTTPRouteInvalidInferencePoolRef (1.29s)
        --- PASS: TestConformance/HTTPRouteInvalidInferencePoolRef/HTTPRoute_should_have_Accepted=True_and_ResolvedRefs=False_for_non-existent_InferencePool (1.04s)
    --- PASS: TestConformance/InferencePoolAccepted (11.07s)
        --- PASS: TestConformance/InferencePoolAccepted/InferencePool_should_have_Accepted_condition_set_to_True (10.03s)
    --- PASS: TestConformance/InferencePoolResolvedRefsCondition (29.22s)
        --- PASS: TestConformance/InferencePoolResolvedRefsCondition/InferencePool_should_show_Accepted:True_by_parents_and_be_routable_via_multiple_HTTPRoutes (12.14s)
        --- PASS: TestConformance/InferencePoolResolvedRefsCondition/Delete_httproute-for-primary-gw_and_verify_InferencePool_status_and_routing_via_secondary_gw (5.34s)
        --- PASS: TestConformance/InferencePoolResolvedRefsCondition/Delete_httproute-for-secondary-gw_and_verify_InferencePool_has_no_parent_statuses_and_is_not_routable (10.15s)
PASS
```
