### PR TITLE
fix(flowcontrol): Prevent panic on nil item during shard shutdown

### DIFF
--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -549,6 +549,9 @@ func (sp *ShardProcessor) shutdown() {
 		for {
 			select {
 			case item := <-sp.enqueueChan:
+				if item == nil { // This is a safeguard against logic errors in the distributor.
+					continue
+				}
 				item.finalize(types.QueueOutcomeRejectedOther,
 					fmt.Errorf("%w: %w", types.ErrRejected, types.ErrFlowControllerShutdown))
 			default:


### PR DESCRIPTION
This PR fixes a race condition in the `ShardProcessor` that could cause a panic during graceful shutdown if a `nil` item was present in its enqueue channel.

tracks #674 

#### The Problem

A race condition existed between the processor's main `Run` loop and its `shutdown` method.

- The `Run` loop correctly checks for and discards `nil` items received from the `enqueueChan`.
- However, the channel drain loop within the `shutdown` method **did not** have this check.

If a shutdown was initiated before the `Run` loop had a chance to process a `nil` item, the `shutdown` method would read the `nil` from the channel and attempt to call `item.finalize()`, leading to a nil pointer dereference and a panic.

#### Why the Flake Was Hard to Reproduce

This bug was exposed by a flaky test (`TestShardProcessor_Lifecycle_should_not_panic_on_nil_item_from_enqueue_channel`) that was difficult to reproduce locally. The test intentionally enqueues a `nil` item and then uses a `time.Sleep(50ms)` to allow the `Run` loop time to handle it before the test finishes and triggers shutdown.

On a typical developer machine, 50ms is more than enough time for the `Run` loop to win this race. However, in a resource-constrained or heavily loaded CI environment, goroutine scheduling can be less predictable. The `Run` loop could be delayed just long enough for the sleep to expire and shutdown to be initiated first, triggering the panic. This explains why the failure was only observed in the CI/CD environment.

#### The Fix

This commit resolves the underlying bug by adding a `nil` check to the drain loop inside the `shutdown` method. This makes the shutdown process robust against this race condition, fixing the production code and stabilizing the associated test regardless of environment timing.