### PR TITLE
Reintroduce Plugin.Name() 

### DIFF
--- a/api/config/v1alpha1/defaults.go
+++ b/api/config/v1alpha1/defaults.go
@@ -23,7 +23,7 @@ package v1alpha1
 func SetDefaults_EndpointPickerConfig(cfg *EndpointPickerConfig) {
 	for idx, pluginConfig := range cfg.Plugins {
 		if pluginConfig.Name == "" {
-			cfg.Plugins[idx].Name = pluginConfig.PluginName
+			cfg.Plugins[idx].Name = pluginConfig.Type
 		}
 	}
 }

--- a/api/config/v1alpha1/endpointpickerconfig_types.go
+++ b/api/config/v1alpha1/endpointpickerconfig_types.go
@@ -52,7 +52,7 @@ type PluginSpec struct {
 	// +required
 	// +kubebuilder:validation:Required
 	// Type specifies the plugin type to be instantiated.
-	Type string `json:"pluginName"`
+	Type string `json:"type"`
 
 	// +optional
 	// Parameters are the set of parameters to be passed to the plugin's

--- a/api/config/v1alpha1/endpointpickerconfig_types.go
+++ b/api/config/v1alpha1/endpointpickerconfig_types.go
@@ -46,13 +46,13 @@ type EndpointPickerConfig struct {
 type PluginSpec struct {
 	// +optional
 	// Name provides a name for plugin entries to reference. If
-	// omitted, the value of the PluginName field will be used.
+	// omitted, the value of the Plugin's Type field will be used.
 	Name string `json:"name"`
 
 	// +required
 	// +kubebuilder:validation:Required
-	// PluginName specifies the plugin to be instantiated.
-	PluginName string `json:"pluginName"`
+	// Type specifies the plugin type to be instantiated.
+	Type string `json:"pluginName"`
 
 	// +optional
 	// Parameters are the set of parameters to be passed to the plugin's

--- a/conformance/testing-epp/plugins/filter/request_header_based_filter.go
+++ b/conformance/testing-epp/plugins/filter/request_header_based_filter.go
@@ -49,6 +49,11 @@ func (f *HeaderBasedTestingFilter) Type() string {
 	return "header-based-testing"
 }
 
+// Name returns the type of the filter.
+func (f *HeaderBasedTestingFilter) Name() string {
+	return "header-based-testing-filter"
+}
+
 // Filter selects pods that match the IP addresses specified in the request header.
 func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *types.CycleState, request *types.LLMRequest, pods []types.Pod) []types.Pod {
 	headerValue, ok := request.Headers[headerTestEppEndPointSelectionKey]

--- a/pkg/epp/common/config/loader/configloader.go
+++ b/pkg/epp/common/config/loader/configloader.go
@@ -136,11 +136,11 @@ func validateConfiguration(theConfig *configapi.EndpointPickerConfig) error {
 
 	for _, pluginConfig := range theConfig.Plugins {
 		if pluginConfig.Type == "" {
-			return errors.New("plugin definition missing a plugin type")
+			return fmt.Errorf("plugin definition for %s is missing a type", pluginConfig.Name)
 		}
 
 		if _, ok := names[pluginConfig.Name]; ok {
-			return fmt.Errorf("the name %s has been specified for more than one plugin", pluginConfig.Name)
+			return fmt.Errorf("plugin name %s used more than once", pluginConfig.Name)
 		}
 		names[pluginConfig.Name] = struct{}{}
 

--- a/pkg/epp/common/config/loader/configloader.go
+++ b/pkg/epp/common/config/loader/configloader.go
@@ -120,13 +120,13 @@ func LoadSchedulerConfig(configProfiles []v1alpha1.SchedulingProfile, handle plu
 }
 
 func instantiatePlugin(pluginSpec configapi.PluginSpec, handle plugins.Handle) (plugins.Plugin, error) {
-	factory, ok := plugins.Registry[pluginSpec.PluginName]
+	factory, ok := plugins.Registry[pluginSpec.Type]
 	if !ok {
-		return nil, fmt.Errorf("failed to instantiate the plugin. plugin %s not found", pluginSpec.PluginName)
+		return nil, fmt.Errorf("failed to instantiate the plugin. plugin type %s not found", pluginSpec.Type)
 	}
 	thePlugin, err := factory(pluginSpec.Name, pluginSpec.Parameters, handle)
 	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate the plugin %s. Error: %s", pluginSpec.PluginName, err)
+		return nil, fmt.Errorf("failed to instantiate the plugin type %s. Error: %s", pluginSpec.Type, err)
 	}
 	return thePlugin, err
 }
@@ -135,8 +135,8 @@ func validateConfiguration(theConfig *configapi.EndpointPickerConfig) error {
 	names := make(map[string]struct{})
 
 	for _, pluginConfig := range theConfig.Plugins {
-		if pluginConfig.PluginName == "" {
-			return errors.New("plugin reference definition missing a plugin name")
+		if pluginConfig.Type == "" {
+			return errors.New("plugin definition missing a plugin type")
 		}
 
 		if _, ok := names[pluginConfig.Name]; ok {
@@ -144,9 +144,9 @@ func validateConfiguration(theConfig *configapi.EndpointPickerConfig) error {
 		}
 		names[pluginConfig.Name] = struct{}{}
 
-		_, ok := plugins.Registry[pluginConfig.PluginName]
+		_, ok := plugins.Registry[pluginConfig.Type]
 		if !ok {
-			return fmt.Errorf("plugin %s is not found", pluginConfig.PluginName)
+			return fmt.Errorf("plugin type %s is not found", pluginConfig.Type)
 		}
 	}
 

--- a/pkg/epp/common/config/loader/configloader_test.go
+++ b/pkg/epp/common/config/loader/configloader_test.go
@@ -559,6 +559,10 @@ func (f *test1) Type() string {
 	return test1Type
 }
 
+func (f *test1) Name() string {
+	return "test-1"
+}
+
 // Filter filters out pods that doesn't meet the filter criteria.
 func (f *test1) Filter(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, pods []types.Pod) []types.Pod {
 	return pods
@@ -572,6 +576,10 @@ type test2 struct{}
 
 func (f *test2) Type() string {
 	return test2Type
+}
+
+func (f *test2) Name() string {
+	return "test-2"
 }
 
 func (m *test2) Score(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, _ []types.Pod) map[types.Pod]float64 {
@@ -589,6 +597,10 @@ func (p *testPicker) Type() string {
 	return testPickerType
 }
 
+func (p *testPicker) Name() string {
+	return "test-picker"
+}
+
 func (p *testPicker) Pick(_ context.Context, _ *types.CycleState, _ []*types.ScoredPod) *types.ProfileRunResult {
 	return nil
 }
@@ -600,6 +612,10 @@ type testProfileHandler struct{}
 
 func (p *testProfileHandler) Type() string {
 	return testProfileHandlerType
+}
+
+func (p *testProfileHandler) Name() string {
+	return "test-profile-handler"
 }
 
 func (p *testProfileHandler) Pick(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, _ map[string]*framework.SchedulerProfile, _ map[string]*types.ProfileRunResult) map[string]*framework.SchedulerProfile {

--- a/pkg/epp/common/config/loader/configloader_test.go
+++ b/pkg/epp/common/config/loader/configloader_test.go
@@ -263,11 +263,6 @@ func TestLoadSchedulerConfig(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "errorPluginReferenceJson",
-			configText: errorPluginReferenceJsonText,
-			wantErr:    true,
-		},
-		{
 			name:       "errorTwoPickers",
 			configText: errorTwoPickersText,
 			wantErr:    true,
@@ -337,16 +332,16 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: profileHandler
-  pluginName: test-profile-handler
-- pluginName: test-two
+  type: test-profile-handler
+- type: test-two
   parameters:
     hashBlockSize: 32
 - name: testPicker
-  pluginName: test-picker
+  type: test-picker
 schedulingProfiles:
 - name: default
   plugins:
@@ -385,9 +380,9 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: testx
-  pluginName: test-x
+  type: test-x
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 `
 
 // missing required profile handler
@@ -398,7 +393,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 schedulingProfiles:
@@ -413,11 +408,11 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 `
 
 // missing required scheduling profile name
@@ -428,11 +423,11 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - plugins:
   - pluginRef: test1
@@ -446,11 +441,11 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - name: default
 `
@@ -463,7 +458,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - name: default
   plugins:
@@ -478,7 +473,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - name: default
   plugins:
@@ -493,11 +488,11 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: asdf
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - name: default
   plugins:
@@ -512,15 +507,15 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 20
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - name: default
   plugins:
@@ -535,15 +530,15 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: test2
   pluginName: test-one
-  parameters:
+  type:
     threshold: 20
 - name: profileHandler
-  pluginName: test-profile-handler
+  type: test-profile-handler
 schedulingProfiles:
 - name: default
   plugins:
@@ -643,23 +638,25 @@ func registerTestPlugins() {
 	)
 }
 
+// valid configuration
+//
 //nolint:dupword
 const successSchedulerConfigText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: lowQueue
-  pluginName: low-queue
+  type: low-queue
   parameters:
     threshold: 10
 - name: prefixCache
-  pluginName: prefix-cache
+  type: prefix-cache
   parameters:
     hashBlockSize: 32
 - name: maxScore
-  pluginName: max-score
+  type: max-score
 - name: profileHandler
-  pluginName: single-profile
+  type: single-profile
 schedulingProfiles:
 - name: default
   plugins:
@@ -669,15 +666,17 @@ schedulingProfiles:
   - pluginRef: maxScore
 `
 
+// invalid parameter configuration for plugin (string passed, in expected)
+//
 //nolint:dupword
 const errorBadPluginJsonText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name:profileHandler
-  pluginName: single-profile
+  type: single-profile
 - name: prefixCache
-  pluginName: prefix-cache
+  type: prefix-cache
   parameters:
     hashBlockSize: asdf
 schedulingProfiles:
@@ -687,15 +686,17 @@ schedulingProfiles:
     weight: 50
 `
 
+// missing weight for scorer
+//
 //nolint:dupword
 const errorBadReferenceNoWeightText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: profileHandler
-  pluginName: single-profile
+  type: single-profile
 - name: prefixCache
-  pluginName: prefix-cache
+  type: prefix-cache
   parameters:
     hashBlockSize: 32
 schedulingProfiles:
@@ -704,34 +705,19 @@ schedulingProfiles:
   - pluginRef: prefixCache
 `
 
-//nolint:dupword
-const errorPluginReferenceJsonText = `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-- name: lowQueue
-  pluginName: low-queue
-  parameters:
-    threshold: qwer
-- name: profileHandler
-  pluginName: single-profile
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: lowQueue
-`
-
+// multiple pickers in scheduling profile
+//
 //nolint:dupword
 const errorTwoPickersText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: profileHandler
-  pluginName: single-profile
+  type: single-profile
 - name: maxScore
-  pluginName: max-score
+  type: max-score
 - name: random
-  pluginName: random
+  type: random
 schedulingProfiles:
 - name: default
   plugins:
@@ -739,6 +725,8 @@ schedulingProfiles:
   - pluginRef: random
 `
 
+// missing required scheduling profile
+//
 //nolint:dupword
 const errorConfigText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -750,30 +738,34 @@ plugins:
     threshold: 10
 `
 
+// multiple profile handlers when only one is allowed
+//
 //nolint:dupword
 const errorTwoProfileHandlersText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: profileHandler
-  pluginName: single-profile
+  type: single-profile
 - name: secondProfileHandler
-  pluginName: single-profile
+  type: single-profile
 - name: maxScore
-  pluginName: max-score
+  type: max-score
 schedulingProfiles:
 - name: default
   plugins:
   - pluginRef: maxScore
 `
 
+// missing required profile handler
+//
 //nolint:dupword
 const errorNoProfileHandlersText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: maxScore
-  pluginName: max-score
+  type: max-score
 schedulingProfiles:
 - name: default
   plugins:

--- a/pkg/epp/common/config/loader/configloader_test.go
+++ b/pkg/epp/common/config/loader/configloader_test.go
@@ -55,21 +55,21 @@ func TestLoadConfiguration(t *testing.T) {
 		Plugins: []configapi.PluginSpec{
 			{
 				Name:       "test1",
-				PluginName: test1Type,
+				Type:       test1Type,
 				Parameters: json.RawMessage("{\"threshold\":10}"),
 			},
 			{
-				Name:       "profileHandler",
-				PluginName: "test-profile-handler",
+				Name: "profileHandler",
+				Type: "test-profile-handler",
 			},
 			{
 				Name:       test2Type,
-				PluginName: test2Type,
+				Type:       test2Type,
 				Parameters: json.RawMessage("{\"hashBlockSize\":32}"),
 			},
 			{
-				Name:       "testPicker",
-				PluginName: testPickerType,
+				Name: "testPicker",
+				Type: testPickerType,
 			},
 		},
 		SchedulingProfiles: []configapi.SchedulingProfile{
@@ -240,7 +240,7 @@ func TestLoadPluginReferences(t *testing.T) {
 }
 
 func TestInstantiatePlugin(t *testing.T) {
-	plugSpec := configapi.PluginSpec{PluginName: "plover"}
+	plugSpec := configapi.PluginSpec{Type: "plover"}
 	_, err := instantiatePlugin(plugSpec, utils.NewTestHandle())
 	if err == nil {
 		t.Fatalf("InstantiatePlugin did not return the expected error")

--- a/pkg/epp/common/config/loader/configloader_test.go
+++ b/pkg/epp/common/config/loader/configloader_test.go
@@ -160,12 +160,6 @@ func TestLoadConfiguration(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "errorBadProfilePluginName",
-			configText: errorBadProfilePluginNameText,
-			configFile: "",
-			wantErr:    true,
-		},
-		{
 			name:       "errorDuplicatePlugin",
 			configText: errorDuplicatePluginText,
 			configFile: "",
@@ -335,6 +329,8 @@ func registerNeededPlgugins() {
 
 // The following multi-line string constants, cause false positive lint errors (dupword)
 
+// valid configuration
+//
 //nolint:dupword
 const successConfigText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -360,6 +356,8 @@ schedulingProfiles:
   - pluginRef: testPicker
 `
 
+// YAML does not follow expected structure of config
+//
 //nolint:dupword
 const errorBadYamlText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -368,6 +366,8 @@ plugins:
 - testing 1 2 3
 `
 
+// missing required Plugin type
+//
 //nolint:dupword
 const errorBadPluginReferenceText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -377,6 +377,8 @@ plugins:
     a: 1234
 `
 
+// plugin type does not exist
+//
 //nolint:dupword
 const errorBadPluginReferencePluginText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -388,6 +390,8 @@ plugins:
   pluginName: test-profile-handler
 `
 
+// missing required profile handler
+//
 //nolint:dupword
 const errorNoProfileHandlerText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -401,6 +405,8 @@ schedulingProfiles:
 - name: default
 `
 
+// missing scheduling profiles
+//
 //nolint:dupword
 const errorNoProfilesText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -414,6 +420,8 @@ plugins:
   pluginName: test-profile-handler
 `
 
+// missing required scheduling profile name
+//
 //nolint:dupword
 const errorNoProfileNameText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -430,6 +438,8 @@ schedulingProfiles:
   - pluginRef: test1
 `
 
+// missing plugins in scheduling profile
+//
 //nolint:dupword
 const errorNoProfilePluginsText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -445,6 +455,8 @@ schedulingProfiles:
 - name: default
 `
 
+// missing required plugin reference name, only weight is provided
+//
 //nolint:dupword
 const errorBadProfilePluginText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -458,6 +470,8 @@ schedulingProfiles:
   - weight: 10
 `
 
+// reference a non-existent plugin
+//
 //nolint:dupword
 const errorBadProfilePluginRefText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -471,18 +485,8 @@ schedulingProfiles:
   - pluginRef: plover
 `
 
-//nolint:dupword
-const errorBadProfilePluginNameText = `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-- pluginName: test-profile-handler
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: plover
-`
-
+// invalid parameters (string provided where int is expected)
+//
 //nolint:dupword
 const errorBadPluginReferenceParametersText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -500,6 +504,8 @@ schedulingProfiles:
   - pluginRef: test1
 `
 
+// duplicate names in plugin list
+//
 //nolint:dupword
 const errorDuplicatePluginText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -521,6 +527,8 @@ schedulingProfiles:
   - pluginRef: test1
 `
 
+// duplicate scheduling profile name
+//
 //nolint:dupword
 const errorDuplicateProfileText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1

--- a/pkg/epp/plugins/plugins.go
+++ b/pkg/epp/plugins/plugins.go
@@ -21,9 +21,11 @@ package plugins
 type Plugin interface {
 	// Type returns the type of the plugin.
 	Type() string
+	// Name returns the name of the plugin.
+	Name() string
 }
 
-// Handle provides plugins  set of standard data and tools to work with
+// Handle provides plugins a set of standard data and tools to work with
 type Handle interface {
 	// Plugins returns the sub-handle for working with instantiated plugins
 	Plugins() HandlePlugins

--- a/pkg/epp/plugins/plugins.go
+++ b/pkg/epp/plugins/plugins.go
@@ -21,7 +21,7 @@ package plugins
 type Plugin interface {
 	// Type returns the type of the plugin.
 	Type() string
-	// Name returns the name of the plugin.
+	// Name returns the name of this plugin instance.
 	Name() string
 }
 

--- a/pkg/epp/plugins/registry.go
+++ b/pkg/epp/plugins/registry.go
@@ -22,12 +22,12 @@ import (
 
 // Factory is the definition of the factory functions that are used to instantiate plugins
 // specified in a configuration.
-type Factory func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
+type FactoryFunc func(name string, parameters json.RawMessage, handle Handle) (Plugin, error)
 
 // Register is a static function that can be called to register plugin factory functions.
-func Register(name string, factory Factory) {
-	Registry[name] = factory
+func Register(pluginType string, factory FactoryFunc) {
+	Registry[pluginType] = factory
 }
 
 // Registry is a mapping from plugin name to Factory function
-var Registry map[string]Factory = map[string]Factory{}
+var Registry map[string]FactoryFunc = map[string]FactoryFunc{}

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -565,6 +565,7 @@ type testPostResponse struct {
 }
 
 func (p *testPostResponse) Type() string { return p.TypeRes }
+func (p *testPostResponse) Name() string { return "test-post-response" }
 
 func (p *testPostResponse) PostResponse(_ context.Context, _ *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {
 	p.lastRespOnResponse = response

--- a/pkg/epp/scheduling/framework/plugins/filter/decision_tree_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/decision_tree_filter.go
@@ -55,6 +55,14 @@ func (f *DecisionTreeFilter) Type() string {
 	return f.Current.Type()
 }
 
+// Name returns the name of the filter.
+func (f *DecisionTreeFilter) Name() string {
+	if f == nil {
+		return ""
+	}
+	return f.Current.Name()
+}
+
 // Filter filters out pods that doesn't meet the filter criteria.
 func (f *DecisionTreeFilter) Filter(ctx context.Context, cycleState *types.CycleState, request *types.LLMRequest, pods []types.Pod) []types.Pod {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)

--- a/pkg/epp/scheduling/framework/plugins/filter/filter_test.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/filter_test.go
@@ -39,6 +39,10 @@ func (f *filterAll) Type() string {
 	return "filter-all"
 }
 
+func (f *filterAll) Name() string {
+	return "test-all"
+}
+
 func (f *filterAll) Filter(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, pods []types.Pod) []types.Pod {
 	return []types.Pod{}
 }

--- a/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
@@ -40,8 +40,9 @@ func LeastKVCacheFilterFactory(name string, _ json.RawMessage, _ plugins.Handle)
 
 // NewLeastKVCacheFilter initializes a new LeastKVCacheFilter and returns its pointer.
 func NewLeastKVCacheFilter() *LeastKVCacheFilter {
-	f := &LeastKVCacheFilter{}
-	return f.WithName("")
+	return &LeastKVCacheFilter{
+		name: LeastKVCacheFilterType,
+	}
 }
 
 // LeastKVCacheFilter finds the max and min KV cache of all pods, divides the whole range
@@ -65,9 +66,6 @@ func (f *LeastKVCacheFilter) Name() string {
 
 // WithName sets the name of the filter.
 func (f *LeastKVCacheFilter) WithName(name string) *LeastKVCacheFilter {
-	if name == "" {
-		name = f.Type()
-	}
 	f.name = name
 	return f
 }

--- a/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
@@ -35,7 +35,9 @@ var _ framework.Filter = &LeastKVCacheFilter{}
 
 // LeastKVCacheFilterFactory defines the factory function for LeastKVCacheFilter.
 func LeastKVCacheFilterFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewLeastKVCacheFilter(), nil
+	return &LeastKVCacheFilter{
+		name: name,
+	}, nil
 }
 
 // NewLeastKVCacheFilter initializes a new LeastKVCacheFilter and returns its pointer.
@@ -48,11 +50,18 @@ func NewLeastKVCacheFilter() *LeastKVCacheFilter {
 // The intuition is that if there are multiple pods that share similar KV cache in the low range, we
 // should consider them all instead of the absolute minimum one. This worked better than picking the
 // least one as it gives more choices for the next filter, which on aggregate gave better results.
-type LeastKVCacheFilter struct{}
+type LeastKVCacheFilter struct {
+	name string
+}
 
 // Type returns the type of the filter.
 func (f *LeastKVCacheFilter) Type() string {
 	return LeastKVCacheFilterType
+}
+
+// Name returns the name of the filter.
+func (f *LeastKVCacheFilter) Name() string {
+	return f.name
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
@@ -35,14 +35,13 @@ var _ framework.Filter = &LeastKVCacheFilter{}
 
 // LeastKVCacheFilterFactory defines the factory function for LeastKVCacheFilter.
 func LeastKVCacheFilterFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &LeastKVCacheFilter{
-		name: name,
-	}, nil
+	return NewLeastKVCacheFilter().WithName(name), nil
 }
 
 // NewLeastKVCacheFilter initializes a new LeastKVCacheFilter and returns its pointer.
 func NewLeastKVCacheFilter() *LeastKVCacheFilter {
-	return &LeastKVCacheFilter{}
+	f := &LeastKVCacheFilter{}
+	return f.WithName("")
 }
 
 // LeastKVCacheFilter finds the max and min KV cache of all pods, divides the whole range
@@ -62,6 +61,15 @@ func (f *LeastKVCacheFilter) Type() string {
 // Name returns the name of the filter.
 func (f *LeastKVCacheFilter) Name() string {
 	return f.name
+}
+
+// WithName sets the name of the filter.
+func (f *LeastKVCacheFilter) WithName(name string) *LeastKVCacheFilter {
+	if name == "" {
+		name = f.Type()
+	}
+	f.name = name
+	return f
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
@@ -35,7 +35,9 @@ var _ framework.Filter = &LeastQueueFilter{}
 
 // LeastQueueFilterFactory defines the factory function for LeastQueueFilter.
 func LeastQueueFilterFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewLeastQueueFilter(), nil
+	return &LeastQueueFilter{
+		name: name,
+	}, nil
 }
 
 // NewLeastQueueFilter initializes a new LeastQueueFilter and returns its pointer.
@@ -48,11 +50,18 @@ func NewLeastQueueFilter() *LeastQueueFilter {
 // The intuition is that if there are multiple pods that share similar queue size in the low range,
 // we should consider them all instead of the absolute minimum one. This worked better than picking
 // the least one as it gives more choices for the next filter, which on aggregate gave better results.
-type LeastQueueFilter struct{}
+type LeastQueueFilter struct {
+	name string
+}
 
 // Type returns the type of the filter.
 func (f *LeastQueueFilter) Type() string {
 	return LeastQueueFilterType
+}
+
+// Name returns the name of the filter.
+func (f *LeastQueueFilter) Name() string {
+	return f.name
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
@@ -40,8 +40,9 @@ func LeastQueueFilterFactory(name string, _ json.RawMessage, _ plugins.Handle) (
 
 // NewLeastQueueFilter initializes a new LeastQueueFilter and returns its pointer.
 func NewLeastQueueFilter() *LeastQueueFilter {
-	f := &LeastQueueFilter{}
-	return f.WithName("")
+	return &LeastQueueFilter{
+		name: LeastQueueFilterType,
+	}
 }
 
 // LeastQueueFilter finds the max and min queue size of all pods, divides the whole range
@@ -65,9 +66,6 @@ func (f *LeastQueueFilter) Name() string {
 
 // WithName sets the name of the filter.
 func (f *LeastQueueFilter) WithName(name string) *LeastQueueFilter {
-	if name == "" {
-		name = f.Type()
-	}
 	f.name = name
 	return f
 }

--- a/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
@@ -35,14 +35,13 @@ var _ framework.Filter = &LeastQueueFilter{}
 
 // LeastQueueFilterFactory defines the factory function for LeastQueueFilter.
 func LeastQueueFilterFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &LeastQueueFilter{
-		name: name,
-	}, nil
+	return NewLeastQueueFilter().WithName(name), nil
 }
 
 // NewLeastQueueFilter initializes a new LeastQueueFilter and returns its pointer.
 func NewLeastQueueFilter() *LeastQueueFilter {
-	return &LeastQueueFilter{}
+	f := &LeastQueueFilter{}
+	return f.WithName("")
 }
 
 // LeastQueueFilter finds the max and min queue size of all pods, divides the whole range
@@ -62,6 +61,15 @@ func (f *LeastQueueFilter) Type() string {
 // Name returns the name of the filter.
 func (f *LeastQueueFilter) Name() string {
 	return f.name
+}
+
+// WithName sets the name of the filter.
+func (f *LeastQueueFilter) WithName(name string) *LeastQueueFilter {
+	if name == "" {
+		name = f.Type()
+	}
+	f.name = name
+	return f
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
@@ -51,10 +51,10 @@ func LoraAffinityFilterFactory(name string, rawParameters json.RawMessage, _ plu
 
 // NewLoraAffinityFilter initializes a new LoraAffinityFilter and returns its pointer.
 func NewLoraAffinityFilter(threshold float64) *LoraAffinityFilter {
-	f := &LoraAffinityFilter{
+	return &LoraAffinityFilter{
+		name:                  LoraAffinityFilterType,
 		loraAffinityThreshold: threshold,
 	}
-	return f.WithName("")
 }
 
 // LoraAffinityFilter implements a pod selection strategy that prioritizes pods
@@ -81,9 +81,6 @@ func (f *LoraAffinityFilter) Name() string {
 
 // WithName sets the type of the filter.
 func (f *LoraAffinityFilter) WithName(name string) *LoraAffinityFilter {
-	if name == "" {
-		name = f.Type()
-	}
 	f.name = name
 	return f
 }

--- a/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
@@ -46,16 +46,15 @@ func LoraAffinityFilterFactory(name string, rawParameters json.RawMessage, _ plu
 	if err := json.Unmarshal(rawParameters, &parameters); err != nil {
 		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LoraAffinityFilterType, err)
 	}
-	return &LoraAffinityFilter{
-		name:                  name,
-		loraAffinityThreshold: parameters.Threshold}, nil
+	return NewLoraAffinityFilter(parameters.Threshold).WithName(name), nil
 }
 
 // NewLoraAffinityFilter initializes a new LoraAffinityFilter and returns its pointer.
 func NewLoraAffinityFilter(threshold float64) *LoraAffinityFilter {
-	return &LoraAffinityFilter{
+	f := &LoraAffinityFilter{
 		loraAffinityThreshold: threshold,
 	}
+	return f.WithName("")
 }
 
 // LoraAffinityFilter implements a pod selection strategy that prioritizes pods
@@ -78,6 +77,15 @@ func (f *LoraAffinityFilter) Type() string {
 // Name returns the type of the filter.
 func (f *LoraAffinityFilter) Name() string {
 	return f.name
+}
+
+// WithName sets the type of the filter.
+func (f *LoraAffinityFilter) WithName(name string) *LoraAffinityFilter {
+	if name == "" {
+		name = f.Type()
+	}
+	f.name = name
+	return f
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
@@ -46,7 +46,9 @@ func LoraAffinityFilterFactory(name string, rawParameters json.RawMessage, _ plu
 	if err := json.Unmarshal(rawParameters, &parameters); err != nil {
 		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LoraAffinityFilterType, err)
 	}
-	return NewLoraAffinityFilter(parameters.Threshold), nil
+	return &LoraAffinityFilter{
+		name:                  name,
+		loraAffinityThreshold: parameters.Threshold}, nil
 }
 
 // NewLoraAffinityFilter initializes a new LoraAffinityFilter and returns its pointer.
@@ -64,12 +66,18 @@ func NewLoraAffinityFilter(threshold float64) *LoraAffinityFilter {
 // 2. Using a probability threshold to sometimes select from non-affinity pods to enable load balancing
 // 3. Falling back to whatever group has pods if one group is empty
 type LoraAffinityFilter struct {
+	name                  string
 	loraAffinityThreshold float64
 }
 
 // Type returns the type of the filter.
 func (f *LoraAffinityFilter) Type() string {
 	return LoraAffinityFilterType
+}
+
+// Name returns the type of the filter.
+func (f *LoraAffinityFilter) Name() string {
+	return f.name
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
@@ -51,10 +51,10 @@ func LowQueueFilterFactory(name string, rawParameters json.RawMessage, _ plugins
 
 // NewLowQueueFilter initializes a new LowQueueFilter and returns its pointer.
 func NewLowQueueFilter(threshold int) *LowQueueFilter {
-	f := &LowQueueFilter{
+	return &LowQueueFilter{
+		name:                  LowQueueFilterType,
 		queueingThresholdLoRA: threshold,
 	}
-	return f.WithName("")
 }
 
 // LowQueueFilter returns pods that their waiting queue size is less than a configured threshold
@@ -75,9 +75,6 @@ func (f *LowQueueFilter) Name() string {
 
 // WithName sets the name of the filter.
 func (f *LowQueueFilter) WithName(name string) *LowQueueFilter {
-	if name == "" {
-		name = f.Type()
-	}
 	f.name = name
 	return f
 }

--- a/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
@@ -46,16 +46,15 @@ func LowQueueFilterFactory(name string, rawParameters json.RawMessage, _ plugins
 		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LowQueueFilterType, err)
 	}
 
-	return &LowQueueFilter{
-		name:                  name,
-		queueingThresholdLoRA: parameters.Threshold}, nil
+	return NewLowQueueFilter(parameters.Threshold).WithName(name), nil
 }
 
 // NewLowQueueFilter initializes a new LowQueueFilter and returns its pointer.
 func NewLowQueueFilter(threshold int) *LowQueueFilter {
-	return &LowQueueFilter{
+	f := &LowQueueFilter{
 		queueingThresholdLoRA: threshold,
 	}
+	return f.WithName("")
 }
 
 // LowQueueFilter returns pods that their waiting queue size is less than a configured threshold
@@ -72,6 +71,15 @@ func (f *LowQueueFilter) Type() string {
 // Name returns the name of the filter.
 func (f *LowQueueFilter) Name() string {
 	return f.name
+}
+
+// WithName sets the name of the filter.
+func (f *LowQueueFilter) WithName(name string) *LowQueueFilter {
+	if name == "" {
+		name = f.Type()
+	}
+	f.name = name
+	return f
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
@@ -46,7 +46,9 @@ func LowQueueFilterFactory(name string, rawParameters json.RawMessage, _ plugins
 		return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", LowQueueFilterType, err)
 	}
 
-	return NewLowQueueFilter(parameters.Threshold), nil
+	return &LowQueueFilter{
+		name:                  name,
+		queueingThresholdLoRA: parameters.Threshold}, nil
 }
 
 // NewLowQueueFilter initializes a new LowQueueFilter and returns its pointer.
@@ -58,12 +60,18 @@ func NewLowQueueFilter(threshold int) *LowQueueFilter {
 
 // LowQueueFilter returns pods that their waiting queue size is less than a configured threshold
 type LowQueueFilter struct {
+	name                  string
 	queueingThresholdLoRA int
 }
 
 // Type returns the type of the filter.
 func (f *LowQueueFilter) Type() string {
 	return LowQueueFilterType
+}
+
+// Name returns the name of the filter.
+func (f *LowQueueFilter) Name() string {
+	return f.name
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -68,6 +68,7 @@ type Config struct {
 
 type Plugin struct {
 	Config
+	name    string
 	indexer Indexer
 }
 
@@ -130,6 +131,7 @@ func PrefixCachePluginFactory(name string, rawParameters json.RawMessage, _ plug
 
 	return &Plugin{
 		Config:  parameters,
+		name:    name,
 		indexer: newIndexer(parameters.LRUCapacityPerServer),
 	}, nil
 }
@@ -155,6 +157,11 @@ func New(config Config) *Plugin {
 // Type returns the type of the plugin.
 func (m *Plugin) Type() string {
 	return PrefixCachePluginType
+}
+
+// Name returns the name of the plugin.
+func (m *Plugin) Name() string {
+	return m.name
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -129,11 +129,7 @@ func PrefixCachePluginFactory(name string, rawParameters json.RawMessage, _ plug
 		return nil, fmt.Errorf("failed to parse the parameters of the %s plugin. Error: %s", PrefixCachePluginType, err)
 	}
 
-	return &Plugin{
-		Config:  parameters,
-		name:    name,
-		indexer: newIndexer(parameters.LRUCapacityPerServer),
-	}, nil
+	return New(parameters).WithName(name), nil
 }
 
 // New initializes a new prefix Plugin and returns its pointer.
@@ -151,7 +147,7 @@ func New(config Config) *Plugin {
 		Config:  config,
 		indexer: newIndexer(capacity),
 	}
-	return m
+	return m.WithName("")
 }
 
 // Type returns the type of the plugin.
@@ -162,6 +158,15 @@ func (m *Plugin) Type() string {
 // Name returns the name of the plugin.
 func (m *Plugin) Name() string {
 	return m.name
+}
+
+// WithName sets the name of the plugin.
+func (m *Plugin) WithName(name string) *Plugin {
+	if name == "" {
+		name = m.Type()
+	}
+	m.name = name
+	return m
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -143,11 +143,11 @@ func New(config Config) *Plugin {
 		)
 	}
 
-	m := &Plugin{
+	return &Plugin{
+		name:    PrefixCachePluginType,
 		Config:  config,
 		indexer: newIndexer(capacity),
 	}
-	return m.WithName("")
 }
 
 // Type returns the type of the plugin.
@@ -162,9 +162,6 @@ func (m *Plugin) Name() string {
 
 // WithName sets the name of the plugin.
 func (m *Plugin) WithName(name string) *Plugin {
-	if name == "" {
-		name = m.Type()
-	}
 	m.name = name
 	return m
 }

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -37,16 +37,15 @@ var _ framework.Picker = &MaxScorePicker{}
 
 // MaxScorePickerFactory defines the factory function for MaxScorePicker.
 func MaxScorePickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &MaxScorePicker{
-		name: name,
-	}, nil
+	return NewMaxScorePicker().WithName(name), nil
 }
 
 // NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
 func NewMaxScorePicker() *MaxScorePicker {
-	return &MaxScorePicker{
+	p := &MaxScorePicker{
 		random: NewRandomPicker(),
 	}
+	return p.WithName("")
 }
 
 // MaxScorePicker picks the pod with the maximum score from the list of candidates.
@@ -63,6 +62,15 @@ func (p *MaxScorePicker) Type() string {
 // Name returns the name of the picker.
 func (p *MaxScorePicker) Name() string {
 	return p.name
+}
+
+// WithName sets the picker's name
+func (p *MaxScorePicker) WithName(name string) *MaxScorePicker {
+	if name == "" {
+		name = p.Type()
+	}
+	p.name = name
+	return p
 }
 
 // Pick selects the pod with the maximum score from the list of candidates.

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -42,10 +42,10 @@ func MaxScorePickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (pl
 
 // NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
 func NewMaxScorePicker() *MaxScorePicker {
-	p := &MaxScorePicker{
+	return &MaxScorePicker{
+		name:   MaxScorePickerType,
 		random: NewRandomPicker(),
 	}
-	return p.WithName("")
 }
 
 // MaxScorePicker picks the pod with the maximum score from the list of candidates.
@@ -66,9 +66,6 @@ func (p *MaxScorePicker) Name() string {
 
 // WithName sets the picker's name
 func (p *MaxScorePicker) WithName(name string) *MaxScorePicker {
-	if name == "" {
-		name = p.Type()
-	}
 	p.name = name
 	return p
 }

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -37,7 +37,9 @@ var _ framework.Picker = &MaxScorePicker{}
 
 // MaxScorePickerFactory defines the factory function for MaxScorePicker.
 func MaxScorePickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewMaxScorePicker(), nil
+	return &MaxScorePicker{
+		name: name,
+	}, nil
 }
 
 // NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
@@ -49,12 +51,18 @@ func NewMaxScorePicker() *MaxScorePicker {
 
 // MaxScorePicker picks the pod with the maximum score from the list of candidates.
 type MaxScorePicker struct {
+	name   string
 	random *RandomPicker
 }
 
 // Type returns the type of the picker.
 func (p *MaxScorePicker) Type() string {
 	return MaxScorePickerType
+}
+
+// Name returns the name of the picker.
+func (p *MaxScorePicker) Name() string {
+	return p.name
 }
 
 // Pick selects the pod with the maximum score from the list of candidates.

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -43,8 +43,9 @@ func RandomPickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plug
 
 // NewRandomPicker initializes a new RandomPicker and returns its pointer.
 func NewRandomPicker() *RandomPicker {
-	p := &RandomPicker{}
-	return p.WithName("")
+	return &RandomPicker{
+		name: RandomPickerType,
+	}
 }
 
 // RandomPicker picks a random pod from the list of candidates.
@@ -64,9 +65,6 @@ func (p *RandomPicker) Name() string {
 
 // WithName sets the picker's name
 func (p *RandomPicker) WithName(name string) *RandomPicker {
-	if name == "" {
-		name = p.Type()
-	}
 	p.name = name
 	return p
 }

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -38,14 +38,13 @@ var _ framework.Picker = &RandomPicker{}
 
 // RandomPickerFactory defines the factory function for RandomPicker.
 func RandomPickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &RandomPicker{
-		name: name,
-	}, nil
+	return NewRandomPicker().WithName(name), nil
 }
 
 // NewRandomPicker initializes a new RandomPicker and returns its pointer.
 func NewRandomPicker() *RandomPicker {
-	return &RandomPicker{}
+	p := &RandomPicker{}
+	return p.WithName("")
 }
 
 // RandomPicker picks a random pod from the list of candidates.
@@ -61,6 +60,15 @@ func (p *RandomPicker) Type() string {
 // Name returns the name of the picker.
 func (p *RandomPicker) Name() string {
 	return p.name
+}
+
+// WithName sets the picker's name
+func (p *RandomPicker) WithName(name string) *RandomPicker {
+	if name == "" {
+		name = p.Type()
+	}
+	p.name = name
+	return p
 }
 
 // Pick selects a random pod from the list of candidates.

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -38,7 +38,9 @@ var _ framework.Picker = &RandomPicker{}
 
 // RandomPickerFactory defines the factory function for RandomPicker.
 func RandomPickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewRandomPicker(), nil
+	return &RandomPicker{
+		name: name,
+	}, nil
 }
 
 // NewRandomPicker initializes a new RandomPicker and returns its pointer.
@@ -47,11 +49,18 @@ func NewRandomPicker() *RandomPicker {
 }
 
 // RandomPicker picks a random pod from the list of candidates.
-type RandomPicker struct{}
+type RandomPicker struct {
+	name string
+}
 
 // Type returns the type of the picker.
 func (p *RandomPicker) Type() string {
 	return RandomPickerType
+}
+
+// Name returns the name of the picker.
+func (p *RandomPicker) Name() string {
+	return p.name
 }
 
 // Pick selects a random pod from the list of candidates.

--- a/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
+++ b/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
@@ -36,14 +36,13 @@ var _ framework.ProfileHandler = &SingleProfileHandler{}
 
 // SingleProfileHandlerFactory defines the factory function for SingleProfileHandler.
 func SingleProfileHandlerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &SingleProfileHandler{
-		name: name,
-	}, nil
+	return NewSingleProfileHandler().WithName(name), nil
 }
 
 // NewSingleProfileHandler initializes a new SingleProfileHandler and returns its pointer.
 func NewSingleProfileHandler() *SingleProfileHandler {
-	return &SingleProfileHandler{}
+	h := &SingleProfileHandler{}
+	return h.WithName("")
 }
 
 // SingleProfileHandler handles a single profile which is always the primary profile.
@@ -59,6 +58,15 @@ func (h *SingleProfileHandler) Type() string {
 // Name returns the name of the profile handler.
 func (h *SingleProfileHandler) Name() string {
 	return h.name
+}
+
+// WithName sets the name of the profile handler.
+func (h *SingleProfileHandler) WithName(name string) *SingleProfileHandler {
+	if name == "" {
+		name = h.Type()
+	}
+	h.name = name
+	return h
 }
 
 // Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the

--- a/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
+++ b/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
@@ -41,8 +41,9 @@ func SingleProfileHandlerFactory(name string, _ json.RawMessage, _ plugins.Handl
 
 // NewSingleProfileHandler initializes a new SingleProfileHandler and returns its pointer.
 func NewSingleProfileHandler() *SingleProfileHandler {
-	h := &SingleProfileHandler{}
-	return h.WithName("")
+	return &SingleProfileHandler{
+		name: SingleProfileHandlerType,
+	}
 }
 
 // SingleProfileHandler handles a single profile which is always the primary profile.
@@ -62,9 +63,6 @@ func (h *SingleProfileHandler) Name() string {
 
 // WithName sets the name of the profile handler.
 func (h *SingleProfileHandler) WithName(name string) *SingleProfileHandler {
-	if name == "" {
-		name = h.Type()
-	}
 	h.name = name
 	return h
 }

--- a/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
+++ b/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
@@ -36,7 +36,9 @@ var _ framework.ProfileHandler = &SingleProfileHandler{}
 
 // SingleProfileHandlerFactory defines the factory function for SingleProfileHandler.
 func SingleProfileHandlerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewSingleProfileHandler(), nil
+	return &SingleProfileHandler{
+		name: name,
+	}, nil
 }
 
 // NewSingleProfileHandler initializes a new SingleProfileHandler and returns its pointer.
@@ -45,11 +47,18 @@ func NewSingleProfileHandler() *SingleProfileHandler {
 }
 
 // SingleProfileHandler handles a single profile which is always the primary profile.
-type SingleProfileHandler struct{}
+type SingleProfileHandler struct {
+	name string
+}
 
 // Type returns the type of the Profile Handler.
 func (h *SingleProfileHandler) Type() string {
 	return SingleProfileHandlerType
+}
+
+// Name returns the name of the profile handler.
+func (h *SingleProfileHandler) Name() string {
+	return h.name
 }
 
 // Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
@@ -40,8 +40,9 @@ func KvCacheScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plu
 
 // NewKVCacheScorer initializes a new KVCacheScorer and returns its pointer.
 func NewKVCacheScorer() *KVCacheScorer {
-	s := &KVCacheScorer{}
-	return s.WithName("")
+	return &KVCacheScorer{
+		name: KvCacheScorerType,
+	}
 }
 
 // KVCacheScorer scores list of candidate pods based on KV cache utilization.
@@ -61,9 +62,6 @@ func (s *KVCacheScorer) Name() string {
 
 // WithName sets the name of the scorer.
 func (s *KVCacheScorer) WithName(name string) *KVCacheScorer {
-	if name == "" {
-		name = s.Type()
-	}
 	s.name = name
 	return s
 }

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
@@ -35,7 +35,9 @@ var _ framework.Scorer = &KVCacheScorer{}
 
 // KvCacheScorerFactory defines the factory function for KVCacheScorer.
 func KvCacheScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewKVCacheScorer(), nil
+	return &KVCacheScorer{
+		name: name,
+	}, nil
 }
 
 // NewKVCacheScorer initializes a new KVCacheScorer and returns its pointer.
@@ -44,11 +46,18 @@ func NewKVCacheScorer() *KVCacheScorer {
 }
 
 // KVCacheScorer scores list of candidate pods based on KV cache utilization.
-type KVCacheScorer struct{}
+type KVCacheScorer struct {
+	name string
+}
 
 // Type returns the type of the scorer.
 func (s *KVCacheScorer) Type() string {
 	return KvCacheScorerType
+}
+
+// Name returns the name of the scorer.
+func (s *KVCacheScorer) Name() string {
+	return s.name
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
@@ -35,14 +35,13 @@ var _ framework.Scorer = &KVCacheScorer{}
 
 // KvCacheScorerFactory defines the factory function for KVCacheScorer.
 func KvCacheScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &KVCacheScorer{
-		name: name,
-	}, nil
+	return NewKVCacheScorer().WithName(name), nil
 }
 
 // NewKVCacheScorer initializes a new KVCacheScorer and returns its pointer.
 func NewKVCacheScorer() *KVCacheScorer {
-	return &KVCacheScorer{}
+	s := &KVCacheScorer{}
+	return s.WithName("")
 }
 
 // KVCacheScorer scores list of candidate pods based on KV cache utilization.
@@ -58,6 +57,15 @@ func (s *KVCacheScorer) Type() string {
 // Name returns the name of the scorer.
 func (s *KVCacheScorer) Name() string {
 	return s.name
+}
+
+// WithName sets the name of the scorer.
+func (s *KVCacheScorer) WithName(name string) *KVCacheScorer {
+	if name == "" {
+		name = s.Type()
+	}
+	s.name = name
+	return s
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue.go
@@ -36,14 +36,13 @@ var _ framework.Scorer = &QueueScorer{}
 
 // QueueScorerFactory defines the factory function for QueueScorer.
 func QueueScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return &QueueScorer{
-		name: name,
-	}, nil
+	return NewQueueScorer().WithName(name), nil
 }
 
 // NewQueueScorer initializes a new QueueScorer and returns its pointer.
 func NewQueueScorer() *QueueScorer {
-	return &QueueScorer{}
+	s := &QueueScorer{}
+	return s.WithName("")
 }
 
 // QueueScorer scores list of candidate pods based on the pod's waiting queue size.
@@ -60,6 +59,15 @@ func (s *QueueScorer) Type() string {
 // Name returns the name of the scorer.
 func (s *QueueScorer) Name() string {
 	return s.name
+}
+
+// WithName sets the name of the scorer.
+func (s *QueueScorer) WithName(name string) *QueueScorer {
+	if name == "" {
+		name = s.Type()
+	}
+	s.name = name
+	return s
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue.go
@@ -41,8 +41,9 @@ func QueueScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugi
 
 // NewQueueScorer initializes a new QueueScorer and returns its pointer.
 func NewQueueScorer() *QueueScorer {
-	s := &QueueScorer{}
-	return s.WithName("")
+	return &QueueScorer{
+		name: QueueScorerType,
+	}
 }
 
 // QueueScorer scores list of candidate pods based on the pod's waiting queue size.
@@ -63,9 +64,6 @@ func (s *QueueScorer) Name() string {
 
 // WithName sets the name of the scorer.
 func (s *QueueScorer) WithName(name string) *QueueScorer {
-	if name == "" {
-		name = s.Type()
-	}
 	s.name = name
 	return s
 }

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue.go
@@ -36,7 +36,9 @@ var _ framework.Scorer = &QueueScorer{}
 
 // QueueScorerFactory defines the factory function for QueueScorer.
 func QueueScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
-	return NewQueueScorer(), nil
+	return &QueueScorer{
+		name: name,
+	}, nil
 }
 
 // NewQueueScorer initializes a new QueueScorer and returns its pointer.
@@ -46,11 +48,18 @@ func NewQueueScorer() *QueueScorer {
 
 // QueueScorer scores list of candidate pods based on the pod's waiting queue size.
 // the less waiting queue size the pod has, the higher score it will get (since it's more available to serve new request).
-type QueueScorer struct{}
+type QueueScorer struct {
+	name string
+}
 
 // Type returns the type of the scorer.
 func (s *QueueScorer) Type() string {
 	return QueueScorerType
+}
+
+// Name returns the name of the scorer.
+func (s *QueueScorer) Name() string {
+	return s.name
 }
 
 // Score returns the scoring result for the given list of pods based on context.

--- a/pkg/epp/scheduling/framework/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile_test.go
@@ -209,6 +209,7 @@ type testPlugin struct {
 }
 
 func (tp *testPlugin) Type() string { return tp.TypeRes }
+func (tp *testPlugin) Name() string { return "test-plugin" }
 
 func (tp *testPlugin) Filter(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, pods []types.Pod) []types.Pod {
 	tp.FilterCallCount++

--- a/test/testdata/configloader_1_test.yaml
+++ b/test/testdata/configloader_1_test.yaml
@@ -2,16 +2,16 @@ apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - name: test1
-  pluginName: test-one
+  type: test-one
   parameters:
     threshold: 10
 - name: profileHandler
-  pluginName: test-profile-handler
-- pluginName: test-two
+  type: test-profile-handler
+- type: test-two
   parameters:
     hashBlockSize: 32
 - name: testPicker
-  pluginName: test-picker
+  type: test-picker
 
 schedulingProfiles:
 - name: default


### PR DESCRIPTION
This is a follow up to #1038.
Fixes #1008 

Plugin changes (cc: @ahg-g @kfswain @nirrozenbaum)
- Name() method to Plugin interface
- Name() implementation for all Plugin implementations
- Rename Factory function to FactoryFunc - similar to (e.g.,)  http.HandlerFunc (to differentiate from http.Handler *interface*)

EPP Configuration changes, see [1038 comment](https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1038#pullrequestreview-2948349467) (cc: @shmuelk @ahg-g)
- Refactor field name from PluginName to Type
- changes to config format to use `type` instead of `pluginName`
- (unrelated) added comments on configuration test cases (since some names could be misleading)
