### PR TITLE
feat(conformance): Use CRD annotation to populate the ConformanceReport GatewayAPIInferenceExtensionVersion

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -191,6 +191,8 @@ func RunConformance(t *testing.T) {
 // RunConformanceWithOptions runs the Inference Extension conformance tests with specific options.
 func RunConformanceWithOptions(t *testing.T, opts confsuite.ConformanceOptions) {
 	t.Helper()
+	ctx := context.Background()
+
 	t.Logf("Running Inference Extension conformance tests with GatewayClass %s", opts.GatewayClassName)
 	logDebugf(t, opts.Debug, "RunConformanceWithOptions: BaseManifests path being used by opts: %q", opts.BaseManifests)
 
@@ -204,7 +206,7 @@ func RunConformanceWithOptions(t *testing.T, opts confsuite.ConformanceOptions) 
 	require.NoError(t, err, "error initializing conformance suite")
 
 	installedCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
-	err = opts.Client.List(context.TODO(), installedCRDs)
+	err = opts.Client.List(ctx, installedCRDs)
 	require.NoError(t, err, "error getting installedCRDs")
 	apiVersion, err := getGatewayInferenceExtentionVersion(installedCRDs.Items)
 	if err != nil {
@@ -214,7 +216,7 @@ func RunConformanceWithOptions(t *testing.T, opts confsuite.ConformanceOptions) 
 			require.NoError(t, err, "error getting the gateway ineference extension version")
 		}
 	}
-	SetupConformanceTestSuite(t, cSuite, opts, tests.ConformanceTests)
+	SetupConformanceTestSuite(ctx, t, cSuite, opts, tests.ConformanceTests)
 	t.Log("Running Inference Extension conformance tests against all registered tests")
 	err = cSuite.Run(t, tests.ConformanceTests)
 	require.NoError(t, err, "error running conformance tests")
@@ -232,7 +234,7 @@ func RunConformanceWithOptions(t *testing.T, opts confsuite.ConformanceOptions) 
 	}
 }
 
-func SetupConformanceTestSuite(t *testing.T, suite *confsuite.ConformanceTestSuite, opts confsuite.ConformanceOptions, tests []confsuite.ConformanceTest) {
+func SetupConformanceTestSuite(ctx context.Context, t *testing.T, suite *confsuite.ConformanceTestSuite, opts confsuite.ConformanceOptions, tests []confsuite.ConformanceTest) {
 	suite.Applier.ManifestFS = suite.ManifestFS
 	if suite.RunTest != "" {
 		idx := slices.IndexFunc(tests, func(t confsuite.ConformanceTest) bool {
@@ -260,8 +262,8 @@ func SetupConformanceTestSuite(t *testing.T, suite *confsuite.ConformanceTestSui
 	}
 	apikubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
 
-	ensureGatewayAvailableAndReady(t, suite.Client, opts, resources.PrimaryGatewayNN)
-	ensureGatewayAvailableAndReady(t, suite.Client, opts, resources.SecondaryGatewayNN)
+	ensureGatewayAvailableAndReady(ctx, t, suite.Client, opts, resources.PrimaryGatewayNN)
+	ensureGatewayAvailableAndReady(ctx, t, suite.Client, opts, resources.SecondaryGatewayNN)
 }
 
 func getGatewayInferenceExtentionVersion(crds []apiextensionsv1.CustomResourceDefinition) (string, error) {
@@ -284,7 +286,7 @@ func getGatewayInferenceExtentionVersion(crds []apiextensionsv1.CustomResourceDe
 
 // ensureGatewayAvailableAndReady polls for the specified Gateway to exist and become ready
 // with an address and programmed condition.
-func ensureGatewayAvailableAndReady(t *testing.T, k8sClient client.Client, opts confsuite.ConformanceOptions, gatewayNN types.NamespacedName) {
+func ensureGatewayAvailableAndReady(ctx context.Context, t *testing.T, k8sClient client.Client, opts confsuite.ConformanceOptions, gatewayNN types.NamespacedName) {
 	t.Helper()
 
 	t.Logf("Attempting to fetch Gateway %s/%s.", gatewayNN.Namespace, gatewayNN.Name)
@@ -298,7 +300,6 @@ func ensureGatewayAvailableAndReady(t *testing.T, k8sClient client.Client, opts 
 
 	logDebugf(t, opts.Debug, "Waiting up to %v for Gateway object %s/%s to appear after manifest application...", waitForGatewayCreationTimeout, gatewayNN.Namespace, gatewayNN.Name)
 
-	ctx := context.TODO()
 	pollErr := wait.PollUntilContextTimeout(ctx, extTimeoutConf.GatewayObjectPollInterval, waitForGatewayCreationTimeout, true, func(pollCtx context.Context) (bool, error) {
 		fetchErr := k8sClient.Get(pollCtx, gatewayNN, gw)
 		if fetchErr == nil {

--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -134,12 +134,7 @@ func DefaultOptions(t *testing.T) confsuite.ConformanceOptions {
 		*confflags.ImplementationContact,
 	)
 
-	// Inference Extension Specific Report Fields
-	inferenceExtensionVersion := "v0.3.0"
-	_ = inferenceExtensionVersion // Avoid unused variable error until implemented
-
 	baseManifestsValue := "resources/base.yaml"
-
 	opts := confsuite.ConformanceOptions{
 		Client:               c,
 		ClientOptions:        clientOptions,
@@ -166,7 +161,6 @@ func DefaultOptions(t *testing.T) confsuite.ConformanceOptions {
 		// TODO: Add the inference extension specific fields to ConformanceOptions struct if needed,
 		// or handle them during report generation.
 		// GatewayAPIInferenceExtensionChannel: inferenceExtensionChannel,
-		// GatewayAPIInferenceExtensionVersion: inferenceExtensionVersion,
 	}
 
 	// Populate SupportedFeatures based on the GatewayLayerProfile.
@@ -209,19 +203,28 @@ func RunConformanceWithOptions(t *testing.T, opts confsuite.ConformanceOptions) 
 	cSuite, err := confsuite.NewConformanceTestSuite(opts)
 	require.NoError(t, err, "error initializing conformance suite")
 
+	installedCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
+	err = opts.Client.List(context.TODO(), installedCRDs)
+	require.NoError(t, err, "error getting installedCRDs")
+	apiVersion, err := getGatewayInferenceExtentionVersion(installedCRDs.Items)
+	if err != nil {
+		if opts.AllowCRDsMismatch {
+			apiVersion = "UNDEFINED"
+		} else {
+			require.NoError(t, err, "error getting the gateway ineference extension version")
+		}
+	}
 	SetupConformanceTestSuite(t, cSuite, opts, tests.ConformanceTests)
-
 	t.Log("Running Inference Extension conformance tests against all registered tests")
 	err = cSuite.Run(t, tests.ConformanceTests)
 	require.NoError(t, err, "error running conformance tests")
 
-	// Generate and write the report if requested.
 	if opts.ReportOutputPath != "" {
 		t.Log("Generating Inference Extension conformance report")
 		report, err := cSuite.Report() // Use the existing report generation logic.
 		require.NoError(t, err, "error generating conformance report")
 		inferenceReport := GatewayAPIInferenceExtensionConformanceReport{
-			GatewayAPIInferenceExtensionVersion: version.BundleVersion,
+			GatewayAPIInferenceExtensionVersion: apiVersion,
 			ConformanceReport:                   *report,
 		}
 		err = inferenceReport.WriteReport(t.Logf, opts.ReportOutputPath)
@@ -259,6 +262,24 @@ func SetupConformanceTestSuite(t *testing.T, suite *confsuite.ConformanceTestSui
 
 	ensureGatewayAvailableAndReady(t, suite.Client, opts, resources.PrimaryGatewayNN)
 	ensureGatewayAvailableAndReady(t, suite.Client, opts, resources.SecondaryGatewayNN)
+}
+
+func getGatewayInferenceExtentionVersion(crds []apiextensionsv1.CustomResourceDefinition) (string, error) {
+	var inferenceVersion string
+	for _, crd := range crds {
+		v, okv := crd.Annotations[version.BundleVersionAnnotation]
+		if !okv {
+			continue
+		}
+		if inferenceVersion != "" && v != inferenceVersion {
+			return "", errors.New("multiple gateway api inference extension CRDs versions detected")
+		}
+		inferenceVersion = v
+	}
+	if inferenceVersion == "" {
+		return "", errors.New("no gateway api inference extension CRDs with the proper annotations found in the cluster")
+	}
+	return inferenceVersion, nil
 }
 
 // ensureGatewayAvailableAndReady polls for the specified Gateway to exist and become ready


### PR DESCRIPTION
Currently, the conformance report is using hard-coded variable `BundleVersion` in `version.go`. This PR get the version from annotation `BundleVersionAnnotation` of installed CRDs.

Tested locally, the following is an example generated report, I installed v0.5.0 CRDs.

```
GatewayAPIInferenceExtensionVersion: v0.5.0
apiVersion: gateway.networking.k8s.io/v1
date: "2025-07-22T05:30:18Z"
gatewayAPIChannel: standard
gatewayAPIVersion: v1.2.1
implementation:
  contact:
  - gke-gateway-dev@google.com
  organization: GKE
  project: gke-gateway
  url: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
  version: TBD
kind: ConformanceReport
mode: default
profiles:
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 9
      Skipped: 0
  name: Gateway
  summary: Core tests succeeded.
```

A follow up PR is to change `BundleVersion` from `v1.0.0-dev` to `main-dev`.