### PR TITLE
Select InferenceObjective by header

### DIFF
--- a/apix/v1alpha2/inferenceobjective_types.go
+++ b/apix/v1alpha2/inferenceobjective_types.go
@@ -63,20 +63,6 @@ type InferenceObjectiveList struct {
 // creation timestamp, will be selected to remain valid. In the event of a race
 // condition, one will be selected at random.
 type InferenceObjectiveSpec struct {
-	// ModelName is the name of the model as it will be set in the "model" parameter for an incoming request.
-	// ModelNames must be unique for a referencing InferencePool
-	// (names can be reused for a different pool in the same cluster).
-	// The modelName with the oldest creation timestamp is retained, and the incoming
-	// InferenceObjective's Ready status is set to false with a corresponding reason.
-	// In the rare case of a race condition, one Model will be selected randomly to be considered valid, and the other rejected.
-	// Names can be reserved without an underlying model configured in the pool.
-	// This can be done by specifying a target model and setting the weight to zero,
-	// an error will be returned specifying that no valid target model is found.
-	//
-	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="modelName is immutable"
-	ModelName string `json:"modelName"`
 
 	// Criticality defines how important it is to serve the model compared to other models referencing the same pool.
 	// Criticality impacts how traffic is handled in resource constrained situations. It handles this by

--- a/client-go/applyconfiguration/apix/v1alpha2/inferenceobjectivespec.go
+++ b/client-go/applyconfiguration/apix/v1alpha2/inferenceobjectivespec.go
@@ -25,7 +25,6 @@ import (
 // InferenceObjectiveSpecApplyConfiguration represents a declarative configuration of the InferenceObjectiveSpec type for use
 // with apply.
 type InferenceObjectiveSpecApplyConfiguration struct {
-	ModelName    *string                                `json:"modelName,omitempty"`
 	Criticality  *apixv1alpha2.Criticality              `json:"criticality,omitempty"`
 	TargetModels []TargetModelApplyConfiguration        `json:"targetModels,omitempty"`
 	PoolRef      *PoolObjectReferenceApplyConfiguration `json:"poolRef,omitempty"`
@@ -35,14 +34,6 @@ type InferenceObjectiveSpecApplyConfiguration struct {
 // apply.
 func InferenceObjectiveSpec() *InferenceObjectiveSpecApplyConfiguration {
 	return &InferenceObjectiveSpecApplyConfiguration{}
-}
-
-// WithModelName sets the ModelName field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ModelName field is set to the value of the last call.
-func (b *InferenceObjectiveSpecApplyConfiguration) WithModelName(value string) *InferenceObjectiveSpecApplyConfiguration {
-	b.ModelName = &value
-	return b
 }
 
 // WithCriticality sets the Criticality field in the declarative configuration to the given value

--- a/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
@@ -83,22 +83,6 @@ spec:
                 - Standard
                 - Sheddable
                 type: string
-              modelName:
-                description: |-
-                  ModelName is the name of the model as it will be set in the "model" parameter for an incoming request.
-                  ModelNames must be unique for a referencing InferencePool
-                  (names can be reused for a different pool in the same cluster).
-                  The modelName with the oldest creation timestamp is retained, and the incoming
-                  InferenceObjective's Ready status is set to false with a corresponding reason.
-                  In the rare case of a race condition, one Model will be selected randomly to be considered valid, and the other rejected.
-                  Names can be reserved without an underlying model configured in the pool.
-                  This can be done by specifying a target model and setting the weight to zero,
-                  an error will be returned specifying that no valid target model is found.
-                maxLength: 256
-                type: string
-                x-kubernetes-validations:
-                - message: modelName is immutable
-                  rule: self == oldSelf
               poolRef:
                 description: PoolRef is a reference to the inference pool, the pool
                   must exist in the same namespace.
@@ -171,7 +155,6 @@ spec:
                 - message: Weights should be set for all models, or none of the models.
                   rule: self.all(model, has(model.weight)) || self.all(model, !has(model.weight))
             required:
-            - modelName
             - poolRef
             type: object
           status:

--- a/config/manifests/inferenceobjective.yaml
+++ b/config/manifests/inferenceobjective.yaml
@@ -3,7 +3,6 @@ kind: InferenceObjective
 metadata:
   name: food-review
 spec:
-  modelName: food-review
   criticality: Standard
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -16,7 +15,6 @@ kind: InferenceObjective
 metadata:
   name: base-model
 spec:
-  modelName: meta-llama/Llama-3.1-8B-Instruct
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -26,7 +24,6 @@ kind: InferenceObjective
 metadata:
   name: base-model-cpu
 spec:
-  modelName: Qwen/Qwen2.5-1.5B-Instruct
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct

--- a/config/manifests/regression-testing/inferenceobjective.yaml
+++ b/config/manifests/regression-testing/inferenceobjective.yaml
@@ -3,7 +3,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-0
 spec:
-  modelName: adapter-0
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -18,7 +17,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-1
 spec:
-  modelName: adapter-1
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -33,7 +31,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-2
 spec:
-  modelName: adapter-2
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -48,7 +45,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-3
 spec:
-  modelName: adapter-3
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -63,7 +59,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-4
 spec:
-  modelName: adapter-4
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -78,7 +73,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-5
 spec:
-  modelName: adapter-5
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -93,7 +87,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-6
 spec:
-  modelName: adapter-6
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -108,7 +101,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-7
 spec:
-  modelName: adapter-7
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -123,7 +115,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-8
 spec:
-  modelName: adapter-8
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -138,7 +129,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-9
 spec:
-  modelName: adapter-9
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -153,7 +143,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-10
 spec:
-  modelName: adapter-10
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -168,7 +157,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-11
 spec:
-  modelName: adapter-11
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -183,7 +171,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-12
 spec:
-  modelName: adapter-12
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -199,7 +186,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-13
 spec:
-  modelName: adapter-13
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -215,7 +201,6 @@ kind: InferenceObjective
 metadata:
   name: adapter-14
 spec:
-  modelName: adapter-14
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -231,7 +216,6 @@ kind: InferenceObjective
 metadata:
   name: base-model
 spec:
-  modelName: meta-llama/Llama-3.1-8B-Instruct
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct

--- a/conformance/tests/epp_unavailable_fail_open.yaml
+++ b/conformance/tests/epp_unavailable_fail_open.yaml
@@ -6,7 +6,6 @@ metadata:
   name: conformance-fake-model-server
   namespace: gateway-conformance-app-backend
 spec:
-  modelName: conformance-fake-model
   criticality: Critical # Mark it as critical to bypass the saturation check since the model server is fake and don't have such metrics. 
   poolRef:
     name: secondary-inference-pool

--- a/conformance/tests/gateway_following_epp_routing.yaml
+++ b/conformance/tests/gateway_following_epp_routing.yaml
@@ -6,7 +6,6 @@ metadata:
   name: conformance-fake-model-server
   namespace: gateway-conformance-app-backend
 spec:
-  modelName: conformance-fake-model
   criticality: Critical # Mark it as critical to bypass the saturation check since the model server is fake and don't have such metrics. 
   poolRef:
     name: primary-inference-pool

--- a/docs/proposals/002-api-proposal/README.md
+++ b/docs/proposals/002-api-proposal/README.md
@@ -341,7 +341,6 @@ kind: InferenceModel
 metadata:
   name: sql-code-assist
 spec:
-  modelName: sql-code-assist
   poolRef:
     name: base-model-pool
 ---
@@ -350,7 +349,6 @@ kind: InferenceModel
 metadata:
   name: npc-bot
 spec:
-  modelName: npc-bot
   criticality: Critical
   targetModels:
     - name: npc-bot-v1

--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"testing"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -56,7 +55,7 @@ func TestHandleRequestHeaders(t *testing.T) {
 		},
 	}
 
-	err := server.HandleRequestHeaders(context.Background(), reqCtx, req)
+	err := server.HandleRequestHeaders(reqCtx, req)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -69,8 +69,8 @@ func (s *StreamingServer) HandleResponseBodyModelStreaming(ctx context.Context, 
 	if strings.Contains(responseText, streamingEndMsg) {
 		resp := parseRespForUsage(ctx, responseText)
 		reqCtx.Usage = resp.Usage
-		metrics.RecordInputTokens(reqCtx.Model, reqCtx.ResolvedTargetModel, resp.Usage.PromptTokens)
-		metrics.RecordOutputTokens(reqCtx.Model, reqCtx.ResolvedTargetModel, resp.Usage.CompletionTokens)
+		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, resp.Usage.PromptTokens)
+		metrics.RecordOutputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, resp.Usage.CompletionTokens)
 	}
 }
 

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -52,10 +52,8 @@ func TestServer(t *testing.T) {
 	expectedSchedulerHeaders := map[string]string{":method": "POST", requestHeader: theHeaderValue}
 
 	t.Run("server", func(t *testing.T) {
-		tsModel := "food-review"
 		model := testutil.MakeInferenceObjective("v1").
-			CreationTimestamp(metav1.Unix(1000, 0)).
-			ModelName(tsModel).ObjRef()
+			CreationTimestamp(metav1.Unix(1000, 0)).ObjRef()
 
 		director := &testDirector{}
 		ctx, cancel, ds, _ := utils.PrepareForTestStreamingServer([]*v1alpha2.InferenceObjective{model},

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -136,11 +136,6 @@ func (m *InferenceObjectiveWrapper) ObjRef() *v1alpha2.InferenceObjective {
 	return &m.InferenceObjective
 }
 
-func (m *InferenceObjectiveWrapper) ModelName(modelName string) *InferenceObjectiveWrapper {
-	m.Spec.ModelName = modelName
-	return m
-}
-
 func (m *InferenceObjectiveWrapper) TargetModel(modelName string) *InferenceObjectiveWrapper {
 	m.Spec.TargetModels = append(m.Spec.TargetModels, v1alpha2.TargetModel{Name: modelName})
 	return m

--- a/site-src/guides/adapter-rollout.md
+++ b/site-src/guides/adapter-rollout.md
@@ -68,7 +68,6 @@ kind: InferenceModel
 metadata:
   name: food-review
 spec:
-  modelName: food-review
   criticality: Standard
   poolRef:
     name: vllm-llama3-8b-instruct
@@ -107,7 +106,6 @@ kind: InferenceModel
 metadata:
   name: food-review
 spec:
-  modelName: food-review
   criticality: Standard
   poolRef:
     name: vllm-llama3-8b-instruct

--- a/site-src/guides/inferencepool-rollout.md
+++ b/site-src/guides/inferencepool-rollout.md
@@ -56,7 +56,6 @@ kind: InferenceModel
 metadata:
   name: food-review-new
 spec:
-  modelName: food-review
   criticality: Standard
   poolRef:
     name: vllm-llama3-8b-instruct-new

--- a/site-src/guides/serve-multiple-lora-adapters.md
+++ b/site-src/guides/serve-multiple-lora-adapters.md
@@ -27,7 +27,6 @@ kind: InferenceModel
 metadata:
   name: english-bot
 spec:
-  modelName: english-bot
   criticality: Standard
   poolRef:
     name: gemma3
@@ -38,7 +37,6 @@ kind: InferenceModel
 metadata:
   name: spanish-bot
 spec:
-  modelName: spanish-bot
   criticality: Critical
   poolRef:
     name: gemma3

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
 	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
@@ -241,7 +242,6 @@ func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	}
 	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
 		SetCriticality(v1alpha2.Critical).
-		SetModelName(modelName).
 		SetPoolRef(modelServerName).
 		SetTargetModels(targets).
 		Obj()
@@ -287,6 +287,8 @@ func getCurlCommand(name, ns, port, model string, timeout time.Duration, api str
 		fmt.Sprintf("%s.%s.svc:%s/v1%s", name, ns, port, api),
 		"-H",
 		"Content-Type: application/json",
+		"-H",
+		fmt.Sprintf("%v: inferenceobjective-sample", handlers.ObjectiveKey),
 		"-d",
 		string(b),
 	}

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -64,6 +64,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/saturationdetector"
@@ -337,6 +338,10 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 										Key:   "hi",
 										Value: "mom",
 									},
+									{
+										Key:   handlers.ObjectiveKey,
+										Value: "sql-lora-sheddable",
+									},
 								},
 							},
 						},
@@ -388,6 +393,10 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 									{
 										Key:   "hi",
 										Value: "mom",
+									},
+									{
+										Key:   handlers.ObjectiveKey,
+										Value: modelDirect,
 									},
 								},
 							},

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/server"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
@@ -122,6 +123,10 @@ func GenerateStreamedRequestSet(logger logr.Logger, prompt, model string, filter
 						{
 							Key:   "hi",
 							Value: "mom",
+						},
+						{
+							Key:   handlers.ObjectiveKey,
+							Value: model,
 						},
 					},
 				},

--- a/test/testdata/inferencepool-with-model-hermetic.yaml
+++ b/test/testdata/inferencepool-with-model-hermetic.yaml
@@ -13,10 +13,9 @@ spec:
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceObjective
 metadata:
-  name: sample
+  name: sql-lora
   namespace: default
 spec:
-  modelName: sql-lora
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
@@ -27,10 +26,9 @@ spec:
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceObjective
 metadata:
-  name: sheddable
+  name: sql-lora-sheddable
   namespace: default
 spec:
-  modelName: sql-lora-sheddable
   poolRef:
     name: vllm-llama3-8b-instruct-pool
   targetModels:
@@ -40,10 +38,9 @@ spec:
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceObjective
 metadata:
-  name: generic
+  name: my-model
   namespace: default
 spec:
-  modelName: my-model
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
@@ -54,10 +51,9 @@ spec:
 apiVersion: inference.networking.x-k8s.io/v1alpha2
 kind: InferenceObjective
 metadata:
-  name: direct-model-name
+  name: direct-model
   namespace: default
 spec:
-  modelName: direct-model
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool

--- a/test/utils/server.go
+++ b/test/utils/server.go
@@ -55,7 +55,7 @@ func PrepareForTestStreamingServer(objectives []*v1alpha2.InferenceObjective, po
 	initObjs := []client.Object{}
 	for _, objective := range objectives {
 		initObjs = append(initObjs, objective)
-		ds.ObjectiveSetIfOlder(objective)
+		ds.ObjectiveSet(objective)
 	}
 	for _, pod := range pods {
 		initObjs = append(initObjs, pod)

--- a/test/utils/wrappers.go
+++ b/test/utils/wrappers.go
@@ -38,17 +38,10 @@ func MakeModelWrapper(namespacedName types.NamespacedName) *InferenceObjectiveWr
 				Namespace: namespacedName.Namespace,
 			},
 			Spec: v1alpha2.InferenceObjectiveSpec{
-				ModelName: "",
-				PoolRef:   v1alpha2.PoolObjectReference{},
+				PoolRef: v1alpha2.PoolObjectReference{},
 			},
 		},
 	}
-}
-
-// SetModelName sets the value of the InferenceObjective.spec.modelName.
-func (m *InferenceObjectiveWrapper) SetModelName(name string) *InferenceObjectiveWrapper {
-	m.Spec.ModelName = name
-	return m
 }
 
 // SetCriticality sets the value of the InferenceObjective.spec.criticality.


### PR DESCRIPTION
A necessary consequence of selecting InferenceObjective by header is removing the `ModelName` field that was the original 'primary key' for InferenceObjective/Model. 

Given that 'modelName' was such a fundamental piece of the EPP, this PR is irreducably large. :(

Some things to note:
- Much of the reconciler code that required checking InferenceObjective timestamp has since been removed
- This also impacts tests
- Headers have been added to integration/e2e tests to select the InferenceObjective

For reviewing ease suggested review order: 
- `apix` pkg
- `reconciler/controller` pkg
- `handler` pkg
- `requestcontrol` pkg