### PR TITLE
Upper case `Inference` in `metrics.RecordInferencePoolReadyPods` for consistency

### DIFF
--- a/pkg/epp/backend/metrics/logger.go
+++ b/pkg/epp/backend/metrics/logger.go
@@ -111,5 +111,5 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore Datastore) {
 	podTotalCount := len(podMetrics)
 	metrics.RecordInferencePoolAvgKVCache(pool.Name, kvCacheTotal/float64(podTotalCount))
 	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(queueTotal/podTotalCount))
-	metrics.RecordinferencePoolReadyPods(pool.Name, float64(podTotalCount))
+	metrics.RecordInferencePoolReadyPods(pool.Name, float64(podTotalCount))
 }

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -400,7 +400,7 @@ func RecordInferencePoolAvgQueueSize(name string, queueSize float64) {
 	inferencePoolAvgQueueSize.WithLabelValues(name).Set(queueSize)
 }
 
-func RecordinferencePoolReadyPods(name string, runningPods float64) {
+func RecordInferencePoolReadyPods(name string, runningPods float64) {
 	inferencePoolReadyPods.WithLabelValues(name).Set(runningPods)
 }
 


### PR DESCRIPTION
Using upper case to be consistent with similar functions in the same file