### PR TITLE
refactor(flowcontrol): Adopt Composite FlowKey as Primary Identifier

### DIFF
--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -46,9 +46,8 @@ import (
 type MockRegistryShard struct {
 	IDFunc                       func() string
 	IsActiveFunc                 func() bool
-	ActiveManagedQueueFunc       func(flowID string) (contracts.ManagedQueue, error)
-	ManagedQueueFunc             func(flowID string, priority uint) (contracts.ManagedQueue, error)
-	IntraFlowDispatchPolicyFunc  func(flowID string, priority uint) (framework.IntraFlowDispatchPolicy, error)
+	ManagedQueueFunc             func(key types.FlowKey) (contracts.ManagedQueue, error)
+	IntraFlowDispatchPolicyFunc  func(key types.FlowKey) (framework.IntraFlowDispatchPolicy, error)
 	InterFlowDispatchPolicyFunc  func(priority uint) (framework.InterFlowDispatchPolicy, error)
 	PriorityBandAccessorFunc     func(priority uint) (framework.PriorityBandAccessor, error)
 	AllOrderedPriorityLevelsFunc func() []uint
@@ -69,23 +68,16 @@ func (m *MockRegistryShard) IsActive() bool {
 	return false
 }
 
-func (m *MockRegistryShard) ActiveManagedQueue(flowID string) (contracts.ManagedQueue, error) {
-	if m.ActiveManagedQueueFunc != nil {
-		return m.ActiveManagedQueueFunc(flowID)
-	}
-	return nil, nil
-}
-
-func (m *MockRegistryShard) ManagedQueue(flowID string, priority uint) (contracts.ManagedQueue, error) {
+func (m *MockRegistryShard) ManagedQueue(key types.FlowKey) (contracts.ManagedQueue, error) {
 	if m.ManagedQueueFunc != nil {
-		return m.ManagedQueueFunc(flowID, priority)
+		return m.ManagedQueueFunc(key)
 	}
 	return nil, nil
 }
 
-func (m *MockRegistryShard) IntraFlowDispatchPolicy(flowID string, priority uint) (framework.IntraFlowDispatchPolicy, error) {
+func (m *MockRegistryShard) IntraFlowDispatchPolicy(key types.FlowKey) (framework.IntraFlowDispatchPolicy, error) {
 	if m.IntraFlowDispatchPolicyFunc != nil {
-		return m.IntraFlowDispatchPolicyFunc(flowID, priority)
+		return m.IntraFlowDispatchPolicyFunc(key)
 	}
 	return nil, nil
 }
@@ -148,8 +140,8 @@ func (m *MockSaturationDetector) IsSaturated(ctx context.Context) bool {
 //  3. **Self-Wiring**: The `FlowQueueAccessor()` method returns the mock itself, ensuring the accessor is always
 //     correctly connected to the queue's state without manual wiring in tests.
 type MockManagedQueue struct {
-	// FlowSpecV defines the flow specification for this mock queue. It should be set by the test.
-	FlowSpecV types.FlowSpecification
+	// FlowKeyV defines the flow specification for this mock queue. It should be set by the test.
+	FlowKeyV types.FlowKey
 
 	// AddFunc allows a test to completely override the default Add behavior.
 	AddFunc func(item types.QueueItemAccessor) error
@@ -249,7 +241,7 @@ func (m *MockManagedQueue) Drain() ([]types.QueueItemAccessor, error) {
 	return drained, nil
 }
 
-func (m *MockManagedQueue) FlowSpec() types.FlowSpecification         { return m.FlowSpecV }
+func (m *MockManagedQueue) FlowKey() types.FlowKey                    { return m.FlowKeyV }
 func (m *MockManagedQueue) Name() string                              { return "" }
 func (m *MockManagedQueue) Capabilities() []framework.QueueCapability { return nil }
 func (m *MockManagedQueue) Comparator() framework.ItemComparator      { return nil }

--- a/pkg/epp/flowcontrol/controller/internal/item_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/item_test.go
@@ -41,7 +41,8 @@ func TestItem(t *testing.T) {
 
 	t.Run("should have a non-finalized state upon creation", func(t *testing.T) {
 		t.Parallel()
-		req := typesmocks.NewMockFlowControlRequest(100, "req-1", "flow-a", context.Background())
+		key := types.FlowKey{ID: "flow-a", Priority: 10}
+		req := typesmocks.NewMockFlowControlRequest(100, "req-1", key, context.Background())
 		item := NewItem(req, time.Minute, time.Now())
 		require.NotNil(t, item, "NewItem should not return nil")
 		outcome, err := item.FinalState()

--- a/pkg/epp/flowcontrol/framework/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/framework/mocks/mocks.go
@@ -41,7 +41,7 @@ type MockFlowQueueAccessor struct {
 	PeekHeadErrV  error
 	PeekTailV     types.QueueItemAccessor
 	PeekTailErrV  error
-	FlowSpecV     types.FlowSpecification
+	FlowKeyV      types.FlowKey
 	ComparatorV   framework.ItemComparator
 	CapabilitiesV []framework.QueueCapability
 }
@@ -50,7 +50,7 @@ func (m *MockFlowQueueAccessor) Name() string                              { ret
 func (m *MockFlowQueueAccessor) Len() int                                  { return m.LenV }
 func (m *MockFlowQueueAccessor) ByteSize() uint64                          { return m.ByteSizeV }
 func (m *MockFlowQueueAccessor) Comparator() framework.ItemComparator      { return m.ComparatorV }
-func (m *MockFlowQueueAccessor) FlowSpec() types.FlowSpecification         { return m.FlowSpecV }
+func (m *MockFlowQueueAccessor) FlowKey() types.FlowKey                    { return m.FlowKeyV }
 func (m *MockFlowQueueAccessor) Capabilities() []framework.QueueCapability { return m.CapabilitiesV }
 
 func (m *MockFlowQueueAccessor) PeekHead() (types.QueueItemAccessor, error) {
@@ -69,7 +69,7 @@ var _ framework.FlowQueueAccessor = &MockFlowQueueAccessor{}
 type MockPriorityBandAccessor struct {
 	PriorityV         uint
 	PriorityNameV     string
-	FlowIDsFunc       func() []string
+	FlowKeysFunc      func() []types.FlowKey
 	QueueFunc         func(flowID string) framework.FlowQueueAccessor
 	IterateQueuesFunc func(callback func(queue framework.FlowQueueAccessor) (keepIterating bool))
 }
@@ -77,16 +77,16 @@ type MockPriorityBandAccessor struct {
 func (m *MockPriorityBandAccessor) Priority() uint       { return m.PriorityV }
 func (m *MockPriorityBandAccessor) PriorityName() string { return m.PriorityNameV }
 
-func (m *MockPriorityBandAccessor) FlowIDs() []string {
-	if m.FlowIDsFunc != nil {
-		return m.FlowIDsFunc()
+func (m *MockPriorityBandAccessor) FlowKeys() []types.FlowKey {
+	if m.FlowKeysFunc != nil {
+		return m.FlowKeysFunc()
 	}
 	return nil
 }
 
-func (m *MockPriorityBandAccessor) Queue(flowID string) framework.FlowQueueAccessor {
+func (m *MockPriorityBandAccessor) Queue(id string) framework.FlowQueueAccessor {
 	if m.QueueFunc != nil {
-		return m.QueueFunc(flowID)
+		return m.QueueFunc(id)
 	}
 	return nil
 }

--- a/pkg/epp/flowcontrol/framework/plugins/policies/interflow/dispatch/functional_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/interflow/dispatch/functional_test.go
@@ -65,7 +65,7 @@ func runSelectQueueConformanceTests(t *testing.T, policy framework.InterFlowDisp
 	mockQueueEmpty := &frameworkmocks.MockFlowQueueAccessor{
 		LenV:         0,
 		PeekHeadErrV: framework.ErrQueueEmpty,
-		FlowSpecV:    types.FlowSpecification{ID: flowIDEmpty},
+		FlowKeyV:     types.FlowKey{ID: flowIDEmpty},
 	}
 
 	testCases := []struct {
@@ -84,7 +84,7 @@ func runSelectQueueConformanceTests(t *testing.T, policy framework.InterFlowDisp
 		{
 			name: "With an empty priority band accessor",
 			band: &frameworkmocks.MockPriorityBandAccessor{
-				FlowIDsFunc:       func() []string { return []string{} },
+				FlowKeysFunc:      func() []types.FlowKey { return []types.FlowKey{} },
 				IterateQueuesFunc: func(callback func(queue framework.FlowQueueAccessor) bool) { /* no-op */ },
 			},
 			expectErr: false,
@@ -93,7 +93,7 @@ func runSelectQueueConformanceTests(t *testing.T, policy framework.InterFlowDisp
 		{
 			name: "With a band that has one empty queue",
 			band: &frameworkmocks.MockPriorityBandAccessor{
-				FlowIDsFunc: func() []string { return []string{flowIDEmpty} },
+				FlowKeysFunc: func() []types.FlowKey { return []types.FlowKey{{ID: flowIDEmpty}} },
 				QueueFunc: func(fID string) framework.FlowQueueAccessor {
 					if fID == flowIDEmpty {
 						return mockQueueEmpty
@@ -107,7 +107,7 @@ func runSelectQueueConformanceTests(t *testing.T, policy framework.InterFlowDisp
 		{
 			name: "With a band that has multiple empty queues",
 			band: &frameworkmocks.MockPriorityBandAccessor{
-				FlowIDsFunc: func() []string { return []string{flowIDEmpty, "flow-empty-2"} },
+				FlowKeysFunc: func() []types.FlowKey { return []types.FlowKey{{ID: flowIDEmpty}, {ID: "flow-empty-2"}} },
 				QueueFunc: func(fID string) framework.FlowQueueAccessor {
 					return mockQueueEmpty
 				},
@@ -136,7 +136,7 @@ func runSelectQueueConformanceTests(t *testing.T, policy framework.InterFlowDisp
 			}
 
 			if tc.expectedQueue != nil {
-				assert.Equal(t, tc.expectedQueue.FlowSpec().ID, selectedQueue.FlowSpec().ID,
+				assert.Equal(t, tc.expectedQueue.FlowKey(), selectedQueue.FlowKey(),
 					"SelectQueue for policy %s returned an unexpected queue", policy.Name())
 			}
 		})

--- a/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs/fcfs_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/policies/intraflow/dispatch/fcfs/fcfs_test.go
@@ -29,6 +29,8 @@ import (
 	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
 )
 
+var testFlowKey = types.FlowKey{ID: "test-flow", Priority: 0}
+
 func TestFCFS_Name(t *testing.T) {
 	t.Parallel()
 	policy := newFCFS()
@@ -49,7 +51,7 @@ func TestFCFS_SelectItem(t *testing.T) {
 	// This unit test focuses on the policy-specific success path.
 	policy := newFCFS()
 
-	mockItem := typesmocks.NewMockQueueItemAccessor(1, "item1", "flow1")
+	mockItem := typesmocks.NewMockQueueItemAccessor(1, "item1", testFlowKey)
 	mockQueue := &frameworkmocks.MockFlowQueueAccessor{
 		PeekHeadV: mockItem,
 		LenV:      1,
@@ -67,13 +69,13 @@ func TestEnqueueTimeComparator_Func(t *testing.T) {
 	require.NotNil(t, compareFunc)
 
 	now := time.Now()
-	itemA := typesmocks.NewMockQueueItemAccessor(10, "itemA", "test-flow")
+	itemA := typesmocks.NewMockQueueItemAccessor(10, "itemA", testFlowKey)
 	itemA.EnqueueTimeV = now
 
-	itemB := typesmocks.NewMockQueueItemAccessor(20, "itemB", "test-flow")
+	itemB := typesmocks.NewMockQueueItemAccessor(20, "itemB", testFlowKey)
 	itemB.EnqueueTimeV = now.Add(time.Second) // B is later than A
 
-	itemC := typesmocks.NewMockQueueItemAccessor(30, "itemC", "test-flow")
+	itemC := typesmocks.NewMockQueueItemAccessor(30, "itemC", testFlowKey)
 	itemC.EnqueueTimeV = now // C is same time as A
 
 	testCases := []struct {

--- a/pkg/epp/flowcontrol/framework/plugins/queue/benchmark_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/benchmark_test.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
 )
 
+var benchmarkFlowKey = types.FlowKey{ID: "benchmark-flow"}
+
 // BenchmarkQueues runs a series of benchmarks against all registered queue implementations.
 func BenchmarkQueues(b *testing.B) {
 	for queueName, constructor := range queue.RegisteredQueues {
@@ -68,7 +70,7 @@ func benchmarkAddRemove(b *testing.B, q framework.SafeQueue) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			item := mocks.NewMockQueueItemAccessor(1, "item", "benchmark-flow")
+			item := mocks.NewMockQueueItemAccessor(1, "item", benchmarkFlowKey)
 			err := q.Add(item)
 			if err != nil {
 				b.Fatalf("Add failed: %v", err)
@@ -85,7 +87,7 @@ func benchmarkAddRemove(b *testing.B, q framework.SafeQueue) {
 // common consumer pattern where a single worker peeks at an item before deciding to process and remove it.
 func benchmarkAddPeekRemove(b *testing.B, q framework.SafeQueue) {
 	// Pre-add one item so PeekHead doesn't fail on the first iteration.
-	initialItem := mocks.NewMockQueueItemAccessor(1, "initial", "benchmark-flow")
+	initialItem := mocks.NewMockQueueItemAccessor(1, "initial", benchmarkFlowKey)
 	if err := q.Add(initialItem); err != nil {
 		b.Fatalf("Failed to add initial item: %v", err)
 	}
@@ -93,7 +95,7 @@ func benchmarkAddPeekRemove(b *testing.B, q framework.SafeQueue) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		item := mocks.NewMockQueueItemAccessor(1, "item", "benchmark-flow")
+		item := mocks.NewMockQueueItemAccessor(1, "item", benchmarkFlowKey)
 		err := q.Add(item)
 		if err != nil {
 			b.Fatalf("Add failed: %v", err)
@@ -122,7 +124,7 @@ func benchmarkBulkAddThenBulkRemove(b *testing.B, q framework.SafeQueue) {
 		// Add a batch of items
 		items := make([]types.QueueItemAccessor, 100)
 		for j := range items {
-			item := mocks.NewMockQueueItemAccessor(1, fmt.Sprintf("bulk-%d-%d", i, j), "benchmark-flow")
+			item := mocks.NewMockQueueItemAccessor(1, fmt.Sprintf("bulk-%d-%d", i, j), benchmarkFlowKey)
 			items[j] = item
 			if err := q.Add(item); err != nil {
 				b.Fatalf("Add failed: %v", err)
@@ -146,7 +148,7 @@ func benchmarkBulkAddThenBulkRemove(b *testing.B, q framework.SafeQueue) {
 // understanding the performance of accessing the lowest-priority item.
 func benchmarkAddPeekTailRemove(b *testing.B, q framework.SafeQueue) {
 	// Pre-add one item so PeekTail doesn't fail on the first iteration.
-	initialItem := mocks.NewMockQueueItemAccessor(1, "initial", "benchmark-flow")
+	initialItem := mocks.NewMockQueueItemAccessor(1, "initial", benchmarkFlowKey)
 	if err := q.Add(initialItem); err != nil {
 		b.Fatalf("Failed to add initial item: %v", err)
 	}
@@ -154,7 +156,7 @@ func benchmarkAddPeekTailRemove(b *testing.B, q framework.SafeQueue) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		item := mocks.NewMockQueueItemAccessor(1, "item", "benchmark-flow")
+		item := mocks.NewMockQueueItemAccessor(1, "item", benchmarkFlowKey)
 		err := q.Add(item)
 		if err != nil {
 			b.Fatalf("Add failed: %v", err)
@@ -177,7 +179,7 @@ func benchmarkAddPeekTailRemove(b *testing.B, q framework.SafeQueue) {
 func benchmarkHighContention(b *testing.B, q framework.SafeQueue) {
 	// Pre-fill the queue to ensure consumers have work to do immediately.
 	for i := range 1000 {
-		item := mocks.NewMockQueueItemAccessor(1, fmt.Sprintf("prefill-%d", i), "benchmark-flow")
+		item := mocks.NewMockQueueItemAccessor(1, fmt.Sprintf("prefill-%d", i), benchmarkFlowKey)
 		if err := q.Add(item); err != nil {
 			b.Fatalf("Failed to pre-fill queue: %v", err)
 		}
@@ -196,7 +198,7 @@ func benchmarkHighContention(b *testing.B, q framework.SafeQueue) {
 				case <-stopCh:
 					return
 				default:
-					item := mocks.NewMockQueueItemAccessor(1, "item", "benchmark-flow")
+					item := mocks.NewMockQueueItemAccessor(1, "item", benchmarkFlowKey)
 					_ = q.Add(item)
 				}
 			}

--- a/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap/maxminheap_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap/maxminheap_test.go
@@ -46,7 +46,7 @@ func TestMaxMinHeap_InternalProperty(t *testing.T) {
 	now := time.Now()
 	for i := range items {
 		// Add items in a somewhat random order of enqueue times
-		items[i] = typesmocks.NewMockQueueItemAccessor(10, "item", "flow")
+		items[i] = typesmocks.NewMockQueueItemAccessor(10, "item", types.FlowKey{ID: "flow"})
 		items[i].EnqueueTimeV = now.Add(time.Duration((i%5-2)*10) * time.Second)
 		err := q.Add(items[i])
 		require.NoError(t, err, "Add should not fail")

--- a/pkg/epp/flowcontrol/registry/doc.go
+++ b/pkg/epp/flowcontrol/registry/doc.go
@@ -32,7 +32,7 @@ limitations under the License.
 //
 //   - `managedQueue`: A concrete implementation of the `contracts.ManagedQueue` interface. It acts as a stateful
 //     decorator around a `framework.SafeQueue`, adding critical registry-level functionality such as atomic statistics
-//     tracking and lifecycle state enforcement (active vs. draining).
+//     tracking.
 //
 //   - `Config`: The top-level configuration object that defines the structure and default behaviors of the registry,
 //     including the definition of priority bands and default policy selections. This configuration is partitioned and

--- a/pkg/epp/flowcontrol/types/flow.go
+++ b/pkg/epp/flowcontrol/types/flow.go
@@ -16,13 +16,63 @@ limitations under the License.
 
 package types
 
-// FlowSpecification defines the complete configuration for a single logical flow.
-// It is the data contract used by the `contracts.FlowRegistry` to create and manage the lifecycle of queues and
-// policies.
-type FlowSpecification struct {
-	// ID is the unique identifier for this flow (e.g., model name, tenant ID).
+import (
+	"fmt"
+	"strings"
+)
+
+// FlowKey is the unique, immutable identifier for a single, independently managed flow instance within the
+// `contracts.FlowRegistry`.
+// It combines a logical grouping `ID` with a specific `Priority` level to form a composite primary key.
+//
+// The core architectural principle of this model is that each unique, immutable `FlowKey` represents a completely
+// separate stream of traffic with its own queue, lifecycle and statistics.
+type FlowKey struct {
+	// ID is the logical grouping identifier for a flow, such as a tenant ID or a model name. This ID can be shared across
+	// multiple `FlowKey`s to represent different classes of traffic for the same logical entity. It provides a way to
+	// group related traffic but does not uniquely identify a manageable flow instance on its own.
 	ID string
 
-	// Priority is the numerical priority level for this flow. Lower values indicate higher priority.
+	// Priority is the numerical priority level that defines the priority band for this specific flow instance.
+	//
+	// A different Priority value for the same ID creates a distinct flow instance. For example, the keys
+	// `{ID: "TenantA", Priority: 10}` and `{ID: "TenantA", Priority: 100}` are treated as two completely separate,
+	// concurrently active flows. This allows a single tenant to serve traffic at multiple priority levels simultaneously.
+	//
+	// Because the `FlowKey` is immutable, changing the priority of traffic requires using a new `FlowKey`; the old flow
+	// instance will be automatically garbage collected by the registry when it becomes idle.
 	Priority uint
+}
+
+// Compare provides a stable comparison function for two FlowKey instances, suitable for use with sorting algorithms.
+// It returns -1 if the key is less than the other, 0 if they are equal, and 1 if the key is greater than the other.
+// The comparison is performed first by Priority (descending) and then by ID (ascending).
+func (k FlowKey) Compare(other FlowKey) int {
+	if k.Priority > other.Priority {
+		return -1
+	}
+	if k.Priority < other.Priority {
+		return 1
+	}
+	return strings.Compare(k.ID, other.ID)
+}
+
+func (k FlowKey) String() string {
+	return fmt.Sprintf("%s::%d", k.ID, k.Priority)
+}
+
+// FlowSpecification defines the complete configuration for a single logical flow instance, which is uniquely identified
+// by its immutable `Key`.
+//
+// It is the primary data contract used by the `contracts.FlowRegistry` to register or update a flow instance. The
+// registry manages one flow instance for each unique `FlowKey`. While the `Key` itself is immutable, the specification
+// can be updated via `RegisterOrUpdateFlow` to modify configurable parameters (e.g., policies, capacity limits) for the
+// existing flow instance (when these update stories are supported).
+type FlowSpecification struct {
+	// Key is the unique, immutable identifier for the flow instance this specification describes.
+	Key FlowKey
+
+	// TODO: Add other flow-scoped configuration fields here, such as:
+	// - IntraFlowDispatchPolicy intra.RegisteredPolicyName
+	// - CapacityBytes uint64
 }

--- a/pkg/epp/flowcontrol/types/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/types/mocks/mocks.go
@@ -28,27 +28,32 @@ import (
 // MockFlowControlRequest provides a mock implementation of the `types.FlowControlRequest` interface.
 type MockFlowControlRequest struct {
 	Ctx                  context.Context
-	FlowIDV              string
+	FlowKeyV             types.FlowKey
 	ByteSizeV            uint64
 	InitialEffectiveTTLV time.Duration
 	IDV                  string
 }
 
 // NewMockFlowControlRequest creates a new `MockFlowControlRequest` instance.
-func NewMockFlowControlRequest(byteSize uint64, id, flowID string, ctx context.Context) *MockFlowControlRequest {
+func NewMockFlowControlRequest(
+	byteSize uint64,
+	id string,
+	key types.FlowKey,
+	ctx context.Context,
+) *MockFlowControlRequest {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	return &MockFlowControlRequest{
 		ByteSizeV: byteSize,
 		IDV:       id,
-		FlowIDV:   flowID,
+		FlowKeyV:  key,
 		Ctx:       ctx,
 	}
 }
 
 func (m *MockFlowControlRequest) Context() context.Context           { return m.Ctx }
-func (m *MockFlowControlRequest) FlowID() string                     { return m.FlowIDV }
+func (m *MockFlowControlRequest) FlowKey() types.FlowKey             { return m.FlowKeyV }
 func (m *MockFlowControlRequest) ByteSize() uint64                   { return m.ByteSizeV }
 func (m *MockFlowControlRequest) InitialEffectiveTTL() time.Duration { return m.InitialEffectiveTTLV }
 func (m *MockFlowControlRequest) ID() string                         { return m.IDV }
@@ -92,13 +97,13 @@ var _ types.QueueItemAccessor = &MockQueueItemAccessor{}
 
 // NewMockQueueItemAccessor is a constructor for `MockQueueItemAccessor` that initializes the mock with a default
 // `MockFlowControlRequest` and `MockQueueItemHandle` to prevent nil pointer dereferences in tests.
-func NewMockQueueItemAccessor(byteSize uint64, reqID, flowID string) *MockQueueItemAccessor {
+func NewMockQueueItemAccessor(byteSize uint64, reqID string, key types.FlowKey) *MockQueueItemAccessor {
 	return &MockQueueItemAccessor{
 		EnqueueTimeV: time.Now(),
 		OriginalRequestV: NewMockFlowControlRequest(
 			byteSize,
 			reqID,
-			flowID,
+			key,
 			context.Background(),
 		),
 		HandleV: &MockQueueItemHandle{},

--- a/pkg/epp/flowcontrol/types/request.go
+++ b/pkg/epp/flowcontrol/types/request.go
@@ -33,10 +33,11 @@ type FlowControlRequest interface {
 	// queue.
 	Context() context.Context
 
-	// FlowID returns the unique identifier for the flow this request belongs to (e.g., model name, tenant ID). The
-	// `controller.FlowController` uses this ID to look up the active `contracts.ManagedQueue` and configured
-	// `framework.IntraFlowDispatchPolicy` from a `contracts.RegistryShard`.
-	FlowID() string
+	// FlowKey returns the composite key that uniquely identifies the flow instance this request belongs to.
+	// The `controller.FlowController` uses this key as the primary identifier to look up the correct
+	// `contracts.ManagedQueue` and configured `framework.IntraFlowDispatchPolicy` from a `contracts.RegistryShard`.
+	// The returned key is treated as an immutable value.
+	FlowKey() FlowKey
 
 	// ByteSize returns the request's size in bytes (e.g., prompt size). This is used by the `controller.FlowController`
 	// for managing byte-based capacity limits and for `contracts.FlowRegistry` statistics.


### PR DESCRIPTION
This PR refactors the flow control system to establish the composite `types.FlowKey` (ID + Priority) as the canonical, immutable identifier for a flow instance. This is a direct result of critical feedback and discussions on the open registry PR #1319 , which revealed a fundamental misalignment between the implementation's data model and the API's intended contract.

The previous model treated a flow's priority as a mutable attribute, which required a complex state machine for handling "graceful updates" (managing `active` vs. `draining` states, generation counters, etc.). This PR replaces that model with a simpler, more robust architecture where a flow instance is uniquely and immutably defined by its `FlowKey`.

This tracks #674 

---

### What this PR Does

-   **Introduces `types.FlowKey`:** A new struct combining `ID` and `Priority` is now the primary key for all flow instances.
-   **Refactors Core Contracts:** The `contracts.RegistryShard` and `framework` interfaces have been updated to use `FlowKey` as the primary identifier, removing ambiguity and clarifying the API. `ActiveManagedQueue` has been removed, and methods now consistently use the `FlowKey`.
-   **Removes the Hooks for the Update State Machine:** The preliminary hooks for the complex machinery for managing priority updates, including "draining" states, generation counters, and queue reactivation logic in #1319, has been deleted from  `ManagedQueue`.
-   **Updates the `ShardProcessor`:** The controller's worker implementation has been updated to align with the new, simpler contracts.

---

### Key Benefits

1.  **State Simplification:** By removing the complex priority update logic, the `FlowRegistry` and its components are now significantly simpler, more robust, and easier to reason about.
2.  **Unambiguous API Contracts:** Interfaces throughout the system are now clearer. Methods receive a single, self-contained `FlowKey`, eliminating the need to pass `flowID` and `priority` as separate parameters.
3.  **Architectural Alignment:** The implementation now correctly and directly reflects the agreed-upon domain model where a flow instance is uniquely defined by its ID *and* its priority.

---

### Architectural Consequence & Accepted Trade-off

This PR knowingly accepts a significant architectural trade-off: **inter-flow fairness is now strictly siloed within each priority band.**

Under this new model, the system will never be able to reason about holistic fairness for a single logical tenant across multiple priority levels (e.g., balancing `TenantA-High` against `TenantA-Medium`). Fairness policies operate on `(flowID, priority)` pairs as distinct, unrelated entities.

This trade-off is considered acceptable as the requirement for holistic, cross-priority fairness is currently undefined and out of scope for the system's immediate goals. This change provides a simpler, more robust foundation to build upon.

Thank you to @kfswain  and @ahg-g  for the insightful feedback that led to this design compromise.