### PR TITLE
added plugin state that can be used to share data between different extension point of a plugin

### DIFF
--- a/pkg/epp/plugins/plugin_state.go
+++ b/pkg/epp/plugins/plugin_state.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+const (
+	// stalenessThreshold defines the threshold for considering data as stale.
+	// if data of a request hasn't been read/write in the last "stalenessThreshold", it is considered as stale data
+	// and will be cleaned in the next cleanup cycle.
+	stalenessThreshold = time.Minute * 5
+	// cleanupInterval defines the periodic interval that the cleanup go routine uses to check for stale data.
+	cleanupInterval = time.Minute
+)
+
+// NewPluginState initializes a new PluginState and returns its pointer.
+func NewPluginState(ctx context.Context) *PluginState {
+	pluginState := &PluginState{}
+	go pluginState.cleanup(ctx)
+	return pluginState
+}
+
+// PluginState provides a mechanism for plugins to store and retrieve arbitrary data by multiple extension points.
+// Data stored by the plugin in one extension point can be written, read or altered by another extension point.
+// The data stored in PluginState is always stored in the context of a given request.
+// If the data hasn't been accessed during "stalenessThreshold", it is cleaned by a cleanup internal mechanism.
+//
+// Note: PluginState uses a sync.Map to back the storage, because it is thread safe.
+// It's aimed to optimize for the "write once and read many times" scenarios.
+type PluginState struct {
+	// key: RequestID, value: map[StateKey]StateData
+	storage sync.Map
+	// key: RequestID, value: time.Time
+	requestToLastAccessTime sync.Map
+}
+
+// Read retrieves data with the given "key" in the context of "requestID" from PluginState.
+// If the key is not present, ErrNotFound is returned.
+func (s *PluginState) Read(requestID string, key StateKey) (StateData, error) {
+	s.requestToLastAccessTime.Store(requestID, time.Now())
+	stateMap, ok := s.storage.Load(requestID)
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	stateData := stateMap.(map[StateKey]StateData)
+	if value, ok := stateData[key]; ok {
+		return value, nil
+	}
+
+	return nil, ErrNotFound
+}
+
+// Write stores the given "val" in PluginState with the given "key" in the context of the given "requestID".
+func (s *PluginState) Write(requestID string, key StateKey, val StateData) {
+	s.requestToLastAccessTime.Store(requestID, time.Now())
+	var stateData map[StateKey]StateData
+	stateMap, ok := s.storage.Load(requestID)
+	if ok {
+		stateData = stateMap.(map[StateKey]StateData)
+	} else {
+		stateData = map[StateKey]StateData{}
+	}
+
+	stateData[key] = val
+
+	s.storage.Store(requestID, stateData)
+}
+
+// Delete deletes data associated with the given requestID.
+// It is possible to call Delete explicitly when the handling of a request is completed
+// or alternatively, if the request failed during its processing, a cleanup goroutine will
+// clean data of stale requests.
+func (s *PluginState) Delete(requestID string) {
+	s.storage.Delete(requestID)
+	s.requestToLastAccessTime.Delete(requestID)
+}
+
+// cleanup periodically deletes data associated with the given requestID.
+func (s *PluginState) cleanup(ctx context.Context) {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.FromContext(ctx).V(logutil.DEFAULT).Info("Shutting down plugin state cleanup")
+			return
+		case <-ticker.C:
+			s.requestToLastAccessTime.Range(func(k, v any) bool {
+				requestID := k.(string)
+				lastAccessTime := v.(time.Time)
+				if time.Since(lastAccessTime) > stalenessThreshold {
+					s.Delete(requestID) // cleanup stale requests (this is safe in sync.Map)
+				}
+				return true
+			})
+		}
+	}
+
+}
+
+// ReadPluginStateKey retrieves data with the given key from PluginState and asserts it to type T.
+// Returns an error if the key is not found or the type assertion fails.
+func ReadPluginStateKey[T StateData](state *PluginState, requestID string, key StateKey) (T, error) {
+	var zero T
+
+	raw, err := state.Read(requestID, key)
+	if err != nil {
+		return zero, err
+	}
+
+	val, ok := raw.(T)
+	if !ok {
+		return zero, fmt.Errorf("unexpected type for key %q: got %T", key, raw)
+	}
+
+	return val, nil
+}

--- a/pkg/epp/plugins/shared_state.go
+++ b/pkg/epp/plugins/shared_state.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"errors"
+)
+
+var (
+	// ErrNotFound is the not found error message.
+	ErrNotFound = errors.New("not found")
+)
+
+// StateKey is the type of keys stored in PluginState.
+type StateKey string
+
+// StateData is a generic type for arbitrary data stored in PluginState.
+type StateData interface {
+	// Clone is an interface to make a copy of StateData.
+	Clone() StateData
+}

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -90,7 +90,7 @@ func (s ServerID) String() string {
 }
 
 // compile-time type validation
-var _ types.StateData = &SchedulingContextState{}
+var _ plugins.StateData = &SchedulingContextState{}
 
 // SchedulingContextState is the state of this plugin to be used during a scheduling cycle.
 type SchedulingContextState struct {
@@ -100,7 +100,7 @@ type SchedulingContextState struct {
 	PrefixCacheServers map[ServerID]int
 }
 
-func (s *SchedulingContextState) Clone() types.StateData {
+func (s *SchedulingContextState) Clone() plugins.StateData {
 	prefixHashes := make([]BlockHash, len(s.PrefixHashes))
 	copy(prefixHashes, s.PrefixHashes)
 	prefixCacheServers := make(map[ServerID]int, len(s.PrefixCacheServers))
@@ -174,7 +174,7 @@ func (m *Plugin) Score(ctx context.Context, cycleState *types.CycleState, reques
 		PrefixCacheServers: m.matchLongestPrefix(ctx, hashes),
 	}
 
-	cycleState.Write(types.StateKey(m.TypedName().Type), state)
+	cycleState.Write(plugins.StateKey(m.TypedName().Type), state)
 	loggerTrace.Info(fmt.Sprintf("cached servers: %+v", state.PrefixCacheServers), "hashes", state.PrefixHashes)
 	// calculate the scores of pods
 	scores := make(map[types.Pod]float64, len(pods))

--- a/pkg/epp/scheduling/types/cycle_state.go
+++ b/pkg/epp/scheduling/types/cycle_state.go
@@ -17,24 +17,11 @@ limitations under the License.
 package types
 
 import (
-	"errors"
 	"fmt"
 	"sync"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 )
-
-var (
-	// ErrNotFound is the not found error message.
-	ErrNotFound = errors.New("not found")
-)
-
-// StateData is a generic type for arbitrary data stored in CycleState.
-type StateData interface {
-	// Clone is an interface to make a copy of StateData.
-	Clone() StateData
-}
-
-// StateKey is the type of keys stored in CycleState.
-type StateKey string
 
 // NewCycleState initializes a new CycleState and returns its pointer.
 func NewCycleState() *CycleState {
@@ -55,30 +42,30 @@ type CycleState struct {
 // present, ErrNotFound is returned.
 //
 // See CycleState for notes on concurrency.
-func (c *CycleState) Read(key StateKey) (StateData, error) {
+func (c *CycleState) Read(key plugins.StateKey) (plugins.StateData, error) {
 	if v, ok := c.storage.Load(key); ok {
-		return v.(StateData), nil
+		return v.(plugins.StateData), nil
 	}
-	return nil, ErrNotFound
+	return nil, plugins.ErrNotFound
 }
 
 // Write stores the given "val" in CycleState with the given "key".
 //
 // See CycleState for notes on concurrency.
-func (c *CycleState) Write(key StateKey, val StateData) {
+func (c *CycleState) Write(key plugins.StateKey, val plugins.StateData) {
 	c.storage.Store(key, val)
 }
 
 // Delete deletes data with the given key from CycleState.
 //
 // See CycleState for notes on concurrency.
-func (c *CycleState) Delete(key StateKey) {
+func (c *CycleState) Delete(key plugins.StateKey) {
 	c.storage.Delete(key)
 }
 
 // ReadCycleStateKey  retrieves data with the given key from CycleState and asserts it to type T.
 // Returns an error if the key is not found or the type assertion fails.
-func ReadCycleStateKey[T StateData](c *CycleState, key StateKey) (T, error) {
+func ReadCycleStateKey[T plugins.StateData](c *CycleState, key plugins.StateKey) (T, error) {
 	var zero T
 
 	raw, err := c.Read(key)


### PR DESCRIPTION
This PR adds a new mechanism, `PluginState`, that may be used in a plugin to share a state within different extension point.
a clarification - the intention is that a plugin shares state with itself in different extension points, not with other plugins.

so essentially we should have two mechanisms for sharing state across plugins:
1. for sharing state between different scheduling plugins, one can use scheduling CycleState.
2. for sharing state between different extension point of the same plugin, one can add PluginState as a field in the plugin.

This mechanism adds the option to write/read keys in the context of a request, while keeping in mind that for a given request the plugins do not run in parallel (and therefore using internally a map works).

this looks and feels similar to CycleState in some things, so I exported some common things like StateKey and StateData to a common `plugins/shared_state.go` file (structs that used to share state in the context of plugins).

this PR only adds the generic mechanism, still not using it. 
the next step would be to use it in Prefix scorer and completely remove PostCycle extension point.

LMKWYT.

cc: @kfswain @liu-cong @ahg-g @elevran 

Fix #1084 