### PR TITLE
feat(conformance): add version for conformance test report.

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"slices"
 	"testing"
 
@@ -41,11 +40,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/yaml"
 
 	// Import necessary types and utilities from the core Gateway API conformance suite.
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"            // Import core Gateway API types
-	confapis "sigs.k8s.io/gateway-api/conformance/apis/v1" // Report struct definition
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1" // Import core Gateway API types
+	// Report struct definition
 	confflags "sigs.k8s.io/gateway-api/conformance/utils/flags"
 	apikubernetes "sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -244,13 +242,12 @@ func RunConformanceWithOptions(t *testing.T, opts confsuite.ConformanceOptions) 
 		t.Log("Generating Inference Extension conformance report")
 		report, err := cSuite.Report() // Use the existing report generation logic.
 		require.NoError(t, err, "error generating conformance report")
+		inferenceReport := GatewayAPIInferenceExtentionConformanceReport{
+			GatewayAPIInferenceExtensionVersion: "v0.5.0",
+			ConformanceReport:                   *report,
+		}
 
-		// TODO: Modify the report struct here if channel, version need to be modified.
-		// Example (requires adding fields to confapis.ConformanceReport):
-		// report.GatewayAPIInferenceExtensionChannel = opts.GatewayAPIInferenceExtensionChannel
-		// report.GatewayAPIInferenceExtensionVersion = opts.GatewayAPIInferenceExtensionVersion
-
-		err = writeReport(t.Logf, *report, opts.ReportOutputPath)
+		err = inferenceReport.WriteReport(t.Logf, opts.ReportOutputPath)
 		require.NoError(t, err, "error writing conformance report")
 	}
 }
@@ -346,24 +343,4 @@ func ensureGatewayAvailableAndReady(t *testing.T, k8sClient client.Client, opts 
 	_, err := apikubernetes.WaitForGatewayAddress(t, k8sClient, opts.TimeoutConfig, apikubernetes.NewGatewayRef(gatewayNN))
 	require.NoErrorf(t, err, "shared gateway %s/%s did not get an address", gatewayNN.Namespace, gatewayNN.Name)
 	t.Logf("Shared Gateway %s/%s is ready.", gatewayNN.Namespace, gatewayNN.Name)
-}
-
-// writeReport writes the generated conformance report to the specified output file or logs it.
-// Adapted from the core Gateway API suite.
-func writeReport(logf func(string, ...any), report confapis.ConformanceReport, output string) error {
-	rawReport, err := yaml.Marshal(report)
-	if err != nil {
-		return fmt.Errorf("error marshaling report: %w", err)
-	}
-
-	if output != "" {
-		if err = os.WriteFile(output, rawReport, 0o600); err != nil {
-			return fmt.Errorf("error writing report file %s: %w", output, err)
-		}
-		logf("Conformance report written to %s", output)
-	} else {
-		// Log the report YAML to stdout if no output file is specified.
-		logf("Conformance report:\n%s", string(rawReport))
-	}
-	return nil
 }

--- a/conformance/conformancereport.go
+++ b/conformance/conformancereport.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package conformance contains the core setup and execution logic
+// for the Gateway API Inference Extension conformance test suite.
+package conformance
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/consts"
+	confapis "sigs.k8s.io/gateway-api/conformance/apis/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// GatewayAPIInferenceExtentionConformanceReport
+// GatewayAPIInferenceExtentionConformanceReport is a report of conformance testing results of
+// gateway-api-inference-extention including the specific conformance profiles that were tested
+// and the results of the tests with summaries and statistics.
+type GatewayAPIInferenceExtentionConformanceReport struct {
+	// GatewayAPIInferenceExtensionVersion is the version of the gateway-api-inference-extention the tests run against.
+	GatewayAPIInferenceExtensionVersion string
+	// ConformanceReport is the fields reused from the gateway-api conformance reports.
+	confapis.ConformanceReport
+}
+
+// WriteReport writes the generated conformance report to the specified output file or logs it.
+func (report *GatewayAPIInferenceExtentionConformanceReport) WriteReport(logf func(string, ...any), output string) error {
+	// Override the GatewayAPIInferenceExtensionVersion here from pkg/consts.
+	report.GatewayAPIInferenceExtensionVersion = consts.BundleVersion
+	rawReport, err := yaml.Marshal(*report)
+	if err != nil {
+		return fmt.Errorf("error marshaling report: %w", err)
+	}
+
+	if output != "" {
+		if err = os.WriteFile(output, rawReport, 0o600); err != nil {
+			return fmt.Errorf("error writing report file %s: %w", output, err)
+		}
+		logf("Conformance report written to %s", output)
+	} else {
+		// Log the report YAML to stdout if no output file is specified.
+		logf("Conformance report:\n%s", string(rawReport))
+	}
+	return nil
+}

--- a/conformance/reports/README.md
+++ b/conformance/reports/README.md
@@ -27,13 +27,14 @@ This folder stores conformance reports organized first by the version of the Gat
 
 ## Implementation Submissions
 
-Each implementation conformant with a specific profile of a specific version of the Gateway API Inference Extension should have its own folder within the corresponding version and profile directory (e.g., `/conformance/reports/v0.3.0/Gateway/my-implementation/`).
+Each implementation conformant with a specific profile of a specific version of the Gateway API Inference Extension should have its own folder within the corresponding version and profile directory (e.g., `/conformance/reports/v0.3.0/gateway/my-implementation/`).
 
 The implementation is the owner of its folder and is responsible for:
 
 1.  Uploading one or more conformance reports (YAML files).
 2.  Maintaining a mandatory `README.md` file within their folder, structured as follows:
 
+```
     # My Inference Gateway Implementation (Gateway Profile Conformance)
 
     General information about the My/Implementation project.
@@ -48,6 +49,7 @@ The implementation is the owner of its folder and is responsible for:
     ## Reproduce
 
     Instructions on how to reproduce the claimed report(s).
+```
 
 ### Table of Contents (within Implementation README)
 
@@ -89,7 +91,7 @@ To be accepted, submitted conformance reports must comply with the following rul
 
 Conformance reports demonstrating a `success` result for a specific profile (e.g., `Gateway`) should be submitted via Pull Request directly to this repository (`kubernetes-sigs/gateway-api-inference-extension`).
 
-1.  Create a new folder structure under `/conformance/reports/<extension-version>/<profile-name>/` named after your implementation (e.g., `/conformance/reports/v0.3.0/Gateway/my-implementation/`).
+1.  Create a new folder structure under `/conformance/reports/<extension-version>/<profile-name>/` named after your implementation (e.g., `/conformance/reports/v0.3.0/gateway/my-implementation/`).
 2.  Add your implementation's `README.md` to this folder, following the structure described above.
 3.  Add your generated conformance report YAML file(s) to this folder, ensuring they follow the naming convention `<Implementation Version>-<Mode>-<Profile>-report.yaml`.
 4.  Submit the Pull Request.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consts
+
+const (
+	// BundleVersion is the value used for labeling the version of the gateway-api-inference-extension.
+	BundleVersion = "v0.5.0"
+)


### PR DESCRIPTION
1. add `GatewayAPIInferenceExtensionVersion` to the conformance report.
2. add a consts following the [style](https://github.com/kubernetes-sigs/gateway-api/blob/main/pkg/consts/consts.go#L30) in gateway api. currently only conformance tests is using it, I'll have a following PR to follow the gateway-api [pattern](https://github.com/kubernetes-sigs/gateway-api/pull/945/files#diff-149dfe7bb29d1191dceae3a52915e750e64b7f87257a5fb309c29d3056e2a95d) to generate CRD and add annotations.