### PR TITLE
[bug] Fix datalayer Collector test flake

### DIFF
--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -121,7 +121,12 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep Endpoint, sourc
 		return errors.New("collector start called multiple times")
 	}
 
-	select { // wait for goroutine to signal readiness
+	// Wait for goroutine to signal readiness.
+	// The use of ready channel is mostly to make the function testable, by ensuring
+	// synchronous order of events. Ignoring test requirements, one could let the
+	// go routine start at some arbitrary point in the future, possibly after this
+	// function has returned.
+	select {
 	case <-ready:
 		return nil
 	case <-ctx.Done():

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -108,9 +108,6 @@ func TestCollectorCollectsOnTicks(t *testing.T) {
 		return atomic.LoadInt64(&source.callCount) == 2
 	}, 1*time.Second, 2*time.Millisecond, "expected 2 collections")
 
-	got := atomic.LoadInt64(&source.callCount)
-	want := int64(2)
-	assert.Equal(t, want, got, "call count mismatch")
 	require.NoError(t, c.Stop())
 }
 


### PR DESCRIPTION
This fixes a test race condition when the start of the collector goroutine is delayed (e.g., on a loaded system).

In the original code, ticks are sent immediately upon return from `Start`. Unfortunately, there is a race condition due to timing: the collector's goroutine might not have reached the select statement when the ticks are sent.
The test timing is unpredictable:
- if the collector goroutine starts fast enough to catch both ticks before `Stop` is called, the test passes.
- otherwise, if The collector goroutine starts too slowly, it misses one or both ticks and the test fails.

The fix is in both the test and collector code:
- collector code is synchronized to return only after the goroutine has started (it waits on channel created inside `Do()`)
- test uses `require.Eventually` (with a much shorter timeout compared to before)

/cc @ahg-g 
