### PR TITLE
added scheduler config logging on bootstrap

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -317,6 +317,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		setupLog.Error(err, "failed to create scheduler")
 		return err
 	}
+
+	setupLog.Info("parsed config", "scheduler-config", r.schedulerConfig)
+
 	scheduler := scheduling.NewSchedulerWithConfig(r.schedulerConfig)
 
 	saturationDetector := saturationdetector.NewDetector(sdConfig, datastore, setupLog)
@@ -403,8 +406,6 @@ func (r *Runner) parsePluginsConfiguration(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load the configuration - %w", err)
 	}
-
-	setupLog.Info("Configuration file loaded", "config", config)
 
 	r.schedulerConfig, err = loader.LoadSchedulerConfig(config.SchedulingProfiles, handle)
 	if err != nil {

--- a/pkg/epp/scheduling/framework/scheduler_profile.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -103,6 +104,28 @@ func (p *SchedulerProfile) AddPlugins(pluginObjects ...plugins.Plugin) error {
 		}
 	}
 	return nil
+}
+
+func (p *SchedulerProfile) String() string {
+	filterNames := make([]string, len(p.filters))
+	for i, filter := range p.filters {
+		filterNames[i] = filter.TypedName().String()
+	}
+	scorerNames := make([]string, len(p.scorers))
+	for i, scorer := range p.scorers {
+		scorerNames[i] = fmt.Sprintf("%s: %d", scorer.TypedName(), scorer.Weight())
+	}
+	postCyclePluginNames := make([]string, len(p.postCyclePlugins))
+	for i, postCyclePlugin := range p.postCyclePlugins {
+		postCyclePluginNames[i] = postCyclePlugin.TypedName().String()
+	}
+	return fmt.Sprintf(
+		"{Filters: [%s], Scorers: [%s], Picker: %s, PostCyclePlugins: [%s]}",
+		strings.Join(filterNames, ", "),
+		strings.Join(scorerNames, ", "),
+		p.picker.TypedName(),
+		strings.Join(postCyclePluginNames, ", "),
+	)
 }
 
 // RunCycle runs a SchedulerProfile cycle. In other words, it invokes all the SchedulerProfile plugins in this

--- a/pkg/epp/scheduling/scheduler_config.go
+++ b/pkg/epp/scheduling/scheduler_config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scheduling
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
 )
 
@@ -32,4 +34,12 @@ func NewSchedulerConfig(profileHandler framework.ProfileHandler, profiles map[st
 type SchedulerConfig struct {
 	profileHandler framework.ProfileHandler
 	profiles       map[string]*framework.SchedulerProfile
+}
+
+func (c *SchedulerConfig) String() string {
+	return fmt.Sprintf(
+		"{ProfileHandler: %s, Profiles: %v}",
+		c.profileHandler.TypedName(),
+		c.profiles,
+	)
 }


### PR DESCRIPTION
This PR adds logging of the scheduler config on bootstrap, using String() function on SchedulerConfig and SchedulerProfile. 
before this change, there was a log line `setupLog.Info("Configuration file loaded", "config", config)` that was logging nothing, the output in the log was something like `&EndpointPickerConfig{}`.

After this change, it's very clear what is the scheduler config that is being used.
Tested this change for both canned configurations. 
output of `default-plugins.yaml`:
```
{"level":"info","ts":"2025-07-28T17:58:58Z","logger":"setup","caller":"runner/runner.go:321","msg":"parsed 
config","scheduler-config":"{ProfileHandler: single-profile-handler/single-profile-handler, Profiles: map[default:{Filters: [low-
queue-filter/low-queue-filter], Scorers: [], Picker: random-picker/random-picker, PostCyclePlugins: []}]}"}
```

output of `plugins-v2.yaml`:
```
{"level":"info","ts":"2025-07-28T17:49:58Z","logger":"setup","caller":"runner/runner.go:321","msg":"parsed 
config","scheduler-config":"{ProfileHandler: single-profile-handler/single-profile-handler, Profiles: map[default:{Filters: [], 
Scorers: [queue-scorer/queue-scorer: 1, kv-cache-scorer/kv-cache-scorer: 1, prefix-cache-scorer/prefix-cache-scorer: 1], 
Picker: max-score-picker/max-score-picker, PostCyclePlugins: [prefix-cache-scorer/prefix-cache-scorer]}]}"}
```

cc: @ahg-g @shmuelk @kfswain @elevran 