### PR TITLE
explicit return from test after nil check

### DIFF
--- a/pkg/epp/saturationdetector/saturationdetector_test.go
+++ b/pkg/epp/saturationdetector/saturationdetector_test.go
@@ -114,6 +114,7 @@ func TestNewDetector(t *testing.T) {
 			detector := NewDetector(LoadConfigFromEnv(), test.datastore, logr.Discard())
 			if detector == nil {
 				t.Fatalf("NewDetector() returned nil detector for valid config")
+				return // explicit return so staticcheck does not warn on potential nil detector below.
 			}
 			if detector.config.QueueDepthThreshold != test.expectedQueueDepthThreshold {
 				t.Errorf("NewDetector() QueueDepthThreshold = %d, want %d", detector.config.QueueDepthThreshold, test.expectedQueueDepthThreshold)


### PR DESCRIPTION
some version of staticcheck complains on possible nil dereference. It is a false positive (`t.Fatalf` terminates the test), but adding an explicit return makes it clearer.

```sh
$ make lint
./bin/golangci-lint run --timeout 5m
pkg/epp/saturationdetector/saturationdetector_test.go:115:7: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
                        if detector == nil {
                           ^
pkg/epp/saturationdetector/saturationdetector_test.go:118:16: SA5011: possible nil pointer dereference (staticcheck)
                        if detector.config.QueueDepthThreshold != test.expectedQueueDepthThreshold {
                                    ^
2 issues:
* staticcheck: 2
make: *** [Makefile:153: lint] Error 1
```