### PR TITLE
[Fix] Missing property "apiGroup" error

### DIFF
--- a/config/charts/inferencepool/templates/rbac.yaml
+++ b/config/charts/inferencepool/templates/rbac.yaml
@@ -33,6 +33,7 @@ subjects:
   name: {{ include "gateway-api-inference-extension.name" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "gateway-api-inference-extension.name" . }}
 ---

--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -117,5 +117,6 @@ subjects:
   name: default
   namespace: default
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: pod-read

--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -95,7 +95,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: inference-gateway-metrics-reader
-  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: Secret

--- a/site-src/guides/metrics.md
+++ b/site-src/guides/metrics.md
@@ -92,6 +92,7 @@ subjects:
   name: inference-gateway-sa-metrics-reader
   namespace: default
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: inference-gateway-metrics-reader
   apiGroup: rbac.authorization.k8s.io

--- a/test/testdata/inferencepool-e2e.yaml
+++ b/test/testdata/inferencepool-e2e.yaml
@@ -119,5 +119,6 @@ subjects:
   name: default
   namespace: $E2E_NS
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: pod-read


### PR DESCRIPTION
When I was running `kubectl -f config/manifests/inferencepool-resources.yaml`, I encountered an error：

```
error: error validating "https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/inferencepool-resources.yaml": error validating data: ValidationError(ClusterRoleBinding.roleRef): missing required field "apiGroup" in io.k8s.api.rbac.v1.RoleRef; if you choose to ignore these errors, turn validation off with --validate=false
```

K8s Version: v1.27.3