### PR TITLE
Clarify that connections to EPP should use TLS by default

### DIFF
--- a/api/v1alpha2/inferencepool_types.go
+++ b/api/v1alpha2/inferencepool_types.go
@@ -95,9 +95,14 @@ type Extension struct {
 
 // ExtensionReference is a reference to the extension.
 //
+// Connections to this extension MUST use TLS by default. Implementations MAY
+// provide a way to customize this connection to use cleartext, a different
+// protocol, or custom TLS configuration.
+//
 // If a reference is invalid, the implementation MUST update the `ResolvedRefs`
-// Condition on the InferencePool's status to `status: False`. A 5XX status code MUST be returned
-// for the request that would have otherwise been routed to the invalid backend.
+// Condition on the InferencePool's status to `status: False`. A 5XX status code
+// MUST be returned for the request that would have otherwise been routed to the
+// invalid backend.
 type ExtensionReference struct {
 	// Group is the group of the referent.
 	// The default value is "", representing the Core API group.


### PR DESCRIPTION
This is intended to clarify the default expectation of using TLS when Gateways are connecting to Endpoint Picker(s). This matches the default mode of Endpoint Picker. While it leaves room for configuration of plain-text or other protocols altogether, I think it's sensible for the default behavior here to rely on TLS.

Thanks to @aslakknutsen for raising this as he was reviewing conformance tests earlier. Our conformance tests made this assumption of default behavior without any corresponding guidance in the API spec. This PR intends to resolve that.

/cc @danehans @LiorLieberman @aslakknutsen @zetxqx 