### PR TITLE
Docs: Bumps Kgateway Version

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -215,7 +215,7 @@ This quickstart guide is intended for engineers familiar with k8s and model serv
       2. Set the Kgateway version and install the Kgateway CRDs.
 
          ```bash
-         KGTW_VERSION=v2.0.2
+         KGTW_VERSION=v2.0.3
          helm upgrade -i --create-namespace --namespace kgateway-system --version $KGTW_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
          ```
 


### PR DESCRIPTION
https://github.com/kgateway-dev/kgateway/releases/tag/v2.0.3 was released today. This PR bumps the Kgateway version to v2.0.3.