### PR TITLE
Change String() to accept a value reciever.

### DIFF
--- a/pkg/epp/plugins/typedname.go
+++ b/pkg/epp/plugins/typedname.go
@@ -29,6 +29,6 @@ type TypedName struct {
 }
 
 // String returns the type and name rendered as "<name>/<type>".
-func (tn *TypedName) String() string {
+func (tn TypedName) String() string {
 	return tn.Name + separator + tn.Type
 }


### PR DESCRIPTION
Since `Plugin` returns a `TypedName` by value the `String()` method with pointer receiver was not called. 
Go happily calls the value receiver based methods for pointers as well.
This was causing logs to print `{<type> <name>}` (default string representation) instead of the expected output of String() (`<name>/<type>`).