### PR TITLE
fix(conformance): Use pinned version of EPP for conformance test instead of main.

### DIFF
--- a/conformance/resources/manifests/manifests.yaml
+++ b/conformance/resources/manifests/manifests.yaml
@@ -196,7 +196,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v20250725-fb2dfd8
         imagePullPolicy: Always
         args:
         - --pool-name
@@ -290,7 +290,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v20250725-fb2dfd8
         imagePullPolicy: Always
         args:
         - --pool-name


### PR DESCRIPTION
Fixes #1258, Used a pinned version of EPP