### PR TITLE
chore: added proper `inference-extension-` prefix for demostration manifests

### DIFF
--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -7,6 +7,7 @@ apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferencePool
 metadata:
   name: vllm-llama3-8b-instruct
+  namespace: default
 spec:
   targetPortNumber: 8000
   selector:
@@ -95,7 +96,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: plugins-config
+  name: inference-extension-plugins-config
   namespace: default
 data:
   default-plugins.yaml: |
@@ -177,7 +178,8 @@ data:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pod-read
+  name: inference-extension-read-clusterrole
+  namespace: default
 rules:
 - apiGroups: ["inference.networking.x-k8s.io"]
   resources: ["inferencepools"]
@@ -200,16 +202,16 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
---- 
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pod-read-binding
+  name: inference-extension-read-clusterrole-binding
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: inference-extension-default
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pod-read
+  name: inference-extension-read-clusterrole

--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -91,12 +91,12 @@ spec:
       volumes:
       - name: plugins-config-volume
         configMap:
-          name: plugins-config
+          name: inference-gateway-plugins-config
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: inference-extension-plugins-config
+  name: inference-gateway-plugins-config
   namespace: default
 data:
   default-plugins.yaml: |
@@ -178,7 +178,7 @@ data:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: inference-extension-read-clusterrole
+  name: inference-gateway-read-clusterrole
   namespace: default
 rules:
 - apiGroups: ["inference.networking.x-k8s.io"]
@@ -206,12 +206,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: inference-extension-read-clusterrole-binding
+  name: inference-gateway-read-clusterrole-binding
 subjects:
 - kind: ServiceAccount
-  name: inference-extension-default
+  name: inference-gateway-default
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: inference-extension-read-clusterrole
+  name: inference-gateway-read-clusterrole


### PR DESCRIPTION
## Summary

Followed the naming pattern that Istio uses:

```
istio-reader-clusterrole-istio-system
istiod-clusterrole-istio-system
```

where `<group/type/category>-<role>-<resoucename>`.

## Test

```
$ kubectl apply -f '/Users/neko/Git/kubernetes-sigs/gateway-api-inference-extension/config/manifests/inferencepool-resources.yaml'
inferencepool.inference.networking.x-k8s.io/vllm-llama3-8b-instruct created
service/vllm-llama3-8b-instruct-epp created
deployment.apps/vllm-llama3-8b-instruct-epp created
configmap/inference-extension-plugins-config created
clusterrole.rbac.authorization.k8s.io/inference-extension-read-clusterrole created
clusterrolebinding.rbac.authorization.k8s.io/inference-extension-read-clusterrole-binding created
```