### PR TITLE
updated env var example in helm chart

### DIFF
--- a/config/charts/inferencepool/values.yaml
+++ b/config/charts/inferencepool/values.yaml
@@ -28,7 +28,7 @@ inferenceExtension:
 
   # Example environment variables:
   # env:
-  #   KV_CACHE_SCORE_WEIGHT: "1"
+  #   ENABLE_EXPERIMENTAL_FEATURE: "true"
 
   # Define additional container ports
   extraContainerPorts: []


### PR DESCRIPTION
Current example of env var in the helm chart is confusing. 
This example reads as if we're recommending to set scorer weight through an env var.

This is not the case since we introduced the config API and that was left here as a legacy example.
In fact, the recommendation is to use env vars for temporary flags.
updated the env var example accordingly (e.g., for enabling experimental feature).

no behavior change as this is only a comment, just to reduce confusion of a reader.