### PR TITLE
[Optimization]:  🔨 add thread-safe wrapper around rand.Shuffle and improve performance.

### DIFF
--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -21,6 +21,7 @@ import (
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 

--- a/pkg/epp/scheduling/framework/plugins/picker/common.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/common.go
@@ -31,7 +31,8 @@ type pickerParameters struct {
 	MaxNumOfEndpoints int `json:"maxNumOfEndpoints"`
 }
 
-// safeRand is a thread-safe wrapper around rand.Rand to ensure that random operations are safe to use in concurrent environments.
+// safeRand is a thread-safe wrapper around rand.Rand
+// to ensure that random operations are safe to use in concurrent environments.
 type safeRand struct {
 	r   *rand.Rand
 	mut sync.Mutex
@@ -48,7 +49,6 @@ func NewSafeRand(r *rand.Rand) *safeRand {
 }
 
 // Uint64 is a thread-safe method to get a random number.
-// It locks the mutex to ensure that only one goroutine can access the random number generator at
 func (r *safeRand) Uint64() uint64 {
 	r.mut.Lock()
 	defer r.mut.Unlock()
@@ -56,7 +56,7 @@ func (r *safeRand) Uint64() uint64 {
 	return r.r.Uint64()
 }
 
-// Shuffle is a thread-safe method to shuffle a slice of integers using the underlying random number generator.
+// Shuffle is a thread-safe method to shuffle a slice.
 func (r *safeRand) Shuffle(n int, swap func(i int, j int)) {
 	r.mut.Lock()
 	defer r.mut.Unlock()

--- a/pkg/epp/scheduling/framework/plugins/picker/common_test.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/common_test.go
@@ -1,0 +1,85 @@
+package picker
+
+import (
+	"math/rand/v2"
+	"testing"
+	"time"
+)
+
+// TestNewSafeRand_NilRand checks that NewSafeRand initializes a non-nil rand.Rand when passed nil.
+func TestNewSafeRand_NilRand(t *testing.T) {
+	sr := NewSafeRand(nil)
+	if sr == nil || sr.r == nil {
+		t.Errorf("Expected non-nil safeRand and rand.Rand, got nil")
+	}
+}
+
+// TestNewSafeRand_CustomRand checks that NewSafeRand uses the provided rand.Rand.
+func TestNewSafeRand_CustomRand(t *testing.T) {
+	src := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 42))
+	sr := NewSafeRand(src)
+	if sr.r != src {
+		t.Errorf("Expected safeRand to use provided rand.Rand")
+	}
+}
+
+// TestSafeRand_Uint64_ThreadSafe checks that Uint64 returns a value and is thread-safe.
+func TestSafeRand_Uint64_ThreadSafe(t *testing.T) {
+	sr := NewSafeRand(nil)
+	const goroutines = 10
+	results := make(chan uint64, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			results <- sr.Uint64()
+		}()
+	}
+	seen := make(map[uint64]bool)
+	for i := 0; i < goroutines; i++ {
+		val := <-results
+		if seen[val] {
+			t.Errorf("Duplicate value %v from Uint64, possible lack of randomness", val)
+		}
+		seen[val] = true
+	}
+}
+
+// TestSafeRand_Shuffle checks that Shuffle shuffles a slice.
+func TestSafeRand_Shuffle(t *testing.T) {
+	sr := NewSafeRand(nil)
+	orig := []int{1, 2, 3, 4, 5}
+	shuffled := make([]int, len(orig))
+	copy(shuffled, orig)
+	sr.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	// It's possible (but unlikely) that the slice remains unchanged after shuffling.
+	same := true
+	for i := range orig {
+		if orig[i] != shuffled[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Log("Shuffle did not change the slice; this is rare but possible")
+	}
+}
+
+// TestSafeRand_Shuffle_ThreadSafe checks Shuffle is thread-safe.
+func TestSafeRand_Shuffle_ThreadSafe(t *testing.T) {
+	sr := NewSafeRand(nil)
+	const goroutines = 5
+	done := make(chan bool, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			arr := []int{1, 2, 3, 4, 5}
+			sr.Shuffle(len(arr), func(i, j int) {
+				arr[i], arr[j] = arr[j], arr[i]
+			})
+			done <- true
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}

--- a/pkg/epp/scheduling/framework/plugins/picker/common_test.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/common_test.go
@@ -1,58 +1,34 @@
 package picker
 
 import (
-	"math/rand/v2"
+	"context"
+	"fmt"
 	"testing"
 	"time"
 )
 
-// TestNewSafeRand_NilRand checks that NewSafeRand initializes a non-nil rand.Rand when passed nil.
-func TestNewSafeRand_NilRand(t *testing.T) {
-	sr := NewSafeRand(nil)
-	if sr == nil || sr.r == nil {
-		t.Errorf("Expected non-nil safeRand and rand.Rand, got nil")
+func TestNewSafeRand_NotNil(t *testing.T) {
+	sr := NewSafeRand()
+	if sr == nil {
+		t.Fatal("NewSafeRand returned nil")
+	}
+	if sr.p == nil {
+		t.Fatal("sync.Pool in safeRand is nil")
 	}
 }
 
-// TestNewSafeRand_CustomRand checks that NewSafeRand uses the provided rand.Rand.
-func TestNewSafeRand_CustomRand(t *testing.T) {
-	src := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 42))
-	sr := NewSafeRand(src)
-	if sr.r != src {
-		t.Errorf("Expected safeRand to use provided rand.Rand")
-	}
-}
-
-// TestSafeRand_Uint64_ThreadSafe checks that Uint64 returns a value and is thread-safe.
-func TestSafeRand_Uint64_ThreadSafe(t *testing.T) {
-	sr := NewSafeRand(nil)
-	const goroutines = 10
-	results := make(chan uint64, goroutines)
-	for i := 0; i < goroutines; i++ {
-		go func() {
-			results <- sr.Uint64()
-		}()
-	}
-	seen := make(map[uint64]bool)
-	for i := 0; i < goroutines; i++ {
-		val := <-results
-		if seen[val] {
-			t.Errorf("Duplicate value %v from Uint64, possible lack of randomness", val)
-		}
-		seen[val] = true
-	}
-}
-
-// TestSafeRand_Shuffle checks that Shuffle shuffles a slice.
-func TestSafeRand_Shuffle(t *testing.T) {
-	sr := NewSafeRand(nil)
+func TestSafeRand_Shuffle_ShufflesSlice(t *testing.T) {
+	sr := NewSafeRand()
 	orig := []int{1, 2, 3, 4, 5}
 	shuffled := make([]int, len(orig))
 	copy(shuffled, orig)
+
 	sr.Shuffle(len(shuffled), func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
+
 	// It's possible (but unlikely) that the slice remains unchanged after shuffling.
+	// So we check that at least one element has moved.
 	same := true
 	for i := range orig {
 		if orig[i] != shuffled[i] {
@@ -61,25 +37,217 @@ func TestSafeRand_Shuffle(t *testing.T) {
 		}
 	}
 	if same {
-		t.Log("Shuffle did not change the slice; this is rare but possible")
+		t.Log("Warning: shuffled slice is the same as original (possible but unlikely)")
 	}
 }
 
-// TestSafeRand_Shuffle_ThreadSafe checks Shuffle is thread-safe.
-func TestSafeRand_Shuffle_ThreadSafe(t *testing.T) {
-	sr := NewSafeRand(nil)
-	const goroutines = 5
-	done := make(chan bool, goroutines)
-	for i := 0; i < goroutines; i++ {
+func TestSafeRand_ConcurrentShuffle(t *testing.T) {
+	sr := NewSafeRand()
+	const goroutines = 10
+	const sliceLen = 100
+	done := make(chan struct{}, goroutines)
+
+	for g := 0; g < goroutines; g++ {
 		go func() {
-			arr := []int{1, 2, 3, 4, 5}
-			sr.Shuffle(len(arr), func(i, j int) {
-				arr[i], arr[j] = arr[j], arr[i]
+			s := make([]int, sliceLen)
+			for i := range s {
+				s[i] = i
+			}
+			sr.Shuffle(len(s), func(i, j int) {
+				s[i], s[j] = s[j], s[i]
 			})
-			done <- true
+			done <- struct{}{}
 		}()
 	}
-	for i := 0; i < goroutines; i++ {
+
+	for g := 0; g < goroutines; g++ {
 		<-done
+	}
+}
+
+func TestSafeRand_Shuffle_EmptySlice(t *testing.T) {
+	sr := NewSafeRand()
+	emptySlice := []int{}
+
+	// Should not panic with empty slice
+	sr.Shuffle(len(emptySlice), func(i, j int) {
+		emptySlice[i], emptySlice[j] = emptySlice[j], emptySlice[i]
+	})
+
+	if len(emptySlice) != 0 {
+		t.Errorf("Expected empty slice to remain empty, got length %d", len(emptySlice))
+	}
+}
+
+func TestSafeRand_Shuffle_SingleElement(t *testing.T) {
+	sr := NewSafeRand()
+	singleElement := []int{42}
+
+	sr.Shuffle(len(singleElement), func(i, j int) {
+		singleElement[i], singleElement[j] = singleElement[j], singleElement[i]
+	})
+
+	if len(singleElement) != 1 || singleElement[0] != 42 {
+		t.Errorf("Expected single element slice to remain [42], got %v", singleElement)
+	}
+}
+
+// Benchmark tests for safeRand.
+func BenchmarkSafeRand_Shuffle_Small(b *testing.B) {
+	sr := NewSafeRand()
+	slice := make([]int, 10)
+	for i := range slice {
+		slice[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sr.Shuffle(len(slice), func(i, j int) {
+			slice[i], slice[j] = slice[j], slice[i]
+		})
+	}
+}
+
+func BenchmarkSafeRand_Shuffle_Large(b *testing.B) {
+	sr := NewSafeRand()
+	slice := make([]int, 1000)
+	for i := range slice {
+		slice[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sr.Shuffle(len(slice), func(i, j int) {
+			slice[i], slice[j] = slice[j], slice[i]
+		})
+	}
+}
+
+func BenchmarkSafeRand_Shuffle_Concurrent(b *testing.B) {
+	sr := NewSafeRand()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		slice := make([]int, 100)
+		for i := range slice {
+			slice[i] = i
+		}
+
+		for pb.Next() {
+			sr.Shuffle(len(slice), func(i, j int) {
+				slice[i], slice[j] = slice[j], slice[i]
+			})
+		}
+	})
+}
+
+// Advanced concurrent tests for safeRand
+func TestSafeRand_HighConcurrency(t *testing.T) {
+	sr := NewSafeRand()
+	const numGoroutines = 100
+	const numOperations = 100
+	const sliceSize = 50
+
+	done := make(chan struct{}, numGoroutines)
+	errors := make(chan error, numGoroutines)
+
+	for g := 0; g < numGoroutines; g++ {
+		go func(goroutineID int) {
+			defer func() {
+				if r := recover(); r != nil {
+					errors <- fmt.Errorf("goroutine %d panicked: %v", goroutineID, r)
+					return
+				}
+				done <- struct{}{}
+			}()
+
+			for op := 0; op < numOperations; op++ {
+				slice := make([]int, sliceSize)
+				for i := range slice {
+					slice[i] = i
+				}
+
+				sr.Shuffle(len(slice), func(i, j int) {
+					slice[i], slice[j] = slice[j], slice[i]
+				})
+
+				// Verify all elements are still present
+				for expected := 0; expected < sliceSize; expected++ {
+					found := false
+					for _, actual := range slice {
+						if actual == expected {
+							found = true
+							break
+						}
+					}
+					if !found {
+						errors <- fmt.Errorf("goroutine %d: element %d missing after shuffle", goroutineID, expected)
+						return
+					}
+				}
+			}
+		}(g)
+	}
+
+	// Wait for all goroutines to complete
+	for g := 0; g < numGoroutines; g++ {
+		select {
+		case <-done:
+			// Goroutine completed successfully
+		case err := <-errors:
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestSafeRand_StressTest(t *testing.T) {
+	sr := NewSafeRand()
+	const duration = 100 * time.Millisecond
+	const numGoroutines = 50
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	done := make(chan struct{}, numGoroutines)
+	errors := make(chan error, numGoroutines)
+
+	for g := 0; g < numGoroutines; g++ {
+		go func(goroutineID int) {
+			defer func() {
+				if r := recover(); r != nil {
+					errors <- fmt.Errorf("goroutine %d panicked: %v", goroutineID, r)
+					return
+				}
+				done <- struct{}{}
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					slice := make([]int, 20)
+					for i := range slice {
+						slice[i] = i
+					}
+					sr.Shuffle(len(slice), func(i, j int) {
+						slice[i], slice[j] = slice[j], slice[i]
+					})
+				}
+			}
+		}(g)
+	}
+
+	// Wait for context timeout
+	<-ctx.Done()
+
+	// Wait for all goroutines to complete
+	for g := 0; g < numGoroutines; g++ {
+		select {
+		case <-done:
+			// Goroutine completed successfully
+		case err := <-errors:
+			t.Fatal(err)
+		}
 	}
 }

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -58,7 +58,7 @@ func NewMaxScorePicker(maxNumOfEndpoints int) *MaxScorePicker {
 	return &MaxScorePicker{
 		typedName:         plugins.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
 		maxNumOfEndpoints: maxNumOfEndpoints,
-		rand:              NewSafeRand(nil), // use default safe random generator
+		rand:              NewSafeRand(nil), // init with default safe random source.
 	}
 }
 

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -58,7 +58,7 @@ func NewMaxScorePicker(maxNumOfEndpoints int) *MaxScorePicker {
 	return &MaxScorePicker{
 		typedName:         plugins.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
 		maxNumOfEndpoints: maxNumOfEndpoints,
-		rand:              NewSafeRand(nil), // init with default safe random source.
+		rand:              NewSafeRand(), // init with default safe random source.
 	}
 }
 

--- a/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/max_score_picker.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"slices"
-	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -60,13 +58,15 @@ func NewMaxScorePicker(maxNumOfEndpoints int) *MaxScorePicker {
 	return &MaxScorePicker{
 		typedName:         plugins.TypedName{Type: MaxScorePickerType, Name: MaxScorePickerType},
 		maxNumOfEndpoints: maxNumOfEndpoints,
+		rand:              NewSafeRand(nil), // use default safe random generator
 	}
 }
 
 // MaxScorePicker picks pod(s) with the maximum score from the list of candidates.
 type MaxScorePicker struct {
 	typedName         plugins.TypedName
-	maxNumOfEndpoints int // maximum number of endpoints to pick
+	maxNumOfEndpoints int       // maximum number of endpoints to pick
+	rand              *safeRand // thread-safe random number generator
 }
 
 // WithName sets the picker's name
@@ -85,13 +85,8 @@ func (p *MaxScorePicker) Pick(ctx context.Context, cycleState *types.CycleState,
 	log.FromContext(ctx).V(logutil.DEBUG).Info(fmt.Sprintf("Selecting maximum '%d' pods from %d candidates sorted by max score: %+v", p.maxNumOfEndpoints,
 		len(scoredPods), scoredPods))
 
-	// TODO: merge this with the logic in RandomPicker
-	// Rand package is not safe for concurrent use, so we create a new instance.
-	// Source: https://pkg.go.dev/math/rand#pkg-overview
-	randomGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	// Shuffle in-place - needed for random tie break when scores are equal
-	randomGenerator.Shuffle(len(scoredPods), func(i, j int) {
+	p.rand.Shuffle(len(scoredPods), func(i, j int) {
 		scoredPods[i], scoredPods[j] = scoredPods[j], scoredPods[i]
 	})
 

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -56,7 +56,7 @@ func NewRandomPicker(maxNumOfEndpoints int) *RandomPicker {
 	return &RandomPicker{
 		typedName:         plugins.TypedName{Type: RandomPickerType, Name: RandomPickerType},
 		maxNumOfEndpoints: maxNumOfEndpoints,
-		rand:              NewSafeRand(nil), // use default safe random generator
+		rand:              NewSafeRand(nil), // init with default safe random source.
 	}
 }
 

--- a/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/random_picker.go
@@ -56,7 +56,7 @@ func NewRandomPicker(maxNumOfEndpoints int) *RandomPicker {
 	return &RandomPicker{
 		typedName:         plugins.TypedName{Type: RandomPickerType, Name: RandomPickerType},
 		maxNumOfEndpoints: maxNumOfEndpoints,
-		rand:              NewSafeRand(nil), // init with default safe random source.
+		rand:              NewSafeRand(), // init with default safe random source.
 	}
 }
 

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -19,6 +19,7 @@ package testing
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 )


### PR DESCRIPTION
This PR is aimed at enhancing performance and code maintainability while ensuring concurrent safety.

Here are the simple performance test results:
```sh
Benchmark_SafeRandShuffle/new_rand
Benchmark_SafeRandShuffle/new_rand-12         	   68043	     19829 ns/op	    5376 B/op	       1 allocs/op

Benchmark_SafeRandShuffle/safe_rand
Benchmark_SafeRandShuffle/safe_rand-12        	64563002	        16.04 ns/op	       0 B/op	       0 allocs/op
```

ref: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1314

cc @nirrozenbaum  @ahg-g 