### PR TITLE
release issue template: updated the tag command to include the -s for signing the tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -101,13 +101,13 @@ This document defines the process for releasing Gateway API Inference Extension.
    For a release candidate:
 
     ```shell
-    git tag -a v${MAJOR}.${MINOR}.0-rc.${RC} -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.0-rc.${RC} Release Candidate'
+    git tag -s -a v${MAJOR}.${MINOR}.0-rc.${RC} -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.0-rc.${RC} Release Candidate'
     ```
 
    For a major or minor release:
 
     ```shell
-    git tag -a v${MAJOR}.${MINOR}.0 -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.0 Release'
+    git tag -s -a v${MAJOR}.${MINOR}.0 -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.0 Release'
     ```
 
    **Note:** A PGP key must be [registered] to your GitHub account.


### PR DESCRIPTION
while working on release v0.5 I noticed the tags are Unverified.
when following the release issue, there are some commands that include that -s for signoff (in the commit section).
added the -s for the tag section to have verified tags.

cc @kfswain @danehans 