### PR TITLE
removed USE_STREAMING env var from conformance + tests

### DIFF
--- a/conformance/resources/manifests/manifests.yaml
+++ b/conformance/resources/manifests/manifests.yaml
@@ -213,9 +213,6 @@ spec:
         - "9003"
         - "-configFile"
         - "/config/conformance-plugins.yaml"
-        env:
-        - name: USE_STREAMING
-          value: "true"
         ports:
         - containerPort: 9002
         - containerPort: 9003
@@ -310,9 +307,6 @@ spec:
         - "9003"
         - "-configFile"
         - "/config/conformance-plugins.yaml"
-        env:
-        - name: USE_STREAMING
-          value: "true"
         ports:
         - containerPort: 9002
         - containerPort: 9003

--- a/test/testdata/inferencepool-e2e.yaml
+++ b/test/testdata/inferencepool-e2e.yaml
@@ -64,9 +64,6 @@ spec:
         - "9003"
         - "-configFile"
         - "/config/default-plugins.yaml"
-        env:
-        - name: USE_STREAMING
-          value: "true"
         ports:
         - containerPort: 9002
         - containerPort: 9003


### PR DESCRIPTION
this flag is no longer used (was removed from main)