### PR TITLE
fix(test): update to use existing conformance-primary-gateway

### DIFF
--- a/conformance/tests/basic/inferencepool_httproute_port_validation.go
+++ b/conformance/tests/basic/inferencepool_httproute_port_validation.go
@@ -45,7 +45,7 @@ var InferencePoolHTTPRoutePortValidation = suite.ConformanceTest{
 		const (
 			appBackendNamespace   = "gateway-conformance-app-backend"
 			infraNamespace        = "gateway-conformance-infra"
-			gatewayName           = "conformance-gateway"
+			gatewayName           = "conformance-primary-gateway"
 			poolName              = "target-pool-port-validation"
 			backendDeploymentName = "infra-backend-deployment-port-test"
 		)

--- a/conformance/tests/basic/inferencepool_httproute_port_validation.yaml
+++ b/conformance/tests/basic/inferencepool_httproute_port_validation.yaml
@@ -147,7 +147,7 @@ spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: conformance-gateway
+    name: conformance-primary-gateway
     namespace: gateway-conformance-infra
     sectionName: http
   hostnames:
@@ -173,7 +173,7 @@ spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: conformance-gateway
+    name: conformance-primary-gateway
     namespace: gateway-conformance-infra
     sectionName: http
   hostnames:
@@ -199,7 +199,7 @@ spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: conformance-gateway
+    name: conformance-primary-gateway
     namespace: gateway-conformance-infra
     sectionName: http
   hostnames:


### PR DESCRIPTION
At some point the gateway was renamed from conformance-gateway. Update to use the new conformance-primary-gateway.