### PR TITLE
update sim deployment tag to latest

### DIFF
--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.1
+        image: ghcr.io/llm-d/llm-d-inference-sim:latest
         imagePullPolicy: Always
         args:
         - --model


### PR DESCRIPTION
this fix is part of #1022. tested locally and it works.

reference to sim docker registry with `latest` tag [here](https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim).

cc @danehans 