### PR TITLE
Use Kubernetes Reader instead of full Client

### DIFF
--- a/pkg/epp/controller/pod_reconciler.go
+++ b/pkg/epp/controller/pod_reconciler.go
@@ -35,7 +35,7 @@ import (
 )
 
 type PodReconciler struct {
-	client.Client
+	client.Reader
 	Datastore datastore.Datastore
 	Record    record.EventRecorder
 }

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -187,7 +187,7 @@ func TestPodReconciler(t *testing.T) {
 				store.PodUpdateOrAddIfNotExist(pod)
 			}
 
-			podReconciler := &PodReconciler{Client: fakeClient, Datastore: store}
+			podReconciler := &PodReconciler{Reader: fakeClient, Datastore: store}
 			if test.req == nil {
 				namespacedName := types.NamespacedName{Name: test.incomingPod.Name, Namespace: test.incomingPod.Namespace}
 				test.req = &ctrl.Request{NamespacedName: namespacedName}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -110,7 +110,7 @@ func (r *ExtProcServerRunner) SetupWithManager(ctx context.Context, mgr ctrl.Man
 
 	if err := (&controller.PodReconciler{
 		Datastore: r.Datastore,
-		Client:    mgr.GetClient(),
+		Reader:    mgr.GetClient(),
 		Record:    mgr.GetEventRecorderFor("pod"),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("failed setting up PodReconciler: %v", err)


### PR DESCRIPTION
Replace `client.Client` with `client.Reader` to enforce read only access to k8s API. There is no actual modification expected as part of Pod listing and updating in GIE.