### PR TITLE
InferenceObjective: Updates `PoolRef` Group Version

### DIFF
--- a/apix/v1alpha2/inferenceobjective_types.go
+++ b/apix/v1alpha2/inferenceobjective_types.go
@@ -96,7 +96,7 @@ type PoolObjectReference struct {
 	// Group is the group of the referent.
 	//
 	// +optional
-	// +kubebuilder:default="inference.networking.x-k8s.io"
+	// +kubebuilder:default="inference.networking.k8s.io"
 	Group Group `json:"group,omitempty"`
 
 	// Kind is kind of the referent. For example "InferencePool".

--- a/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
@@ -88,7 +88,7 @@ spec:
                   must exist in the same namespace.
                 properties:
                   group:
-                    default: inference.networking.x-k8s.io
+                    default: inference.networking.k8s.io
                     description: Group is the group of the referent.
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$

--- a/test/testdata/inferencepool-with-model-hermetic.yaml
+++ b/test/testdata/inferencepool-with-model-hermetic.yaml
@@ -19,7 +19,6 @@ spec:
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
-    group: inference.networking.k8s.io
   targetModels:
   - name: sql-lora-1fdg2
     weight: 100
@@ -32,7 +31,6 @@ metadata:
 spec:
   poolRef:
     name: vllm-llama3-8b-instruct-pool
-    group: inference.networking.k8s.io
   targetModels:
   - name: sql-lora-1fdg3
     weight: 100
@@ -46,7 +44,6 @@ spec:
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
-    group: inference.networking.k8s.io
   targetModels:
   - name: my-model-12345
     weight: 100    
@@ -60,4 +57,3 @@ spec:
   criticality: Critical
   poolRef:
     name: vllm-llama3-8b-instruct-pool
-    group: inference.networking.k8s.io


### PR DESCRIPTION
This PR sets the default `poolRef` group of InferenceObjective from `inference.networking.x-k8s.io` to `inference.networking.x-k8s.io`. This aligns with the default InferencePool group used by the EPP binary.