### PR TITLE
moved build details to version package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ COPY cmd/epp ./cmd/epp
 COPY pkg/epp ./pkg/epp
 COPY internal ./internal
 COPY api ./api
+COPY version ./version
 WORKDIR /src/cmd/epp
-RUN go build -ldflags="-X sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics.CommitSHA=${COMMIT_SHA} -X sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics.BuildRef=${BUILD_REF}" -o /epp
+RUN go build -ldflags="-X sigs.k8s.io/gateway-api-inference-extension/version.CommitSHA=${COMMIT_SHA} -X sigs.k8s.io/gateway-api-inference-extension/version.BuildRef=${BUILD_REF}" -o /epp
 
 ## Multistage deploy
 FROM ${BASE_IMAGE}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling"
 	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/server"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/version"
 )
 
 var (
@@ -197,6 +198,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	flag.Parse()
 	initLogging(&opts)
 
+	setupLog.Info("GIE build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
+
 	// Validate flags
 	if err := validateFlags(); err != nil {
 		setupLog.Error(err, "Failed to validate flags")
@@ -242,7 +245,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// --- Setup Metrics Server ---
 	customCollectors := []prometheus.Collector{collectors.NewInferencePoolMetricsCollector(datastore)}
 	metrics.Register(customCollectors...)
-	metrics.RecordInferenceExtensionInfo()
+	metrics.RecordInferenceExtensionInfo(version.CommitSHA, version.BuildRef)
 	// Register metrics handler.
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -37,14 +37,6 @@ const (
 )
 
 var (
-	// The git hash of the latest commit in the build.
-	CommitSHA string
-
-	// The build ref from the _PULL_BASE_REF from cloud build trigger.
-	BuildRef string
-)
-
-var (
 	// Inference Model Metrics
 	requestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -437,6 +429,6 @@ func RecordPrefixCacheMatch(matchedLength, totalLength int) {
 	}
 }
 
-func RecordInferenceExtensionInfo() {
-	InferenceExtensionInfo.WithLabelValues(CommitSHA, BuildRef).Set(1)
+func RecordInferenceExtensionInfo(commitSha, buildRef string) {
+	InferenceExtensionInfo.WithLabelValues(commitSha, buildRef).Set(1)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package version
 
+var (
+	// The git hash of the latest commit in the build.
+	CommitSHA string
+
+	// The build ref from the _PULL_BASE_REF from cloud build trigger.
+	BuildRef string
+)
+
 const (
 	// BundleVersion is the value used for labeling the version of the gateway-api-inference-extension.
 	BundleVersion = "v0.4.0-dev"


### PR DESCRIPTION
This PR moves build versions/details into a version dedicated package, instead of having the build details in metrics package, which seems non-related.

cc @JeffLuoo @kfswain 