### PR TITLE
Fix: Handle empty string healthcheck as readiness healthcheck

### DIFF
--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -65,7 +65,12 @@ func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckReques
 	case ReadinessCheckService:
 		checkName = "readiness"
 		isPassing = isLive && s.isLeader.Load()
-	case LivenessCheckService, "": // Default to liveness check if service is empty
+	case "": // Handle overall server health for load balancers that use an empty service name.
+		checkName = "overall(empty string)"
+		// The overall health for a load balancer should reflect readiness to accept traffic,
+		// which is true only for the leader pod that has synced its data.
+		isPassing = isLive && s.isLeader.Load()
+	case LivenessCheckService:
 		checkName = "liveness"
 		// Any pod that is running and can respond to this gRPC check is considered "live".
 		// The datastore sync status should not affect liveness, only readiness.

--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -66,7 +66,7 @@ func (s *healthServer) Check(ctx context.Context, in *healthPb.HealthCheckReques
 		checkName = "readiness"
 		isPassing = isLive && s.isLeader.Load()
 	case "": // Handle overall server health for load balancers that use an empty service name.
-		checkName = "overall(empty string)"
+		checkName = "empty service name (considered as overall health)"
 		// The overall health for a load balancer should reflect readiness to accept traffic,
 		// which is true only for the leader pod that has synced its data.
 		isPassing = isLive && s.isLeader.Load()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it:**
When High Availability (HA) is enabled on GKE, the GCP backend service health check uses an empty string service name, which incorrectly causes all pods to be reported as healthy, regardless of their actual readiness state.

This PR fixes this behavior by mapping the empty string health check to use the pod's readiness probe status. This ensures that the GCP backend service only considers ready pods as healthy and prevents traffic from being routed to pods that are not yet able to serve requests. This change does not affect the standard Kubernetes liveness and readiness probes.

**Which issue(s) this PR fixes:**
Fixes failing-test on GKE for #1337 

**Does this PR introduce a user-facing change?:**
No