### PR TITLE
fix(cleanup): change spec doc

### DIFF
--- a/api/v1/inferencepool_types.go
+++ b/api/v1/inferencepool_types.go
@@ -100,8 +100,8 @@ type EndpointPickerRef struct {
 
 	// Kind is the Kubernetes resource kind of the referent.
 	//
-	// Required if the referent is ambiguous(e.g. service with one port is unambiguous)
-	// 
+	// Required if the referent is ambiguous(e.g. service with one port is unambiguous).
+	//
 	// Defaults to "Service" when not specified.
 	//
 	// ExternalName services can refer to CNAME DNS records that may live

--- a/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
@@ -70,7 +70,7 @@ spec:
                     description: |-
                       Kind is the Kubernetes resource kind of the referent.
 
-                      Required if the referent is ambiguous(e.g. service with one port is unambiguous)
+                      Required if the referent is ambiguous(e.g. service with one port is unambiguous).
 
                       Defaults to "Service" when not specified.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
Part of https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1173/files#r2292256667

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
part of https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1173/files#r2292256667

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
