### PR TITLE
Making inferenceModel optional

### DIFF
--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -269,6 +269,27 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantMutatedBodyModel: "resolved-target-model-A",
 		},
 		{
+			name: "nonexistent target defined, use default inference model",
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			wantReqCtx: &handlers.RequestContext{
+				Model:               "food-review-1",
+				ResolvedTargetModel: "food-review-1",
+				TargetPod: &backend.Pod{
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:        "192.168.1.100",
+				},
+				TargetEndpoint: "192.168.1.100:8000",
+			},
+			wantMutatedBodyModel: "food-review-1",
+			reqBodyMap: map[string]interface{}{
+				"model":  "food-review-1",
+				"prompt": "test prompt",
+			},
+			mockSaturationDetector: &mockSaturationDetector{isSaturated: false},
+		},
+		{
 
 			name: "request dropped (sheddable, saturated)",
 			reqBodyMap: map[string]interface{}{
@@ -297,24 +318,6 @@ func TestDirector_HandleRequest(t *testing.T) {
 				"messages": []interface{}{},
 			},
 			wantErrCode: errutil.BadRequest,
-		},
-		{
-			name: "invalid model defined, expect err",
-			reqBodyMap: map[string]interface{}{
-				"model":  "non-existent-model",
-				"prompt": "test prompt",
-			},
-			mockSaturationDetector: &mockSaturationDetector{isSaturated: false},
-			wantErrCode:            errutil.BadConfiguration,
-		},
-		{
-			name: "invalid target defined, expect err",
-			reqBodyMap: map[string]interface{}{
-				"model":  "food-review-1",
-				"prompt": "test prompt",
-			},
-			mockSaturationDetector: &mockSaturationDetector{isSaturated: false},
-			wantErrCode:            errutil.BadConfiguration,
 		},
 		{
 			name: "scheduler returns error",


### PR DESCRIPTION
Fixes: #1001 

This PR makes the InferenceModel an optional CRD. If no match is found, the matched model is set to the lowest criticality.

Currently this is hard-coded just to unblock: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1001

Future PRs will allow for configuration of the default (implemented with the implementation of `InferenceSchedulingObjective`: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1007