### PR TITLE
Refactor LLMRequest: Structured RequestData for Completions & Chat-Completions

### DIFF
--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -103,7 +103,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 	reqCtx.Request.Body["model"] = reqCtx.TargetModelName
 
-	requestData, err := requtil.ExtractRequestData(reqCtx.Request.Body)
+	requestBody, err := requtil.ExtractRequestBody(reqCtx.Request.Body)
 	if err != nil {
 		return reqCtx, errutil.Error{Code: errutil.BadRequest, Msg: fmt.Errorf("failed to extract request data: %w", err).Error()}
 	}
@@ -125,7 +125,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	reqCtx.SchedulingRequest = &schedulingtypes.LLMRequest{
 		RequestId:   reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
 		TargetModel: reqCtx.TargetModelName,
-		Data:        requestData,
+		Body:        requestBody,
 		Headers:     reqCtx.Request.Headers,
 	}
 

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -261,7 +261,7 @@ func (p *Plugin) matchLongestPrefix(ctx context.Context, hashes []BlockHash) map
 // For block i, hash(i) = hash(block i content, hash(i-1)).
 func hashPrompt(ctx context.Context, request *types.LLMRequest, cacheBlockSize int, maxPrefixBlocks int) []BlockHash {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
-	if request == nil || request.Data == nil {
+	if request == nil || request.Body == nil {
 		loggerDebug.Info("Request or request data is nil, skipping hashing")
 		return nil
 	}
@@ -305,10 +305,10 @@ func toBytes(i BlockHash) []byte {
 }
 
 func getUserInputBytes(request *types.LLMRequest) ([]byte, error) {
-	if request.Data.Completions != nil { // assumed to be valid if not nil
-		return []byte(request.Data.Completions.Prompt), nil
+	if request.Body.Completions != nil { // assumed to be valid if not nil
+		return []byte(request.Body.Completions.Prompt), nil
 	}
 
 	// must be chat-completions request at this point, return bytes of entire messages
-	return json.Marshal(request.Data.ChatCompletions.Messages)
+	return json.Marshal(request.Body.ChatCompletions.Messages)
 }

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -49,7 +49,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	req1 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			Completions: &types.CompletionsRequest{
 				Prompt: "aaaaaa",
 			},
@@ -81,7 +81,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	req2 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model2",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			Completions: &types.CompletionsRequest{
 				Prompt: "bbbbbb",
 			},
@@ -112,7 +112,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	req3 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			Completions: &types.CompletionsRequest{
 				Prompt: "aaaabbbb",
 			},
@@ -142,7 +142,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	req4 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model-new",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			Completions: &types.CompletionsRequest{
 				Prompt: "aaaabbbb",
 			},
@@ -172,7 +172,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	req5 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			Completions: &types.CompletionsRequest{
 				Prompt: "aaaabbbbcccc",
 			},
@@ -214,7 +214,7 @@ func TestPrefixPluginChatCompletions(t *testing.T) {
 	req1 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			ChatCompletions: &types.ChatCompletionsRequest{
 				Messages: []types.Message{
 					{Role: "user", Content: "hello world"},
@@ -223,8 +223,8 @@ func TestPrefixPluginChatCompletions(t *testing.T) {
 			},
 		},
 	}
-	scores := plugin.Score(context.Background(), nil, req1, pods)
-	state, err := plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req1.RequestId, PrefixCachePluginType)
+	scores := plugin.Score(context.Background(), types.NewCycleState(), req1, pods)
+	state, err := plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req1.RequestId, plugins.StateKey(plugin.TypedName().String()))
 	assert.NoError(t, err)
 	t.Logf("Chat completions - Hashes %+v, cached servers: %+v", state.PrefixHashes, state.PrefixCacheServers)
 	// Should have some hashes for the JSON-encoded messages
@@ -249,7 +249,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 	req1 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			ChatCompletions: &types.ChatCompletionsRequest{
 				Messages: []types.Message{
 					{Role: "system", Content: "You are a helpful assistant"},
@@ -258,8 +258,8 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 			},
 		},
 	}
-	scores := plugin.Score(context.Background(), nil, req1, pods)
-	state, err := plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req1.RequestId, PrefixCachePluginType)
+	scores := plugin.Score(context.Background(), types.NewCycleState(), req1, pods)
+	state, err := plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req1.RequestId, plugins.StateKey(plugin.TypedName().String()))
 	assert.NoError(t, err)
 	t.Logf("Initial conversation - Hashes %+v, cached servers: %+v", len(state.PrefixHashes), state.PrefixCacheServers)
 	initialHashCount := len(state.PrefixHashes)
@@ -281,7 +281,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 	req2 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			ChatCompletions: &types.ChatCompletionsRequest{
 				Messages: []types.Message{
 					{Role: "system", Content: "You are a helpful assistant"},
@@ -292,8 +292,8 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 			},
 		},
 	}
-	scores = plugin.Score(context.Background(), nil, req2, pods)
-	state, err = plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req2.RequestId, PrefixCachePluginType)
+	scores = plugin.Score(context.Background(), types.NewCycleState(), req2, pods)
+	state, err = plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req2.RequestId, plugins.StateKey(plugin.TypedName().String()))
 	assert.NoError(t, err)
 	t.Logf("Extended conversation - Hashes %+v, cached servers: %+v", len(state.PrefixHashes), state.PrefixCacheServers)
 	extendedHashCount := len(state.PrefixHashes)
@@ -313,7 +313,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 	req3 := &types.LLMRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Data: &types.LLMRequestData{
+		Body: &types.LLMRequestBody{
 			ChatCompletions: &types.ChatCompletionsRequest{
 				Messages: []types.Message{
 					{Role: "system", Content: "You are a helpful assistant"},
@@ -326,8 +326,8 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 			},
 		},
 	}
-	scores = plugin.Score(context.Background(), nil, req3, pods)
-	state, err = plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req3.RequestId, PrefixCachePluginType)
+	scores = plugin.Score(context.Background(), types.NewCycleState(), req3, pods)
+	state, err = plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req3.RequestId, plugins.StateKey(plugin.TypedName().String()))
 	assert.NoError(t, err)
 	t.Logf("Long conversation - Hashes %+v, cached servers: %+v", len(state.PrefixHashes), state.PrefixCacheServers)
 	longHashCount := len(state.PrefixHashes)
@@ -375,7 +375,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 		req := &types.LLMRequest{
 			RequestId:   uuid.NewString(),
 			TargetModel: "model-stress",
-			Data: &types.LLMRequestData{
+			Body: &types.LLMRequestBody{
 				Completions: &types.CompletionsRequest{
 					Prompt: prompt,
 				},
@@ -396,7 +396,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 		// Second cycle: validate internal state
 		state, err := plugins.ReadPluginStateKey[*SchedulingContextState](plugin.pluginState, req.RequestId, plugins.StateKey(plugin.TypedName().String()))
 		assert.NoError(b, err)
-		expectedHashes := int(math.Min(float64(maxPrefixBlocks), float64(len(req.Data.Completions.Prompt)/blockSize)))
+		expectedHashes := int(math.Min(float64(maxPrefixBlocks), float64(len(req.Body.Completions.Prompt)/blockSize)))
 		assert.Equal(b, expectedHashes, len(state.PrefixHashes), "number of hashes is incorrect")
 	}
 }
@@ -464,7 +464,7 @@ func BenchmarkPrefixPluginChatCompletionsStress(b *testing.B) {
 			req := &types.LLMRequest{
 				RequestId:   uuid.NewString(),
 				TargetModel: "chat-model-stress",
-				Data: &types.LLMRequestData{
+				Body: &types.LLMRequestBody{
 					ChatCompletions: &types.ChatCompletionsRequest{
 						Messages: messages,
 					},

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -32,7 +32,7 @@ type LLMRequest struct {
 	// TargetModel is the final target model after traffic split.
 	TargetModel string
 	// Data contains the request-body fields that we parse out as user input.
-	Data *LLMRequestData
+	Body *LLMRequestBody
 	// Headers is a map of the request headers.
 	Headers map[string]string
 }
@@ -42,14 +42,14 @@ func (r *LLMRequest) String() string {
 		return nilString
 	}
 
-	return fmt.Sprintf("RequestID: %s, TargetModel: %s, RequestData: %s, Headers: %v",
-		r.RequestId, r.TargetModel, r.Data, r.Headers)
+	return fmt.Sprintf("RequestID: %s, TargetModel: %s, Body: %s, Headers: %v",
+		r.RequestId, r.TargetModel, r.Body, r.Headers)
 }
 
-// LLMRequestData contains the request-body fields that we parse out as user input,
+// LLMRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
-// An LLMRequestData must contain exactly one of CompletionsRequest or ChatCompletionsRequest.
-type LLMRequestData struct {
+// An LLMRequestBody must contain exactly one of CompletionsRequest or ChatCompletionsRequest.
+type LLMRequestBody struct {
 	// CompletionsRequest is the representation of the OpenAI /v1/completions request body.
 	Completions *CompletionsRequest `json:"completions,omitempty"`
 	// ChatCompletionsRequest is the representation of the OpenAI /v1/chat_completions request body.

--- a/pkg/epp/util/request/body.go
+++ b/pkg/epp/util/request/body.go
@@ -23,10 +23,10 @@ import (
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
-// ExtractRequestData extracts the LLMRequestData from the given request body map.
-func ExtractRequestData(body map[string]any) (*types.LLMRequestData, error) {
+// ExtractRequestBody extracts the LLMRequestBody from the given request body map.
+func ExtractRequestBody(rawBody map[string]any) (*types.LLMRequestBody, error) {
 	// Convert map back to JSON bytes
-	jsonBytes, err := json.Marshal(body)
+	jsonBytes, err := json.Marshal(rawBody)
 	if err != nil {
 		return nil, errutil.Error{Code: errutil.BadRequest, Msg: "invalid request body"}
 	}
@@ -34,7 +34,7 @@ func ExtractRequestData(body map[string]any) (*types.LLMRequestData, error) {
 	// Try completions request first
 	var completions types.CompletionsRequest
 	if err = json.Unmarshal(jsonBytes, &completions); err == nil && completions.Prompt != "" {
-		return &types.LLMRequestData{Completions: &completions}, nil
+		return &types.LLMRequestBody{Completions: &completions}, nil
 	}
 
 	// Try chat completions
@@ -47,7 +47,7 @@ func ExtractRequestData(body map[string]any) (*types.LLMRequestData, error) {
 		return nil, errutil.Error{Code: errutil.BadRequest, Msg: "invalid chat-completions request: " + err.Error()}
 	}
 
-	return &types.LLMRequestData{ChatCompletions: &chatCompletions}, nil
+	return &types.LLMRequestBody{ChatCompletions: &chatCompletions}, nil
 }
 
 func validateChatCompletionsMessages(messages []types.Message) error {

--- a/pkg/epp/util/request/body_test.go
+++ b/pkg/epp/util/request/body_test.go
@@ -27,7 +27,7 @@ func TestExtractRequestData(t *testing.T) {
 	tests := []struct {
 		name    string
 		body    map[string]any
-		want    *types.LLMRequestData
+		want    *types.LLMRequestBody
 		wantErr bool
 	}{
 		{
@@ -36,7 +36,7 @@ func TestExtractRequestData(t *testing.T) {
 				"model":  "test",
 				"prompt": "test prompt",
 			},
-			want: &types.LLMRequestData{
+			want: &types.LLMRequestBody{
 				Completions: &types.CompletionsRequest{
 					Prompt: "test prompt",
 				},
@@ -55,7 +55,7 @@ func TestExtractRequestData(t *testing.T) {
 					},
 				},
 			},
-			want: &types.LLMRequestData{
+			want: &types.LLMRequestBody{
 				ChatCompletions: &types.ChatCompletionsRequest{
 					Messages: []types.Message{
 						{Role: "system", Content: "this is a system message"},
@@ -79,7 +79,7 @@ func TestExtractRequestData(t *testing.T) {
 				"add_generation_prompt":        true,
 				"chat_template_kwargs":         map[string]any{"key": "value"},
 			},
-			want: &types.LLMRequestData{
+			want: &types.LLMRequestBody{
 				ChatCompletions: &types.ChatCompletionsRequest{
 					Messages:                  []types.Message{{Role: "user", Content: "hello"}},
 					Tools:                     []any{map[string]any{"type": "function"}},
@@ -229,9 +229,9 @@ func TestExtractRequestData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ExtractRequestData(tt.body)
+			got, err := ExtractRequestBody(tt.body)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ExtractRequestData() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ExtractRequestBody() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.wantErr {
@@ -239,7 +239,7 @@ func TestExtractRequestData(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("ExtractRequestData() mismatch (-want +got):\n%s", diff)
+				t.Errorf("ExtractRequestBody() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -254,7 +254,7 @@ func BenchmarkExtractRequestData_Completions(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ExtractRequestData(body)
+		_, err := ExtractRequestBody(body)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -271,7 +271,7 @@ func BenchmarkExtractRequestData_ChatCompletions(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ExtractRequestData(body)
+		_, err := ExtractRequestBody(body)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -295,7 +295,7 @@ func BenchmarkExtractRequestData_ChatCompletionsWithOptionals(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ExtractRequestData(body)
+		_, err := ExtractRequestBody(body)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
## **Motivation**

The types.LLMRequest struct is the core API for scheduling plugins.
Until now, it only exposed a flat Prompt string.
* For `/v1/completions`, this was sufficient.
* For `/v1/chat/completions`, messages were flattened into a pseudo-prompt via naive templating.

This flattening discards useful fields (e.g., `tools`, `chat_template`, etc.) that plugins may need. For example, the **llm-d** `precise-prefix-cache-scorer` plugin recreates vLLM's tokenization (including `jinja2` templating), but today's API does not provide all the necessary inputs.

To support richer scheduling logic and prepare for newer APIs (e.g., OpenAI responses), we need to preserve raw, structured request data instead of flattening it upfront.

## **Summary of Changes**

* **types.LLMRequest**
   * Replaced flat `Prompt` string with structured `LLMRequestData`, a disjoint union of `CompletionsRequest` and `ChatCompletionsRequest` - the latter includes fields from the HuggingFace transformers chat-templating API.
   * Request data is preserved as-is, **local** transformations are left to plugins.

* **Prefix-cache scorer**
   * No longer depends on naive prompt reconstruction for chat-completions:
     * This was originally done in order to attempt to hold the 1:4 chars-to-tokens estimation ratio. This attempt fails in that in actual chat-templating, the added special-keywords map to **individual preserved tokens** that are a part of the model's vocabulary. Therefore the existence of the naive templating as a whole is questionable, and can be avoided.

* **requestcontrol.Director**
   * Now responsible for parsing and populating the request fields as-is.
    
## **Testing**

* **Unit tests**
   * Added coverage for both completions and chat-completions request parsing.
   * Validated optional fields (tools, documents, chat_template, etc.).

* **Prefix plugin tests**
   * Verified prefix scoring works with both completions and chat-completions.
   * Added growth tests to confirm correct prefix matching across extended conversations.

* **Benchmarks**
   * Stress tests for long prompts and large chat histories.
   * Confirmed cache scoring scales correctly under load.

## **Related Issues**
* Fixes #827

cc @nirrozenbaum @kfswain @liu-cong