### PR TITLE
chore: update CRD BundleVersion to main-dev

### DIFF
--- a/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, experimental-only
-    inference.networking.k8s.io/bundle-version: v1.0.0-dev
+    inference.networking.k8s.io/bundle-version: main-dev
   creationTimestamp: null
   name: inferencepools.inference.networking.k8s.io
 spec:

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencemodels.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    inference.networking.k8s.io/bundle-version: v1.0.0-dev
+    inference.networking.k8s.io/bundle-version: main-dev
   creationTimestamp: null
   name: inferencemodels.inference.networking.x-k8s.io
 spec:

--- a/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferencepools.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, experimental-only
-    inference.networking.k8s.io/bundle-version: v1.0.0-dev
+    inference.networking.k8s.io/bundle-version: main-dev
   creationTimestamp: null
   name: inferencepools.inference.networking.x-k8s.io
 spec:

--- a/version/version.go
+++ b/version/version.go
@@ -30,5 +30,5 @@ const (
 	BundleVersionAnnotation = "inference.networking.k8s.io/bundle-version"
 
 	// BundleVersion is the value used for labeling the version of the gateway-api-inference-extension.
-	BundleVersion = "v1.0.0-dev"
+	BundleVersion = "main-dev"
 )


### PR DESCRIPTION
Update the CRD bundleVersion to main-dev for the main branch. Run the make generate to update the CRD's annotation in the main branch.

This should be merged after https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1214.