### PR TITLE
fix: Update bbr fqdn to use helm release namespace

### DIFF
--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -31,7 +31,7 @@ spec:
             response_trailer_mode: "SKIP"
           grpc_service:
             envoy_grpc:
-              cluster_name: outbound|{{ .Values.bbr.port }}||{{ .Values.bbr.name }}.default.svc.cluster.local
+              cluster_name: outbound|{{ .Values.bbr.port }}||{{ .Values.bbr.name }}.{{ .Release.Namespace }}.svc.cluster.local
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -39,7 +39,7 @@ metadata:
   name: {{ .Values.bbr.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  host: {{ .Values.bbr.name }}.default.svc.cluster.local
+  host: {{ .Values.bbr.name }}.{{ .Release.Namespace }}.svc.cluster.local
   trafficPolicy:
       tls:
         mode: SIMPLE


### PR DESCRIPTION
Making sure that the generated cluster and host names correctly reference the release namespace instead of defaulting to the `default` namespace.
