### PR TITLE
feat(flowcontrol): Introduce ManagedQueue and Service Contracts

### DIFF
--- a/pkg/epp/flowcontrol/README.md
+++ b/pkg/epp/flowcontrol/README.md
@@ -59,7 +59,7 @@ graph LR
 
         subgraph Internal Interactions
             direction LR
-            D(Ports) -- "abstracts state" --> E(Flow Registry);
+            D(Contracts) -- "abstracts state" --> E(Flow Registry);
             D -- "abstracts load" --> SD(Saturation Detector);
             E -- "configures" --> F(Framework);
             F -- "defines" --> P(Plugins: Queues & Policies);
@@ -107,10 +107,10 @@ their justifications, please refer to the detailed documentation within the rele
     concurrent-safe request storage. It uses a `QueueCapability` system that allows for diverse and extensible queue
     implementations (e.g., FIFO, Priority Heap) while maintaining a stable interface.
 
-4.  **The `FlowRegistry` (`./registry`, `./ports`)**: This is the stateful control plane of the system. It manages the
-    configuration and lifecycle of all flows, policies, and queues. It presents a sharded view of its state to the
+4.  **The `FlowRegistry` (`./registry`, `./contracts`)**: This is the stateful control plane of the system. It manages
+    the configuration and lifecycle of all flows, policies, and queues. It presents a sharded view of its state to the
     `FlowController` workers to enable parallel operation with minimal lock contention.
 
-5.  **Core Types and Service Ports (`./types`, `./ports`)**: These packages define the foundational data structures
-    (e.g., `FlowControlRequest`), errors, and service interfaces that decouple the engine from its dependencies,
-    following a "Ports and Adapters" architectural style.
+5.  **Core Types and Service Contracts (`./types`, `./contracts`)**: These packages define the foundational data
+    structures (e.g., `FlowControlRequest`), errors, and service interfaces that decouple the engine from its
+    dependencies, following a "Ports and Adapters" architectural style.

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package contracts defines the service interfaces that decouple the core `controller.FlowController` engine from its
+// primary dependencies. In alignment with a "Ports and Adapters" (or "Hexagonal") architectural style, these
+// interfaces represent the "ports" through which the engine communicates.
+//
+// This package contains the primary service contracts for the Flow Registry and Saturation Detector.
+package contracts
+
+import (
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+)
+
+// ManagedQueue defines the interface for a flow's queue instance on a specific shard.
+// It wraps an underlying `framework.SafeQueue`, augmenting it with lifecycle validation against the `FlowRegistry` and
+// integrating atomic statistics updates.
+//
+// Conformance:
+//   - All methods (including those embedded from `framework.SafeQueue`) MUST be goroutine-safe.
+//   - Mutating methods (`Add()`, `Remove()`, `CleanupExpired()`, `Drain()`) MUST ensure the flow instance still exists
+//     and is valid within the `FlowRegistry` before proceeding. They MUST also atomically update relevant statistics
+//     (e.g., queue length, byte size) at both the queue and priority-band levels.
+type ManagedQueue interface {
+	framework.SafeQueue
+
+	// FlowQueueAccessor returns a read-only, flow-aware accessor for this queue.
+	// This accessor is primarily used by policy plugins to inspect the queue's state in a structured way.
+	//
+	// Conformance: This method MUST NOT return nil.
+	FlowQueueAccessor() framework.FlowQueueAccessor
+}

--- a/pkg/epp/flowcontrol/framework/errors.go
+++ b/pkg/epp/flowcontrol/framework/errors.go
@@ -23,7 +23,7 @@ import (
 // `SafeQueue` Errors
 //
 // These errors relate to operations directly on a `SafeQueue` implementation. They are returned by `SafeQueue` methods
-// and might be handled or wrapped by the `ports.FlowRegistry`'s `ports.ManagedQueue` or the
+// and might be handled or wrapped by the `contracts.FlowRegistry`'s `contracts.ManagedQueue` or the
 // `controller.FlowController`.
 var (
 	// ErrNilQueueItem indicates that a nil `types.QueueItemAccessor` was passed to `SafeQueue.Add()`.

--- a/pkg/epp/flowcontrol/framework/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/framework/mocks/mocks.go
@@ -102,3 +102,84 @@ func (m *MockPriorityBandAccessor) IterateQueues(callback func(queue framework.F
 }
 
 var _ framework.PriorityBandAccessor = &MockPriorityBandAccessor{}
+
+// MockSafeQueue is a mock implementation of the `framework.SafeQueue` interface.
+type MockSafeQueue struct {
+	NameV         string
+	CapabilitiesV []framework.QueueCapability
+	LenV          int
+	ByteSizeV     uint64
+	PeekHeadV     types.QueueItemAccessor
+	PeekHeadErrV  error
+	PeekTailV     types.QueueItemAccessor
+	PeekTailErrV  error
+	AddFunc       func(item types.QueueItemAccessor) error
+	RemoveFunc    func(handle types.QueueItemHandle) (types.QueueItemAccessor, error)
+	CleanupFunc   func(predicate framework.PredicateFunc) ([]types.QueueItemAccessor, error)
+	DrainFunc     func() ([]types.QueueItemAccessor, error)
+}
+
+func (m *MockSafeQueue) Name() string                              { return m.NameV }
+func (m *MockSafeQueue) Capabilities() []framework.QueueCapability { return m.CapabilitiesV }
+func (m *MockSafeQueue) Len() int                                  { return m.LenV }
+func (m *MockSafeQueue) ByteSize() uint64                          { return m.ByteSizeV }
+
+func (m *MockSafeQueue) PeekHead() (types.QueueItemAccessor, error) {
+	return m.PeekHeadV, m.PeekHeadErrV
+}
+
+func (m *MockSafeQueue) PeekTail() (types.QueueItemAccessor, error) {
+	return m.PeekTailV, m.PeekTailErrV
+}
+
+func (m *MockSafeQueue) Add(item types.QueueItemAccessor) error {
+	if m.AddFunc != nil {
+		return m.AddFunc(item)
+	}
+	return nil
+}
+
+func (m *MockSafeQueue) Remove(handle types.QueueItemHandle) (types.QueueItemAccessor, error) {
+	if m.RemoveFunc != nil {
+		return m.RemoveFunc(handle)
+	}
+	return nil, nil
+}
+
+func (m *MockSafeQueue) Cleanup(predicate framework.PredicateFunc) ([]types.QueueItemAccessor, error) {
+	if m.CleanupFunc != nil {
+		return m.CleanupFunc(predicate)
+	}
+	return nil, nil
+}
+
+func (m *MockSafeQueue) Drain() ([]types.QueueItemAccessor, error) {
+	if m.DrainFunc != nil {
+		return m.DrainFunc()
+	}
+	return nil, nil
+}
+
+var _ framework.SafeQueue = &MockSafeQueue{}
+
+// MockIntraFlowDispatchPolicy is a mock implementation of the `framework.IntraFlowDispatchPolicy` interface.
+type MockIntraFlowDispatchPolicy struct {
+	NameV                      string
+	SelectItemV                types.QueueItemAccessor
+	SelectItemErrV             error
+	ComparatorV                framework.ItemComparator
+	RequiredQueueCapabilitiesV []framework.QueueCapability
+}
+
+func (m *MockIntraFlowDispatchPolicy) Name() string                         { return m.NameV }
+func (m *MockIntraFlowDispatchPolicy) Comparator() framework.ItemComparator { return m.ComparatorV }
+
+func (m *MockIntraFlowDispatchPolicy) SelectItem(queue framework.FlowQueueAccessor) (types.QueueItemAccessor, error) {
+	return m.SelectItemV, m.SelectItemErrV
+}
+
+func (m *MockIntraFlowDispatchPolicy) RequiredQueueCapabilities() []framework.QueueCapability {
+	return m.RequiredQueueCapabilitiesV
+}
+
+var _ framework.IntraFlowDispatchPolicy = &MockIntraFlowDispatchPolicy{}

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/README.md
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/README.md
@@ -29,7 +29,7 @@ Key responsibilities and characteristics of a `framework.IntraFlowDispatchPolicy
 3.  **Queue Compatibility (`RequiredQueueCapabilities`)**: The policy specifies the capabilities its associated
     [`framework.SafeQueue`](../../../queue.go) must support for it to function correctly. For example, a simple FCFS
     policy would require `framework.CapabilityFIFO`, while a more complex, priority-based policy would require
-    `framework.CapabilityPriorityConfigurable`. The `ports.FlowRegistry` uses this information to pair policies with
+    `framework.CapabilityPriorityConfigurable`. The `contracts.FlowRegistry` uses this information to pair policies with
     compatible queues.
 
 The `framework.IntraFlowDispatchPolicy` allows for fine-grained control over how individual requests within a single flow are

--- a/pkg/epp/flowcontrol/framework/plugins/queue/factory.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/factory.go
@@ -51,7 +51,7 @@ func MustRegisterQueue(name RegisteredQueueName, constructor QueueConstructor) {
 
 // NewQueueFromName creates a new SafeQueue given its registered name and the `framework.ItemComparator` that will be
 // optionally used to configure the queue (provided it declares `framework.CapabilityPriorityConfigurable`).
-// This is called by the `registry.FlowRegistry` during initialization of a flow's `ports.ManagedQueue`.
+// This is called by the `registry.FlowRegistry` during initialization of a flow's `contracts.ManagedQueue`.
 func NewQueueFromName(name RegisteredQueueName, comparator framework.ItemComparator) (framework.SafeQueue, error) {
 	mu.RLock()
 	defer mu.RUnlock()

--- a/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap/maxminheap_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap/maxminheap_test.go
@@ -47,7 +47,7 @@ func TestMaxMinHeap_InternalProperty(t *testing.T) {
 		// Add items in a somewhat random order of enqueue times
 		items[i] = typesmocks.NewMockQueueItemAccessor(10, "item", "flow")
 		items[i].EnqueueTimeV = now.Add(time.Duration((i%5-2)*10) * time.Second)
-		_, _, err := q.Add(items[i])
+		err := q.Add(items[i])
 		require.NoError(t, err, "Add should not fail")
 		assertHeapProperty(t, q, "after adding item %d", i)
 	}
@@ -55,7 +55,7 @@ func TestMaxMinHeap_InternalProperty(t *testing.T) {
 	// Remove a few items from the middle and validate the heap property
 	for _, i := range []int{15, 7, 11} {
 		handle := items[i].Handle()
-		_, _, _, err := q.Remove(handle)
+		_, err := q.Remove(handle)
 		require.NoError(t, err, "Remove should not fail for item %d", i)
 		assertHeapProperty(t, q, "after removing item %d", i)
 	}
@@ -64,7 +64,7 @@ func TestMaxMinHeap_InternalProperty(t *testing.T) {
 	for q.Len() > 0 {
 		head, err := q.PeekHead()
 		require.NoError(t, err)
-		_, _, _, err = q.Remove(head.Handle())
+		_, err = q.Remove(head.Handle())
 		require.NoError(t, err)
 		assertHeapProperty(t, q, "after removing head item")
 	}

--- a/pkg/epp/flowcontrol/framework/policies.go
+++ b/pkg/epp/flowcontrol/framework/policies.go
@@ -91,7 +91,7 @@ type IntraFlowDispatchPolicy interface {
 	// For queues that inherently order items by dispatch preference, this method will typically just call
 	// `queue.PeekHead()`.
 	//
-	// The `controller.FlowController` uses the handle from the returned item to instruct the `ports.ManagedQueue` to
+	// The `controller.FlowController` uses the handle from the returned item to instruct the `contracts.ManagedQueue` to
 	// remove it.
 	//
 	// Returns:
@@ -144,7 +144,7 @@ type InterFlowDispatchPolicy interface {
 // FlowQueueAccessor provides a policy-facing, read-only view of a single flow's queue.
 // It combines general queue inspection methods (embedded via `QueueInspectionMethods`) with flow-specific metadata.
 //
-// Instances of `FlowQueueAccessor` are vended by a `ports.ManagedQueue` and are the primary means by which policies
+// Instances of `FlowQueueAccessor` are vended by a `contracts.ManagedQueue` and are the primary means by which policies
 // inspect individual queue state.
 //
 // Conformance: Implementations MUST ensure all methods (including those embedded from `QueueInspectionMethods`) are

--- a/pkg/epp/flowcontrol/framework/queue.go
+++ b/pkg/epp/flowcontrol/framework/queue.go
@@ -25,7 +25,7 @@ import (
 // ensuring that a policy is always paired with a compatible queue.
 //
 // For example, a policy that requires a priority-ordered queue would declare `CapabilityPriorityConfigurable`, and the
-// `ports.FlowRegistry` would ensure it is paired with a queue implementation (like a heap) that provides this
+// `contracts.FlowRegistry` would ensure it is paired with a queue implementation (like a heap) that provides this
 // capability.
 //
 // While a simpler boolean method (e.g., `IsPriorityConfigurable()`) could satisfy current needs, this slice-based
@@ -82,18 +82,16 @@ type SafeQueue interface {
 
 	// Add attempts to enqueue an item. On success, it must associate a new, unique `types.QueueItemHandle` with the item
 	// by calling `item.SetHandle()`.
-	//
-	// Returns the new length and byte size of the queue.
-	Add(item types.QueueItemAccessor) (newLen, newByteSize uint64, err error)
+	Add(item types.QueueItemAccessor) error
 
 	// Remove atomically finds and removes the item identified by the given handle.
 	//
 	// On success, implementations MUST invalidate the provided handle by calling `handle.Invalidate()`.
 	//
-	// Returns the removed item and the new length and byte size of the queue.
+	// Returns the removed item.
 	// Returns `ErrInvalidQueueItemHandle` if the handle is invalid (e.g., nil, wrong type, already invalidated).
 	// Returns `ErrQueueItemNotFound` if the handle is valid but the item is not in the queue.
-	Remove(handle types.QueueItemHandle) (removedItem types.QueueItemAccessor, newLen, newByteSize uint64, err error)
+	Remove(handle types.QueueItemHandle) (removedItem types.QueueItemAccessor, err error)
 
 	// Cleanup iterates through the queue and atomically removes all items for which the predicate returns true, returning
 	// them in a slice.

--- a/pkg/epp/flowcontrol/registry/managedqueue.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registry provides the concrete implementation of the Flow Registry, which is the stateful control plane for
+// the Flow Control system. It implements the service interfaces defined in the `contracts` package.
+//
+// This initial version includes the implementation of the `contracts.ManagedQueue`, a stateful wrapper that adds atomic
+// statistics tracking to a `framework.SafeQueue`.
+package registry
+
+import (
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+)
+
+type parentStatsReconciler func(lenDelta, byteSizeDelta int64)
+
+// managedQueue implements `contracts.ManagedQueue`. It wraps a `framework.SafeQueue` and is responsible for maintaining
+// accurate, atomically-updated statistics that are aggregated at the shard level.
+//
+// # Statistical Integrity
+//
+// For performance, `managedQueue` maintains its own `len` and `byteSize` fields using atomic operations. This provides
+// O(1) access for the parent `contracts.RegistryShard`'s aggregated statistics without needing to lock the underlying
+// queue.
+//
+// This design is predicated on two critical assumptions:
+//  1. Exclusive Access: All mutating operations on the underlying `framework.SafeQueue` MUST be performed exclusively
+//     through this `managedQueue` wrapper. Direct access to the underlying queue will cause statistical drift.
+//  2. In-Process Queue: The `framework.SafeQueue` implementation is an in-process data structure (e.g., a list or
+//     heap). Its state MUST NOT change through external mechanisms. For example, a queue implementation backed by a
+//     distributed cache like Redis with its own TTL-based eviction policy would violate this assumption and lead to
+//     state inconsistency, as items could be removed without notifying the `managedQueue`.
+//
+// This approach avoids the need for the `framework.SafeQueue` interface to return state deltas on each operation,
+// keeping its contract simpler.
+type managedQueue struct {
+	// Note: There is no mutex here. Concurrency control is delegated to the underlying `framework.SafeQueue` and the
+	// atomic operations on the stats fields.
+	queue               framework.SafeQueue
+	dispatchPolicy      framework.IntraFlowDispatchPolicy
+	flowSpec            types.FlowSpecification
+	byteSize            atomic.Uint64
+	len                 atomic.Uint64
+	reconcileShardStats parentStatsReconciler
+	logger              logr.Logger
+}
+
+// newManagedQueue creates a new instance of a `managedQueue`.
+func newManagedQueue(
+	queue framework.SafeQueue,
+	dispatchPolicy framework.IntraFlowDispatchPolicy,
+	flowSpec types.FlowSpecification,
+	logger logr.Logger,
+	reconcileShardStats func(lenDelta, byteSizeDelta int64),
+) *managedQueue {
+	mqLogger := logger.WithName("managed-queue").WithValues(
+		"flowID", flowSpec.ID,
+		"priority", flowSpec.Priority,
+		"queueType", queue.Name(),
+	)
+	return &managedQueue{
+		queue:               queue,
+		dispatchPolicy:      dispatchPolicy,
+		flowSpec:            flowSpec,
+		reconcileShardStats: reconcileShardStats,
+		logger:              mqLogger,
+	}
+}
+
+// FlowQueueAccessor returns a new `flowQueueAccessor` instance.
+func (mq *managedQueue) FlowQueueAccessor() framework.FlowQueueAccessor {
+	return &flowQueueAccessor{mq: mq}
+}
+
+func (mq *managedQueue) Add(item types.QueueItemAccessor) error {
+	if err := mq.queue.Add(item); err != nil {
+		return err
+	}
+	mq.reconcileStats(1, int64(item.OriginalRequest().ByteSize()))
+	return nil
+}
+
+func (mq *managedQueue) Remove(handle types.QueueItemHandle) (types.QueueItemAccessor, error) {
+	removedItem, err := mq.queue.Remove(handle)
+	if err != nil {
+		return nil, err
+	}
+	mq.reconcileStats(-1, -int64(removedItem.OriginalRequest().ByteSize()))
+	// TODO: If mq.len.Load() == 0, signal shard for optimistic instance cleanup.
+	return removedItem, nil
+}
+
+func (mq *managedQueue) Cleanup(predicate framework.PredicateFunc) (cleanedItems []types.QueueItemAccessor, err error) {
+	cleanedItems, err = mq.queue.Cleanup(predicate)
+	if err != nil || len(cleanedItems) == 0 {
+		return cleanedItems, err
+	}
+
+	var lenDelta int64
+	var byteSizeDelta int64
+	for _, item := range cleanedItems {
+		lenDelta--
+		byteSizeDelta -= int64(item.OriginalRequest().ByteSize())
+	}
+	mq.reconcileStats(lenDelta, byteSizeDelta)
+	// TODO: If mq.len.Load() == 0, signal shard for optimistic instance cleanup.
+	return cleanedItems, nil
+}
+
+func (mq *managedQueue) Drain() ([]types.QueueItemAccessor, error) {
+	drainedItems, err := mq.queue.Drain()
+	if err != nil || len(drainedItems) == 0 {
+		return drainedItems, err
+	}
+
+	var lenDelta int64
+	var byteSizeDelta int64
+	for _, item := range drainedItems {
+		lenDelta--
+		byteSizeDelta -= int64(item.OriginalRequest().ByteSize())
+	}
+	mq.reconcileStats(lenDelta, byteSizeDelta)
+	// TODO: If mq.len.Load() == 0, signal shard for optimistic instance cleanup.
+	return drainedItems, nil
+}
+
+// reconcileStats atomically updates the queue's own statistics and calls the parent shard's reconciler to ensure
+// aggregated stats remain consistent.
+func (mq *managedQueue) reconcileStats(lenDelta, byteSizeDelta int64) {
+	// The use of Add with a negative number on a Uint64 is the standard Go atomic way to perform subtraction, leveraging
+	// two's complement arithmetic.
+	mq.len.Add(uint64(lenDelta))
+	mq.byteSize.Add(uint64(byteSizeDelta))
+	mq.reconcileShardStats(lenDelta, byteSizeDelta)
+}
+
+// --- Pass-through and accessor methods ---
+
+func (mq *managedQueue) Name() string                               { return mq.queue.Name() }
+func (mq *managedQueue) Capabilities() []framework.QueueCapability  { return mq.queue.Capabilities() }
+func (mq *managedQueue) Len() int                                   { return int(mq.len.Load()) }
+func (mq *managedQueue) ByteSize() uint64                           { return mq.byteSize.Load() }
+func (mq *managedQueue) PeekHead() (types.QueueItemAccessor, error) { return mq.queue.PeekHead() }
+func (mq *managedQueue) PeekTail() (types.QueueItemAccessor, error) { return mq.queue.PeekTail() }
+func (mq *managedQueue) Comparator() framework.ItemComparator       { return mq.dispatchPolicy.Comparator() }
+
+var _ contracts.ManagedQueue = &managedQueue{}
+
+// --- flowQueueAccessor ---
+
+// flowQueueAccessor implements `framework.FlowQueueAccessor`. It provides a read-only, policy-facing view of a
+// `managedQueue`.
+type flowQueueAccessor struct {
+	mq *managedQueue
+}
+
+func (a *flowQueueAccessor) Name() string                               { return a.mq.Name() }
+func (a *flowQueueAccessor) Capabilities() []framework.QueueCapability  { return a.mq.Capabilities() }
+func (a *flowQueueAccessor) Len() int                                   { return a.mq.Len() }
+func (a *flowQueueAccessor) ByteSize() uint64                           { return a.mq.ByteSize() }
+func (a *flowQueueAccessor) PeekHead() (types.QueueItemAccessor, error) { return a.mq.PeekHead() }
+func (a *flowQueueAccessor) PeekTail() (types.QueueItemAccessor, error) { return a.mq.PeekTail() }
+func (a *flowQueueAccessor) Comparator() framework.ItemComparator       { return a.mq.Comparator() }
+func (a *flowQueueAccessor) FlowSpec() types.FlowSpecification          { return a.mq.flowSpec }
+
+var _ framework.FlowQueueAccessor = &flowQueueAccessor{}

--- a/pkg/epp/flowcontrol/registry/managedqueue_test.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue_test.go
@@ -1,0 +1,465 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue/listqueue"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+)
+
+// testStatsReconciler is a mock implementation of the `parentStatsReconciler` function.
+// It captures the deltas it's called with, allowing tests to assert on them.
+type testStatsReconciler struct {
+	mu              sync.Mutex
+	lenDelta        int64
+	byteSizeDelta   int64
+	invocationCount int
+}
+
+func (r *testStatsReconciler) reconcile(lenDelta, byteSizeDelta int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lenDelta += lenDelta
+	r.byteSizeDelta += byteSizeDelta
+	r.invocationCount++
+}
+
+func (r *testStatsReconciler) getStats() (lenDelta, byteSizeDelta int64, count int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lenDelta, r.byteSizeDelta, r.invocationCount
+}
+
+// testFixture holds the components needed for a `managedQueue` test.
+type testFixture struct {
+	mq             *managedQueue
+	mockQueue      *frameworkmocks.MockSafeQueue
+	mockPolicy     *frameworkmocks.MockIntraFlowDispatchPolicy
+	reconciler     *testStatsReconciler
+	flowSpec       types.FlowSpecification
+	mockComparator *frameworkmocks.MockItemComparator
+}
+
+// setupTestManagedQueue creates a new test fixture for testing the `managedQueue`.
+func setupTestManagedQueue(t *testing.T) *testFixture {
+	t.Helper()
+
+	mockQueue := &frameworkmocks.MockSafeQueue{}
+	reconciler := &testStatsReconciler{}
+	flowSpec := types.FlowSpecification{ID: "test-flow", Priority: 1}
+	mockComparator := &frameworkmocks.MockItemComparator{}
+	mockPolicy := &frameworkmocks.MockIntraFlowDispatchPolicy{
+		ComparatorV: mockComparator,
+	}
+
+	mq := newManagedQueue(
+		mockQueue,
+		mockPolicy,
+		flowSpec,
+		logr.Discard(),
+		reconciler.reconcile,
+	)
+	require.NotNil(t, mq, "newManagedQueue should not return nil")
+
+	return &testFixture{
+		mq:             mq,
+		mockQueue:      mockQueue,
+		mockPolicy:     mockPolicy,
+		reconciler:     reconciler,
+		flowSpec:       flowSpec,
+		mockComparator: mockComparator,
+	}
+}
+
+func TestManagedQueue_New(t *testing.T) {
+	t.Parallel()
+	f := setupTestManagedQueue(t)
+
+	assert.Zero(t, f.mq.Len(), "A new managedQueue should have a length of 0")
+	assert.Zero(t, f.mq.ByteSize(), "A new managedQueue should have a byte size of 0")
+}
+
+func TestManagedQueue_Add(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		itemByteSize          uint64
+		mockAddError          error
+		expectError           bool
+		expectedLen           int
+		expectedByteSize      uint64
+		expectedLenDelta      int64
+		expectedByteSizeDelta int64
+		expectedReconcile     bool
+	}{
+		{
+			name:                  "Success",
+			itemByteSize:          100,
+			mockAddError:          nil,
+			expectError:           false,
+			expectedLen:           1,
+			expectedByteSize:      100,
+			expectedLenDelta:      1,
+			expectedByteSizeDelta: 100,
+			expectedReconcile:     true,
+		},
+		{
+			name:                  "Error from underlying queue",
+			itemByteSize:          100,
+			mockAddError:          errors.New("queue full"),
+			expectError:           true,
+			expectedLen:           0,
+			expectedByteSize:      0,
+			expectedLenDelta:      0,
+			expectedByteSizeDelta: 0,
+			expectedReconcile:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := setupTestManagedQueue(t)
+
+			// Configure mock
+			f.mockQueue.AddFunc = func(item types.QueueItemAccessor) error {
+				return tc.mockAddError
+			}
+
+			item := typesmocks.NewMockQueueItemAccessor(tc.itemByteSize, "req-1", "test-flow")
+			err := f.mq.Add(item)
+
+			if tc.expectError {
+				require.Error(t, err, "Add should have returned an error")
+			} else {
+				require.NoError(t, err, "Add should not have returned an error")
+			}
+
+			// Assert final state
+			assert.Equal(t, tc.expectedLen, f.mq.Len(), "Final length should be as expected")
+			assert.Equal(t, tc.expectedByteSize, f.mq.ByteSize(), "Final byte size should be as expected")
+
+			// Assert reconciler state
+			lenDelta, byteSizeDelta, count := f.reconciler.getStats()
+			assert.Equal(t, tc.expectedLenDelta, lenDelta, "Reconciler length delta should be as expected")
+			assert.Equal(t, tc.expectedByteSizeDelta, byteSizeDelta, "Reconciler byte size delta should be as expected")
+			if tc.expectedReconcile {
+				assert.Equal(t, 1, count, "Reconciler should have been called once")
+			} else {
+				assert.Zero(t, count, "Reconciler should not have been called")
+			}
+		})
+	}
+}
+
+func TestManagedQueue_Remove(t *testing.T) {
+	t.Parallel()
+	f := setupTestManagedQueue(t)
+
+	// Setup initial state
+	initialItem := typesmocks.NewMockQueueItemAccessor(100, "req-1", "test-flow")
+	f.mockQueue.AddFunc = func(item types.QueueItemAccessor) error { return nil }
+	err := f.mq.Add(initialItem)
+	require.NoError(t, err, "Setup: Adding an item should not fail")
+	require.Equal(t, 1, f.mq.Len(), "Setup: Length should be 1 after adding an item")
+
+	// --- Test Success ---
+	t.Run("Success", func(t *testing.T) {
+		// Configure mock for Remove
+		f.mockQueue.RemoveFunc = func(handle types.QueueItemHandle) (types.QueueItemAccessor, error) {
+			return initialItem, nil
+		}
+
+		// Perform Remove
+		removedItem, err := f.mq.Remove(initialItem.Handle())
+		require.NoError(t, err, "Remove should not return an error")
+		assert.Equal(t, initialItem, removedItem, "Remove should return the correct item")
+
+		// Assert final state
+		assert.Zero(t, f.mq.Len(), "Length should be 0 after removing the only item")
+		assert.Zero(t, f.mq.ByteSize(), "ByteSize should be 0 after removing the only item")
+
+		// Assert reconciler state
+		lenDelta, byteSizeDelta, count := f.reconciler.getStats()
+		assert.Equal(t, int64(0), lenDelta, "Net length delta should be 0 after add and remove")
+		assert.Equal(t, int64(0), byteSizeDelta, "Net byte size delta should be 0 after add and remove")
+		assert.Equal(t, 2, count, "Reconciler should have been called for both Add and Remove")
+	})
+
+	// --- Test Error ---
+	t.Run("Error", func(t *testing.T) {
+		f := setupTestManagedQueue(t)
+		require.NoError(t, f.mq.Add(initialItem), "Setup: Adding an item should not fail")
+
+		// Configure mock to return an error
+		expectedErr := errors.New("item not found")
+		f.mockQueue.RemoveFunc = func(handle types.QueueItemHandle) (types.QueueItemAccessor, error) {
+			return nil, expectedErr
+		}
+
+		_, err := f.mq.Remove(initialItem.Handle())
+		require.ErrorIs(t, err, expectedErr, "Remove should propagate the error")
+
+		// Assert state did not change
+		assert.Equal(t, 1, f.mq.Len(), "Length should not change on a failed remove")
+		assert.Equal(t, uint64(100), f.mq.ByteSize(), "ByteSize should not change on a failed remove")
+
+		// Assert reconciler was not called for the remove
+		_, _, count := f.reconciler.getStats()
+		assert.Equal(t, 1, count, "Reconciler should only have been called for the initial Add")
+	})
+}
+
+func TestManagedQueue_CleanupAndDrain(t *testing.T) {
+	t.Parallel()
+	item1 := typesmocks.NewMockQueueItemAccessor(10, "req-1", "test-flow")
+	item2 := typesmocks.NewMockQueueItemAccessor(20, "req-2", "test-flow")
+	item3 := typesmocks.NewMockQueueItemAccessor(30, "req-3", "test-flow")
+
+	// --- Test Cleanup ---
+	t.Run("Cleanup", func(t *testing.T) {
+		t.Parallel()
+		f := setupTestManagedQueue(t)
+		// Add initial items
+		require.NoError(t, f.mq.Add(item1), "Setup: Add item1 should not fail")
+		require.NoError(t, f.mq.Add(item2), "Setup: Add item2 should not fail")
+		require.NoError(t, f.mq.Add(item3), "Setup: Add item3 should not fail")
+		require.Equal(t, 3, f.mq.Len(), "Setup: Initial length should be 3")
+		require.Equal(t, uint64(60), f.mq.ByteSize(), "Setup: Initial byte size should be 60")
+
+		// Configure mock to clean up item2
+		f.mockQueue.CleanupFunc = func(p framework.PredicateFunc) ([]types.QueueItemAccessor, error) {
+			return []types.QueueItemAccessor{item2}, nil
+		}
+
+		cleaned, err := f.mq.Cleanup(func(i types.QueueItemAccessor) bool { return true })
+		require.NoError(t, err, "Cleanup should not return an error")
+		require.Len(t, cleaned, 1, "Cleanup should return one item")
+
+		// Assert final state
+		assert.Equal(t, 2, f.mq.Len(), "Length should be 2 after cleanup")
+		assert.Equal(t, uint64(40), f.mq.ByteSize(), "ByteSize should be 40 after cleanup")
+
+		// Assert reconciler state (3 adds, 1 cleanup)
+		lenDelta, byteSizeDelta, count := f.reconciler.getStats()
+		assert.Equal(t, int64(2), lenDelta, "Net length delta should be 2")
+		assert.Equal(t, int64(40), byteSizeDelta, "Net byte size delta should be 40")
+		assert.Equal(t, 4, count, "Reconciler should have been called 4 times")
+	})
+
+	// --- Test Drain ---
+	t.Run("Drain", func(t *testing.T) {
+		t.Parallel()
+		f := setupTestManagedQueue(t)
+		// Add initial items
+		require.NoError(t, f.mq.Add(item1), "Setup: Add item1 should not fail")
+		require.NoError(t, f.mq.Add(item2), "Setup: Add item2 should not fail")
+		require.Equal(t, 2, f.mq.Len(), "Setup: Initial length should be 2")
+		require.Equal(t, uint64(30), f.mq.ByteSize(), "Setup: Initial byte size should be 30")
+
+		// Configure mock to drain both items
+		f.mockQueue.DrainFunc = func() ([]types.QueueItemAccessor, error) {
+			return []types.QueueItemAccessor{item1, item2}, nil
+		}
+
+		drained, err := f.mq.Drain()
+		require.NoError(t, err, "Drain should not return an error")
+		require.Len(t, drained, 2, "Drain should return two items")
+
+		// Assert final state
+		assert.Zero(t, f.mq.Len(), "Length should be 0 after drain")
+		assert.Zero(t, f.mq.ByteSize(), "ByteSize should be 0 after drain")
+
+		// Assert reconciler state (2 adds, 1 drain)
+		lenDelta, byteSizeDelta, count := f.reconciler.getStats()
+		assert.Equal(t, int64(0), lenDelta, "Net length delta should be 0")
+		assert.Equal(t, int64(0), byteSizeDelta, "Net byte size delta should be 0")
+		assert.Equal(t, 3, count, "Reconciler should have been called 3 times")
+	})
+
+	// --- Test Error Paths ---
+	t.Run("ErrorPaths", func(t *testing.T) {
+		f := setupTestManagedQueue(t)
+		require.NoError(t, f.mq.Add(item1))
+		initialLen, initialByteSize := f.mq.Len(), f.mq.ByteSize()
+
+		expectedErr := errors.New("internal error")
+
+		// Cleanup error
+		f.mockQueue.CleanupFunc = func(p framework.PredicateFunc) ([]types.QueueItemAccessor, error) {
+			return nil, expectedErr
+		}
+		_, err := f.mq.Cleanup(func(i types.QueueItemAccessor) bool { return true })
+		require.ErrorIs(t, err, expectedErr, "Cleanup should propagate error")
+		assert.Equal(t, initialLen, f.mq.Len(), "Len should not change on Cleanup error")
+		assert.Equal(t, initialByteSize, f.mq.ByteSize(), "ByteSize should not change on Cleanup error")
+
+		// Drain error
+		f.mockQueue.DrainFunc = func() ([]types.QueueItemAccessor, error) {
+			return nil, expectedErr
+		}
+		_, err = f.mq.Drain()
+		require.ErrorIs(t, err, expectedErr, "Drain should propagate error")
+		assert.Equal(t, initialLen, f.mq.Len(), "Len should not change on Drain error")
+		assert.Equal(t, initialByteSize, f.mq.ByteSize(), "ByteSize should not change on Drain error")
+	})
+}
+
+func TestManagedQueue_FlowQueueAccessor(t *testing.T) {
+	t.Parallel()
+	f := setupTestManagedQueue(t)
+	item := typesmocks.NewMockQueueItemAccessor(100, "req-1", "test-flow")
+
+	// Setup underlying queue state
+	f.mockQueue.PeekHeadV = item
+	f.mockQueue.PeekTailV = item
+	f.mockQueue.NameV = "MockQueue"
+	f.mockQueue.CapabilitiesV = []framework.QueueCapability{framework.CapabilityFIFO}
+
+	// Add an item to populate the managed queue's stats
+	require.NoError(t, f.mq.Add(item), "Setup: Adding an item should not fail")
+
+	// Get the accessor
+	accessor := f.mq.FlowQueueAccessor()
+	require.NotNil(t, accessor, "FlowQueueAccessor should not be nil")
+
+	// Assert that the accessor methods reflect the underlying state
+	assert.Equal(t, f.mq.Name(), accessor.Name(), "Accessor Name() should match managed queue")
+	assert.Equal(t, f.mq.Capabilities(), accessor.Capabilities(), "Accessor Capabilities() should match managed queue")
+	assert.Equal(t, f.mq.Len(), accessor.Len(), "Accessor Len() should match managed queue")
+	assert.Equal(t, f.mq.ByteSize(), accessor.ByteSize(), "Accessor ByteSize() should match managed queue")
+	assert.Equal(t, f.flowSpec, accessor.FlowSpec(), "Accessor FlowSpec() should match managed queue")
+	assert.Equal(t, f.mockComparator, accessor.Comparator(), "Accessor Comparator() should match the one from the policy")
+	assert.Equal(t, f.mockComparator, f.mq.Comparator(), "ManagedQueue Comparator() should match the one from the policy")
+
+	peekedHead, err := accessor.PeekHead()
+	require.NoError(t, err, "Accessor PeekHead() should not return an error")
+	assert.Equal(t, item, peekedHead, "Accessor PeekHead() should return the correct item")
+
+	peekedTail, err := accessor.PeekTail()
+	require.NoError(t, err, "Accessor PeekTail() should not return an error")
+	assert.Equal(t, item, peekedTail, "Accessor PeekTail() should return the correct item")
+}
+
+func TestManagedQueue_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	// Use a real `listqueue` since it's concurrent-safe.
+	lq, err := queue.NewQueueFromName(listqueue.ListQueueName, nil)
+	require.NoError(t, err, "Setup: creating a real listqueue should not fail")
+
+	reconciler := &testStatsReconciler{}
+	flowSpec := types.FlowSpecification{ID: "conc-test-flow", Priority: 1}
+	mq := newManagedQueue(lq, nil, flowSpec, logr.Discard(), reconciler.reconcile)
+
+	const (
+		numGoroutines   = 20
+		opsPerGoroutine = 200
+		itemByteSize    = 10
+		initialItems    = 500
+	)
+
+	var wg sync.WaitGroup
+	var successfulAdds, successfulRemoves atomic.Int64
+
+	// Use a channel as a concurrent-safe pool of handles for removal.
+	handles := make(chan types.QueueItemHandle, initialItems+(numGoroutines*opsPerGoroutine))
+
+	// Pre-fill the queue to give removers something to do immediately.
+	for range initialItems {
+		item := typesmocks.NewMockQueueItemAccessor(uint64(itemByteSize), "initial", "flow")
+		require.NoError(t, mq.Add(item), "Setup: pre-filling queue should not fail")
+		handles <- item.Handle()
+	}
+	// Reset reconciler stats after setup so we only measure the concurrent phase.
+	*reconciler = testStatsReconciler{}
+
+	// Launch goroutines to perform a mix of concurrent operations.
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func(routineID int) {
+			defer wg.Done()
+			for j := range opsPerGoroutine {
+				// Mix up operations between adding and removing.
+				if (routineID+j)%2 == 0 {
+					// Add operation
+					item := typesmocks.NewMockQueueItemAccessor(uint64(itemByteSize), "req", "flow")
+					if err := mq.Add(item); err == nil {
+						successfulAdds.Add(1)
+						handles <- item.Handle()
+					}
+				} else {
+					// Remove operation
+					select {
+					case handle := <-handles:
+						if _, err := mq.Remove(handle); err == nil {
+							successfulRemoves.Add(1)
+						}
+					default:
+						// No handles available, do nothing. This can happen if removers are faster than adders.
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// All concurrent operations are complete. Drain any remaining items to get the final count.
+	drainedItems, err := mq.Drain()
+	require.NoError(t, err, "Draining the queue at the end should not fail")
+
+	// Final consistency checks.
+	finalItemCount := len(drainedItems)
+	finalByteSize := mq.ByteSize()
+
+	// The number of items left in the queue should match our tracking.
+	expectedFinalItemCount := initialItems + int(successfulAdds.Load()) - int(successfulRemoves.Load())
+	assert.Equal(t, expectedFinalItemCount, finalItemCount, "Final item count should match initial + adds - removes")
+
+	// The queue's internal stats must be zero after draining.
+	assert.Zero(t, mq.Len(), "Managed queue length must be zero after drain")
+	assert.Zero(t, finalByteSize, "Managed queue byte size must be zero after drain")
+
+	// The net change reported to the reconciler must match the net change from the concurrent phase,
+	// plus the final drain.
+	netLenChangeDuringConcurrentPhase := successfulAdds.Load() - successfulRemoves.Load()
+	netByteSizeChangeDuringConcurrentPhase := netLenChangeDuringConcurrentPhase * itemByteSize
+
+	lenDelta, byteSizeDelta, _ := reconciler.getStats()
+
+	expectedLenDelta := netLenChangeDuringConcurrentPhase - int64(finalItemCount)
+	expectedByteSizeDelta := netByteSizeChangeDuringConcurrentPhase - int64(uint64(finalItemCount)*itemByteSize)
+
+	assert.Equal(t, expectedLenDelta, lenDelta,
+		"Net length delta in reconciler should match the net change from all operations")
+	assert.Equal(t, expectedByteSizeDelta, byteSizeDelta,
+		"Net byte size delta in reconciler should match the net change from all operations")
+}

--- a/pkg/epp/flowcontrol/types/flow.go
+++ b/pkg/epp/flowcontrol/types/flow.go
@@ -18,13 +18,14 @@ package types
 
 // FlowSpecification defines the configuration of a logical flow, encapsulating its identity and registered priority.
 //
-// It acts as the registration key for a flow within the `ports.FlowRegistry`.
+// It acts as the registration key for a flow within the `contracts.FlowRegistry`.
 type FlowSpecification struct {
 	// ID returns the unique name or identifier for this logical flow, corresponding to the value from
 	// `FlowControlRequest.FlowID()`.
 	ID string
 
-	// Priority returns the numerical priority level currently associated with this flow within the `ports.FlowRegistry`.
+	// Priority returns the numerical priority level currently associated with this flow within the
+	// `contracts.FlowRegistry`.
 	//
 	// Convention: Lower numerical values indicate higher priority.
 	Priority uint

--- a/pkg/epp/flowcontrol/types/request.go
+++ b/pkg/epp/flowcontrol/types/request.go
@@ -35,11 +35,11 @@ type FlowControlRequest interface {
 
 	// FlowID returns the unique identifier for the flow this request belongs to (e.g., model name, tenant ID). The
 	// `controller.FlowController` uses this ID, in conjunction with the flow's registered priority, to look up the
-	// active `ports.ManagedQueue` from the `ports.FlowRegistry`'s `ports.RegistryShard`.
+	// active `contracts.ManagedQueue` from the `contracts.FlowRegistry`'s `contracts.RegistryShard`.
 	FlowID() string
 
 	// ByteSize returns the request's size in bytes (e.g., prompt size). This is used by the `controller.FlowController`
-	// and for managing byte-based capacity limits and for `ports.FlowRegistry` statistics.
+	// and for managing byte-based capacity limits and for `contracts.FlowRegistry` statistics.
 	ByteSize() uint64
 
 	// InitialEffectiveTTL returns the suggested Time-To-Live for this request.


### PR DESCRIPTION
This work tracks #674 

This PR introduces the foundational layer for the Flow Registry, which will act as the stateful control plane for managing queues and policies. It establishes the core service `contracts` for the system and provides the `ManagedQueue`, a stateful decorator that wraps queue plugins.

This work is a prerequisite for the full `FlowRegistry` implementation.

### Key Changes:

1.  **`ports` -> `contracts` Rename**: The `ports` package has been renamed to `contracts` to more accurately reflect its purpose in defining the service interfaces for our "Ports and Adapters" architecture. This avoids potential confusion with network-related "ports" in the Kubernetes ecosystem.

2.  **`ManagedQueue` Decorator**: A new `registry.managedQueue` component is introduced. It follows the decorator pattern, wrapping a `framework.SafeQueue` to add critical registry-level functionality without complicating the underlying queue interface:
    - **Atomic Statistics**: It maintains its own atomic `len` and `byteSize` counters for high-performance, lock-free reads (useful for efficient metric reporting and capacity checking logic).
    - **State Reconciliation**: It uses a callback to propagate statistical deltas to its parent (the future `RegistryShard`), ensuring aggregated stats remain consistent.

3.  **`SafeQueue` Interface Simplification**: To support the `ManagedQueue` decorator, the `framework.SafeQueue` interface has been simplified. The `Add` and `Remove` methods no longer return the new queue state. This responsibility is now correctly handled by the `ManagedQueue`, making the `SafeQueue` contract cleaner and more focused on its core queuing logic.