### PR TITLE
fix image not build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ image-build: ## Build the EPP image using Docker Buildx.
 
 .PHONY: image-push
 image-push: PUSH=--push ## Build the EPP image and push it to $IMAGE_REPO.
-image-push: MULTI=true image-build
+image-push: image-build
 
 .PHONY: image-load
 image-load: LOAD=--load ## Build the EPP image and load it in the local Docker registry.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,7 @@ steps:
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
     - GIT_COMMIT_SHA=$_PULL_BASE_SHA
+    - MULTI=true
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
     entrypoint: make
     args:


### PR DESCRIPTION
The original make target does not generate any image, see the following command and result
```
❯ make image-push
make: Nothing to be done for 'image-push'.
```

Moving the $(MULTI) to build.yaml instead of putting it in the make target. Because it won't evaluate because 
while `MULTI` is only read at parse time (by the `ifdef MULTI` block)

However, I didn't verify if the cloud build can generate multiple platform image. We can merge this PR and see the post submit.