### PR TITLE
refactor: prevent double logging of NamespacedName across reconcilers

### DIFF
--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -39,7 +39,7 @@ type InferenceObjectiveReconciler struct {
 }
 
 func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).V(logutil.DEFAULT).WithValues("InferenceObjective", req.NamespacedName)
+	logger := log.FromContext(ctx).V(logutil.DEFAULT)
 	ctx = ctrl.LoggerInto(ctx, logger)
 
 	logger.Info("Reconciling InferenceObjective")

--- a/pkg/epp/controller/inferencepool_reconciler.go
+++ b/pkg/epp/controller/inferencepool_reconciler.go
@@ -42,10 +42,10 @@ type InferencePoolReconciler struct {
 }
 
 func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithValues("group", c.PoolGKNN.Group, "inferencePool", req.NamespacedName).V(logutil.DEFAULT)
+	logger := log.FromContext(ctx).WithValues("group", c.PoolGKNN.Group).V(logutil.DEFAULT)
 	ctx = ctrl.LoggerInto(ctx, logger)
 
-	logger.Info("Reconciling InferencePool", "group", c.PoolGKNN.Group, "inferencePool", req.NamespacedName)
+	logger.Info("Reconciling InferencePool")
 
 	// 1. Initialize a generic client.Object based on the group.
 	var obj client.Object

--- a/pkg/epp/controller/pod_reconciler.go
+++ b/pkg/epp/controller/pod_reconciler.go
@@ -47,7 +47,7 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	logger.V(logutil.VERBOSE).Info("Pod being reconciled", "name", req.NamespacedName)
+	logger.V(logutil.VERBOSE).Info("Pod being reconciled")
 
 	pod := &corev1.Pod{}
 	if err := c.Get(ctx, req.NamespacedName, pod); err != nil {
@@ -55,7 +55,7 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			c.Datastore.PodDelete(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
-		logger.V(logutil.DEFAULT).Error(err, "Unable to get pod", "name", req.NamespacedName)
+		logger.V(logutil.DEFAULT).Error(err, "Unable to get pod")
 		return ctrl.Result{}, err
 	}
 
@@ -92,13 +92,13 @@ func (c *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (c *PodReconciler) updateDatastore(logger logr.Logger, pod *corev1.Pod) {
 	namespacedName := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 	if !podutil.IsPodReady(pod) || !c.Datastore.PoolLabelsMatch(pod.Labels) {
-		logger.V(logutil.DEBUG).Info("Pod removed or not added", "name", namespacedName)
+		logger.V(logutil.DEBUG).Info("Pod removed or not added")
 		c.Datastore.PodDelete(namespacedName)
 	} else {
 		if c.Datastore.PodUpdateOrAddIfNotExist(pod) {
-			logger.V(logutil.DEFAULT).Info("Pod added", "name", namespacedName)
+			logger.V(logutil.DEFAULT).Info("Pod added")
 		} else {
-			logger.V(logutil.DEFAULT).Info("Pod already exists", "name", namespacedName)
+			logger.V(logutil.DEFAULT).Info("Pod already exists")
 		}
 	}
 }


### PR DESCRIPTION
controller-runtime’s context logger for Reconcile already carries the object’s name/namespace. Adding req.NamespacedName again (either via `WithValues` or as a "name" field) duplicates the information and adds noise to the logs.

Quick test:

Before:




```
​2025-08-14T15:21:43Z    LEVEL(-2)    controller/inferencepool_reconciler.go:45    Reconciling InferencePool    {"controller": "inferencepool", "controllerGroup": "inference.networking.x-k8s.io", "controllerKind": "InferencePool", "InferencePool": {"name":"workspace-phi-4-mini inferencepool","namespace":"default"}, "namespace": "default", "name": "workspace-phi-4-mini-inferencepool", "reconcileID": "e924eda7-1535-434c-8c00-5003cfa58fbe", "inferencePool": {"name":"workspace-phi-4-mini-inferencepool","namespace":"default"}}
```

```
​2025-08-14T13:18:32Z    LEVEL(-2)    controller/pod_reconciler.go:100    Pod added    {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"workspace-phi-4-mini-5f478f5956-bg8lg" ,"namespace":"default"}, "namespace": "default", "name": "workspace-phi-4-mini-5f478f5956-bg8lg", "reconcileID": "c6a06a13-62c1-4075-ba70-230447d9fda6", "name": {"name":"workspace-phi-4-mini-5f478f5956-bg8lg","namespace":"default"}}
```

After:

```
​2025-08-14T17:02:49Z    LEVEL(-2)    controller/inferencepool_reconciler.go:48    Reconciling InferencePool    {"controller": "inferencepool", "controllerGroup": "inference.networking.k8s.io", "controllerKind": "InferencePool", "InferencePool": {"name":"workspace-phi-4-mini-inferencepool","namespace":"default"}, "namespace": "default", "name": "workspace-phi-4-mini-inferencepool", "reconcileID": "b1f8017c-0aac-48df-8fc1-330a476d5ec7", "group": "inference.networking.k8s.io"}
```

```
​2025-08-14T17:03:13Z    LEVEL(-3)    controller/pod_reconciler.go:50    Pod being reconciled    {"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"workspace-phi-4-mini-5f478f5956-n4m9f","namespace":"default"}, "namespace": "default", "name": "workspace-phi-4-mini-5f478f5956-n4m9f", "reconcileID": "a48760b8-8c88-4395-8deb-128f925be209"}
```


