### PR TITLE
Fix epp startup error due to missing plugin config file flag

### DIFF
--- a/config/charts/inferencepool/templates/epp-deployment.yaml
+++ b/config/charts/inferencepool/templates/epp-deployment.yaml
@@ -29,6 +29,8 @@ spec:
         - {{ .Release.Namespace }}
         - --zap-encoder
         - "json"
+        - --config-file
+        - "/config/default-plugins.yaml"
         {{- range .Values.inferenceExtension.flags }}
         - "--{{ .name }}={{ .value }}"
         {{- end }}


### PR DESCRIPTION
The `config-file` default is empty, we need to specify it in the charts, otherwise we get error:


```
{"level":"error","ts":"2025-08-22T22:38:56Z","logger":"setup","caller":"runner/runner.go:242","msg":"failed to create scheduler","error":"scheduler config must be set either by config api or through code","stacktrace":"sigs.k8s.io/gateway-api-inference-extension/cmd/epp/runner.(*Runner).Run\n\t/src/cmd/epp/runner/runner.go:242\nmain.main\n\t/src/cmd/epp/main.go:31\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:283"}
```