### PR TITLE
Conformance: Adds InferenceObjective Request Header

### DIFF
--- a/conformance/tests/epp_unavailable_fail_open.go
+++ b/conformance/tests/epp_unavailable_fail_open.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/conformance/utils/config"
 	k8sutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/kubernetes"
 	trafficutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/traffic"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	testfilter "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/test/filter"
 )
 
@@ -53,6 +54,7 @@ var EppUnAvailableFailOpen = suite.ConformanceTest{
                 "model": "conformance-fake-model",
                 "prompt": "Write as if you were a critic: San Francisco"
             }`
+			inferenceObjName = "conformance-fake-model-server"
 		)
 
 		httpRouteNN := types.NamespacedName{Name: "httproute-for-failopen-pool-gw", Namespace: resources.AppBackendNamespace}
@@ -75,9 +77,12 @@ var EppUnAvailableFailOpen = suite.ConformanceTest{
 				s.TimeoutConfig,
 				gwAddr,
 				trafficutils.Request{
-					Host:      hostname,
-					Path:      path,
-					Headers:   map[string]string{testfilter.HeaderTestEppEndPointSelectionKey: targetPodIP},
+					Host: hostname,
+					Path: path,
+					Headers: map[string]string{
+						testfilter.HeaderTestEppEndPointSelectionKey: targetPodIP,
+						metadata.ObjectiveKey:                        inferenceObjName,
+					},
 					Method:    http.MethodPost,
 					Body:      requestBody,
 					Backend:   pods[0].Name, // Make sure the request is from the targetPod when the EPP is alive.
@@ -100,9 +105,12 @@ var EppUnAvailableFailOpen = suite.ConformanceTest{
 				s.TimeoutConfig,
 				gwAddr,
 				trafficutils.Request{
-					Host:      hostname,
-					Path:      path,
-					Headers:   map[string]string{testfilter.HeaderTestEppEndPointSelectionKey: targetPodIP},
+					Host: hostname,
+					Path: path,
+					Headers: map[string]string{
+						testfilter.HeaderTestEppEndPointSelectionKey: targetPodIP,
+						metadata.ObjectiveKey:                        inferenceObjName,
+					},
 					Method:    http.MethodPost,
 					Body:      requestBody,
 					Backend:   appPodBackendPrefix, // Only checks the prefix since the EPP is not alive and the response can return from any Pod.


### PR DESCRIPTION
Adds the "x-gateway-inference-objective" metadata header to conformance tests that specify an InferenceObjective.

Fixes #1352