### PR TITLE
API: Adds 5xx Status Code for Invalid ExtRef

### DIFF
--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -80,14 +80,18 @@ type EndpointPickerConfig struct {
 
 // Extension specifies how to configure an extension that runs the endpoint picker.
 type Extension struct {
-	// Reference is a reference to a service extension.
+	// Reference is a reference to a service extension. When ExtensionReference is invalid,
+	// a 5XX status code MUST be returned for the request that would have otherwise been routed
+	// to the invalid backend.
 	ExtensionReference `json:",inline"`
 
 	// ExtensionConnection configures the connection between the gateway and the extension.
 	ExtensionConnection `json:",inline"`
 }
 
-// ExtensionReference is a reference to the extension deployment.
+// ExtensionReference is a reference to the extension deployment. When ExtensionReference is invalid,
+// a 5XX status code MUST be returned for the request that would have otherwise been routed to the
+// invalid backend.
 type ExtensionReference struct {
 	// Group is the group of the referent.
 	// The default value is "", representing the Core API group.


### PR DESCRIPTION
Updates godocs for InferencePool `ExtensionReference` field to include expected 5xx response code for invalid EPP references.

xref: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/959/files#r2145990979