### PR TITLE
fix: missing permission to list inference.networking.k8s.io/v1/inferencepool

### DIFF
--- a/config/manifests/inferencepool-resources.yaml
+++ b/config/manifests/inferencepool-resources.yaml
@@ -179,6 +179,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-read
 rules:
+- apiGroups: ["inference.networking.k8s.io"]
+  resources: ["inferencepools"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: ["inference.networking.x-k8s.io"]
   resources: ["inferencepools"]
   verbs: ["get", "watch", "list"]
@@ -200,7 +203,7 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
---- 
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Follow up of https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1213