### PR TITLE
Add Makefile to run unit tests of tools/dynamic-lora-sidecar locally

### DIFF
--- a/tools/dynamic-lora-sidecar/Dockerfile
+++ b/tools/dynamic-lora-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster AS test
+FROM python:3.10-slim-buster AS test
 
 WORKDIR /dynamic-lora-reconciler-test
 COPY requirements.txt .

--- a/tools/dynamic-lora-sidecar/Makefile
+++ b/tools/dynamic-lora-sidecar/Makefile
@@ -1,0 +1,33 @@
+# Makefile for dynamic-lora-sidecar
+
+PYTHON_VERSION := 3.10
+VENV_DIR := venv
+PYTHON := $(VENV_DIR)/bin/python
+PIP := $(VENV_DIR)/bin/pip
+
+.PHONY: help venv install test clean
+
+help: ## Show available targets
+	@echo "Available targets:"
+	@echo "  venv     - Create virtual environment"
+	@echo "  install  - Install dependencies"
+	@echo "  test     - Run unit tests"
+	@echo "  clean    - Clean up virtual environment"
+
+venv: $(VENV_DIR)/bin/activate ## Create virtual environment
+
+$(VENV_DIR)/bin/activate:
+	python$(PYTHON_VERSION) -m venv $(VENV_DIR)
+
+install: venv ## Install dependencies
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+
+test: install ## Run unit tests
+	$(PYTHON) -m unittest discover -v -s sidecar
+
+clean: ## Clean up virtual environment
+	rm -rf $(VENV_DIR)
+	rm -rf .pytest_cache
+	find . -name "*.pyc" -delete
+	find . -name "__pycache__" -type d -exec rm -rf {} +

--- a/tools/dynamic-lora-sidecar/README.md
+++ b/tools/dynamic-lora-sidecar/README.md
@@ -1,6 +1,6 @@
 # Dynamic LORA Adapter Sidecar for vLLM
 
-This is a sidecar-based tool to help rolling out new LoRA adapters to a set of running vLLM model servers. The user deploys the sidecar with a vLLM server, and using a ConfigMap, the user can express their intent as to which LoRA adapters they want to have the running vLLM servers to be configure with. The sidecar watches the ConfigMap and sends load/unload requests to the vLLM container to actuate on the user intent. 
+This is a sidecar-based tool to help rolling out new LoRA adapters to a set of running vLLM model servers. The user deploys the sidecar with a vLLM server, and using a ConfigMap, the user can express their intent as to which LoRA adapters they want to have the running vLLM servers to be configure with. The sidecar watches the ConfigMap and sends load/unload requests to the vLLM container to actuate on the user intent.
 
 ## Overview
 
@@ -48,6 +48,17 @@ The sidecar uses the vLLM server's API to load or unload adapters based on the c
    ```
    Do not use subPath, since configmap updates are not reflected in the file
 
+## Development
+
+For local development and testing, use the provided Makefile:
+
+```bash
+make venv      # Create Python 3.10 virtual environment
+make install   # Install dependencies
+make test      # Run unit tests
+make clean     # Clean up
+```
+
 ## Command Line Arguments
 
 The sidecar supports the following command-line arguments:
@@ -59,7 +70,7 @@ The sidecar supports the following command-line arguments:
 - `--config-validation`: Enable config validation (default: True)
 
 ## Configuration Fields
-- `vLLMLoRAConfig`[**required**]  base key 
+- `vLLMLoRAConfig`[**required**]  base key
 - `host` [*optional*] Model server's host. defaults to localhost
 - `port` [*optional*] Model server's port. defaults to 8000
 - `name` [*optional*] Name of this config


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/987

Add Makefile to run unit tests of tools/dynamic-lora-sidecar locally. I plan to use it for a CI job.