### PR TITLE
minor refactor to config loading from file/text

### DIFF
--- a/pkg/epp/common/config/loader/configloader.go
+++ b/pkg/epp/common/config/loader/configloader.go
@@ -19,11 +19,11 @@ package loader
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/gateway-api-inference-extension/api/config/v1alpha1"
 	configapi "sigs.k8s.io/gateway-api-inference-extension/api/config/v1alpha1"
@@ -39,77 +39,54 @@ func init() {
 	utilruntime.Must(configapi.Install(scheme))
 }
 
-// Load config either from supplied text or from a file
-func LoadConfig(configText []byte, fileName string) (*configapi.EndpointPickerConfig, error) {
-	var err error
-	if len(configText) == 0 {
-		configText, err = os.ReadFile(fileName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load config file. Error: %s", err)
-		}
-	}
-
-	theConfig := &configapi.EndpointPickerConfig{}
+// Load config from supplied text that was converted to []byte
+func LoadConfig(configBytes []byte, handle plugins.Handle) (*configapi.EndpointPickerConfig, error) {
+	config := &configapi.EndpointPickerConfig{}
 
 	codecs := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
-	err = runtime.DecodeInto(codecs.UniversalDecoder(), configText, theConfig)
+	err := runtime.DecodeInto(codecs.UniversalDecoder(), configBytes, config)
 	if err != nil {
-		return nil, fmt.Errorf("the configuration is invalid. Error: %s", err)
+		return nil, fmt.Errorf("the configuration is invalid - %w", err)
 	}
 
-	// Validate loaded configuration
-	err = validateConfiguration(theConfig)
-	if err != nil {
-		return nil, fmt.Errorf("the configuration is invalid. error: %s", err)
+	// instantiate loaded plugins
+	if err = instantiatePlugins(config.Plugins, handle); err != nil {
+		return nil, fmt.Errorf("failed to instantiate plugins - %w", err)
 	}
-	return theConfig, nil
-}
 
-func LoadPluginReferences(thePlugins []configapi.PluginSpec, handle plugins.Handle) error {
-	for _, pluginConfig := range thePlugins {
-		thePlugin, err := instantiatePlugin(pluginConfig, handle)
-		if err != nil {
-			return err
-		}
-		handle.Plugins().AddPlugin(pluginConfig.Name, thePlugin)
+	if err = validateSchedulingProfiles(config); err != nil {
+		return nil, fmt.Errorf("failed to validate scheduling profiles - %w", err)
 	}
-	return nil
+
+	return config, nil
 }
 
 func LoadSchedulerConfig(configProfiles []v1alpha1.SchedulingProfile, handle plugins.Handle) (*scheduling.SchedulerConfig, error) {
-
-	var profiles = map[string]*framework.SchedulerProfile{}
-
-	for _, configProfile := range configProfiles {
-		profile := framework.SchedulerProfile{}
-
-		for _, plugin := range configProfile.Plugins {
-			var err error
-			thePlugin := handle.Plugins().Plugin(plugin.PluginRef)
-			if theScorer, ok := thePlugin.(framework.Scorer); ok {
+	profiles := map[string]*framework.SchedulerProfile{}
+	for _, namedProfile := range configProfiles {
+		profile := framework.NewSchedulerProfile()
+		for _, plugin := range namedProfile.Plugins {
+			referencedPlugin := handle.Plugins().Plugin(plugin.PluginRef)
+			if scorer, ok := referencedPlugin.(framework.Scorer); ok {
 				if plugin.Weight == nil {
 					return nil, fmt.Errorf("scorer '%s' is missing a weight", plugin.PluginRef)
 				}
-				thePlugin = framework.NewWeightedScorer(theScorer, *plugin.Weight)
+				referencedPlugin = framework.NewWeightedScorer(scorer, *plugin.Weight)
 			}
-			err = profile.AddPlugins(thePlugin)
-			if err != nil {
-				return nil, err
+			if err := profile.AddPlugins(referencedPlugin); err != nil {
+				return nil, fmt.Errorf("failed to load scheduler config - %w", err)
 			}
 		}
-		profiles[configProfile.Name] = &profile
+		profiles[namedProfile.Name] = profile
 	}
 
 	var profileHandler framework.ProfileHandler
-	var profileHandlerName string
-
-	for pluginName, thePlugin := range handle.Plugins().GetAllPluginsWithNames() {
-		if theProfileHandler, ok := thePlugin.(framework.ProfileHandler); ok {
+	for pluginName, plugin := range handle.Plugins().GetAllPluginsWithNames() {
+		if theProfileHandler, ok := plugin.(framework.ProfileHandler); ok {
 			if profileHandler != nil {
-				return nil, fmt.Errorf("only one profile handler is allowed. Both %s and %s are profile handlers", profileHandlerName, pluginName)
+				return nil, fmt.Errorf("only one profile handler is allowed. Both %s and %s are profile handlers", profileHandler.TypedName().Name, pluginName)
 			}
 			profileHandler = theProfileHandler
-			profileHandlerName = pluginName
 		}
 	}
 	if profileHandler == nil {
@@ -119,62 +96,61 @@ func LoadSchedulerConfig(configProfiles []v1alpha1.SchedulingProfile, handle plu
 	return scheduling.NewSchedulerConfig(profileHandler, profiles), nil
 }
 
-func instantiatePlugin(pluginSpec configapi.PluginSpec, handle plugins.Handle) (plugins.Plugin, error) {
-	factory, ok := plugins.Registry[pluginSpec.Type]
-	if !ok {
-		return nil, fmt.Errorf("failed to instantiate the plugin. plugin type %s not found", pluginSpec.Type)
+func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle plugins.Handle) error {
+	pluginNames := sets.New[string]() // set of plugin names, a name must be unique
+
+	for _, pluginConfig := range configuredPlugins {
+		if pluginConfig.Type == "" {
+			return fmt.Errorf("plugin definition for '%s' is missing a type", pluginConfig.Name)
+		}
+
+		if pluginNames.Has(pluginConfig.Name) {
+			return fmt.Errorf("plugin name '%s' used more than once", pluginConfig.Name)
+		}
+		pluginNames.Insert(pluginConfig.Name)
+
+		factory, ok := plugins.Registry[pluginConfig.Type]
+		if !ok {
+			return fmt.Errorf("plugin type '%s' is not found in registry", pluginConfig.Type)
+		}
+
+		plugin, err := factory(pluginConfig.Name, pluginConfig.Parameters, handle)
+		if err != nil {
+			return fmt.Errorf("failed to instantiate the plugin type '%s' - %w", pluginConfig.Type, err)
+		}
+
+		handle.Plugins().AddPlugin(pluginConfig.Name, plugin)
 	}
-	thePlugin, err := factory(pluginSpec.Name, pluginSpec.Parameters, handle)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate the plugin type %s. Error: %s", pluginSpec.Type, err)
-	}
-	return thePlugin, err
+
+	return nil
 }
 
-func validateConfiguration(theConfig *configapi.EndpointPickerConfig) error {
-	names := make(map[string]struct{})
-
-	for _, pluginConfig := range theConfig.Plugins {
-		if pluginConfig.Type == "" {
-			return fmt.Errorf("plugin definition for %s is missing a type", pluginConfig.Name)
-		}
-
-		if _, ok := names[pluginConfig.Name]; ok {
-			return fmt.Errorf("plugin name %s used more than once", pluginConfig.Name)
-		}
-		names[pluginConfig.Name] = struct{}{}
-
-		_, ok := plugins.Registry[pluginConfig.Type]
-		if !ok {
-			return fmt.Errorf("plugin type %s is not found", pluginConfig.Type)
-		}
-	}
-
-	if len(theConfig.SchedulingProfiles) == 0 {
+func validateSchedulingProfiles(config *configapi.EndpointPickerConfig) error {
+	if len(config.SchedulingProfiles) == 0 {
 		return errors.New("there must be at least one scheduling profile in the configuration")
 	}
 
-	names = map[string]struct{}{}
-	for _, profile := range theConfig.SchedulingProfiles {
+	profileNames := sets.New[string]()
+	for _, profile := range config.SchedulingProfiles {
 		if profile.Name == "" {
-			return errors.New("SchedulingProfiles need a name")
+			return errors.New("SchedulingProfile must have a name")
 		}
 
-		if _, ok := names[profile.Name]; ok {
-			return fmt.Errorf("the name %s has been specified for more than one SchedulingProfile", profile.Name)
+		if profileNames.Has(profile.Name) {
+			return fmt.Errorf("the name '%s' has been specified for more than one SchedulingProfile", profile.Name)
 		}
-		names[profile.Name] = struct{}{}
+		profileNames.Insert(profile.Name)
 
 		if len(profile.Plugins) == 0 {
-			return errors.New("SchedulingProfiles need at least one plugin")
+			return fmt.Errorf("SchedulingProfile '%s' must have at least one plugin", profile.Name)
 		}
 		for _, plugin := range profile.Plugins {
 			if len(plugin.PluginRef) == 0 {
-				return errors.New("SchedulingProfile's plugins need a plugin reference")
+				return fmt.Errorf("SchedulingProfile '%s' plugins must have a plugin reference", profile.Name)
 			}
 
 			notFound := true
-			for _, pluginConfig := range theConfig.Plugins {
+			for _, pluginConfig := range config.Plugins {
 				if plugin.PluginRef == pluginConfig.Name {
 					notFound = false
 					break


### PR DESCRIPTION
This PR does minor refactoring to config loading from file/text.
the following changes are included:
- when working with sets, the best practice in k8s is to use `"k8s.io/apimachinery/pkg/util/sets"`, which is backed by map[T]struct{}, but is more readable. updated config loader to use k8s sets.
- config loader doesn't get both text (as bytes) and file anymore. this should be handled in the caller and the config loader gets bytes after the caller converted the file or text into bytes. 
**generally speaking, I'm not sure we need to maintain the two options and using a filepath seems sufficient and more aligned with k8s (e.g., mounting configmap to file system). but this is open for discussion and **not part of this PR**.
- config loader gets as input the configBytes and the handle to add the plugins. I noticed that `LoadConfig` and `LoadPluginReferences` are always called together one after the other, the separation into two functions wasn't making sense.
- updated tests accordingly.

there are more improvements that can be done, e.g., load scheduling profiles with the general config loading. there is no good reason to separate. but this is out of scope of this PR.