### PR TITLE
Only create LOCALBIN directory when it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ release: artifacts release-quickstart verify test # Create a release.
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
-	mkdir -p $(LOCALBIN)
+	[ -d $@ ] || mkdir -p $@
 
 ## Tool Binaries
 KUBECTL ?= kubectl


### PR DESCRIPTION
The current Makefile rule was calling mkdir -p without checking existence first.

This would change the directory's mtime and cause all files underneath to become "older".
Since all tools underneath also declare LOCALBIN directory as a dependency, they would be
downloaded/rebuilt more frequently than needed.