### PR TITLE
Modifying Criticality; from string, to int

### DIFF
--- a/apix/v1alpha2/zz_generated.deepcopy.go
+++ b/apix/v1alpha2/zz_generated.deepcopy.go
@@ -176,7 +176,7 @@ func (in *InferenceObjectiveSpec) DeepCopyInto(out *InferenceObjectiveSpec) {
 	*out = *in
 	if in.Criticality != nil {
 		in, out := &in.Criticality, &out.Criticality
-		*out = new(Criticality)
+		*out = new(int)
 		**out = **in
 	}
 	out.PoolRef = in.PoolRef

--- a/client-go/applyconfiguration/apix/v1alpha2/inferenceobjectivespec.go
+++ b/client-go/applyconfiguration/apix/v1alpha2/inferenceobjectivespec.go
@@ -18,14 +18,10 @@ limitations under the License.
 
 package v1alpha2
 
-import (
-	apixv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
-)
-
 // InferenceObjectiveSpecApplyConfiguration represents a declarative configuration of the InferenceObjectiveSpec type for use
 // with apply.
 type InferenceObjectiveSpecApplyConfiguration struct {
-	Criticality *apixv1alpha2.Criticality              `json:"criticality,omitempty"`
+	Criticality *int                                   `json:"criticality,omitempty"`
 	PoolRef     *PoolObjectReferenceApplyConfiguration `json:"poolRef,omitempty"`
 }
 
@@ -38,7 +34,7 @@ func InferenceObjectiveSpec() *InferenceObjectiveSpecApplyConfiguration {
 // WithCriticality sets the Criticality field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Criticality field is set to the value of the last call.
-func (b *InferenceObjectiveSpecApplyConfiguration) WithCriticality(value apixv1alpha2.Criticality) *InferenceObjectiveSpecApplyConfiguration {
+func (b *InferenceObjectiveSpecApplyConfiguration) WithCriticality(value int) *InferenceObjectiveSpecApplyConfiguration {
 	b.Criticality = &value
 	return b
 }

--- a/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
+++ b/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
@@ -70,19 +70,19 @@ spec:
             properties:
               criticality:
                 description: |-
-                  Criticality defines how important it is to serve the model compared to other models referencing the same pool.
-                  Criticality impacts how traffic is handled in resource constrained situations. It handles this by
-                  queuing or rejecting requests of lower criticality. InferenceObjectives of an equivalent Criticality will
-                  fairly share resources over throughput of tokens. In the future, the metric used to calculate fairness,
-                  and the proportionality of fairness will be configurable.
+                  Criticality defines how important it is to serve the request compared to other requests in the same pool.
+                  Criticality is an integer value that defines the priority of the request.
+                  The higher the value, the more critical the request is; negative values _are_ allowed.
+                  No default value is set for this field, allowing for future additions of new fields that may 'one of' with this field.
+                  However, implementations that consume this field (such as the Endpoint Picker) will treat an unset value as '0'.
+                  Criticality is used in flow control, primarily in the event of resource scarcity(reqeusts need to be queued).
+                  All requests will be queued, and flow control will _always_ allow requests of higher criticality to be served first.
+                  Fairness is only enforced and tracked between requests of the same criticality.
 
-                  Default values for this field will not be set, to allow for future additions of new field that may 'one of' with this field.
-                  Any implementations that may consume this field may treat an unset value as the 'Standard' range.
-                enum:
-                - Critical
-                - Standard
-                - Sheddable
-                type: string
+                  Example: requests with Criticality 10 will always be served before
+                  requests with Criticality of 0(the value used if Criticality is unset or no InfereneceObjective is specified).
+                  Similarly requests with a Criticality of -10 will always be served after requests with Criticality of 0.
+                type: integer
               poolRef:
                 description: PoolRef is a reference to the inference pool, the pool
                   must exist in the same namespace.

--- a/config/manifests/inferenceobjective.yaml
+++ b/config/manifests/inferenceobjective.yaml
@@ -3,7 +3,7 @@ kind: InferenceObjective
 metadata:
   name: food-review
 spec:
-  criticality: Standard
+  criticality: 1
   poolRef:
     name: vllm-llama3-8b-instruct
 ---
@@ -12,7 +12,7 @@ kind: InferenceObjective
 metadata:
   name: base-model
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 ---
@@ -21,6 +21,6 @@ kind: InferenceObjective
 metadata:
   name: base-model-cpu
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct

--- a/config/manifests/regression-testing/inferenceobjective.yaml
+++ b/config/manifests/regression-testing/inferenceobjective.yaml
@@ -3,7 +3,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-0
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -14,7 +14,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-1
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -25,7 +25,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-2
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -36,7 +36,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-3
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -47,7 +47,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-4
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -58,7 +58,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-5
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -69,7 +69,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-6
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -80,7 +80,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-7
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -91,7 +91,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-8
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -102,7 +102,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-9
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -113,7 +113,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-10
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -124,7 +124,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-11
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -135,7 +135,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-12
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -147,7 +147,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-13
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -159,7 +159,7 @@ kind: InferenceObjective
 metadata:
   name: adapter-14
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct
 
@@ -171,6 +171,6 @@ kind: InferenceObjective
 metadata:
   name: base-model
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct

--- a/conformance/tests/epp_unavailable_fail_open.yaml
+++ b/conformance/tests/epp_unavailable_fail_open.yaml
@@ -6,7 +6,7 @@ metadata:
   name: conformance-fake-model-server
   namespace: gateway-conformance-app-backend
 spec:
-  criticality: Critical # Mark it as critical to bypass the saturation check since the model server is fake and don't have such metrics. 
+  criticality: 2 # Mark criticality high enough to bypass the saturation check since the model server is fake and don't have such metrics. 
   poolRef:
     name: secondary-inference-pool
 ---

--- a/conformance/tests/gateway_following_epp_routing.yaml
+++ b/conformance/tests/gateway_following_epp_routing.yaml
@@ -6,7 +6,7 @@ metadata:
   name: conformance-fake-model-server
   namespace: gateway-conformance-app-backend
 spec:
-  criticality: Critical # Mark it as critical to bypass the saturation check since the model server is fake and don't have such metrics. 
+  criticality: 2 # Mark criticality high enough to bypass the saturation check since the model server is fake and don't have such metrics.
   poolRef:
     name: primary-inference-pool
 ---

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -43,7 +43,7 @@ var (
 	pool          = utiltest.MakeInferencePool("test-pool1").Namespace("ns1").ObjRef()
 	infObjective1 = utiltest.MakeInferenceObjective("model1").
 			Namespace(pool.Namespace).
-			Criticality(v1alpha2.Standard).
+			Criticality(1).
 			CreationTimestamp(metav1.Unix(1000, 0)).
 			PoolName(pool.Name).
 			PoolGroup("inference.networking.k8s.io").ObjRef()
@@ -55,7 +55,7 @@ var (
 				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1Critical = utiltest.MakeInferenceObjective(infObjective1.Name).
 				Namespace(infObjective1.Namespace).
-				Criticality(v1alpha2.Critical).
+				Criticality(2).
 				CreationTimestamp(metav1.Unix(1003, 0)).
 				PoolName(pool.Name).
 				PoolGroup("inference.networking.k8s.io").ObjRef()
@@ -67,7 +67,7 @@ var (
 				PoolGroup("inference.networking.k8s.io").ObjRef()
 	infObjective1DiffGroup = utiltest.MakeInferenceObjective(infObjective1.Name).
 				Namespace(pool.Namespace).
-				Criticality(v1alpha2.Standard).
+				Criticality(1).
 				CreationTimestamp(metav1.Unix(1005, 0)).
 				PoolName(pool.Name).
 				PoolGroup("inference.networking.x-k8s.io").ObjRef()

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -114,7 +114,7 @@ func TestObjective(t *testing.T) {
 	model2ts := testutil.MakeInferenceObjective("model2").ObjRef()
 	// Same model name as model1ts, newer timestamp
 	model1tsCritical := testutil.MakeInferenceObjective("model1").
-		Criticality(v1alpha2.Critical).ObjRef()
+		Criticality(2).ObjRef()
 	// Same object name as model2ts, different model name.
 	model2chat := testutil.MakeInferenceObjective(model2ts.Name).ObjRef()
 

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
-	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
@@ -81,15 +80,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 	// InferenceObjective definitions
 	ioFoodReview := testutil.MakeInferenceObjective("ioFoodReview").
 		CreationTimestamp(metav1.Unix(1000, 0)).
-		Criticality(v1alpha2.Critical).
+		Criticality(2).
 		ObjRef()
 	ioFoodReviewSheddable := testutil.MakeInferenceObjective("imFoodReviewSheddable").
 		CreationTimestamp(metav1.Unix(1000, 0)).
-		Criticality(v1alpha2.Sheddable).
+		Criticality(0).
 		ObjRef()
 	ioFoodReviewResolve := testutil.MakeInferenceObjective("imFoodReviewResolve").
 		CreationTimestamp(metav1.Unix(1000, 0)).
-		Criticality(v1alpha2.Standard).
+		Criticality(1).
 		ObjRef()
 
 	// Datastore setup

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -146,7 +146,7 @@ func (m *InferenceObjectiveWrapper) PoolGroup(poolGroup string) *InferenceObject
 	return m
 }
 
-func (m *InferenceObjectiveWrapper) Criticality(criticality v1alpha2.Criticality) *InferenceObjectiveWrapper {
+func (m *InferenceObjectiveWrapper) Criticality(criticality int) *InferenceObjectiveWrapper {
 	m.Spec.Criticality = &criticality
 	return m
 }

--- a/site-src/guides/adapter-rollout.md
+++ b/site-src/guides/adapter-rollout.md
@@ -68,7 +68,7 @@ kind: InferenceModel
 metadata:
   name: food-review
 spec:
-  criticality: Standard
+  criticality: 1
   poolRef:
     name: vllm-llama3-8b-instruct
   targetModels:
@@ -106,7 +106,7 @@ kind: InferenceModel
 metadata:
   name: food-review
 spec:
-  criticality: Standard
+  criticality: 1
   poolRef:
     name: vllm-llama3-8b-instruct
   targetModels:

--- a/site-src/guides/inferencepool-rollout.md
+++ b/site-src/guides/inferencepool-rollout.md
@@ -56,7 +56,7 @@ kind: InferenceModel
 metadata:
   name: food-review-new
 spec:
-  criticality: Standard
+  criticality: 1
   poolRef:
     name: vllm-llama3-8b-instruct-new
   targetModels:

--- a/site-src/guides/serve-multiple-lora-adapters.md
+++ b/site-src/guides/serve-multiple-lora-adapters.md
@@ -27,7 +27,7 @@ kind: InferenceModel
 metadata:
   name: english-bot
 spec:
-  criticality: Standard
+  criticality: 1
   poolRef:
     name: gemma3
         
@@ -37,7 +37,7 @@ kind: InferenceModel
 metadata:
   name: spanish-bot
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: gemma3
     

--- a/test/e2e/epp/e2e_test.go
+++ b/test/e2e/epp/e2e_test.go
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("InferencePool", func() {
 // newInferenceObjective creates an InferenceObjective in the given namespace for testutils.
 func newInferenceObjective(ns string) *v1alpha2.InferenceObjective {
 	return testutils.MakeModelWrapper(types.NamespacedName{Name: "inferenceobjective-sample", Namespace: ns}).
-		SetCriticality(v1alpha2.Critical).
+		SetCriticality(2).
 		SetPoolRef(modelServerName).
 		Obj()
 }

--- a/test/testdata/inferencepool-with-model-hermetic.yaml
+++ b/test/testdata/inferencepool-with-model-hermetic.yaml
@@ -16,7 +16,7 @@ metadata:
   name: sql-lora
   namespace: default
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct-pool
     group: inference.networking.k8s.io
@@ -43,7 +43,7 @@ metadata:
   name: my-model
   namespace: default
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct-pool
     group: inference.networking.k8s.io
@@ -57,7 +57,7 @@ metadata:
   name: direct-model
   namespace: default
 spec:
-  criticality: Critical
+  criticality: 2
   poolRef:
     name: vllm-llama3-8b-instruct-pool
     group: inference.networking.k8s.io

--- a/test/utils/wrappers.go
+++ b/test/utils/wrappers.go
@@ -45,7 +45,7 @@ func MakeModelWrapper(namespacedName types.NamespacedName) *InferenceObjectiveWr
 }
 
 // SetCriticality sets the value of the InferenceObjective.spec.criticality.
-func (m *InferenceObjectiveWrapper) SetCriticality(level v1alpha2.Criticality) *InferenceObjectiveWrapper {
+func (m *InferenceObjectiveWrapper) SetCriticality(level int) *InferenceObjectiveWrapper {
 	m.Spec.Criticality = &level
 	return m
 }


### PR DESCRIPTION
Fixes: #1243

This PR changes Criticality to an optional int field; setting & documenting behavior handling the optional state. This is the final PR for the code-related API changes. Documentation still needs to be updated, and a small configuration issue was created (documented in comments). 


FYI CC: @ahg-g @nirrozenbaum @danehans 