### PR TITLE
Removing concurrency issues from Random Picker

### DIFF
--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -87,8 +87,13 @@ func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *types.CycleState,
 	log.FromContext(ctx).V(logutil.DEBUG).Info(fmt.Sprintf("Selecting maximum '%d' pods from %d candidates sorted by max score: %+v", p.maxNumOfEndpoints,
 		len(scoredPods), scoredPods))
 
+	// TODO: merge this with the logic in RandomPicker
+	// Rand package is not safe for concurrent use, so we create a new instance.
+	// Source: https://pkg.go.dev/math/rand#pkg-overview
+	randomGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	// Shuffle in-place - needed for random tie break when scores are equal
-	p.randomGenerator.Shuffle(len(scoredPods), func(i, j int) {
+	randomGenerator.Shuffle(len(scoredPods), func(i, j int) {
 		scoredPods[i], scoredPods[j] = scoredPods[j], scoredPods[i]
 	})
 


### PR DESCRIPTION
In high concurrency tests, EPP would hard crash with a stack trace:
```
panic: runtime error: index out of range [-1]

goroutine 8462092 [running]:
math/rand.(*rngSource).Uint64(...)
    /usr/local/go/src/math/rand/rng.go:249
math/rand.(*rngSource).Int63(0xc000000000?)
    /usr/local/go/src/math/rand/rng.go:234 +0x85
math/rand.(*Rand).Int63(...)
    /usr/local/go/src/math/rand/rand.go:96
math/rand.(*Rand).Uint32(...)
    /usr/local/go/src/math/rand/rand.go:99
math/rand.(*Rand).int31n(0xc0008eff50, 0x3)
    /usr/local/go/src/math/rand/rand.go:162 +0x31
math/rand.(*Rand).Shuffle(0xc0008eff50, 0xc001be6c60?, 0xc0020ef030)
    /usr/local/go/src/math/rand/rand.go:264 +0x79
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/picker.(*RandomPicker).Pick(0xc000b0c6c0, {0x2636070?, 0xc001d055c0?}, 0x22df74b?, {0xc002094c30, 0x3, 0x3})
    /src/pkg/epp/scheduling/framework/plugins/picker/random_picker.go:89 +0x19c
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework
...
```

This change fixes that issue, as the math/rand lib is not meant for concurrent use. (creating a new rand source per request showed no perf impact, which makes this is preferable to having a single source protected by a lock, or designing a pool of rand sources to pick from). The occurence rate low so creating a test for this is not considered for this PR