### PR TITLE
fixed sim deployment for e2e tests

### DIFF
--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.2.0
         imagePullPolicy: Always
         args:
         - --model
@@ -23,8 +23,10 @@ spec:
         - "8000"
         - --max-loras
         - "2"
-        - --lora
-        - food-review-1
+        - "--max-cpu-loras"
+        - "2"
+        - "--lora-modules"
+        - '[{"name": "food-review-1"}]'
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -23,8 +23,6 @@ spec:
         - "8000"
         - --max-loras
         - "2"
-        - "--max-cpu-loras"
-        - "2"
         - --lora
         - food-review-1
         env:

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.2.0
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.1
         imagePullPolicy: Always
         args:
         - --model
@@ -25,8 +25,8 @@ spec:
         - "2"
         - "--max-cpu-loras"
         - "2"
-        - "--lora-modules"
-        - '[{"name": "food-review-1"}]'
+        - --lora
+        - food-review-1
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.1
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.2
         imagePullPolicy: Always
         args:
         - --model


### PR DESCRIPTION
a new version of llm-d simulator was just release (v0.2.0).
unfortunately, this release had some breaking changes and the e2e tests are now broken.

this PR is rolling back to use a specific sim version and not latest (the one that previously worked), as we don't want our ci tests to break on simulator release in case there are breaking changes. it would be better to update the version in a controlled manner until simulator releases and apis become more stable.

I've made the necessary changes to update the sim deployment to the latest v0.2.0 release and tested it but it wasn't working for me. we would need to further explore (in a different issue) the version update.

This PR is rolling back to the latest version that working before the sim release.  