### PR TITLE
refactor: rename plugin.Name() => plugin.Type()

### DIFF
--- a/cmd/epp/runner/register.go
+++ b/cmd/epp/runner/register.go
@@ -27,16 +27,16 @@ import (
 
 // RegisterAllPlugins registers the factory functions of all known plugins
 func RegisterAllPlugins() {
-	plugins.Register(filter.LeastKVCacheFilterName, filter.LeastKVCacheFilterFactory)
-	plugins.Register(filter.LeastQueueFilterName, filter.LeastQueueFilterFactory)
-	plugins.Register(filter.LoraAffinityFilterName, filter.LoraAffinityFilterFactory)
-	plugins.Register(filter.LowQueueFilterName, filter.LowQueueFilterFactory)
-	plugins.Register(prefix.PrefixCachePluginName, prefix.PrefixCachePluginFactory)
-	plugins.Register(picker.MaxScorePickerName, picker.MaxScorePickerFactory)
-	plugins.Register(picker.RandomPickerName, picker.RandomPickerFactory)
-	plugins.Register(profile.SingleProfileHandlerName, profile.SingleProfileHandlerFactory)
-	plugins.Register(scorer.KvCacheScorerName, scorer.KvCacheScorerFactory)
-	plugins.Register(scorer.QueueScorerName, scorer.QueueScorerFactory)
+	plugins.Register(filter.LeastKVCacheFilterType, filter.LeastKVCacheFilterFactory)
+	plugins.Register(filter.LeastQueueFilterType, filter.LeastQueueFilterFactory)
+	plugins.Register(filter.LoraAffinityFilterType, filter.LoraAffinityFilterFactory)
+	plugins.Register(filter.LowQueueFilterType, filter.LowQueueFilterFactory)
+	plugins.Register(prefix.PrefixCachePluginType, prefix.PrefixCachePluginFactory)
+	plugins.Register(picker.MaxScorePickerType, picker.MaxScorePickerFactory)
+	plugins.Register(picker.RandomPickerType, picker.RandomPickerFactory)
+	plugins.Register(profile.SingleProfileHandlerType, profile.SingleProfileHandlerFactory)
+	plugins.Register(scorer.KvCacheScorerType, scorer.KvCacheScorerFactory)
+	plugins.Register(scorer.QueueScorerType, scorer.QueueScorerFactory)
 }
 
 // eppHandle is a temporary implementation of the interface plugins.Handle

--- a/conformance/testing-epp/plugins/filter/request_header_based_filter.go
+++ b/conformance/testing-epp/plugins/filter/request_header_based_filter.go
@@ -44,8 +44,8 @@ func NewHeaderBasedTestingFilter() *HeaderBasedTestingFilter {
 // HeaderBasedTestingFilter filters Pods based on an address specified in the "test-epp-endpoint-selection" request header.
 type HeaderBasedTestingFilter struct{}
 
-// Name returns the name of the filter.
-func (f *HeaderBasedTestingFilter) Name() string {
+// Type returns the type of the filter.
+func (f *HeaderBasedTestingFilter) Type() string {
 	return "header-based-testing"
 }
 

--- a/docs/proposals/0845-scheduler-architecture-proposal/interfaces/interface.go
+++ b/docs/proposals/0845-scheduler-architecture-proposal/interfaces/interface.go
@@ -85,7 +85,7 @@ type SchedulingResult struct {
 
 // Plugin is the parent type for all the scheduling framework plugins.
 type Plugin interface {
-	Name() string
+	Type() string
 }
 
 // ProfileHandler defines the interface for handling multi SchedulerProfile instances.

--- a/pkg/epp/common/config/configloader_test.go
+++ b/pkg/epp/common/config/configloader_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	testProfileHandlerName = "test-profile-handler"
-	test1Name              = "test-one"
-	test2Name              = "test-two"
-	testPickerName         = "test-picker"
+	testProfileHandlerType = "test-profile-handler"
+	test1Type              = "test-one"
+	test2Type              = "test-two"
+	testPickerType         = "test-picker"
 )
 
 func TestLoadConfiguration(t *testing.T) {
@@ -50,7 +50,7 @@ func TestLoadConfiguration(t *testing.T) {
 		Plugins: []configapi.PluginSpec{
 			{
 				Name:       "test1",
-				PluginName: test1Name,
+				PluginName: test1Type,
 				Parameters: json.RawMessage("{\"threshold\":10}"),
 			},
 			{
@@ -58,13 +58,13 @@ func TestLoadConfiguration(t *testing.T) {
 				PluginName: "test-profile-handler",
 			},
 			{
-				Name:       test2Name,
-				PluginName: test2Name,
+				Name:       test2Type,
+				PluginName: test2Type,
 				Parameters: json.RawMessage("{\"hashBlockSize\":32}"),
 			},
 			{
 				Name:       "testPicker",
-				PluginName: testPickerName,
+				PluginName: testPickerType,
 			},
 		},
 		SchedulingProfiles: []configapi.SchedulingProfile{
@@ -463,8 +463,8 @@ type test1 struct {
 	Threshold int `json:"threshold"`
 }
 
-func (f *test1) Name() string {
-	return test1Name
+func (f *test1) Type() string {
+	return test1Type
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.
@@ -478,8 +478,8 @@ var _ framework.PostCycle = &test2{}
 
 type test2 struct{}
 
-func (f *test2) Name() string {
-	return test2Name
+func (f *test2) Type() string {
+	return test2Type
 }
 
 func (m *test2) Score(ctx context.Context, request *types.LLMRequest, cycleState *types.CycleState, pods []types.Pod) map[types.Pod]float64 {
@@ -494,8 +494,8 @@ var _ framework.Picker = &testPicker{}
 
 type testPicker struct{}
 
-func (p *testPicker) Name() string {
-	return testPickerName
+func (p *testPicker) Type() string {
+	return testPickerType
 }
 
 func (p *testPicker) Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.ProfileRunResult {
@@ -507,8 +507,8 @@ var _ framework.ProfileHandler = &testProfileHandler{}
 
 type testProfileHandler struct{}
 
-func (p *testProfileHandler) Name() string {
-	return testProfileHandlerName
+func (p *testProfileHandler) Type() string {
+	return testProfileHandlerType
 }
 
 func (p *testProfileHandler) Pick(ctx context.Context, request *types.LLMRequest, profiles map[string]*framework.SchedulerProfile, executionResults map[string]*types.ProfileRunResult) map[string]*framework.SchedulerProfile {
@@ -520,7 +520,7 @@ func (p *testProfileHandler) ProcessResults(ctx context.Context, request *types.
 }
 
 func registerTestPlugins() {
-	plugins.Register(test1Name,
+	plugins.Register(test1Type,
 		func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 			result := test1{}
 			err := json.Unmarshal(parameters, &result)
@@ -528,19 +528,19 @@ func registerTestPlugins() {
 		},
 	)
 
-	plugins.Register(test2Name,
+	plugins.Register(test2Type,
 		func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 			return &test2{}, nil
 		},
 	)
 
-	plugins.Register(testPickerName,
+	plugins.Register(testPickerType,
 		func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 			return &testPicker{}, nil
 		},
 	)
 
-	plugins.Register(testProfileHandlerName,
+	plugins.Register(testProfileHandlerType,
 		func(name string, parameters json.RawMessage, handle plugins.Handle) (plugins.Plugin, error) {
 			return &testProfileHandler{}, nil
 		},

--- a/pkg/epp/plugins/plugins.go
+++ b/pkg/epp/plugins/plugins.go
@@ -19,8 +19,8 @@ package plugins
 // Plugin defines the interface for a plugin.
 // This interface should be embedded in all plugins across the code.
 type Plugin interface {
-	// Name returns the name of the plugin.
-	Name() string
+	// Type returns the type of the plugin.
+	Type() string
 }
 
 // Handle provides plugins  set of standard data and tools to work with

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -254,18 +254,18 @@ func RandomWeightedDraw(logger logr.Logger, model *v1alpha2.InferenceModel, seed
 func (d *Director) runPreRequestPlugins(ctx context.Context, request *schedulingtypes.LLMRequest, schedulingResult *schedulingtypes.SchedulingResult,
 	targetPort int) {
 	for _, plugin := range d.preRequestPlugins {
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Running pre-request plugin", "plugin", plugin.Name())
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Running pre-request plugin", "plugin", plugin.Type())
 		before := time.Now()
 		plugin.PreRequest(ctx, request, schedulingResult, targetPort)
-		metrics.RecordRequestControlPluginProcessingLatency(PreRequestPluginType, plugin.Name(), time.Since(before))
+		metrics.RecordRequestControlPluginProcessingLatency(PreRequestPluginType, plugin.Type(), time.Since(before))
 	}
 }
 
 func (d *Director) runPostResponsePlugins(ctx context.Context, request *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {
 	for _, plugin := range d.postResponsePlugins {
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.Name())
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.Type())
 		before := time.Now()
 		plugin.PostResponse(ctx, request, response, targetPod)
-		metrics.RecordRequestControlPluginProcessingLatency(PostResponsePluginType, plugin.Name(), time.Since(before))
+		metrics.RecordRequestControlPluginProcessingLatency(PostResponsePluginType, plugin.Type(), time.Since(before))
 	}
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -521,7 +521,7 @@ func pointer(v int32) *int32 {
 
 func TestDirector_HandleResponse(t *testing.T) {
 	pr1 := &testPostResponse{
-		NameRes: "pr1",
+		TypeRes: "pr1",
 	}
 
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
@@ -559,12 +559,12 @@ func TestDirector_HandleResponse(t *testing.T) {
 }
 
 type testPostResponse struct {
-	NameRes                 string
+	TypeRes                 string
 	lastRespOnResponse      *Response
 	lastTargetPodOnResponse string
 }
 
-func (p *testPostResponse) Name() string { return p.NameRes }
+func (p *testPostResponse) Type() string { return p.TypeRes }
 
 func (p *testPostResponse) PostResponse(_ context.Context, _ *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {
 	p.lastRespOnResponse = response

--- a/pkg/epp/scheduling/framework/plugins/filter/decision_tree_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/decision_tree_filter.go
@@ -47,12 +47,12 @@ type DecisionTreeFilter struct {
 	NextOnSuccessOrFailure framework.Filter
 }
 
-// Name returns the name of the filter.
-func (f *DecisionTreeFilter) Name() string {
+// Type returns the type of the filter.
+func (f *DecisionTreeFilter) Type() string {
 	if f == nil {
 		return "nil"
 	}
-	return f.Current.Name()
+	return f.Current.Type()
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.
@@ -69,7 +69,7 @@ func (f *DecisionTreeFilter) Filter(ctx context.Context, request *types.LLMReque
 		if f.NextOnSuccess != nil {
 			next = f.NextOnSuccess
 		}
-		loggerTrace.Info("Filter succeeded", "filter", f.Name(), "next", next.Name(), "filteredPodCount", len(filteredPod))
+		loggerTrace.Info("Filter succeeded", "filter", f.Type(), "next", next.Type(), "filteredPodCount", len(filteredPod))
 		// On success, pass the filtered result to the next filter.
 		return next.Filter(ctx, request, cycleState, filteredPod)
 	} else {
@@ -80,7 +80,7 @@ func (f *DecisionTreeFilter) Filter(ctx context.Context, request *types.LLMReque
 		if f.NextOnFailure != nil {
 			next = f.NextOnFailure
 		}
-		loggerTrace.Info("Filter failed", "filter", f.Name(), "next", next.Name())
+		loggerTrace.Info("Filter failed", "filter", f.Type(), "next", next.Type())
 		// On failure, pass the initial set of pods to the next filter.
 		return next.Filter(ctx, request, cycleState, pods)
 	}

--- a/pkg/epp/scheduling/framework/plugins/filter/filter_test.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/filter_test.go
@@ -35,8 +35,8 @@ var _ framework.Filter = &filterAll{}
 
 type filterAll struct{}
 
-func (f *filterAll) Name() string {
-	return "filter all"
+func (f *filterAll) Type() string {
+	return "filter-all"
 }
 
 func (f *filterAll) Filter(_ context.Context, _ *types.LLMRequest, _ *types.CycleState, pods []types.Pod) []types.Pod {

--- a/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	LeastKVCacheFilterName = "least-KV-cache"
+	LeastKVCacheFilterType = "least-KV-cache"
 )
 
 // compile-time type validation
@@ -50,9 +50,9 @@ func NewLeastKVCacheFilter() *LeastKVCacheFilter {
 // least one as it gives more choices for the next filter, which on aggregate gave better results.
 type LeastKVCacheFilter struct{}
 
-// Name returns the name of the filter.
-func (f *LeastKVCacheFilter) Name() string {
-	return LeastKVCacheFilterName
+// Type returns the type of the filter.
+func (f *LeastKVCacheFilter) Type() string {
+	return LeastKVCacheFilterType
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	LeastQueueFilterName = "least-queue"
+	LeastQueueFilterType = "least-queue"
 )
 
 // compile-time type validation
@@ -50,9 +50,9 @@ func NewLeastQueueFilter() *LeastQueueFilter {
 // the least one as it gives more choices for the next filter, which on aggregate gave better results.
 type LeastQueueFilter struct{}
 
-// Name returns the name of the filter.
-func (f *LeastQueueFilter) Name() string {
-	return LeastQueueFilterName
+// Type returns the type of the filter.
+func (f *LeastQueueFilter) Type() string {
+	return LeastQueueFilterType
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	LoraAffinityFilterName = "lora-affinity"
+	LoraAffinityFilterType = "lora-affinity"
 )
 
 type loraAffinityFilterParameters struct {
@@ -44,7 +44,7 @@ var _ framework.Filter = &LoraAffinityFilter{}
 func LoraAffinityFilterFactory(name string, rawParameters json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
 	parameters := loraAffinityFilterParameters{Threshold: config.DefaultLoraAffinityThreshold}
 	if err := json.Unmarshal(rawParameters, &parameters); err != nil {
-		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LoraAffinityFilterName, err)
+		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LoraAffinityFilterType, err)
 	}
 	return NewLoraAffinityFilter(parameters.Threshold), nil
 }
@@ -67,9 +67,9 @@ type LoraAffinityFilter struct {
 	loraAffinityThreshold float64
 }
 
-// Name returns the name of the filter.
-func (f *LoraAffinityFilter) Name() string {
-	return LoraAffinityFilterName
+// Type returns the type of the filter.
+func (f *LoraAffinityFilter) Type() string {
+	return LoraAffinityFilterType
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	LowQueueFilterName = "low-queue"
+	LowQueueFilterType = "low-queue"
 )
 
 type lowQueueFilterParameters struct {
@@ -43,7 +43,7 @@ var _ framework.Filter = &LowQueueFilter{}
 func LowQueueFilterFactory(name string, rawParameters json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
 	parameters := lowQueueFilterParameters{Threshold: config.DefaultQueueingThresholdLoRA}
 	if err := json.Unmarshal(rawParameters, &parameters); err != nil {
-		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LowQueueFilterName, err)
+		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LowQueueFilterType, err)
 	}
 
 	return NewLowQueueFilter(parameters.Threshold), nil
@@ -61,9 +61,9 @@ type LowQueueFilter struct {
 	queueingThresholdLoRA int
 }
 
-// Name returns the name of the filter.
-func (f *LowQueueFilter) Name() string {
-	return LowQueueFilterName
+// Type returns the type of the filter.
+func (f *LowQueueFilter) Type() string {
+	return LowQueueFilterType
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	MaxScorePickerName = "max-score"
+	MaxScorePickerType = "max-score"
 )
 
 // compile-time type validation
@@ -52,9 +52,9 @@ type MaxScorePicker struct {
 	random *RandomPicker
 }
 
-// Name returns the name of the picker.
-func (p *MaxScorePicker) Name() string {
-	return MaxScorePickerName
+// Type returns the type of the picker.
+func (p *MaxScorePicker) Type() string {
+	return MaxScorePickerType
 }
 
 // Pick selects the pod with the maximum score from the list of candidates.

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	RandomPickerName = "random"
+	RandomPickerType = "random"
 )
 
 // compile-time type validation
@@ -49,9 +49,9 @@ func NewRandomPicker() *RandomPicker {
 // RandomPicker picks a random pod from the list of candidates.
 type RandomPicker struct{}
 
-// Name returns the name of the picker.
-func (p *RandomPicker) Name() string {
-	return RandomPickerName
+// Type returns the type of the picker.
+func (p *RandomPicker) Type() string {
+	return RandomPickerType
 }
 
 // Pick selects a random pod from the list of candidates.

--- a/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
+++ b/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	SingleProfileHandlerName = "single-profile"
+	SingleProfileHandlerType = "single-profile"
 )
 
 // compile-time type assertion
@@ -47,9 +47,9 @@ func NewSingleProfileHandler() *SingleProfileHandler {
 // SingleProfileHandler handles a single profile which is always the primary profile.
 type SingleProfileHandler struct{}
 
-// Name returns the name of the Profile Handler.
-func (h *SingleProfileHandler) Name() string {
-	return SingleProfileHandlerName
+// Type returns the type of the Profile Handler.
+func (h *SingleProfileHandler) Type() string {
+	return SingleProfileHandlerType
 }
 
 // Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	DefaultKVCacheScorerWeight = 1
-	KvCacheScorerName          = "kv-cache"
+	KvCacheScorerType          = "kv-cache"
 )
 
 // compile-time type assertion
@@ -46,9 +46,9 @@ func NewKVCacheScorer() *KVCacheScorer {
 // KVCacheScorer scores list of candidate pods based on KV cache utilization.
 type KVCacheScorer struct{}
 
-// Name returns the name of the scorer.
-func (s *KVCacheScorer) Name() string {
-	return KvCacheScorerName
+// Type returns the type of the scorer.
+func (s *KVCacheScorer) Type() string {
+	return KvCacheScorerType
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	DefaultQueueScorerWeight = 1
-	QueueScorerName          = "queue"
+	QueueScorerType          = "queue"
 )
 
 // compile-time type assertion
@@ -48,9 +48,9 @@ func NewQueueScorer() *QueueScorer {
 // the less waiting queue size the pod has, the higher score it will get (since it's more available to serve new request).
 type QueueScorer struct{}
 
-// Name returns the name of the scorer.
-func (s *QueueScorer) Name() string {
-	return QueueScorerName
+// Type returns the type of the scorer.
+func (s *QueueScorer) Type() string {
+	return QueueScorerType
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile_test.go
@@ -30,21 +30,21 @@ import (
 
 func TestSchedulePlugins(t *testing.T) {
 	tp1 := &testPlugin{
-		NameRes:   "test1",
+		TypeRes:   "test1",
 		ScoreRes:  0.3,
 		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}, {Name: "pod3"}},
 	}
 	tp2 := &testPlugin{
-		NameRes:   "test2",
+		TypeRes:   "test2",
 		ScoreRes:  0.8,
 		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}},
 	}
 	tp_filterAll := &testPlugin{
-		NameRes:   "filter all",
+		TypeRes:   "filter all",
 		FilterRes: []k8stypes.NamespacedName{},
 	}
 	pickerPlugin := &testPlugin{
-		NameRes: "picker",
+		TypeRes: "picker",
 		PickRes: k8stypes.NamespacedName{Name: "pod1"},
 	}
 
@@ -155,24 +155,24 @@ func TestSchedulePlugins(t *testing.T) {
 			for _, plugin := range test.profile.filters {
 				tp, _ := plugin.(*testPlugin)
 				if tp.FilterCallCount != 1 {
-					t.Errorf("Plugin %s Filter() called %d times, expected 1", plugin.Name(), tp.FilterCallCount)
+					t.Errorf("Plugin %s Filter() called %d times, expected 1", plugin.Type(), tp.FilterCallCount)
 				}
 			}
 			for _, plugin := range test.profile.scorers {
 				tp, _ := plugin.Scorer.(*testPlugin)
 				if tp.ScoreCallCount != 1 {
-					t.Errorf("Plugin %s Score() called %d times, expected 1", plugin.Name(), tp.ScoreCallCount)
+					t.Errorf("Plugin %s Score() called %d times, expected 1", plugin.Type(), tp.ScoreCallCount)
 				}
 				if test.numPodsToScore != tp.NumOfScoredPods {
-					t.Errorf("Plugin %s Score() called with %d pods, expected %d", plugin.Name(), tp.NumOfScoredPods, test.numPodsToScore)
+					t.Errorf("Plugin %s Score() called with %d pods, expected %d", plugin.Type(), tp.NumOfScoredPods, test.numPodsToScore)
 				}
 			}
 			tp, _ := test.profile.picker.(*testPlugin)
 			if tp.NumOfPickerCandidates != test.numPodsToScore {
-				t.Errorf("Picker plugin %s Pick() called with %d candidates, expected %d", tp.Name(), tp.NumOfPickerCandidates, tp.NumOfScoredPods)
+				t.Errorf("Picker plugin %s Pick() called with %d candidates, expected %d", tp.Type(), tp.NumOfPickerCandidates, tp.NumOfScoredPods)
 			}
 			if tp.PickCallCount != 1 {
-				t.Errorf("Picker plugin %s Pick() called %d times, expected 1", tp.Name(), tp.PickCallCount)
+				t.Errorf("Picker plugin %s Pick() called %d times, expected 1", tp.Type(), tp.PickCallCount)
 			}
 			if tp.WinnderPodScore != test.targetPodScore {
 				t.Errorf("winnder pod score %v, expected %v", tp.WinnderPodScore, test.targetPodScore)
@@ -180,7 +180,7 @@ func TestSchedulePlugins(t *testing.T) {
 			for _, plugin := range test.profile.postCyclePlugins {
 				tp, _ := plugin.(*testPlugin)
 				if tp.PostScheduleCallCount != 1 {
-					t.Errorf("Plugin %s PostSchedule() called %d times, expected 1", plugin.Name(), tp.PostScheduleCallCount)
+					t.Errorf("Plugin %s PostSchedule() called %d times, expected 1", plugin.Type(), tp.PostScheduleCallCount)
 				}
 			}
 		})
@@ -195,7 +195,7 @@ var _ PostCycle = &testPlugin{}
 
 // testPlugin is an implementation useful in unit tests.
 type testPlugin struct {
-	NameRes               string
+	TypeRes               string
 	ScoreCallCount        int
 	NumOfScoredPods       int
 	ScoreRes              float64
@@ -208,7 +208,7 @@ type testPlugin struct {
 	WinnderPodScore       float64
 }
 
-func (tp *testPlugin) Name() string { return tp.NameRes }
+func (tp *testPlugin) Type() string { return tp.TypeRes }
 
 func (tp *testPlugin) Filter(_ context.Context, _ *types.LLMRequest, _ *types.CycleState, pods []types.Pod) []types.Pod {
 	tp.FilterCallCount++

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -115,7 +115,7 @@ func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest) (*t
 	for { // get the next set of profiles to run iteratively based on the request and the previous execution results
 		before := time.Now()
 		profiles := s.profileHandler.Pick(ctx, request, s.profiles, profileRunResults)
-		metrics.RecordSchedulerPluginProcessingLatency(framework.ProfilePickerType, s.profileHandler.Name(), time.Since(before))
+		metrics.RecordSchedulerPluginProcessingLatency(framework.ProfilePickerType, s.profileHandler.Type(), time.Since(before))
 		if len(profiles) == 0 { // profile picker didn't pick any profile to run
 			break
 		}
@@ -137,7 +137,7 @@ func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest) (*t
 
 	before := time.Now()
 	result, err := s.profileHandler.ProcessResults(ctx, request, profileRunResults)
-	metrics.RecordSchedulerPluginProcessingLatency(framework.ProcessProfilesResultsType, s.profileHandler.Name(), time.Since(before))
+	metrics.RecordSchedulerPluginProcessingLatency(framework.ProcessProfilesResultsType, s.profileHandler.Type(), time.Since(before))
 
 	return result, err
 }

--- a/pkg/epp/scheduling/scheduler_config_test.go
+++ b/pkg/epp/scheduling/scheduler_config_test.go
@@ -108,11 +108,11 @@ type testHandle struct {
 }
 
 func registerNeededPlgugins() {
-	plugins.Register(filter.LowQueueFilterName, filter.LowQueueFilterFactory)
-	plugins.Register(prefix.PrefixCachePluginName, prefix.PrefixCachePluginFactory)
-	plugins.Register(picker.MaxScorePickerName, picker.MaxScorePickerFactory)
-	plugins.Register(picker.RandomPickerName, picker.RandomPickerFactory)
-	plugins.Register(profile.SingleProfileHandlerName, profile.SingleProfileHandlerFactory)
+	plugins.Register(filter.LowQueueFilterType, filter.LowQueueFilterFactory)
+	plugins.Register(prefix.PrefixCachePluginType, prefix.PrefixCachePluginFactory)
+	plugins.Register(picker.MaxScorePickerType, picker.MaxScorePickerFactory)
+	plugins.Register(picker.RandomPickerType, picker.RandomPickerFactory)
+	plugins.Register(profile.SingleProfileHandlerType, profile.SingleProfileHandlerFactory)
 }
 
 // The following multi-line string constants, cause false positive lint errors (dupword)


### PR DESCRIPTION
Following up on #1008, this replace Name() with Type() everywhere (incl. constants and fields names).

A follow up would reintroduce Name() (which can be assigned or auto-generated when unspecified [^1]) and then, depending on context, use Type(), Name() or both when plugin information is logged is loaded from config.

@ahg-g @kfswain @nirrozenbaum - please let me know if you prefer a single PR or two for the complete change.

[^1]: in the case of configuration, names must be provided or made consistent (e.g., default to Type()) so they can be used  with well known reference name. For other cases a random generated name (`<type>-xxxxx`) would be used.