### PR TITLE
feat: Introduce pluggable intra-flow dispatch policy framework

### DIFF
--- a/pkg/epp/flowcontrol/framework/doc.go
+++ b/pkg/epp/flowcontrol/framework/doc.go
@@ -20,8 +20,13 @@ limitations under the License.
 // to. By building on these interfaces, the Flow Control system can be extended and customized without modifying the
 // core controller logic.
 //
-// The primary interfaces defined here are:
-//   - `SafeQueue`: The contract for concurrent-safe queue implementations.
-//   - `ItemComparator`: The contract for policy-driven logic that defines the relative priority of items within a
+// The primary contracts are:
+//   - `SafeQueue`: An interface for concurrent-safe queue implementations.
+//   - `IntraFlowDispatchPolicy`: An interface for policies that decide which item to select from within a single flow's
 //     queue.
+//   - `ItemComparator`: An interface vended by policies to make their internal item-ordering logic explicit and
+//     available to other components.
+//
+// These components are linked by `QueueCapability`, which allows policies to declare their queue requirements (e.g.,
+// FIFO or priority-based ordering).
 package framework

--- a/pkg/epp/flowcontrol/framework/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/framework/mocks/mocks.go
@@ -18,6 +18,7 @@ package mocks
 
 import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 )
 
 // MockItemComparator provides a mock implementation of the `framework.ItemComparator` interface.
@@ -30,3 +31,35 @@ func (m *MockItemComparator) Func() framework.ItemComparatorFunc { return m.Func
 func (m *MockItemComparator) ScoreType() string                  { return m.ScoreTypeV }
 
 var _ framework.ItemComparator = &MockItemComparator{}
+
+// MockFlowQueueAccessor is a mock implementation of the `framework.FlowQueueAccessor` interface.
+type MockFlowQueueAccessor struct {
+	NameV         string
+	CapabilitiesV []framework.QueueCapability
+	LenV          int
+	ByteSizeV     uint64
+	PeekHeadV     types.QueueItemAccessor
+	PeekHeadErrV  error
+	PeekTailV     types.QueueItemAccessor
+	PeekTailErrV  error
+	FlowSpecV     types.FlowSpecification
+	ComparatorV   framework.ItemComparator
+}
+
+func (m *MockFlowQueueAccessor) Name() string                              { return m.NameV }
+func (m *MockFlowQueueAccessor) Capabilities() []framework.QueueCapability { return m.CapabilitiesV }
+func (m *MockFlowQueueAccessor) Len() int                                  { return m.LenV }
+func (m *MockFlowQueueAccessor) ByteSize() uint64                          { return m.ByteSizeV }
+
+func (m *MockFlowQueueAccessor) PeekHead() (types.QueueItemAccessor, error) {
+	return m.PeekHeadV, m.PeekHeadErrV
+}
+
+func (m *MockFlowQueueAccessor) PeekTail() (types.QueueItemAccessor, error) {
+	return m.PeekTailV, m.PeekTailErrV
+}
+
+func (m *MockFlowQueueAccessor) Comparator() framework.ItemComparator { return m.ComparatorV }
+func (m *MockFlowQueueAccessor) FlowSpec() types.FlowSpecification    { return m.FlowSpecV }
+
+var _ framework.FlowQueueAccessor = &MockFlowQueueAccessor{}

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/README.md
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/README.md
@@ -1,0 +1,63 @@
+# Flow Controller Intra-Flow Dispatch Policy Plugins
+
+This directory contains concrete implementations of the [`framework.IntraFlowDispatchPolicy`](../../../policies.go)
+interface. These policies are responsible for **temporal scheduling**: determining the order in which requests are
+selected for dispatch *from within a single flow's queue*.
+
+## Overview
+
+The `controller.FlowController` uses a two-tier policy system to manage requests. `framework.IntraFlowDispatchPolicy`
+plugins represent the first tier, making tactical decisions about the ordering of requests *within* a single logical
+flow (e.g., for a specific model or tenant).
+
+This contrasts with the `framework.InterFlowDispatchPolicy` (not yet implemented), which is responsible for
+**spatial fairness**: deciding *which flow's queue* gets the next opportunity to dispatch a request. The
+`framework.IntraFlowDispatchPolicy` only operates *after* the inter-flow policy has selected a specific queue.
+
+Key responsibilities and characteristics of a `framework.IntraFlowDispatchPolicy`:
+
+1.  **Request Selection (`SelectItem`)**: The primary method, `SelectItem(queue framework.FlowQueueAccessor)`, inspects
+    the given flow's queue (via a read-only accessor) and decides which item, if any, should be dispatched next from
+    *that specific queue*.
+
+2.  **Priority Definition (`ItemComparator`)**:
+    - This policy type is unique because it defines the nature of priority for items *within its specific managed
+      queue*. It makes this logic explicit by vending a [`framework.ItemComparator`](../../../policies.go).
+    - The vended comparator defines the "less than" relationship between two items and exposes a `ScoreType()` string
+      (e.g., `"enqueue_time_ns_asc"`, `"slo_deadline_urgency"`) that gives a semantic meaning to the comparison.
+
+3.  **Queue Compatibility (`RequiredQueueCapabilities`)**: The policy specifies the capabilities its associated
+    [`framework.SafeQueue`](../../../queue.go) must support for it to function correctly. For example, a simple FCFS
+    policy would require `framework.CapabilityFIFO`, while a more complex, priority-based policy would require
+    `framework.CapabilityPriorityConfigurable`. The `ports.FlowRegistry` uses this information to pair policies with
+    compatible queues.
+
+The `framework.IntraFlowDispatchPolicy` allows for fine-grained control over how individual requests within a single flow are
+serviced, enabling strategies like basic FCFS or more advanced schemes based on SLOs or deadlines.
+
+## Contributing a New `framework.IntraFlowDispatchPolicy` Implementation
+
+To contribute a new dispatch policy implementation, follow these steps:
+
+1.  **Define Your Implementation**
+    - Create a new Go package in a subdirectory (e.g., `mycustompolicy/`).
+    - Implement the `framework.IntraFlowDispatchPolicy` interface.
+    - Ensure all methods are goroutine-safe if your policy maintains any internal state.
+
+2.  **Register Your Policy**
+    - In an `init()` function within your policy's Go file, call [`MustRegisterPolicy()`](./factory.go) with a
+      unique name and a constructor function that matches the `PolicyConstructor` signature.
+
+3.  **Add to the Functional Test**
+    - Add a blank import for your new package to [`functional_test.go`](./functional_test.go). Your policy will then
+      be automatically included in the functional test suite, which validates the basic
+      `framework.IntraFlowDispatchPolicy` contract (e.g., correct initialization, handling of nil/empty queues).
+
+4.  **Add Policy-Specific Tests**
+    - The functional test suite only validates the universal contract. You MUST add a separate `_test.go` file within
+      your package to test the specific logic of your policy.
+    - For example, your tests should validate that your `Comparator()` works as expected and that `SelectItem()`
+      correctly implements your desired selection logic for a non-empty queue.
+
+5.  **Documentation**
+    - Add a package-level GoDoc comment to your new policy's Go file, explaining its behavior and any trade-offs.

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/factory.go
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/factory.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dispatch provides the factory and registration mechanism for all `framework.IntraFlowDispatchPolicy`
+// implementations.
+// It allows new policies to be added to the system and instantiated by name.
+package dispatch
+
+import (
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+)
+
+// RegisteredPolicyName is the unique name under which a policy is registered.
+type RegisteredPolicyName string
+
+// PolicyConstructor defines the function signature for creating a `framework.IntraFlowDispatchPolicy`.
+type PolicyConstructor func() (framework.IntraFlowDispatchPolicy, error)
+
+var (
+	// mu guards the registration map.
+	mu sync.RWMutex
+	// RegisteredPolicies stores the constructors for all registered policies.
+	RegisteredPolicies = make(map[RegisteredPolicyName]PolicyConstructor)
+)
+
+// MustRegisterPolicy registers a policy constructor, and panics if the name is already registered.
+// This is intended to be called from the `init()` function of a policy implementation.
+func MustRegisterPolicy(name RegisteredPolicyName, constructor PolicyConstructor) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := RegisteredPolicies[name]; ok {
+		panic(fmt.Sprintf("IntraFlowDispatchPolicy already registered with name %q", name))
+	}
+	RegisteredPolicies[name] = constructor
+}
+
+// NewPolicyFromName creates a new `IntraFlowDispatchPolicy` given its registered name.
+// This is called by the `registry.FlowRegistry` when configuring a flow.
+func NewPolicyFromName(name RegisteredPolicyName) (framework.IntraFlowDispatchPolicy, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	constructor, ok := RegisteredPolicies[name]
+	if !ok {
+		return nil, fmt.Errorf("no IntraFlowDispatchPolicy registered with name %q", name)
+	}
+	return constructor()
+}

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs/fcfs.go
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs/fcfs.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fcfs provides a First-Come, First-Served implementation of the `framework.IntraFlowDispatchPolicy`.
+package fcfs
+
+import (
+	"errors"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+)
+
+// FCFSPolicyName is the name of the FCFS policy implementation.
+const FCFSPolicyName = "FCFS"
+
+func init() {
+	dispatch.MustRegisterPolicy(dispatch.RegisteredPolicyName(FCFSPolicyName),
+		func() (framework.IntraFlowDispatchPolicy, error) {
+			return newFCFS(), nil
+		})
+}
+
+// fcfs (First-Come, First-Served) implements the `framework.IntraFlowDispatchPolicy` interface.
+type fcfs struct {
+	comparator framework.ItemComparator
+}
+
+// newFCFS creates a new `fcfs` policy instance.
+func newFCFS() *fcfs {
+	return &fcfs{
+		comparator: &enqueueTimeComparator{},
+	}
+}
+
+// Name returns the name of the policy.
+func (p *fcfs) Name() string {
+	return FCFSPolicyName
+}
+
+// SelectItem selects the next item from the queue by peeking its head. This implementation relies on the queue being
+// ordered by dispatch preference, as indicated by its `RequiredQueueCapabilities`.
+func (p *fcfs) SelectItem(queue framework.FlowQueueAccessor) (types.QueueItemAccessor, error) {
+	if queue == nil {
+		return nil, nil
+	}
+	item, err := queue.PeekHead()
+	if errors.Is(err, framework.ErrQueueEmpty) {
+		return nil, nil
+	}
+	return item, err
+}
+
+// Comparator returns a `framework.ItemComparator` based on enqueue time.
+func (p *fcfs) Comparator() framework.ItemComparator {
+	return p.comparator
+}
+
+// RequiredQueueCapabilities specifies that this policy needs a queue that supports FIFO operations.
+func (p *fcfs) RequiredQueueCapabilities() []framework.QueueCapability {
+	return []framework.QueueCapability{framework.CapabilityFIFO}
+}
+
+// --- enqueueTimeComparator ---
+
+// enqueueTimeComparator implements `framework.ItemComparator` for FCFS logic.
+// It prioritizes items with earlier enqueue times.
+type enqueueTimeComparator struct{}
+
+// Func returns the comparison logic.
+// It returns true if item 'a' should be dispatched before item 'b'.
+func (c *enqueueTimeComparator) Func() framework.ItemComparatorFunc {
+	return func(a, b types.QueueItemAccessor) bool {
+		if a == nil && b == nil {
+			return false
+		}
+		if a == nil { // Treat nil as lowest priority
+			return false
+		}
+		if b == nil { // Treat non-nil 'a' as higher priority than nil 'b'
+			return true
+		}
+		return a.EnqueueTime().Before(b.EnqueueTime())
+	}
+}
+
+// ScoreType returns a string descriptor for the comparison logic.
+func (c *enqueueTimeComparator) ScoreType() string {
+	return string(framework.EnqueueTimePriorityScoreType)
+}

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs/fcfs_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs/fcfs_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fcfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+)
+
+func TestFCFS_Name(t *testing.T) {
+	t.Parallel()
+	policy := newFCFS()
+	assert.Equal(t, FCFSPolicyName, policy.Name())
+}
+
+func TestFCFS_RequiredQueueCapabilities(t *testing.T) {
+	t.Parallel()
+	policy := newFCFS()
+	caps := policy.RequiredQueueCapabilities()
+	require.Len(t, caps, 1, "RequiredQueueCapabilities should return one capability")
+	assert.Equal(t, framework.CapabilityFIFO, caps[0], "Required capability should be FIFO")
+}
+
+func TestFCFS_SelectItem(t *testing.T) {
+	t.Parallel()
+	// Note: The conformance suite validates the policy's contract for nil and empty queues.
+	// This unit test focuses on the policy-specific success path.
+	policy := newFCFS()
+
+	mockItem := typesmocks.NewMockQueueItemAccessor(1, "item1", "flow1")
+	mockQueue := &frameworkmocks.MockFlowQueueAccessor{
+		PeekHeadV: mockItem,
+		LenV:      1,
+	}
+
+	item, err := policy.SelectItem(mockQueue)
+	require.NoError(t, err)
+	assert.Equal(t, mockItem, item, "Should return the item from the head of the queue")
+}
+
+func TestEnqueueTimeComparator_Func(t *testing.T) {
+	t.Parallel()
+	comparator := &enqueueTimeComparator{} // Test the internal comparator directly
+	compareFunc := comparator.Func()
+	require.NotNil(t, compareFunc)
+
+	now := time.Now()
+	itemA := typesmocks.NewMockQueueItemAccessor(10, "itemA", "test-flow")
+	itemA.EnqueueTimeV = now
+
+	itemB := typesmocks.NewMockQueueItemAccessor(20, "itemB", "test-flow")
+	itemB.EnqueueTimeV = now.Add(time.Second) // B is later than A
+
+	itemC := typesmocks.NewMockQueueItemAccessor(30, "itemC", "test-flow")
+	itemC.EnqueueTimeV = now // C is same time as A
+
+	testCases := []struct {
+		name     string
+		item1    types.QueueItemAccessor
+		item2    types.QueueItemAccessor
+		expected bool // true if item1 is higher priority (earlier) than item2
+	}{
+		{"A before B", itemA, itemB, true},
+		{"B after A", itemB, itemA, false},
+		{"A same as C (A not strictly before C)", itemA, itemC, false},
+		{"C same as A (C not strictly before A)", itemC, itemA, false},
+		{"A vs nil B (A is preferred)", itemA, nil, true},
+		{"nil A vs B (B is preferred)", nil, itemB, false},
+		{"nil A vs nil B (no preference)", nil, nil, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, compareFunc(tc.item1, tc.item2))
+		})
+	}
+}
+
+func TestEnqueueTimeComparator_ScoreType(t *testing.T) {
+	t.Parallel()
+	comparator := &enqueueTimeComparator{}
+	assert.Equal(t, string(framework.EnqueueTimePriorityScoreType), comparator.ScoreType())
+}

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/functional_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/functional_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatch_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch"
+
+	_ "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs"
+)
+
+// TestIntraFlowDispatchPolicyConformance is the main conformance test suite for `framework.IntraFlowDispatchPolicy`
+// implementations.
+// It iterates over all policy implementations registered via `dispatch.MustRegisterPolicy` and runs a series of
+// sub-tests to ensure they adhere to the `framework.IntraFlowDispatchPolicy` contract.
+func TestIntraFlowDispatchPolicyConformance(t *testing.T) {
+	t.Parallel()
+
+	for policyName, constructor := range dispatch.RegisteredPolicies {
+		t.Run(string(policyName), func(t *testing.T) {
+			t.Parallel()
+
+			policy, err := constructor()
+			require.NoError(t, err, "Policy constructor for %s failed", policyName)
+			require.NotNil(t, policy, "Constructor for %s should return a non-nil policy instance", policyName)
+
+			t.Run("Initialization", func(t *testing.T) {
+				t.Parallel()
+				assert.NotEmpty(t, policy.Name(), "Name() for %s should not be empty", policyName)
+
+				comp := policy.Comparator()
+				require.NotNil(t, comp, "Comparator() for %s should not return nil", policyName)
+				assert.NotNil(t, comp.Func(), "Comparator().Func() for %s should not be nil", policyName)
+				assert.NotEmpty(t, comp.ScoreType(), "Comparator().ScoreType() for %s should not be empty", policyName)
+
+				caps := policy.RequiredQueueCapabilities()
+				assert.NotNil(t, caps, "RequiredQueueCapabilities() for %s should not return a nil slice", policyName)
+			})
+
+			t.Run("SelectItemFromNilQueue", func(t *testing.T) {
+				t.Parallel()
+				item, err := policy.SelectItem(nil)
+				require.NoError(t, err, "SelectItem(nil) for %s should not return an error", policyName)
+				assert.Nil(t, item, "SelectItem(nil) for %s should return a nil item", policyName)
+			})
+
+			t.Run("SelectItemFromEmptyQueue", func(t *testing.T) {
+				t.Parallel()
+				mockQueue := &frameworkmocks.MockFlowQueueAccessor{
+					PeekHeadErrV: framework.ErrQueueEmpty,
+					LenV:         0,
+				}
+				item, err := policy.SelectItem(mockQueue)
+				require.NoError(t, err, "SelectItem from an empty queue for %s should not return an error", policyName)
+				assert.Nil(t, item, "SelectItem from an empty queue for %s should return a nil item", policyName)
+			})
+		})
+	}
+}

--- a/pkg/epp/flowcontrol/framework/plugins/queue/README.md
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/README.md
@@ -1,14 +1,14 @@
 # Flow Controller Queue Plugins (`plugins/queue/`)
 
-This directory contains concrete implementations of the `framework.SafeQueue` interface. This contract defines core,
-self-contained queue data structures used by the `controller.FlowController`.
+This directory contains concrete implementations of the [`framework.SafeQueue`](../../queue.go) interface. This contract
+defines core, self-contained queue data structures used by the `controller.FlowController`.
 
 ## Overview
 
-The `controller.FlowController` manages requests by organizing them into queues. Each logical "flow" (e.g., a specific
-model or workload) within a given priority band has its own `ports.ManagedQueue` instance, which wraps a
-`framework.SafeQueue`. This design allows the `controller.FlowController` to apply policies at both the inter-flow
-(across different flows) and intra-flow (within a single flow's queue) levels.
+The `controller.FlowController` manages requests by organizing them into queues. Each logical "flow" within a given
+priority band has its own `ports.ManagedQueue` instance, which wraps a `framework.SafeQueue`. This design allows the
+`controller.FlowController` to apply policies at both the inter-flow (across different flows) and intra-flow (within a
+single flow's queue) levels.
 
 The `framework.SafeQueue` interface abstracts the underlying data structure and its ordering logic. This pluggable
 design allows for:
@@ -30,16 +30,16 @@ To contribute a new queue implementation, follow these steps:
     - Implement the `framework.SafeQueue` and `types.QueueItemHandle` interfaces.
     - Ensure all methods of `framework.SafeQueue` are goroutine-safe, typically by using a `sync.Mutex` or
       `sync.RWMutex`.
-    - If your queue declares `framework.CapabilityPriorityConfigurable`, it MUST use the `framework.ItemComparator`
-      passed to its constructor for all internal ordering logic.
+    - If your queue declares `framework.CapabilityPriorityConfigurable`, it MUST use the
+      [`framework.ItemComparator`](../../policies.go) passed to its constructor for all internal ordering logic.
 
 2. **Register Your Queue**
-    - In an `init()` function within your queue's Go file, call `queue.MustRegisterQueue()` with a unique name and a
-      constructor function that matches the `queue.QueueConstructor` signature.
+    - In an `init()` function within your queue's Go file, call [`queue.MustRegisterQueue()`](./factory.go) with a
+      unique name and a constructor function that matches the `queue.QueueConstructor` signature.
 
-3.  **Add to the Conformance Test**
-    - Add a blank import for your new package to [`conformance_test.go`](./conformance_test.go). Your queue will then be
-      automatically included in the conformance suite, which validates the `SafeQueue` contract.
+3.  **Add to the Functional Test**
+    - Add a blank import for your new package to [`functional_test.go`](./functional_test.go). Your queue will then be
+      automatically included in the functional test suite, which validates the `framework.SafeQueue` contract.
 
 4.  **Documentation**
     - Add GoDoc comments to your new queue type, explaining its behavior, capabilities, and any trade-offs.
@@ -51,7 +51,7 @@ To contribute a new queue implementation, follow these steps:
 
 ## Benchmarking Strategy and Results
 
-A centralized benchmark suite runs against all registered `SafeQueue` implementations to provide a consistent
+A centralized benchmark suite runs against all registered `framework.SafeQueue` implementations to provide a consistent
 performance comparison. To run the benchmarks, use the following command:
 
 ```sh
@@ -95,8 +95,7 @@ The benchmark results highlight the trade-offs between the different queue imple
 data structures:
 
 - **`ListQueue`**: As a linked list, it excels in scenarios involving frequent additions or removals from either end of
-  the queue (`AddPeekRemove`, `AddPeekTailRemove`), which are O(1) operations. Its performance is less competitive in
-  high-contention and bulk scenarios, which reflects the necessary per-item memory allocation and pointer manipulation
+  the queue (`AddPeekRemove`, `AddPeekTailRemove`), which are O(1) operations. Its performance is less competitive in high-contention and bulk scenarios, which reflects the necessary per-item memory allocation and pointer manipulation
   overhead.
 - **`MaxMinHeap`**: As a slice-based heap, it has a lower allocation overhead per operation, making it efficient for
   high-throughput `AddRemove` cycles. Peeking and removing items involves maintaining the heap property, which has an

--- a/pkg/epp/flowcontrol/framework/plugins/queue/factory.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/factory.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package queue defines interfaces and implementations for various queue data structures used by the FlowController.
+// Package queue provides the factory and registration mechanism for all `framework.SafeQueue` implementations.
+// It allows new queues to be added to the system and instantiated by name.
 package queue
 
 import (
@@ -24,20 +25,20 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 )
 
+// RegisteredQueueName is the unique name under which a queue is registered.
 type RegisteredQueueName string
 
 // QueueConstructor defines the function signature for creating a `framework.SafeQueue`.
 type QueueConstructor func(comparator framework.ItemComparator) (framework.SafeQueue, error)
 
 var (
-	// mu guards the registration maps.
+	// mu guards the registration map.
 	mu sync.RWMutex
 	// RegisteredQueues stores the constructors for all registered queues.
 	RegisteredQueues = make(map[RegisteredQueueName]QueueConstructor)
 )
 
-// MustRegisterQueue registers a queue constructor, and panics if the name is
-// already registered.
+// MustRegisterQueue registers a queue constructor, and panics if the name is already registered.
 // This is intended to be called from init() functions.
 func MustRegisterQueue(name RegisteredQueueName, constructor QueueConstructor) {
 	mu.Lock()

--- a/pkg/epp/flowcontrol/framework/plugins/queue/functional_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/functional_test.go
@@ -179,7 +179,7 @@ func testLifecycleAndOrdering(
 	assert.Nil(t, peeked, "[%s] PeekHead on an empty queue should return a nil item again", comparatorName)
 }
 
-// TestQueueConformance is the entry point for the conformance test suite.
+// TestQueueConformance is the main conformance test suite for `framework.SafeQueue` implementations.
 // It iterates over all queue implementations registered via `queue.MustRegisterQueue` and runs a series of sub-tests to
 // ensure they adhere to the `framework.SafeQueue` contract.
 func TestQueueConformance(t *testing.T) {

--- a/pkg/epp/flowcontrol/framework/queue.go
+++ b/pkg/epp/flowcontrol/framework/queue.go
@@ -21,7 +21,12 @@ import (
 )
 
 // QueueCapability defines a functional capability that a `SafeQueue` implementation can provide.
-// These capabilities allow policies to declare their operational requirements.
+// These capabilities allow policies (like `IntraFlowDispatchPolicy`) to declare their operational requirements,
+// ensuring that a policy is always paired with a compatible queue.
+//
+// For example, a policy that requires a priority-ordered queue would declare `CapabilityPriorityConfigurable`, and the
+// `ports.FlowRegistry` would ensure it is paired with a queue implementation (like a heap) that provides this
+// capability.
 //
 // While a simpler boolean method (e.g., `IsPriorityConfigurable()`) could satisfy current needs, this slice-based
 // approach is intentionally chosen for future extensibility. It allows a queue to advertise multiple features (e.g.,


### PR DESCRIPTION
This PR is part of a stack.

1. **PR #1138:** Pluggable queues
2. **This PR:** Pluggable intra flow dispatch policies

**Incremental diff against #1138:** https://github.com/LukeAVanDrie/gateway-api-inference-extension/compare/feat/flow-control-framework-plugins-queue...feat/flow-control-frameowrk-plugins-intra-flow-dispatch

This work tracks #674 

This PR introduces the second major component of the new pluggable flow control system: the **Intra-Flow Dispatch Policy framework**.

While the previous PR introduced the `SafeQueue` framework for managing the *storage* of requests, this PR introduces the `IntraFlowDispatchPolicy` framework for managing the *logic* of request selection. It is responsible for **temporal scheduling**: determining the order in which requests are selected for dispatch *from within a single flow's queue*.

### Key Contributions

- **`IntraFlowDispatchPolicy` Interface**: Defines a clear contract for implementing tactical dispatch logic (e.g., FCFS, SLO-aware).
- **Queue Compatibility**: Policies now declare their required queue capabilities (e.g., `CapabilityFIFO`), and the framework will ensure they are paired with a compatible `SafeQueue` implementation.
- **Plugin Factory**: A registration mechanism (`dispatch.MustRegisterPolicy`) allows new policies to be easily added and instantiated by name.
- **Conformance Test Suite**: A new test suite ensures that all registered policy plugins adhere to the core API contract, simplifying validation for future contributions.
- **`FCFS` Reference Implementation**: Includes a simple, robust "First-Come, First-Served" policy as the first concrete implementation and a reference for future plugins.

### Architectural Impact

This change establishes the first tier of our two-tier policy design:

1.  **Intra-Flow Policy (This PR)**: Makes tactical decisions *within* a single flow's queue.
3.  **Inter-Flow Policy (Future Work)**: Will make strategic decisions about fairness *between* different flows.

By decoupling the dispatch logic from the data structure, we can now develop and experiment with sophisticated scheduling algorithms without modifying the core flow control engine.