### PR TITLE
chore: 🔨 Use the v0.3.0 llm-d-inference-sim image tag.

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -42,7 +42,7 @@ This document defines the process for releasing Gateway API Inference Extension.
    ```shell
    export VLLM_GPU=0.9.2
    export VLLM_CPU=0.9.3
-   export VLLM_SIM=0.1.2
+   export VLLM_SIM=0.3.0
    ```
 
 ## Release Process

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.2
+        image: ghcr.io/llm-d/llm-d-inference-sim:latest
         imagePullPolicy: Always
         args:
         - --model

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.3.0
         imagePullPolicy: Always
         args:
         - --model
@@ -23,8 +23,8 @@ spec:
         - "8000"
         - --max-loras
         - "2"
-        - --lora
-        - food-review-1
+        - --lora-modules
+        - '{"name": "food-review-1"}'
         env:
         - name: POD_NAME
           valueFrom:

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -35,7 +35,7 @@ VLLM_GPU="${VLLM_GPU:-0.9.1}"
 # The CPU image is from https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
 VLLM_CPU="${VLLM_CPU:-0.9.1}"
 # The sim image is from https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim
-VLLM_SIM="${VLLM_SIM:-0.1.1}"
+VLLM_SIM="${VLLM_SIM:-0.3.0}"
 
 echo "Using release tag: ${RELEASE_TAG}"
 echo "Using vLLM GPU image version: ${VLLM_GPU}"


### PR DESCRIPTION
As the title suggests, we use the v0.3.0(latest) sim image to take advantage of the latest features. 

For example, the size of the mirror image, etc. (121MB -> 37.2MB)