### PR TITLE
Switch to the new default scheduler plugins in integration test

### DIFF
--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -55,6 +55,12 @@ const (
 	PrefixCachePluginType = "prefix-cache-scorer"
 )
 
+var DefaultConfig = Config{
+	HashBlockSize:          DefaultHashBlockSize,
+	MaxPrefixBlocksToMatch: DefaultMaxPrefixBlocks,
+	LRUCapacityPerServer:   DefaultLRUCapacityPerServer,
+}
+
 type Config struct {
 	// The input prompt is broken into sizes of HashBlockSize to calculate block hashes . Requests
 	// with length shorter than the block size will be ignored.


### PR DESCRIPTION
This an incremental step to deprecate the legacy plugins and switch to the new scorers.

cc @ahg-g @kfswain @nirrozenbaum 