### PR TITLE
Fix makefile: test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test: manifests generate fmt vet envtest image-build ## Run tests.
 	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /conformance) -race -coverprofile cover.out
 
 .PHONY: test-unit
-test-unit: envtest ## Run unit tests.
+test-unit: ## Run unit tests.
 	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./pkg/... -race -coverprofile cover.out
 
 .PHONY: test-integration

--- a/Makefile
+++ b/Makefile
@@ -136,11 +136,11 @@ test: manifests generate fmt vet envtest image-build ## Run tests.
 	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /conformance) -race -coverprofile cover.out
 
 .PHONY: test-unit
-test-unit: ## Run unit tests.
+test-unit: envtest ## Run unit tests.
 	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./pkg/... -race -coverprofile cover.out
 
 .PHONY: test-integration
-test-integration: ## Run integration tests.
+test-integration: envtest ## Run integration tests.
 	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./test/integration/epp/... -race -coverprofile cover.out
 
 .PHONY: test-e2e


### PR DESCRIPTION
```
(base) ➜  gateway-api-inference-extension git:(main) make test-integration
bash: line 1: /Users/kiki/workspace/golang/src/sigs.k8s.io/gateway-api-inference-extension/bin/setup-envtest: No such file or directory
CGO_ENABLED=1 KUBEBUILDER_ASSETS="" go test ./test/integration/epp/... -race -coverprofile cover.out
# sigs.k8s.io/gateway-api-inference-extension/test/integration/epp.test
ld: warning: '/private/var/folders/n6/33y75ytn36g38k2wnkb6lp8r0000gn/T/go-link-1877484310/000013.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
2025-07-11T16:52:58+08:00	ERROR	logging/fatal.go:29	Failed to start test environment	{"config": "<nil>", "error": "unable to start control plane itself: failed to start the controlplane. retried 5 times: unable to run command \"kube-apiserver\" to check for flag \"insecure-port\": exec: \"kube-apiserver\": executable file not found in $PATH"}
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging.Fatal
	/Users/kiki/workspace/golang/src/sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging/fatal.go:29
sigs.k8s.io/gateway-api-inference-extension/test/integration/epp.BeforeSuite
	/Users/kiki/workspace/golang/src/sigs.k8s.io/gateway-api-inference-extension/test/integration/epp/hermetic_test.go:984
sigs.k8s.io/gateway-api-inference-extension/test/integration/epp.TestMain
	/Users/kiki/workspace/golang/src/sigs.k8s.io/gateway-api-inference-extension/test/integration/epp/hermetic_test.go:100
main.main
	_testmain.go:57
runtime.main
	/opt/homebrew/Cellar/go/1.24.4/libexec/src/runtime/proc.go:283
program not built with -cover
FAIL	sigs.k8s.io/gateway-api-inference-extension/test/integration/epp	4.853s
FAIL
make: *** [test-integration] Error 1
(base) ➜  gateway-api-inference-extension git:(main)
```