### PR TITLE
moved the creation of the context to main.go.

### DIFF
--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -19,11 +19,13 @@ package main
 import (
 	"os"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"sigs.k8s.io/gateway-api-inference-extension/cmd/epp/runner"
 )
 
 func main() {
-	if err := runner.NewRunner().Run(); err != nil {
+	if err := runner.NewRunner().Run(ctrl.SetupSignalHandler()); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runner
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -139,7 +140,7 @@ func (r *Runner) WithSchedulerConfig(schedulerConfig *scheduling.SchedulerConfig
 	return r
 }
 
-func (r *Runner) Run() error {
+func (r *Runner) Run(ctx context.Context) error {
 	opts := zap.Options{
 		Development: true,
 	}
@@ -182,7 +183,7 @@ func (r *Runner) Run() error {
 	}
 	verifyMetricMapping(*mapping, setupLog)
 	pmf := backendmetrics.NewPodMetricsFactory(&backendmetrics.PodMetricsClientImpl{MetricMapping: mapping}, *refreshMetricsInterval)
-	ctx := ctrl.SetupSignalHandler()
+
 	datastore := datastore.NewDatastore(ctx, pmf)
 
 	// --- Setup Metrics Server ---


### PR DESCRIPTION
This PR moves context creation to `main.go` rather than internally in `runner`. 
this is useful when writing a different main like llm-d, 
allowing to propagate the same context to the whole system.