### PR TITLE
feat(prefix-cache): use post response instead of postCycle

### DIFF
--- a/pkg/epp/common/config/loader/configloader_test.go
+++ b/pkg/epp/common/config/loader/configloader_test.go
@@ -550,7 +550,6 @@ func (f *test1) Filter(_ context.Context, _ *types.CycleState, _ *types.LLMReque
 
 // compile-time type validation
 var _ framework.Scorer = &test2{}
-var _ framework.PostCycle = &test2{}
 
 type test2 struct {
 	typedName plugins.TypedName
@@ -569,8 +568,6 @@ func (m *test2) TypedName() plugins.TypedName {
 func (m *test2) Score(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, _ []types.Pod) map[types.Pod]float64 {
 	return map[types.Pod]float64{}
 }
-
-func (m *test2) PostCycle(_ context.Context, _ *types.CycleState, _ *types.ProfileRunResult) {}
 
 // compile-time type validation
 var _ framework.Picker = &testPicker{}

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -28,7 +28,6 @@ const (
 	FilterPluginType           = "Filter"
 	ScorerPluginType           = "Scorer"
 	PickerPluginType           = "Picker"
-	PostCyclePluginType        = "PostCycle"
 	ProcessProfilesResultsType = "ProcessProfilesResults"
 )
 
@@ -66,11 +65,4 @@ type Scorer interface {
 type Picker interface {
 	plugins.Plugin
 	Pick(ctx context.Context, cycleState *types.CycleState, scoredPods []*types.ScoredPod) *types.ProfileRunResult
-}
-
-// PostCycle is called by the scheduler after it selects a targetPod for the request in the SchedulerProfile cycle.
-// DEPRECATED - do not use PostCycle. this is in the process of deprecation.
-type PostCycle interface {
-	plugins.Plugin
-	PostCycle(ctx context.Context, cycleState *types.CycleState, res *types.ProfileRunResult)
 }

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
 
@@ -60,8 +61,12 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	// Simulate pod1 was picked.
-	plugin.PostCycle(context.Background(), cycleState1, &types.ProfileRunResult{TargetPods: []types.Pod{pod1}})
+	// Simulate pod1 was picked - use PostResponse instead
+	response1 := &requestcontrol.Response{
+		RequestId: "req1",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+	plugin.PostResponse(context.Background(), req1, response1, pod1.Pod)
 
 	// Second request doesn't share any prefix with first one. It should be added to the cache but
 	// the pod score should be 0.
@@ -81,8 +86,12 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	// Simulate pod2 was picked.
-	plugin.PostCycle(context.Background(), cycleState2, &types.ProfileRunResult{TargetPods: []types.Pod{pod2}})
+	// Simulate pod2 was picked - use PostResponse instead
+	response2 := &requestcontrol.Response{
+		RequestId: "req2",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+	plugin.PostResponse(context.Background(), req2, response2, pod2.Pod)
 
 	// Third request shares partial prefix with first one.
 	req3 := &types.LLMRequest{
@@ -101,7 +110,12 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(2)/float64(3), scores[pod1], "score should be 2/3 - the model and the first prefix block match")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	plugin.PostCycle(context.Background(), cycleState3, &types.ProfileRunResult{TargetPods: []types.Pod{pod1}})
+	// Simulate pod1 was picked - use PostResponse instead
+	response3 := &requestcontrol.Response{
+		RequestId: "req3",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+	plugin.PostResponse(context.Background(), req3, response3, pod1.Pod)
 
 	// 4th request is same as req3 except the model is different, still no match.
 	req4 := &types.LLMRequest{
@@ -120,7 +134,12 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, float64(0), scores[pod1], "score for pod1")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	plugin.PostCycle(context.Background(), cycleState4, &types.ProfileRunResult{TargetPods: []types.Pod{pod1}})
+	// Simulate pod1 was picked - use PostResponse instead
+	response4 := &requestcontrol.Response{
+		RequestId: "req4",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+	plugin.PostResponse(context.Background(), req4, response4, pod1.Pod)
 
 	// 5th request shares partial prefix with 3rd one.
 	req5 := &types.LLMRequest{
@@ -139,7 +158,76 @@ func TestPrefixPlugin(t *testing.T) {
 	assert.Equal(t, 0.75, scores[pod1], "score should be 0.75 - the model and the first 2 prefix blocks match")
 	assert.Equal(t, float64(0), scores[pod2], "score for pod2")
 
-	plugin.PostCycle(context.Background(), cycleState5, &types.ProfileRunResult{TargetPods: []types.Pod{pod1}})
+	// Simulate pod1 was picked - use PostResponse instead
+	response5 := &requestcontrol.Response{
+		RequestId: "req5",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+	plugin.PostResponse(context.Background(), req5, response5, pod1.Pod)
+}
+
+// TestPrefixPluginPostResponse tests the PostResponse method functionality
+func TestPrefixPluginPostResponse(t *testing.T) {
+	config := Config{
+		HashBlockSize:          4,
+		MaxPrefixBlocksToMatch: DefaultMaxPrefixBlocks,
+		LRUCapacityPerServer:   DefaultLRUCapacityPerServer,
+	}
+	plugin := New(config)
+
+	pod1 := &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}
+	pod2 := &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}
+
+	// First request - use PostResponse to cache prefix
+	req1 := &types.LLMRequest{
+		TargetModel: "test-model1",
+		Prompt:      "aaaaaa",
+	}
+	response1 := &requestcontrol.Response{
+		RequestId: "req1",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+
+	// Call PostResponse to cache the prefix for pod1
+	plugin.PostResponse(context.Background(), req1, response1, pod1)
+
+	// Second request with same prefix - should get cache hit on pod1
+	req2 := &types.LLMRequest{
+		TargetModel: "test-model1",
+		Prompt:      "aaaabbbb",
+	}
+
+	// Test scoring to verify cache hit
+	pods := []types.Pod{
+		&types.PodMetrics{Pod: pod1},
+		&types.PodMetrics{Pod: pod2},
+	}
+	cycleState := types.NewCycleState()
+	scores := plugin.Score(context.Background(), cycleState, req2, pods)
+
+	// pod1 should have a higher score due to prefix cache hit
+	assert.Greater(t, scores[pods[0]], scores[pods[1]], "pod1 should have higher score due to prefix cache")
+	assert.Greater(t, scores[pods[0]], float64(0), "pod1 should have non-zero score")
+	assert.Equal(t, float64(0), scores[pods[1]], "pod2 should have zero score")
+
+	// Use PostResponse for the second request on pod1
+	response2 := &requestcontrol.Response{
+		RequestId: "req2",
+		Headers:   map[string]string{"content-type": "application/json"},
+	}
+	plugin.PostResponse(context.Background(), req2, response2, pod1)
+
+	// Third request with different model - should not get cache hit
+	req3 := &types.LLMRequest{
+		TargetModel: "test-model2", // Different model
+		Prompt:      "aaaaaa",
+	}
+	cycleState3 := types.NewCycleState()
+	scores3 := plugin.Score(context.Background(), cycleState3, req3, pods)
+
+	// Both pods should have zero score since model is different
+	assert.Equal(t, float64(0), scores3[pods[0]], "pod1 should have zero score for different model")
+	assert.Equal(t, float64(0), scores3[pods[1]], "pod2 should have zero score for different model")
 }
 
 // TestPrefixPluginStress is a stress test for the prefix scoring plugin, using prompts of increasing length.
@@ -180,7 +268,12 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 		// First cycle: simulate scheduling and insert prefix info into the cache
 		cycleState := types.NewCycleState()
 		plugin.Score(context.Background(), cycleState, req, pods)
-		plugin.PostCycle(context.Background(), cycleState, &types.ProfileRunResult{TargetPods: []types.Pod{pod}})
+		// Use PostResponse instead of PostCycle
+		response := &requestcontrol.Response{
+			RequestId: fmt.Sprintf("req-%d", i),
+			Headers:   map[string]string{"content-type": "application/json"},
+		}
+		plugin.PostResponse(context.Background(), req, response, pod.Pod)
 
 		// Second cycle: validate internal state
 		state, err := types.ReadCycleStateKey[*SchedulingContextState](cycleState, PrefixCachePluginType)

--- a/pkg/epp/scheduling/framework/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile_test.go
@@ -64,8 +64,7 @@ func TestSchedulePlugins(t *testing.T) {
 			profile: NewSchedulerProfile().
 				WithFilters(tp1, tp2).
 				WithScorers(NewWeightedScorer(tp1, 1), NewWeightedScorer(tp2, 1)).
-				WithPicker(pickerPlugin).
-				WithPostCyclePlugins(tp1, tp2),
+				WithPicker(pickerPlugin),
 			input: []types.Pod{
 				&types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
 				&types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}},
@@ -81,8 +80,7 @@ func TestSchedulePlugins(t *testing.T) {
 			profile: NewSchedulerProfile().
 				WithFilters(tp1, tp2).
 				WithScorers(NewWeightedScorer(tp1, 60), NewWeightedScorer(tp2, 40)).
-				WithPicker(pickerPlugin).
-				WithPostCyclePlugins(tp1, tp2),
+				WithPicker(pickerPlugin),
 			input: []types.Pod{
 				&types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
 				&types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}},
@@ -98,8 +96,7 @@ func TestSchedulePlugins(t *testing.T) {
 			profile: NewSchedulerProfile().
 				WithFilters(tp1, tp_filterAll).
 				WithScorers(NewWeightedScorer(tp1, 1), NewWeightedScorer(tp2, 1)).
-				WithPicker(pickerPlugin).
-				WithPostCyclePlugins(tp1, tp2),
+				WithPicker(pickerPlugin),
 			input: []types.Pod{
 				&types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}},
 				&types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}},
@@ -120,9 +117,6 @@ func TestSchedulePlugins(t *testing.T) {
 				plugin.Scorer.(*testPlugin).reset()
 			}
 			test.profile.picker.(*testPlugin).reset()
-			for _, plugin := range test.profile.postCyclePlugins {
-				plugin.(*testPlugin).reset()
-			}
 
 			// Initialize the scheduling context
 			request := &types.LLMRequest{
@@ -179,12 +173,7 @@ func TestSchedulePlugins(t *testing.T) {
 			if tp.WinnerPodScore != test.targetPodScore {
 				t.Errorf("winner pod score %v, expected %v", tp.WinnerPodScore, test.targetPodScore)
 			}
-			for _, plugin := range test.profile.postCyclePlugins {
-				tp, _ := plugin.(*testPlugin)
-				if tp.PostCycleCallCount != 1 {
-					t.Errorf("Plugin '%s' PostCycle() called %d times, expected 1", plugin.TypedName(), tp.PostCycleCallCount)
-				}
-			}
+
 		})
 	}
 }
@@ -193,7 +182,6 @@ func TestSchedulePlugins(t *testing.T) {
 var _ Filter = &testPlugin{}
 var _ Scorer = &testPlugin{}
 var _ Picker = &testPlugin{}
-var _ PostCycle = &testPlugin{}
 
 // testPlugin is an implementation useful in unit tests.
 type testPlugin struct {
@@ -204,7 +192,6 @@ type testPlugin struct {
 	ScoreRes              float64
 	FilterCallCount       int
 	FilterRes             []k8stypes.NamespacedName
-	PostCycleCallCount    int
 	PickCallCount         int
 	NumOfPickerCandidates int
 	PickRes               k8stypes.NamespacedName
@@ -246,15 +233,10 @@ func (tp *testPlugin) Pick(_ context.Context, _ *types.CycleState, scoredPods []
 	return &types.ProfileRunResult{TargetPods: winnerPods}
 }
 
-func (tp *testPlugin) PostCycle(_ context.Context, _ *types.CycleState, res *types.ProfileRunResult) {
-	tp.PostCycleCallCount++
-}
-
 func (tp *testPlugin) reset() {
 	tp.FilterCallCount = 0
 	tp.ScoreCallCount = 0
 	tp.NumOfScoredPods = 0
-	tp.PostCycleCallCount = 0
 	tp.PickCallCount = 0
 	tp.NumOfPickerCandidates = 0
 }


### PR DESCRIPTION
Follow up of https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/937