### PR TITLE
Do not log potentially sensitive data below DEBUG log level

### DIFF
--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -82,7 +82,11 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 				responses, err = s.HandleRequestHeaders(req.GetRequestHeaders())
 			}
 		case *extProcPb.ProcessingRequest_RequestBody:
-			loggerVerbose.Info("Incoming body chunk", "body", string(v.RequestBody.Body), "EoS", v.RequestBody.EndOfStream)
+			if logger.V(logutil.DEBUG).Enabled() {
+				logger.V(logutil.DEBUG).Info("Incoming body chunk", "body", string(v.RequestBody.Body), "EoS", v.RequestBody.EndOfStream)
+			} else {
+				loggerVerbose.Info("Incoming body chunk", "EoS", v.RequestBody.EndOfStream)
+			}
 			responses, err = s.processRequestBody(ctx, req.GetRequestBody(), streamedBody, logger)
 		case *extProcPb.ProcessingRequest_RequestTrailers:
 			responses, err = s.HandleRequestTrailers(req.GetRequestTrailers())
@@ -96,12 +100,20 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		}
 
 		if err != nil {
-			logger.V(logutil.DEFAULT).Error(err, "Failed to process request", "request", req)
+			if logger.V(logutil.DEBUG).Enabled() {
+				logger.V(logutil.DEBUG).Error(err, "Failed to process request", "request", req)
+			} else {
+				logger.V(logutil.DEFAULT).Error(err, "Failed to process request")
+			}
 			return status.Errorf(status.Code(err), "failed to handle request: %v", err)
 		}
 
 		for _, resp := range responses {
-			loggerVerbose.Info("Response generated", "response", resp)
+			if logger.V(logutil.DEBUG).Enabled() {
+				logger.V(logutil.DEBUG).Info("Response generated", "response", resp)
+			} else {
+				loggerVerbose.Info("Response generated")
+			}
 			if err := srv.Send(resp); err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Send failed")
 				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -49,7 +49,7 @@ type Scheduler struct {
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.
 func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest, candidatePods []types.Pod) (*types.SchedulingResult, error) {
-	logger := log.FromContext(ctx).WithValues("request", request)
+	logger := log.FromContext(ctx).WithValues("requestId", request.RequestId, "targetModel", request.TargetModel)
 	loggerDebug := logger.V(logutil.DEBUG)
 
 	scheduleStart := time.Now()
@@ -85,7 +85,7 @@ func (s *Scheduler) Schedule(ctx context.Context, request *types.LLMRequest, can
 	}
 
 	if len(profileRunResults) == 0 {
-		return nil, fmt.Errorf("failed to run any scheduler profile for the request - %s", request)
+		return nil, fmt.Errorf("failed to run any scheduler profile for request %s", request.RequestId)
 	}
 
 	loggerDebug.Info("Running profile handler, ProcessResults", "plugin", s.profileHandler.TypedName().Type)


### PR DESCRIPTION
Currently EPP and BBR might log potentially sensitive data at `DEFAULT` or `VERBOSE` log level.