### PR TITLE
remove NewScheduler function

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -272,16 +272,16 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	err = r.parseConfiguration(ctx)
+	err = r.parsePluginsConfiguration(ctx)
 	if err != nil {
-		setupLog.Error(err, "Failed to parse the configuration")
+		setupLog.Error(err, "Failed to parse plugins configuration")
 		return err
 	}
 
 	// --- Initialize Core EPP Components ---
-	scheduler := r.initializeScheduler()
+	scheduler := scheduling.NewSchedulerWithConfig(r.schedulerConfig)
 
-	saturationDetector := saturationdetector.NewDetector(sdConfig, datastore, ctrl.Log)
+	saturationDetector := saturationdetector.NewDetector(sdConfig, datastore, setupLog)
 
 	director := requestcontrol.NewDirectorWithConfig(datastore, scheduler, saturationDetector, r.requestControlConfig)
 
@@ -326,16 +326,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runner) initializeScheduler() *scheduling.Scheduler {
-	if r.schedulerConfig != nil {
-		return scheduling.NewSchedulerWithConfig(r.schedulerConfig)
-	}
-
-	// otherwise, no one configured from outside scheduler config. use existing configuration
-	return scheduling.NewScheduler()
-}
-
-func (r *Runner) parseConfiguration(ctx context.Context) error {
+func (r *Runner) parsePluginsConfiguration(ctx context.Context) error {
 	if *configText == "" && *configFile == "" {
 		return nil // configuring through code, not through file
 	}

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -25,57 +25,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/config"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/filter"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/picker"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/profile"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
 type Datastore interface {
 	PodGetAll() []backendmetrics.PodMetrics
-}
-
-// NewScheduler returns a new scheduler with default scheduler plugins configuration.
-func NewScheduler() *Scheduler {
-	// When the scheduler is initialized with NewScheduler function, thw below config will be used as default.
-	// it's possible to call NewSchedulerWithConfig to pass a different scheduler config.
-	// For build time plugins changes, it's recommended to call in main.go to NewSchedulerWithConfig.
-	loraAffinityFilter := filter.NewLoraAffinityFilter(config.Conf.LoraAffinityThreshold)
-	leastQueueFilter := filter.NewLeastQueueFilter()
-	leastKvCacheFilter := filter.NewLeastKVCacheFilter()
-
-	lowLatencyFilter := &filter.DecisionTreeFilter{
-		Current: filter.NewLowQueueFilter(config.Conf.QueueingThresholdLoRA),
-		NextOnSuccess: &filter.DecisionTreeFilter{
-			Current: loraAffinityFilter,
-			NextOnSuccessOrFailure: &filter.DecisionTreeFilter{
-				Current: leastQueueFilter,
-				NextOnSuccessOrFailure: &filter.DecisionTreeFilter{
-					Current: leastKvCacheFilter,
-				},
-			},
-		},
-		NextOnFailure: &filter.DecisionTreeFilter{
-			Current: leastQueueFilter,
-			NextOnSuccessOrFailure: &filter.DecisionTreeFilter{
-				Current: loraAffinityFilter,
-				NextOnSuccessOrFailure: &filter.DecisionTreeFilter{
-					Current: leastKvCacheFilter,
-				},
-			},
-		},
-	}
-
-	defaultProfile := framework.NewSchedulerProfile().
-		WithFilters(lowLatencyFilter).
-		WithPicker(picker.NewRandomPicker(picker.DefaultMaxNumOfEndpoints))
-
-	profileHandler := profile.NewSingleProfileHandler()
-
-	return NewSchedulerWithConfig(NewSchedulerConfig(profileHandler, map[string]*framework.SchedulerProfile{"default": defaultProfile}))
 }
 
 // NewSchedulerWithConfig returns a new scheduler with the given scheduler plugins configuration.


### PR DESCRIPTION
This PR removes the NewScheduler function and all its usage in the code.
Instead, in order to create scheduler one should use NewSchedulerWithConfig.

This PR is built on top of  #1151 and #1152 and therefore should be merged only after them.
once that is done, I will rebase this one.

/hold to make sure other PRs are reviewed and merged first.

this PR completes the work required by #1130.

fix #1130 

cc @ahg-g @kfswain 