### PR TITLE
Enhanced InferencePool Chart Configurability

### DIFF
--- a/config/charts/inferencepool/templates/epp-deployment.yaml
+++ b/config/charts/inferencepool/templates/epp-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - --pool-namespace
         - {{ .Release.Namespace }}
         - --v
-        - "3"
+        - "{{ .Values.inferenceExtension.logVerbosity | default "3" }}"
         - --grpc-port
         - "9002"
         - --grpc-health-port
@@ -54,6 +54,9 @@ spec:
           containerPort: 9003
         - name: metrics
           containerPort: 9090
+        {{- with .Values.inferenceExtension.extraContainerPorts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         livenessProbe:
           grpc:
             port: 9003
@@ -66,10 +69,9 @@ spec:
             service: inference-extension
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{- with .Values.inferenceExtension.env }}
         env:
-        {{- range $key, $value := .Values.inferenceExtension.env }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:
         - name: plugins-config-volume

--- a/config/charts/inferencepool/templates/epp-service.yaml
+++ b/config/charts/inferencepool/templates/epp-service.yaml
@@ -15,4 +15,7 @@ spec:
     - name: http-metrics
       protocol: TCP
       port: {{ .Values.inferenceExtension.metricsPort | default 9090 }}
+    {{- with .Values.inferenceExtension.extraServicePorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   type: ClusterIP

--- a/config/charts/inferencepool/values.yaml
+++ b/config/charts/inferencepool/values.yaml
@@ -6,7 +6,7 @@ inferenceExtension:
     tag: main
     pullPolicy: Always
   extProcPort: 9002
-  env: {}
+  env: []
   enablePprof: true # Enable pprof handlers for profiling and debugging
   # This is the plugins configuration file. 
   pluginsConfigFile: "default-plugins.yaml"
@@ -31,6 +31,11 @@ inferenceExtension:
   # Example environment variables:
   # env:
   #   KV_CACHE_SCORE_WEIGHT: "1"
+
+  # Define additional container ports
+  extraContainerPorts: []
+  # Define additional service ports
+  extraServicePorts: []
 
 inferencePool:
   targetPortNumber: 8000


### PR DESCRIPTION
## Summary
This PR introduces configurability for epp logging verbosity, environment variables, and extensible ports in the epp deployment/service.

## Changes Made
- Logging Verbosity: Added logVerbosity field to configure logging verbosity in the epp container
- Environment Variables: Made env configurable using free-form YAML. Note that Kubernetes would handle the validation - if a problem is present, the helm deployment would fail
- Ports Configurability: Added support for extraContainerPorts and extraServicePorts to define additional ports dynamically. E.g., ZMQ port for a vLLM KVEvents subscriber
- Documentation: Updated README.md to include examples and explanations for the new configurations