### PR TITLE
Filter inference objectives based on inference pool group

### DIFF
--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -83,5 +83,5 @@ func (c *InferenceObjectiveReconciler) SetupWithManager(ctx context.Context, mgr
 }
 
 func (c *InferenceObjectiveReconciler) eventPredicate(infObjective *v1alpha2.InferenceObjective) bool {
-	return string(infObjective.Spec.PoolRef.Name) == c.PoolGKNN.Name
+	return string(infObjective.Spec.PoolRef.Name) == c.PoolGKNN.Name && string(infObjective.Spec.PoolRef.Group) == c.PoolGKNN.Group
 }

--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -54,7 +54,7 @@ func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.R
 		notFound = true
 	}
 
-	if notFound || !infObjective.DeletionTimestamp.IsZero() || infObjective.Spec.PoolRef.Name != v1alpha2.ObjectName(c.PoolGKNN.Name) {
+	if notFound || !infObjective.DeletionTimestamp.IsZero() || infObjective.Spec.PoolRef.Name != v1alpha2.ObjectName(c.PoolGKNN.Name) || infObjective.Spec.PoolRef.Group != v1alpha2.Group(c.PoolGKNN.Group) {
 		// InferenceObjective object got deleted or changed the referenced pool.
 		c.Datastore.ObjectiveDelete(req.NamespacedName)
 		return ctrl.Result{}, nil

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -61,7 +61,12 @@ var (
 				CreationTimestamp(metav1.Unix(1004, 0)).
 				DeletionTimestamp().
 				PoolName(pool.Name).ObjRef()
-
+	infObjective1DiffGroup = utiltest.MakeInferenceObjective("model1").
+				Namespace(pool.Namespace).
+				Criticality(v1alpha2.Standard).
+				CreationTimestamp(metav1.Unix(1000, 0)).
+				PoolName(pool.Name).
+				PoolGroup("diff-group").ObjRef()
 	infObjective2 = utiltest.MakeInferenceObjective("model2").
 			Namespace(pool.Namespace).
 			CreationTimestamp(metav1.Unix(1000, 0)).
@@ -118,6 +123,17 @@ func TestInferenceObjectiveReconciler(t *testing.T) {
 			objectivessInStore: []*v1alpha2.InferenceObjective{infObjective1},
 			objective:          infObjective2,
 			wantObjectives:     []*v1alpha2.InferenceObjective{infObjective1, infObjective2},
+		},
+		{
+			name:               "Objective deleted due to group mismatch for the inference pool",
+			objectivessInStore: []*v1alpha2.InferenceObjective{infObjective1},
+			objective:          infObjective1DiffGroup,
+			wantObjectives:     []*v1alpha2.InferenceObjective{},
+		},
+		{
+			name:           "Objective ignored due to group mismatch for the inference pool",
+			objective:      infObjective1DiffGroup,
+			wantObjectives: []*v1alpha2.InferenceObjective{},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -45,22 +45,26 @@ var (
 			Namespace(pool.Namespace).
 			Criticality(v1alpha2.Standard).
 			CreationTimestamp(metav1.Unix(1000, 0)).
-			PoolName(pool.Name).ObjRef()
+			PoolName(pool.Name).
+			PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1Pool2 = utiltest.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
 				Criticality(*infObjective1.Spec.Criticality).
 				CreationTimestamp(metav1.Unix(1001, 0)).
-				PoolName("test-pool2").ObjRef()
+				PoolName("test-pool2").
+				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1Critical = utiltest.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
 				Criticality(v1alpha2.Critical).
 				CreationTimestamp(metav1.Unix(1003, 0)).
-				PoolName(pool.Name).ObjRef()
+				PoolName(pool.Name).
+				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1Deleted = utiltest.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
 				CreationTimestamp(metav1.Unix(1004, 0)).
 				DeletionTimestamp().
-				PoolName(pool.Name).ObjRef()
+				PoolName(pool.Name).
+				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1DiffGroup = utiltest.MakeInferenceObjective("model1").
 				Namespace(pool.Namespace).
 				Criticality(v1alpha2.Standard).
@@ -70,7 +74,8 @@ var (
 	infObjective2 = utiltest.MakeInferenceObjective("model2").
 			Namespace(pool.Namespace).
 			CreationTimestamp(metav1.Unix(1000, 0)).
-			PoolName(pool.Name).ObjRef()
+			PoolName(pool.Name).
+			PoolGroup("inference.networking.k8s.io").ObjRef()
 )
 
 func TestInferenceObjectiveReconciler(t *testing.T) {
@@ -150,7 +155,6 @@ func TestInferenceObjectiveReconciler(t *testing.T) {
 			for _, m := range test.objectivesInAPIServer {
 				initObjs = append(initObjs, m)
 			}
-
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(initObjs...).

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -66,7 +66,7 @@ var (
 				Criticality(v1alpha2.Standard).
 				CreationTimestamp(metav1.Unix(1000, 0)).
 				PoolName(pool.Name).
-				PoolGroup("diff-group").ObjRef()
+				PoolGroup("inference.networking.x-k8s.io").ObjRef()
 	infObjective2 = utiltest.MakeInferenceObjective("model2").
 			Namespace(pool.Namespace).
 			CreationTimestamp(metav1.Unix(1000, 0)).

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -65,10 +65,10 @@ var (
 				DeletionTimestamp().
 				PoolName(pool.Name).
 				PoolGroup("inference.networking.k8s.io").ObjRef()
-	infObjective1DiffGroup = utiltest.MakeInferenceObjective("model1").
+	infObjective1DiffGroup = utiltest.MakeInferenceObjective(infObjective1.Name).
 				Namespace(pool.Namespace).
 				Criticality(v1alpha2.Standard).
-				CreationTimestamp(metav1.Unix(1000, 0)).
+				CreationTimestamp(metav1.Unix(1005, 0)).
 				PoolName(pool.Name).
 				PoolGroup("inference.networking.x-k8s.io").ObjRef()
 	infObjective2 = utiltest.MakeInferenceObjective("model2").

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -142,12 +142,12 @@ func (m *InferenceObjectiveWrapper) TargetModel(modelName string) *InferenceObje
 }
 
 func (m *InferenceObjectiveWrapper) PoolName(poolName string) *InferenceObjectiveWrapper {
-	m.Spec.PoolRef = v1alpha2.PoolObjectReference{Name: v1alpha2.ObjectName(poolName)}
+	m.Spec.PoolRef.Name = v1alpha2.ObjectName(poolName)
 	return m
 }
 
 func (m *InferenceObjectiveWrapper) PoolGroup(poolGroup string) *InferenceObjectiveWrapper {
-	m.Spec.PoolRef = v1alpha2.PoolObjectReference{Group: v1alpha2.Group(poolGroup)}
+	m.Spec.PoolRef.Group = v1alpha2.Group(poolGroup)
 	return m
 }
 
@@ -179,6 +179,10 @@ func MakeInferencePool(name string) *InferencePoolWrapper {
 		v1.InferencePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "inference.networking.k8s.io/v1",
+				Kind:       "InferencePool",
 			},
 			Spec: v1.InferencePoolSpec{},
 		},

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -146,6 +146,11 @@ func (m *InferenceObjectiveWrapper) PoolName(poolName string) *InferenceObjectiv
 	return m
 }
 
+func (m *InferenceObjectiveWrapper) PoolGroup(poolGroup string) *InferenceObjectiveWrapper {
+	m.Spec.PoolRef = v1alpha2.PoolObjectReference{Group: v1alpha2.Group(poolGroup)}
+	return m
+}
+
 func (m *InferenceObjectiveWrapper) Criticality(criticality v1alpha2.Criticality) *InferenceObjectiveWrapper {
 	m.Spec.Criticality = &criticality
 	return m

--- a/test/testdata/inferencepool-with-model-hermetic.yaml
+++ b/test/testdata/inferencepool-with-model-hermetic.yaml
@@ -19,6 +19,7 @@ spec:
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
+    group: inference.networking.k8s.io
   targetModels:
   - name: sql-lora-1fdg2
     weight: 100
@@ -31,6 +32,7 @@ metadata:
 spec:
   poolRef:
     name: vllm-llama3-8b-instruct-pool
+    group: inference.networking.k8s.io
   targetModels:
   - name: sql-lora-1fdg3
     weight: 100
@@ -44,6 +46,7 @@ spec:
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
+    group: inference.networking.k8s.io
   targetModels:
   - name: my-model-12345
     weight: 100    
@@ -57,3 +60,4 @@ spec:
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
+    group: inference.networking.k8s.io


### PR DESCRIPTION
fixed #1275 

Previously, EPP reconciles more InferenceModels than the InferenceModel related to the specified InferencePool. We check against the inference pool name and namespace, but not the group.

This PR added the check against inference pool group.

NOTE: Currently the poolRef.group defaults to "inference.networking.x-k8s.io" (see https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/apix/v1alpha2/inferenceobjective_types.go#L114), which is inconsistent with the default defined in EPP startup arg "--pool-group=inference.networking.k8s.io" in #1277.