### PR TITLE
Fixes Quickstart Script

### DIFF
--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -78,7 +78,7 @@ EPP="config/manifests/inferencepool-resources.yaml"
 #TODO: Put all helm values files into an array to loop over
 EPP_HELM="config/charts/inferencepool/values.yaml"
 BBR_HELM="config/charts/body-based-routing/values.yaml"
-CONFORMANCE_MANIFESTS="conformance/resources/manifests/manifests.yaml"
+CONFORMANCE_MANIFESTS="conformance/resources/base.yaml"
 echo "Updating ${EPP}, ${EPP_HELM}, ${BBR_HELM}, and ${CONFORMANCE_MANIFESTS} ..."
 
 # Update the container tag.

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -30,12 +30,12 @@ else
 fi
 
 # The vLLM image versions
-# The GPU image is from https://hub.docker.com/layers/vllm/vllm-openai
-VLLM_GPU="${VLLM_GPU:-0.9.1}"
+# The GPU image is from https://hub.docker.com/r/vllm/vllm-openai/tags
+VLLM_GPU="${VLLM_GPU:-0.10.0}"
 # The CPU image is from https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
-VLLM_CPU="${VLLM_CPU:-0.9.1}"
+VLLM_CPU="${VLLM_CPU:-0.10.0}"
 # The sim image is from https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim
-VLLM_SIM="${VLLM_SIM:-0.3.0}"
+VLLM_SIM="${VLLM_SIM:-0.3.2-fix}"
 
 echo "Using release tag: ${RELEASE_TAG}"
 echo "Using vLLM GPU image version: ${VLLM_GPU}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated `hack/release-quickstart.sh`:

- Updates default values of vLLM images.
- Updates path to conformance base manifest.

**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
