### PR TITLE
Bumps VERSION to v0.4.0 in Quickstart

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -74,7 +74,7 @@ This quickstart guide is intended for engineers familiar with k8s and model serv
 === "Latest Release"
 
       ```bash
-      VERSION=v0.3.0
+      VERSION=v0.4.0
       kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$VERSION/manifests.yaml
       ```
 


### PR DESCRIPTION
Bumps the `VERSION` to v0.4.0 in the [quickstart guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/).