### PR TITLE
Release: Updates EPP tag sed for quickstart script

### DIFF
--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -65,8 +65,12 @@ EPP_HELM="config/charts/inferencepool/values.yaml"
 BBR_HELM="config/charts/body-based-routing/values.yaml"
 echo "Updating ${EPP} & ${EPP_HELM} ..."
 
-# Update the container tag.
-sed -i.bak -E "s|(us-central1-docker\.pkg\.dev/k8s-staging-images/gateway-api-inference-extension/epp:)[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$EPP"
+# Update epp tag on any registry.
+sed -i.bak -E \
+  "s|(.*/gateway-api-inference-extension/epp:)[^\"[:space:]]+|\1${RELEASE_TAG}|g" \
+  "$EPP"
+
+# Update the container tag on Helm charts.
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$EPP_HELM"
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$BBR_HELM"
 


### PR DESCRIPTION
The quickstart script was not bumping the EPP image tag when creating a release from an RC because the `sed` command was too specific. `sed` was only looking for the staging registry (`us-central1-docker.pkg.dev/k8s-staging-images/.../epp:`), but the prod registry (`registry.k8s.io/gateway-api-inference-extension/epp:`) was already set when the RC was cut, so nothing changes. This PR updates the `sed` command to match any registry path up to `/epp:`.