### PR TITLE
Conformance: Updates InferencePoolResolvedRefsCondition Test

### DIFF
--- a/conformance/tests/inferencepool_resolvedrefs_condition.go
+++ b/conformance/tests/inferencepool_resolvedrefs_condition.go
@@ -152,7 +152,7 @@ var InferencePoolParentStatus = suite.ConformanceTest{
 			t.Logf("Waiting for %v for Gateway conditions to update after deleting HTTPRoute %s", inferenceTimeoutConfig.HTTPRouteDeletionReconciliationTimeout, httpRouteSecondaryNN.String())
 			time.Sleep(inferenceTimeoutConfig.HTTPRouteDeletionReconciliationTimeout)
 
-			k8sutils.InferencePoolMustHaveNoParents(t, s.Client, poolNN)
+			k8sutils.InferencePoolMustHaveDefaultParent(t, s.Client, poolNN)
 			t.Logf("InferencePool %s correctly shows no parent statuses, indicating it's no longer referenced.", poolNN.String())
 
 			trafficutils.MakeRequestAndExpectEventuallyConsistentResponse(


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

Optionally add one or more of the following kinds if applicable:

/kind failing-test
/area conformance-test

**What this PR does / why we need it**:

Updates the InferencePoolResolvedRefsCondition conformance test to comply with the API spec by checking for the default parent condition when a controller no longer manages the InferencePool and no other parents exist:

```go
type InferencePoolStatus struct {
	// Parents is a list of parent resources (usually Gateways) that are
	// associated with the InferencePool, and the status of the InferencePool with respect to
	// each parent.
	//
	// A maximum of 32 Gateways will be represented in this list. When the list contains
	// `kind: Status, name: default`, it indicates that the InferencePool is not
	// associated with any Gateway and a controller must perform the following:
	//
	//  - Remove the parent when setting the "Accepted" condition.
	//  - Add the parent when the controller will no longer manage the InferencePool
	//    and no other parents exist.
	//
	// +kubebuilder:validation:MaxItems=32
	// +optional
	// +listType=atomic
	Parents []PoolStatus `json:"parent,omitempty"`
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1407

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
