### PR TITLE
Introduce plugins.TypedName to be used for Plugin base implementation

### DIFF
--- a/conformance/testing-epp/plugins/filter/request_header_based_filter.go
+++ b/conformance/testing-epp/plugins/filter/request_header_based_filter.go
@@ -40,13 +40,18 @@ var _ framework.Filter = &HeaderBasedTestingFilter{}
 // This should only be used for testing purposes.
 func NewHeaderBasedTestingFilter() *HeaderBasedTestingFilter {
 	return &HeaderBasedTestingFilter{
-		TypedName: plugins.TypedName{Type: "header-based-testing", Name: "header-based-testing-filter"},
+		tn: plugins.TypedName{Type: "header-based-testing", Name: "header-based-testing-filter"},
 	}
 }
 
 // HeaderBasedTestingFilter filters Pods based on an address specified in the "test-epp-endpoint-selection" request header.
 type HeaderBasedTestingFilter struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (f *HeaderBasedTestingFilter) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 // Filter selects pods that match the IP addresses specified in the request header.

--- a/pkg/epp/common/config/loader/configloader_test.go
+++ b/pkg/epp/common/config/loader/configloader_test.go
@@ -555,14 +555,18 @@ schedulingProfiles:
 var _ framework.Filter = &test1{}
 
 type test1 struct {
-	plugins.TypedName
+	tn        plugins.TypedName
 	Threshold int `json:"threshold"`
 }
 
 func newTest1() *test1 {
 	return &test1{
-		TypedName: plugins.TypedName{Type: test1Type, Name: "test-1"},
+		tn: plugins.TypedName{Type: test1Type, Name: "test-1"},
 	}
+}
+
+func (f *test1) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.
@@ -575,13 +579,17 @@ var _ framework.Scorer = &test2{}
 var _ framework.PostCycle = &test2{}
 
 type test2 struct {
-	plugins.TypedName
+	tn plugins.TypedName
 }
 
 func newTest2() *test2 {
 	return &test2{
-		TypedName: plugins.TypedName{Type: test2Type, Name: "test-2"},
+		tn: plugins.TypedName{Type: test2Type, Name: "test-2"},
 	}
+}
+
+func (m *test2) TypedName() plugins.TypedName {
+	return m.tn
 }
 
 func (m *test2) Score(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, _ []types.Pod) map[types.Pod]float64 {
@@ -594,13 +602,17 @@ func (m *test2) PostCycle(_ context.Context, _ *types.CycleState, _ *types.Profi
 var _ framework.Picker = &testPicker{}
 
 type testPicker struct {
-	plugins.TypedName
+	tn plugins.TypedName
 }
 
 func newTestPicker() *testPicker {
 	return &testPicker{
-		TypedName: plugins.TypedName{Type: testPickerType, Name: "test-picker"},
+		tn: plugins.TypedName{Type: testPickerType, Name: "test-picker"},
 	}
+}
+
+func (p *testPicker) TypedName() plugins.TypedName {
+	return p.tn
 }
 
 func (p *testPicker) Pick(_ context.Context, _ *types.CycleState, _ []*types.ScoredPod) *types.ProfileRunResult {
@@ -611,13 +623,17 @@ func (p *testPicker) Pick(_ context.Context, _ *types.CycleState, _ []*types.Sco
 var _ framework.ProfileHandler = &testProfileHandler{}
 
 type testProfileHandler struct {
-	plugins.TypedName
+	tn plugins.TypedName
 }
 
 func newTestProfileHandler() *testProfileHandler {
 	return &testProfileHandler{
-		TypedName: plugins.TypedName{Type: testProfileHandlerType, Name: "test-profile-handler"},
+		tn: plugins.TypedName{Type: testProfileHandlerType, Name: "test-profile-handler"},
 	}
+}
+
+func (p *testProfileHandler) TypedName() plugins.TypedName {
+	return p.tn
 }
 
 func (p *testProfileHandler) Pick(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, _ map[string]*framework.SchedulerProfile, _ map[string]*types.ProfileRunResult) map[string]*framework.SchedulerProfile {

--- a/pkg/epp/plugins/plugins.go
+++ b/pkg/epp/plugins/plugins.go
@@ -24,8 +24,8 @@ import (
 // Plugin defines the interface for a plugin.
 // This interface should be embedded in all plugins across the code.
 type Plugin interface {
-	// GetTypedName returns the type and name of this plugin instance.
-	GetTypedName() TypedName
+	// TypedName returns the type and name tuple of this plugin instance.
+	TypedName() TypedName
 }
 
 // Handle provides plugins a set of standard data and tools to work with

--- a/pkg/epp/plugins/typedname.go
+++ b/pkg/epp/plugins/typedname.go
@@ -36,7 +36,3 @@ const (
 func (tn *TypedName) String() string {
 	return tn.Type + Separator + tn.Name
 }
-
-func (tn *TypedName) GetTypedName() TypedName {
-	return *tn
-}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -312,18 +312,18 @@ func RandomWeightedDraw(logger logr.Logger, model *v1alpha2.InferenceModel, seed
 func (d *Director) runPreRequestPlugins(ctx context.Context, request *schedulingtypes.LLMRequest, schedulingResult *schedulingtypes.SchedulingResult,
 	targetPort int) {
 	for _, plugin := range d.preRequestPlugins {
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Running pre-request plugin", "plugin", plugin.GetTypedName().Type)
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Running pre-request plugin", "plugin", plugin.TypedName().Type)
 		before := time.Now()
 		plugin.PreRequest(ctx, request, schedulingResult, targetPort)
-		metrics.RecordRequestControlPluginProcessingLatency(PreRequestPluginType, plugin.GetTypedName().Type, time.Since(before))
+		metrics.RecordRequestControlPluginProcessingLatency(PreRequestPluginType, plugin.TypedName().Type, time.Since(before))
 	}
 }
 
 func (d *Director) runPostResponsePlugins(ctx context.Context, request *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {
 	for _, plugin := range d.postResponsePlugins {
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.GetTypedName().Type)
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.TypedName().Type)
 		before := time.Now()
 		plugin.PostResponse(ctx, request, response, targetPod)
-		metrics.RecordRequestControlPluginProcessingLatency(PostResponsePluginType, plugin.GetTypedName().Type, time.Since(before))
+		metrics.RecordRequestControlPluginProcessingLatency(PostResponsePluginType, plugin.TypedName().Type, time.Since(before))
 	}
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -695,15 +695,19 @@ const (
 )
 
 type testPostResponse struct {
-	plugins.TypedName
+	tn                      plugins.TypedName
 	lastRespOnResponse      *Response
 	lastTargetPodOnResponse string
 }
 
 func newTestPostResponse(name string) *testPostResponse {
 	return &testPostResponse{
-		TypedName: plugins.TypedName{Type: testPostResponseType, Name: name},
+		tn: plugins.TypedName{Type: testPostResponseType, Name: name},
 	}
+}
+
+func (p *testPostResponse) TypedName() plugins.TypedName {
+	return p.tn
 }
 
 func (p *testPostResponse) PostResponse(_ context.Context, _ *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {

--- a/pkg/epp/scheduling/framework/plugins/filter/decision_tree_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/decision_tree_filter.go
@@ -133,14 +133,14 @@ func loadDecisionTreeEntry(entry *decisionTreeFilterEntry, handle plugins.Handle
 	return nil, errors.New("either pluginRef or decisionTree must be specified")
 }
 
-func (f *DecisionTreeFilter) GetTypedName() plugins.TypedName {
+func (f *DecisionTreeFilter) TypedName() plugins.TypedName {
 	if f == nil {
 		// TODO: this keeps the previous behavior ("nil"/"") - not sure
 		// why done this way.
 		// Change to empty TypedName or some more meaningful values?
 		return plugins.TypedName{Type: "nil", Name: ""}
 	}
-	return f.Current.GetTypedName()
+	return f.Current.TypedName()
 }
 
 // Filter filters out pods that doesn't meet the filter criteria.
@@ -157,7 +157,7 @@ func (f *DecisionTreeFilter) Filter(ctx context.Context, cycleState *types.Cycle
 		if f.NextOnSuccess != nil {
 			next = f.NextOnSuccess
 		}
-		loggerTrace.Info("Filter succeeded", "filter", f.GetTypedName(), "next", next.GetTypedName(), "filteredPodCount", len(filteredPod))
+		loggerTrace.Info("Filter succeeded", "filter", f.TypedName(), "next", next.TypedName(), "filteredPodCount", len(filteredPod))
 		// On success, pass the filtered result to the next filter.
 		return next.Filter(ctx, cycleState, request, filteredPod)
 	} else {
@@ -168,7 +168,7 @@ func (f *DecisionTreeFilter) Filter(ctx context.Context, cycleState *types.Cycle
 		if f.NextOnFailure != nil {
 			next = f.NextOnFailure
 		}
-		loggerTrace.Info("Filter failed", "filter", f.GetTypedName(), "next", next.GetTypedName())
+		loggerTrace.Info("Filter failed", "filter", f.TypedName(), "next", next.TypedName())
 		// On failure, pass the initial set of pods to the next filter.
 		return next.Filter(ctx, cycleState, request, pods)
 	}

--- a/pkg/epp/scheduling/framework/plugins/filter/filter_test.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/filter_test.go
@@ -40,12 +40,16 @@ import (
 var _ framework.Filter = &filterAll{}
 
 type filterAll struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+func (f *filterAll) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 func newFilterAll() *filterAll {
 	return &filterAll{
-		TypedName: plugins.TypedName{Type: "filter-all", Name: "test-all"},
+		tn: plugins.TypedName{Type: "filter-all", Name: "test-all"},
 	}
 }
 

--- a/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_kvcache_filter.go
@@ -41,7 +41,7 @@ func LeastKVCacheFilterFactory(name string, _ json.RawMessage, _ plugins.Handle)
 // NewLeastKVCacheFilter initializes a new LeastKVCacheFilter and returns its pointer.
 func NewLeastKVCacheFilter() *LeastKVCacheFilter {
 	return &LeastKVCacheFilter{
-		TypedName: plugins.TypedName{Type: LeastKVCacheFilterType, Name: LeastKVCacheFilterType},
+		tn: plugins.TypedName{Type: LeastKVCacheFilterType, Name: LeastKVCacheFilterType},
 	}
 }
 
@@ -51,12 +51,17 @@ func NewLeastKVCacheFilter() *LeastKVCacheFilter {
 // should consider them all instead of the absolute minimum one. This worked better than picking the
 // least one as it gives more choices for the next filter, which on aggregate gave better results.
 type LeastKVCacheFilter struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (f *LeastKVCacheFilter) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 // WithName sets the name of the filter.
 func (f *LeastKVCacheFilter) WithName(name string) *LeastKVCacheFilter {
-	f.Name = name
+	f.tn.Name = name
 	return f
 }
 

--- a/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/least_queue_filter.go
@@ -41,7 +41,7 @@ func LeastQueueFilterFactory(name string, _ json.RawMessage, _ plugins.Handle) (
 // NewLeastQueueFilter initializes a new LeastQueueFilter and returns its pointer.
 func NewLeastQueueFilter() *LeastQueueFilter {
 	return &LeastQueueFilter{
-		TypedName: plugins.TypedName{Type: LeastQueueFilterType, Name: LeastQueueFilterType},
+		tn: plugins.TypedName{Type: LeastQueueFilterType, Name: LeastQueueFilterType},
 	}
 }
 
@@ -51,12 +51,17 @@ func NewLeastQueueFilter() *LeastQueueFilter {
 // we should consider them all instead of the absolute minimum one. This worked better than picking
 // the least one as it gives more choices for the next filter, which on aggregate gave better results.
 type LeastQueueFilter struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (f *LeastQueueFilter) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 // WithName sets the name of the filter.
 func (f *LeastQueueFilter) WithName(name string) *LeastQueueFilter {
-	f.Name = name
+	f.tn.Name = name
 	return f
 }
 

--- a/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/lora_affinity_filter.go
@@ -52,7 +52,7 @@ func LoraAffinityFilterFactory(name string, rawParameters json.RawMessage, _ plu
 // NewLoraAffinityFilter initializes a new LoraAffinityFilter and returns its pointer.
 func NewLoraAffinityFilter(threshold float64) *LoraAffinityFilter {
 	return &LoraAffinityFilter{
-		TypedName:             plugins.TypedName{Type: LoraAffinityFilterType, Name: LoraAffinityFilterType},
+		tn:                    plugins.TypedName{Type: LoraAffinityFilterType, Name: LoraAffinityFilterType},
 		loraAffinityThreshold: threshold,
 	}
 }
@@ -65,13 +65,18 @@ func NewLoraAffinityFilter(threshold float64) *LoraAffinityFilter {
 // 2. Using a probability threshold to sometimes select from non-affinity pods to enable load balancing
 // 3. Falling back to whatever group has pods if one group is empty
 type LoraAffinityFilter struct {
-	plugins.TypedName
+	tn                    plugins.TypedName
 	loraAffinityThreshold float64
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (f *LoraAffinityFilter) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 // WithName sets the type of the filter.
 func (f *LoraAffinityFilter) WithName(name string) *LoraAffinityFilter {
-	f.Name = name
+	f.tn.Name = name
 	return f
 }
 

--- a/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
+++ b/pkg/epp/scheduling/framework/plugins/filter/low_queue_filter.go
@@ -52,20 +52,25 @@ func LowQueueFilterFactory(name string, rawParameters json.RawMessage, _ plugins
 // NewLowQueueFilter initializes a new LowQueueFilter and returns its pointer.
 func NewLowQueueFilter(threshold int) *LowQueueFilter {
 	return &LowQueueFilter{
-		TypedName:             plugins.TypedName{Type: LowQueueFilterType, Name: LowQueueFilterType},
+		tn:                    plugins.TypedName{Type: LowQueueFilterType, Name: LowQueueFilterType},
 		queueingThresholdLoRA: threshold,
 	}
 }
 
 // LowQueueFilter returns pods that their waiting queue size is less than a configured threshold
 type LowQueueFilter struct {
-	plugins.TypedName
+	tn                    plugins.TypedName
 	queueingThresholdLoRA int
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (f *LowQueueFilter) TypedName() plugins.TypedName {
+	return f.tn
 }
 
 // WithName sets the name of the filter.
 func (f *LowQueueFilter) WithName(name string) *LowQueueFilter {
-	f.Name = name
+	f.tn.Name = name
 	return f
 }
 

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -68,7 +68,7 @@ type Config struct {
 
 type Plugin struct {
 	Config
-	plugins.TypedName
+	tn      plugins.TypedName
 	indexer Indexer
 }
 
@@ -144,15 +144,20 @@ func New(config Config) *Plugin {
 	}
 
 	return &Plugin{
-		TypedName: plugins.TypedName{Type: PrefixCachePluginType, Name: PrefixCachePluginType},
-		Config:    config,
-		indexer:   newIndexer(capacity),
+		tn:      plugins.TypedName{Type: PrefixCachePluginType, Name: PrefixCachePluginType},
+		Config:  config,
+		indexer: newIndexer(capacity),
 	}
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (m *Plugin) TypedName() plugins.TypedName {
+	return m.tn
 }
 
 // WithName sets the name of the plugin.
 func (m *Plugin) WithName(name string) *Plugin {
-	m.Name = name
+	m.tn.Name = name
 	return m
 }
 
@@ -166,7 +171,7 @@ func (m *Plugin) Score(ctx context.Context, cycleState *types.CycleState, reques
 		PrefixCacheServers: m.matchLongestPrefix(ctx, hashes),
 	}
 
-	cycleState.Write(types.StateKey(m.GetTypedName().Type), state)
+	cycleState.Write(types.StateKey(m.TypedName().Type), state)
 	loggerTrace.Info(fmt.Sprintf("cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
 	// calculate the scores of pods
 	scores := make(map[types.Pod]float64, len(pods))

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -43,20 +43,25 @@ func MaxScorePickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (pl
 // NewMaxScorePicker initializes a new MaxScorePicker and returns its pointer.
 func NewMaxScorePicker() *MaxScorePicker {
 	return &MaxScorePicker{
-		TypedName: plugins.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
-		random:    NewRandomPicker(),
+		tn:     plugins.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
+		random: NewRandomPicker(),
 	}
 }
 
 // MaxScorePicker picks the pod with the maximum score from the list of candidates.
 type MaxScorePicker struct {
-	plugins.TypedName
+	tn     plugins.TypedName
 	random *RandomPicker
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *MaxScorePicker) TypedName() plugins.TypedName {
+	return p.tn
 }
 
 // WithName sets the picker's name
 func (p *MaxScorePicker) WithName(name string) *MaxScorePicker {
-	p.Name = name
+	p.tn.Name = name
 	return p
 }
 

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -45,18 +45,23 @@ func RandomPickerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plug
 // NewRandomPicker initializes a new RandomPicker and returns its pointer.
 func NewRandomPicker() *RandomPicker {
 	return &RandomPicker{
-		TypedName: plugins.TypedName{Type: RandomPickerType, Name: RandomPickerType},
+		tn: plugins.TypedName{Type: RandomPickerType, Name: RandomPickerType},
 	}
 }
 
 // RandomPicker picks a random pod from the list of candidates.
 type RandomPicker struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *RandomPicker) TypedName() plugins.TypedName {
+	return p.tn
 }
 
 // WithName sets the name of the picker.
 func (p *RandomPicker) WithName(name string) *RandomPicker {
-	p.Name = name
+	p.tn.Name = name
 	return p
 }
 

--- a/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
+++ b/pkg/epp/scheduling/framework/plugins/profile/single_profile_handler.go
@@ -42,18 +42,23 @@ func SingleProfileHandlerFactory(name string, _ json.RawMessage, _ plugins.Handl
 // NewSingleProfileHandler initializes a new SingleProfileHandler and returns its pointer.
 func NewSingleProfileHandler() *SingleProfileHandler {
 	return &SingleProfileHandler{
-		TypedName: plugins.TypedName{Type: SingleProfileHandlerType, Name: SingleProfileHandlerType},
+		tn: plugins.TypedName{Type: SingleProfileHandlerType, Name: SingleProfileHandlerType},
 	}
 }
 
 // SingleProfileHandler handles a single profile which is always the primary profile.
 type SingleProfileHandler struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (h *SingleProfileHandler) TypedName() plugins.TypedName {
+	return h.tn
 }
 
 // WithName sets the name of the profile handler.
 func (h *SingleProfileHandler) WithName(name string) *SingleProfileHandler {
-	h.Name = name
+	h.tn.Name = name
 	return h
 }
 

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache.go
@@ -41,18 +41,23 @@ func KvCacheScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plu
 // NewKVCacheScorer initializes a new KVCacheScorer and returns its pointer.
 func NewKVCacheScorer() *KVCacheScorer {
 	return &KVCacheScorer{
-		TypedName: plugins.TypedName{Type: KvCacheScorerType, Name: KvCacheScorerType},
+		tn: plugins.TypedName{Type: KvCacheScorerType, Name: KvCacheScorerType},
 	}
 }
 
 // KVCacheScorer scores list of candidate pods based on KV cache utilization.
 type KVCacheScorer struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (s *KVCacheScorer) TypedName() plugins.TypedName {
+	return s.tn
 }
 
 // WithName sets the name of the scorer.
 func (s *KVCacheScorer) WithName(name string) *KVCacheScorer {
-	s.Name = name
+	s.tn.Name = name
 	return s
 }
 

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue.go
@@ -42,19 +42,24 @@ func QueueScorerFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugi
 // NewQueueScorer initializes a new QueueScorer and returns its pointer.
 func NewQueueScorer() *QueueScorer {
 	return &QueueScorer{
-		TypedName: plugins.TypedName{Type: QueueScorerType, Name: QueueScorerType},
+		tn: plugins.TypedName{Type: QueueScorerType, Name: QueueScorerType},
 	}
 }
 
 // QueueScorer scores list of candidate pods based on the pod's waiting queue size.
 // the less waiting queue size the pod has, the higher score it will get (since it's more available to serve new request).
 type QueueScorer struct {
-	plugins.TypedName
+	tn plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (s *QueueScorer) TypedName() plugins.TypedName {
+	return s.tn
 }
 
 // WithName sets the name of the scorer.
 func (s *QueueScorer) WithName(name string) *QueueScorer {
-	s.Name = name
+	s.tn.Name = name
 	return s
 }
 

--- a/pkg/epp/scheduling/framework/scheduler_profile.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile.go
@@ -86,14 +86,14 @@ func (p *SchedulerProfile) AddPlugins(pluginObjects ...plugins.Plugin) error {
 			p.scorers = append(p.scorers, weightedScorer)
 			plugin = weightedScorer.Scorer // if we got WeightedScorer, unwrap the plugin
 		} else if scorer, ok := plugin.(Scorer); ok { // if we got a Scorer instead of WeightedScorer that's an error.
-			return fmt.Errorf("failed to register scorer '%s' without a weight. follow function documentation to register a scorer", scorer.GetTypedName())
+			return fmt.Errorf("failed to register scorer '%s' without a weight. follow function documentation to register a scorer", scorer.TypedName())
 		}
 		if filter, ok := plugin.(Filter); ok {
 			p.filters = append(p.filters, filter)
 		}
 		if picker, ok := plugin.(Picker); ok {
 			if p.picker != nil {
-				return fmt.Errorf("failed to set '%s' as picker, already have a registered picker plugin '%s'", picker.GetTypedName(), p.picker.GetTypedName())
+				return fmt.Errorf("failed to set '%s' as picker, already have a registered picker plugin '%s'", picker.TypedName(), p.picker.TypedName())
 			}
 			p.picker = picker
 		}
@@ -127,11 +127,11 @@ func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *types.
 	loggerDebug.Info("Before running filter plugins", "pods", filteredPods)
 
 	for _, filter := range p.filters {
-		loggerDebug.Info("Running filter plugin", "plugin", filter.GetTypedName().Type)
+		loggerDebug.Info("Running filter plugin", "plugin", filter.TypedName().Type)
 		before := time.Now()
 		filteredPods = filter.Filter(ctx, cycleState, request, filteredPods)
-		metrics.RecordSchedulerPluginProcessingLatency(FilterPluginType, filter.GetTypedName().Type, time.Since(before))
-		loggerDebug.Info("Filter plugin result", "plugin", filter.GetTypedName().Type, "pods", filteredPods)
+		metrics.RecordSchedulerPluginProcessingLatency(FilterPluginType, filter.TypedName().Type, time.Since(before))
+		loggerDebug.Info("Filter plugin result", "plugin", filter.TypedName().Type, "pods", filteredPods)
 		if len(filteredPods) == 0 {
 			break
 		}
@@ -151,14 +151,14 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *types.
 	}
 	// Iterate through each scorer in the chain and accumulate the weighted scores.
 	for _, scorer := range p.scorers {
-		loggerDebug.Info("Running scorer", "scorer", scorer.GetTypedName().Type)
+		loggerDebug.Info("Running scorer", "scorer", scorer.TypedName().Type)
 		before := time.Now()
 		scores := scorer.Score(ctx, cycleState, request, pods)
-		metrics.RecordSchedulerPluginProcessingLatency(ScorerPluginType, scorer.GetTypedName().Type, time.Since(before))
+		metrics.RecordSchedulerPluginProcessingLatency(ScorerPluginType, scorer.TypedName().Type, time.Since(before))
 		for pod, score := range scores { // weight is relative to the sum of weights
 			weightedScorePerPod[pod] += score * float64(scorer.Weight())
 		}
-		loggerDebug.Info("After running scorer", "scorer", scorer.GetTypedName().Type)
+		loggerDebug.Info("After running scorer", "scorer", scorer.TypedName().Type)
 	}
 	loggerDebug.Info("After running scorer plugins")
 
@@ -177,7 +177,7 @@ func (p *SchedulerProfile) runPickerPlugin(ctx context.Context, cycleState *type
 	loggerDebug.Info("Before running picker plugin", "pods weighted score", fmt.Sprint(weightedScorePerPod))
 	before := time.Now()
 	result := p.picker.Pick(ctx, cycleState, scoredPods)
-	metrics.RecordSchedulerPluginProcessingLatency(PickerPluginType, p.picker.GetTypedName().Type, time.Since(before))
+	metrics.RecordSchedulerPluginProcessingLatency(PickerPluginType, p.picker.TypedName().Type, time.Since(before))
 	loggerDebug.Info("After running picker plugin", "result", result)
 
 	return result
@@ -185,9 +185,9 @@ func (p *SchedulerProfile) runPickerPlugin(ctx context.Context, cycleState *type
 
 func (p *SchedulerProfile) runPostCyclePlugins(ctx context.Context, cycleState *types.CycleState, result *types.ProfileRunResult) {
 	for _, plugin := range p.postCyclePlugins {
-		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-cycle plugin", "plugin", plugin.GetTypedName().Type)
+		log.FromContext(ctx).V(logutil.DEBUG).Info("Running post-cycle plugin", "plugin", plugin.TypedName().Type)
 		before := time.Now()
 		plugin.PostCycle(ctx, cycleState, result)
-		metrics.RecordSchedulerPluginProcessingLatency(PostCyclePluginType, plugin.GetTypedName().Type, time.Since(before))
+		metrics.RecordSchedulerPluginProcessingLatency(PostCyclePluginType, plugin.TypedName().Type, time.Since(before))
 	}
 }

--- a/pkg/epp/scheduling/framework/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile_test.go
@@ -149,24 +149,24 @@ func TestSchedulePlugins(t *testing.T) {
 			for _, plugin := range test.profile.filters {
 				tp, _ := plugin.(*testPlugin)
 				if tp.FilterCallCount != 1 {
-					t.Errorf("Plugin %s Filter() called %d times, expected 1", plugin.GetTypedName(), tp.FilterCallCount)
+					t.Errorf("Plugin %s Filter() called %d times, expected 1", plugin.TypedName(), tp.FilterCallCount)
 				}
 			}
 			for _, plugin := range test.profile.scorers {
 				tp, _ := plugin.Scorer.(*testPlugin)
 				if tp.ScoreCallCount != 1 {
-					t.Errorf("Plugin %s Score() called %d times, expected 1", plugin.GetTypedName(), tp.ScoreCallCount)
+					t.Errorf("Plugin %s Score() called %d times, expected 1", plugin.TypedName(), tp.ScoreCallCount)
 				}
 				if test.numPodsToScore != tp.NumOfScoredPods {
-					t.Errorf("Plugin %s Score() called with %d pods, expected %d", plugin.GetTypedName(), tp.NumOfScoredPods, test.numPodsToScore)
+					t.Errorf("Plugin %s Score() called with %d pods, expected %d", plugin.TypedName(), tp.NumOfScoredPods, test.numPodsToScore)
 				}
 			}
 			tp, _ := test.profile.picker.(*testPlugin)
 			if tp.NumOfPickerCandidates != test.numPodsToScore {
-				t.Errorf("Picker plugin %s Pick() called with %d candidates, expected %d", tp.GetTypedName(), tp.NumOfPickerCandidates, tp.NumOfScoredPods)
+				t.Errorf("Picker plugin %s Pick() called with %d candidates, expected %d", tp.TypedName(), tp.NumOfPickerCandidates, tp.NumOfScoredPods)
 			}
 			if tp.PickCallCount != 1 {
-				t.Errorf("Picker plugin %s Pick() called %d times, expected 1", tp.GetTypedName(), tp.PickCallCount)
+				t.Errorf("Picker plugin %s Pick() called %d times, expected 1", tp.TypedName(), tp.PickCallCount)
 			}
 			if tp.WinnerPodScore != test.targetPodScore {
 				t.Errorf("winner pod score %v, expected %v", tp.WinnerPodScore, test.targetPodScore)
@@ -174,7 +174,7 @@ func TestSchedulePlugins(t *testing.T) {
 			for _, plugin := range test.profile.postCyclePlugins {
 				tp, _ := plugin.(*testPlugin)
 				if tp.PostScheduleCallCount != 1 {
-					t.Errorf("Plugin %s PostSchedule() called %d times, expected 1", plugin.GetTypedName(), tp.PostScheduleCallCount)
+					t.Errorf("Plugin %s PostSchedule() called %d times, expected 1", plugin.TypedName(), tp.PostScheduleCallCount)
 				}
 			}
 		})
@@ -189,7 +189,7 @@ var _ PostCycle = &testPlugin{}
 
 // testPlugin is an implementation useful in unit tests.
 type testPlugin struct {
-	plugins.TypedName
+	tn                    plugins.TypedName
 	TypeRes               string
 	ScoreCallCount        int
 	NumOfScoredPods       int
@@ -206,11 +206,15 @@ type testPlugin struct {
 func newTestPlugin(typeRes string, score float64, pruned []k8stypes.NamespacedName,
 	target k8stypes.NamespacedName) *testPlugin {
 	return &testPlugin{
-		TypedName: plugins.TypedName{Type: typeRes, Name: "test-plugin"},
+		tn:        plugins.TypedName{Type: typeRes, Name: "test-plugin"},
 		ScoreRes:  score,
 		FilterRes: pruned,
 		PickRes:   target,
 	}
+}
+
+func (tp *testPlugin) TypedName() plugins.TypedName {
+	return tp.tn
 }
 
 func (tp *testPlugin) Filter(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, pods []types.Pod) []types.Pod {

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -107,7 +107,7 @@ func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest, can
 	for { // get the next set of profiles to run iteratively based on the request and the previous execution results
 		before := time.Now()
 		profiles := s.profileHandler.Pick(ctx, cycleState, request, s.profiles, profileRunResults)
-		metrics.RecordSchedulerPluginProcessingLatency(framework.ProfilePickerType, s.profileHandler.GetTypedName().Type, time.Since(before))
+		metrics.RecordSchedulerPluginProcessingLatency(framework.ProfilePickerType, s.profileHandler.TypedName().Type, time.Since(before))
 		if len(profiles) == 0 { // profile picker didn't pick any profile to run
 			break
 		}
@@ -129,7 +129,7 @@ func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest, can
 
 	before := time.Now()
 	result, err := s.profileHandler.ProcessResults(ctx, cycleState, request, profileRunResults)
-	metrics.RecordSchedulerPluginProcessingLatency(framework.ProcessProfilesResultsType, s.profileHandler.GetTypedName().Type, time.Since(before))
+	metrics.RecordSchedulerPluginProcessingLatency(framework.ProcessProfilesResultsType, s.profileHandler.TypedName().Type, time.Since(before))
 
 	return result, err
 }


### PR DESCRIPTION
Reduce boilerplate in Plugins by embedding a TypedName into each, implementing the Plugin methods.