### PR TITLE
API: Refine ResolvedRefs condition for invalid ExtensionReference and expand InferencePoolReason values

### DIFF
--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -201,7 +201,7 @@ type InferencePoolConditionType string
 type InferencePoolReason string
 
 const (
-	// This condition indicates whether the inference pool has been accepted or rejected
+	// This condition indicates whether the InferencePool has been accepted or rejected
 	// by a Gateway, and why.
 	//
 	// Possible reasons for this condition to be True are:
@@ -210,51 +210,34 @@ const (
 	//
 	// Possible reasons for this condition to be False are:
 	//
-	// * "NotAllowedByListeners"
-	// * "NoMatchingListenerHostname"
-	// * "NoMatchingParent"
-	// * "UnsupportedValue"
+	// * "NotSupportedByGateway"
+	// * "HTTPRouteNotAccepted"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
 	// * "Pending"
 	//
-	// Controllers may raise this condition with other reasons,
-	// but should prefer to use the reasons listed above to improve
-	// interoperability.
+	// Controllers MAY raise this condition with other reasons, but should
+	// prefer to use the reasons listed above to improve interoperability.
 	InferencePoolConditionAccepted InferencePoolConditionType = "Accepted"
 
 	// This reason is used with the "Accepted" condition when the InferencePool has been
-	// accepted by the Gateway.
+	// accepted by the Gateway because it is referenced by a valid and accepted HTTPRoute.
 	InferencePoolReasonAccepted InferencePoolReason = "Accepted"
 
-	// This reason is used with the "Accepted" condition when the inference pool has not
-	// been accepted by a Gateway because the Gateway has no Listener whose
-	// allowedRoutes criteria permit the inference pool
-	InferencePoolReasonNotAllowedByListeners InferencePoolReason = "NotAllowedByListeners"
+	// This reason is used with the "Accepted" condition when the InferencePool
+	// has not been accepted by a Gateway because the Gateway does not support
+	// InferencePool as a backend.
+	InferencePoolReasonNotSupportedByGateway InferencePoolReason = "NotSupportedByGateway"
 
-	// This reason is used with the "Accepted" condition when the Gateway has no
-	// compatible Listeners whose Hostname matches the inference pool
-	InferencePoolReasonNoMatchingListenerHostname InferencePoolReason = "NoMatchingListenerHostname"
-
-	// This reason is used with the "Accepted" condition when there are
-	// no matching Parents. In the case of Gateways, this can occur when
-	// a InferencePool ParentRef specifies a Port and/or SectionName that does not
-	// match any Listeners in the Gateway.
-	InferencePoolReasonNoMatchingParent InferencePoolReason = "NoMatchingParent"
-
-	// This reason is used with the "Accepted" condition when a value for an Enum
-	// is not recognized.
-	InferencePoolReasonUnsupportedValue InferencePoolReason = "UnsupportedValue"
+	// This reason is used with the "Accepted" condition when the InferencePool is
+	// referenced by an HTTPRoute that has been rejected by the Gateway. The user
+	// should inspect the status of the referring HTTPRoute for the specific reason.
+	InferencePoolReasonHTTPRouteNotAccepted InferencePoolReason = "HTTPRouteNotAccepted"
 
 	// This reason is used with the "Accepted" when a controller has not yet
-	// reconciled the inference pool.
+	// reconciled the InferencePool.
 	InferencePoolReasonPending InferencePoolReason = "Pending"
-
-	// This reason is used with the "Accepted" condition when there
-	// are incompatible filters present on a inference pool rule (for example if
-	// the URLRewrite and RequestRedirect are both present on an HTTPRoute).
-	InferencePoolReasonIncompatibleFilters InferencePoolReason = "IncompatibleFilters"
 )
 
 const (
@@ -267,10 +250,7 @@ const (
 	//
 	// Possible reasons for this condition to be False are:
 	//
-	// * "RefNotPermitted"
-	// * "InvalidKind"
-	// * "BackendNotFound"
-	// * "UnsupportedProtocol"
+	// * "InvalidExtensionRef"
 	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
@@ -281,23 +261,8 @@ const (
 	// is true.
 	InferencePoolReasonResolvedRefs InferencePoolReason = "ResolvedRefs"
 
-	// This reason is used with the "ResolvedRefs" condition when
-	// one of the Listener's InferencePools has a BackendRef to an object in
-	// another namespace, where the object in the other namespace does
-	// not have a ReferenceGrant explicitly allowing the reference.
-	InferencePoolReasonRefNotPermitted InferencePoolReason = "RefNotPermitted"
-
-	// This reason is used with the "ResolvedRefs" condition when
-	// one of the InferencePool's rules has a reference to an unknown or unsupported
-	// Group and/or Kind.
-	InferencePoolReasonInvalidKind InferencePoolReason = "InvalidKind"
-
-	// This reason is used with the "ResolvedRefs" condition when one of the
-	// InferencePool's rules has a reference to a resource that does not exist.
-	InferencePoolReasonBackendNotFound InferencePoolReason = "BackendNotFound"
-
-	// This reason is used with the "ResolvedRefs" condition when one of the
-	// InferencePool's rules has a reference to a resource with an app protocol that
-	// is not supported by this implementation.
-	InferencePoolReasonUnsupportedProtocol InferencePoolReason = "UnsupportedProtocol"
+	// This reason is used with the "ResolvedRefs" condition when the
+	// ExtensionRef is invalid in some way. This can include an unsupported kind
+	// or API group, or a reference to a resource that can not be found.
+	InferencePoolReasonInvalidExtensionRef InferencePoolReason = "InvalidExtensionRef"
 )

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -93,9 +93,11 @@ type Extension struct {
 	ExtensionConnection `json:",inline"`
 }
 
-// ExtensionReference is a reference to the extension deployment. When ExtensionReference is invalid,
-// a 5XX status code MUST be returned for the request that would have otherwise been routed to the
-// invalid backend.
+// ExtensionReference is a reference to the extension service.
+//
+// If a reference is invalid, the implementation MUST update the `ResolvedRefs`
+// Condition on the InferencePool's status to `status: False`. All affected
+// requests MUST receive a 5XX status code.
 type ExtensionReference struct {
 	// Group is the group of the referent.
 	// The default value is "", representing the Core API group.
@@ -183,6 +185,9 @@ type PoolStatus struct {
 	//
 	// * "Accepted"
 	// * "ResolvedRefs"
+	//
+	// For more information about the meaning of these conditions, see the
+	// documentation for InferencePoolConditionType.
 	//
 	// +optional
 	// +listType=map

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -194,14 +194,14 @@ type PoolStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// InferencePoolConditionType is a type of condition for the InferencePool
+// InferencePoolConditionType is a type of condition for a inference pool.
 type InferencePoolConditionType string
 
-// InferencePoolReason is the reason for a given InferencePoolConditionType
+// InferencePoolReason is a reason for a inference pool condition.
 type InferencePoolReason string
 
 const (
-	// This condition indicates whether the InferencePool has been accepted or rejected
+	// This condition indicates whether the inference pool has been accepted or rejected
 	// by a Gateway, and why.
 	//
 	// Possible reasons for this condition to be True are:
@@ -210,52 +210,94 @@ const (
 	//
 	// Possible reasons for this condition to be False are:
 	//
-	// * "NotSupportedByGateway"
+	// * "NotAllowedByListeners"
+	// * "NoMatchingListenerHostname"
+	// * "NoMatchingParent"
+	// * "UnsupportedValue"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
 	// * "Pending"
 	//
-	// Controllers MAY raise this condition with other reasons, but should
-	// prefer to use the reasons listed above to improve interoperability.
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
 	InferencePoolConditionAccepted InferencePoolConditionType = "Accepted"
 
 	// This reason is used with the "Accepted" condition when the InferencePool has been
 	// accepted by the Gateway.
 	InferencePoolReasonAccepted InferencePoolReason = "Accepted"
 
-	// This reason is used with the "Accepted" condition when the InferencePool
-	// has not been accepted by a Gateway because the Gateway does not support
-	// InferencePool as a backend.
-	InferencePoolReasonNotSupportedByGateway InferencePoolReason = "NotSupportedByGateway"
+	// This reason is used with the "Accepted" condition when the inference pool has not
+	// been accepted by a Gateway because the Gateway has no Listener whose
+	// allowedRoutes criteria permit the inference pool
+	InferencePoolReasonNotAllowedByListeners InferencePoolReason = "NotAllowedByListeners"
+
+	// This reason is used with the "Accepted" condition when the Gateway has no
+	// compatible Listeners whose Hostname matches the inference pool
+	InferencePoolReasonNoMatchingListenerHostname InferencePoolReason = "NoMatchingListenerHostname"
+
+	// This reason is used with the "Accepted" condition when there are
+	// no matching Parents. In the case of Gateways, this can occur when
+	// a InferencePool ParentRef specifies a Port and/or SectionName that does not
+	// match any Listeners in the Gateway.
+	InferencePoolReasonNoMatchingParent InferencePoolReason = "NoMatchingParent"
+
+	// This reason is used with the "Accepted" condition when a value for an Enum
+	// is not recognized.
+	InferencePoolReasonUnsupportedValue InferencePoolReason = "UnsupportedValue"
 
 	// This reason is used with the "Accepted" when a controller has not yet
-	// reconciled the InferencePool.
+	// reconciled the inference pool.
 	InferencePoolReasonPending InferencePoolReason = "Pending"
+
+	// This reason is used with the "Accepted" condition when there
+	// are incompatible filters present on a inference pool rule (for example if
+	// the URLRewrite and RequestRedirect are both present on an HTTPRoute).
+	InferencePoolReasonIncompatibleFilters InferencePoolReason = "IncompatibleFilters"
 )
 
 const (
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the InferencePool.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
 	//
 	// * "ResolvedRefs"
 	//
 	// Possible reasons for this condition to be False are:
 	//
-	// * "InvalidExtensionRef"
+	// * "RefNotPermitted"
+	// * "InvalidKind"
+	// * "BackendNotFound"
+	// * "UnsupportedProtocol"
 	//
-	// Controllers MAY raise this condition with other reasons, but should
-	// prefer to use the reasons listed above to improve interoperability.
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
 	InferencePoolConditionResolvedRefs InferencePoolConditionType = "ResolvedRefs"
 
 	// This reason is used with the "ResolvedRefs" condition when the condition
 	// is true.
 	InferencePoolReasonResolvedRefs InferencePoolReason = "ResolvedRefs"
 
-	// This reason is used with the "ResolvedRefs" condition when the
-	// ExtensionRef is invalid in some way. This can include an unsupported kind
-	// or API group, or a reference to a resource that can not be found.
-	InferencePoolReasonInvalidExtensionRef InferencePoolReason = "InvalidExtensionRef"
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the Listener's InferencePools has a BackendRef to an object in
+	// another namespace, where the object in the other namespace does
+	// not have a ReferenceGrant explicitly allowing the reference.
+	InferencePoolReasonRefNotPermitted InferencePoolReason = "RefNotPermitted"
+
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the InferencePool's rules has a reference to an unknown or unsupported
+	// Group and/or Kind.
+	InferencePoolReasonInvalidKind InferencePoolReason = "InvalidKind"
+
+	// This reason is used with the "ResolvedRefs" condition when one of the
+	// InferencePool's rules has a reference to a resource that does not exist.
+	InferencePoolReasonBackendNotFound InferencePoolReason = "BackendNotFound"
+
+	// This reason is used with the "ResolvedRefs" condition when one of the
+	// InferencePool's rules has a reference to a resource with an app protocol that
+	// is not supported by this implementation.
+	InferencePoolReasonUnsupportedProtocol InferencePoolReason = "UnsupportedProtocol"
 )

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -96,8 +96,8 @@ type Extension struct {
 // ExtensionReference is a reference to the extension service.
 //
 // If a reference is invalid, the implementation MUST update the `ResolvedRefs`
-// Condition on the InferencePool's status to `status: False`. All affected
-// requests MUST receive a 5XX status code.
+// Condition on the InferencePool's status to `status: False`. A 5XX status code MUST be returned
+// for the request that would have otherwise been routed to the invalid backend.
 type ExtensionReference struct {
 	// Group is the group of the referent.
 	// The default value is "", representing the Core API group.
@@ -185,9 +185,6 @@ type PoolStatus struct {
 	//
 	// * "Accepted"
 	// * "ResolvedRefs"
-	//
-	// For more information about the meaning of these conditions, see the
-	// documentation for InferencePoolConditionType.
 	//
 	// +optional
 	// +listType=map

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -93,7 +93,7 @@ type Extension struct {
 	ExtensionConnection `json:",inline"`
 }
 
-// ExtensionReference is a reference to the extension service.
+// ExtensionReference is a reference to the extension.
 //
 // If a reference is invalid, the implementation MUST update the `ResolvedRefs`
 // Condition on the InferencePool's status to `status: False`. A 5XX status code MUST be returned

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -222,7 +222,7 @@ const (
 	InferencePoolConditionAccepted InferencePoolConditionType = "Accepted"
 
 	// This reason is used with the "Accepted" condition when the InferencePool has been
-	// accepted by the Gateway because it is referenced by a valid and accepted HTTPRoute.
+	// accepted by the Gateway.
 	InferencePoolReasonAccepted InferencePoolReason = "Accepted"
 
 	// This reason is used with the "Accepted" condition when the InferencePool

--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -194,10 +194,10 @@ type PoolStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// InferencePoolConditionType is a type of condition for a inference pool.
+// InferencePoolConditionType is a type of condition for the InferencePool
 type InferencePoolConditionType string
 
-// InferencePoolReason is a reason for a inference pool condition.
+// InferencePoolReason is the reason for a given InferencePoolConditionType
 type InferencePoolReason string
 
 const (
@@ -252,9 +252,8 @@ const (
 	//
 	// * "InvalidExtensionRef"
 	//
-	// Controllers may raise this condition with other reasons,
-	// but should prefer to use the reasons listed above to improve
-	// interoperability.
+	// Controllers MAY raise this condition with other reasons, but should
+	// prefer to use the reasons listed above to improve interoperability.
 	InferencePoolConditionResolvedRefs InferencePoolConditionType = "ResolvedRefs"
 
 	// This reason is used with the "ResolvedRefs" condition when the condition

--- a/docs/proposals/002-api-proposal/README.md
+++ b/docs/proposals/002-api-proposal/README.md
@@ -166,29 +166,29 @@ type Extension struct {
 // Condition on the InferencePool's status to `status: False`. A 5XX status code MUST be returned
 // for the request that would have otherwise been routed to the invalid backend.
 type ExtensionReference struct {
-	// Group is the group of the referent.
-	// The default value is "", representing the Core API group.
-	Group *Group `json:"group,omitempty"`
+      // Group is the group of the referent.
+      // The default value is "", representing the Core API group.
+      Group *Group `json:"group,omitempty"`
 
-	// Kind is the Kubernetes resource kind of the referent. For example
-	// "Service".
-	//
-	// Defaults to "Service" when not specified.
-	//
-	// ExternalName services can refer to CNAME DNS records that may live
-	// outside of the cluster and as such are difficult to reason about in
-	// terms of conformance. They also may not be safe to forward to (see
-	// CVE-2021-25740 for more information). Implementations MUST NOT
-	// support ExternalName Services.
-	Kind *Kind `json:"kind,omitempty"`
+      // Kind is the Kubernetes resource kind of the referent. For example
+      // "Service".
+      //
+      // Defaults to "Service" when not specified.
+      //
+      // ExternalName services can refer to CNAME DNS records that may live
+      // outside of the cluster and as such are difficult to reason about in
+      // terms of conformance. They also may not be safe to forward to (see
+      // CVE-2021-25740 for more information). Implementations MUST NOT
+      // support ExternalName Services.
+      Kind *Kind `json:"kind,omitempty"`
 
-	// Name is the name of the referent.
-	Name ObjectName `json:"name"`
+      // Name is the name of the referent.
+      Name ObjectName `json:"name"`
 
-	// The port number on the service running the extension. When unspecified,
-	// implementations SHOULD infer a default value of 9002 when the Kind is
-	// Service.
-	PortNumber *PortNumber `json:"portNumber,omitempty"`
+      // The port number on the service running the extension. When unspecified,
+      // implementations SHOULD infer a default value of 9002 when the Kind is
+      // Service.
+      PortNumber *PortNumber `json:"portNumber,omitempty"`
 }
 
 // ExtensionConnection encapsulates options that configures the connection to the extension.

--- a/docs/proposals/002-api-proposal/README.md
+++ b/docs/proposals/002-api-proposal/README.md
@@ -160,31 +160,35 @@ type Extension struct {
       ExtensionConnection `json:",inline"`
 }
 
-// ExtensionReference is a reference to the extension deployment.
+// ExtensionReference is a reference to the extension.
+//
+// If a reference is invalid, the implementation MUST update the `ResolvedRefs`
+// Condition on the InferencePool's status to `status: False`. A 5XX status code MUST be returned
+// for the request that would have otherwise been routed to the invalid backend.
 type ExtensionReference struct {
-      // Group is the group of the referent.
-      // The default value is "", representing the Core API group.
-      Group *Group `json:"group,omitempty"`
+	// Group is the group of the referent.
+	// The default value is "", representing the Core API group.
+	Group *Group `json:"group,omitempty"`
 
-      // Kind is the Kubernetes resource kind of the referent. For example
-      // "Service".
-      //
-      // Defaults to "Service" when not specified.
-      //
-      // ExternalName services can refer to CNAME DNS records that may live
-      // outside of the cluster and as such are difficult to reason about in
-      // terms of conformance. They also may not be safe to forward to (see
-      // CVE-2021-25740 for more information). Implementations MUST NOT
-      // support ExternalName Services.
-      Kind *Kind `json:"kind,omitempty"`
+	// Kind is the Kubernetes resource kind of the referent. For example
+	// "Service".
+	//
+	// Defaults to "Service" when not specified.
+	//
+	// ExternalName services can refer to CNAME DNS records that may live
+	// outside of the cluster and as such are difficult to reason about in
+	// terms of conformance. They also may not be safe to forward to (see
+	// CVE-2021-25740 for more information). Implementations MUST NOT
+	// support ExternalName Services.
+	Kind *Kind `json:"kind,omitempty"`
 
-      // Name is the name of the referent.
-      Name ObjectName `json:"name"`
+	// Name is the name of the referent.
+	Name ObjectName `json:"name"`
 
-      // The port number on the service running the extension. When unspecified,
-      // implementations SHOULD infer a default value of 9002 when the Kind is
-      // Service.
-      PortNumber *PortNumber `json:"portNumber,omitempty"`
+	// The port number on the service running the extension. When unspecified,
+	// implementations SHOULD infer a default value of 9002 when the Kind is
+	// Service.
+	PortNumber *PortNumber `json:"portNumber,omitempty"`
 }
 
 // ExtensionConnection encapsulates options that configures the connection to the extension.


### PR DESCRIPTION
### Key Changes:

1.  **Clarified Status for Invalid `ExtensionReference`**
    *   The specification is updated to explicitly state that when an `ExtensionReference` in an `InferencePool` points to an invalid `EndpointPicker` (EPP), the `ResolvedRefs` condition on the `InferencePool` must be set to `status: false`.
    *   This makes the behavior unambiguous and aligns it with the conformance test implemented in #1061.

2.  **Expanded `InferencePoolReason` Values**
    *   New `InferencePoolReasonHTTPRouteNotAccepted` value for inferencePoolReason have been added to provide more granular status information.
    *   This change is inspired by the detailed reasons available for resources like [`HTTPRoute`](https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1/shared_types.go#L289-L395) in the Gateway API per suggestion from https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1061#discussion_r2167808392

