### PR TITLE
Update the Endpoint Picker Protocol with a new metadata field that communicates status associated with picked endpoints

### DIFF
--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -69,10 +69,10 @@ Constraints:
 
 For each HTTP response, the data plane MUST communicate to the EPP endpoint status as follows:
 
-In the ext_proc [ProcessingResponse.dynamic_metadata](https://github.com/envoyproxy/envoy/blob/v1.35.0/api/envoy/service/ext_proc/v3/external_processor.proto#L208) field, a new metadata field "x-gateway-destination-endpoint-status" is added:
+In the ext_proc [ProcessingRequest.metadata_context](https://github.com/envoyproxy/envoy/blob/v1.35.0/api/envoy/service/ext_proc/v3/external_processor.proto#L130) field, a new metadata field "x-gateway-destination-endpoint-status" is added as an unstructured entry with an outer key (which represents the metadata namespace) with a default value of `envoy.lb`:
 
 ```go
-dynamicMetadata: {
+filterMetadata: {
   "envoy.lb": {
     "x-gateway-destination-endpoint-status": endpoint=<ip:port>,
 }

--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -11,7 +11,7 @@ The EPP MUST implement the Envoy
 
 ## Endpoint Subset
 
-[REQUEST: Data Plane -> Endpoint Picker Extension]
+[REQUEST: Data Plane -> EPP]
 
 For each HTTP request, the proxy CAN communicate the subset of endpoints the EPP MUST pick from by setting an unstructured entry in the [filter metadata](https://github.com/envoyproxy/go-control-plane/blob/63a55395d7a39a8d43dcc7acc3d05e4cae7eb7a2/envoy/config/core/v3/base.pb.go#L819) field of the ext-proc request. The metadata entry for the subset list MUST be wrapped with an outer key (which represents the metadata namespace) with a default of `envoy.lb.subset_hint`.
 
@@ -29,7 +29,7 @@ If the key `x-gateway-destination-endpoint-subset` is not set, then the EPP MUST
 
 ## Destination Endpoint
 
-[REQUEST: Endpoint Picker Extension -> Data Plane]
+[REQUEST: EPP -> Data Plane]
 
 For each HTTP request, the EPP MUST communicate to the proxy one or more selected model server endpoints via:
 
@@ -65,7 +65,7 @@ Constraints:
 
 ## Destination Endpoint Status
 
-[RESPONSE: Data Plane -> Endpoint Picker Extension]
+[RESPONSE: Data Plane -> EPP]
 
 In the ext_proc [ProcessingResponse.dynamic_metadata](https://github.com/envoyproxy/envoy/blob/v1.35.0/api/envoy/service/ext_proc/v3/external_processor.proto#L208) field, status associated with the endpoint used by the data plane is communicated to the Endpoint Picker:
 
@@ -78,7 +78,7 @@ dynamicMetadata: {
 
 The value associated with this metadata field is a comma delimited string. The following status values are supported:
 
-- endpoint=<ip:port>: the endpoint which received the request; depending on endpoint health and connectivity status, the data plane may have had to attempt multiple endpoints (see [#DestinationEndpoint]).
+- endpoint=ip:port: the endpoint which received the request; depending on endpoint health and connectivity status, the data plane may have had to attempt multiple endpoints (see [Destination Endpoint](#destination-endpoint)).
 
 ### Why envoy.lb namespace as a default?
 The `envoy.lb` namespace is a predefined namespace. One common way to use the selected endpoint returned from the server, is [envoy subsets](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/subsets)  where host metadata for subset load balancing must be placed under `envoy.lb`. Note that this is not related to the subsetting feature discussed above, this is an enovy implementation detail.

--- a/docs/proposals/004-endpoint-picker-protocol/README.md
+++ b/docs/proposals/004-endpoint-picker-protocol/README.md
@@ -67,7 +67,9 @@ Constraints:
 
 [RESPONSE: Data Plane -> EPP]
 
-In the ext_proc [ProcessingResponse.dynamic_metadata](https://github.com/envoyproxy/envoy/blob/v1.35.0/api/envoy/service/ext_proc/v3/external_processor.proto#L208) field, status associated with the endpoint used by the data plane is communicated to the Endpoint Picker:
+For each HTTP response, the data plane MUST communicate to the EPP endpoint status as follows:
+
+In the ext_proc [ProcessingResponse.dynamic_metadata](https://github.com/envoyproxy/envoy/blob/v1.35.0/api/envoy/service/ext_proc/v3/external_processor.proto#L208) field, a new metadata field "x-gateway-destination-endpoint-status" is added:
 
 ```go
 dynamicMetadata: {


### PR DESCRIPTION
This PR enhances the EPP protocol with a new metadata field, `x-gateway-destination-endpoint-status`, added to the ext_proc request metadata (i.e., sent by the data plane to the EPP) during HTTP response processing.

This field will communicate status associated with endpoints selected by the EPP during HTTP request processing (the 'x-gateway-destination-endpoint' metadata).

With this PR, a single status field (`endpoint`) is introduced, to communicate the endpoint that the data plane actually sent the request to. This is required because data planes are expected to support retries and attempt sending requests, in order, to the endpoints specified in 'x-gateway-destination-endpoint'.