### PR TITLE
added graceful shutdown when scheduler config is not initialized

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http/pprof"
@@ -282,6 +283,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	// --- Initialize Core EPP Components ---
+	if r.schedulerConfig == nil {
+		err := errors.New("scheduler config must be set either by config api or through code")
+		setupLog.Error(err, "failed to create scheduler")
+		return err
+	}
 	scheduler := scheduling.NewSchedulerWithConfig(r.schedulerConfig)
 
 	saturationDetector := saturationdetector.NewDetector(sdConfig, datastore, setupLog)


### PR DESCRIPTION
This PR fixes segmentation fault that may happen if the scheduler config is not initialized.
in GIE we allow configuring plugins either through config api or through code.
therefore when the config flags are missing, the program doesn't exit (to allow configuration by code to work).

we should add a nil check to validate we don't get segmentation fault when trying to initialize the scheduler.

this issue was originally hit in llm-d-scheduler, and reported here:
https://github.com/llm-d/llm-d-inference-scheduler/issues/255