### PR TITLE
remove empty condition list when doing v1 and v1alpha2 conversion.

### DIFF
--- a/apix/v1alpha2/inferencepool_conversion.go
+++ b/apix/v1alpha2/inferencepool_conversion.go
@@ -103,8 +103,7 @@ func convertStatusToV1(src *InferencePoolStatus) (*v1.InferencePoolStatus, error
 	}
 	for _, p := range src.Parents {
 		ps := v1.ParentStatus{
-			ParentRef:  toV1ParentRef(p.GatewayRef),
-			Conditions: make([]metav1.Condition, 0, len(p.Conditions)),
+			ParentRef: toV1ParentRef(p.GatewayRef),
 		}
 		for _, c := range p.Conditions {
 			cc := c
@@ -133,7 +132,6 @@ func convertStatusFromV1(src *v1.InferencePoolStatus) (*InferencePoolStatus, err
 	for _, p := range src.Parents {
 		ps := PoolStatus{
 			GatewayRef: fromV1ParentRef(p.ParentRef),
-			Conditions: make([]metav1.Condition, 0, len(p.Conditions)),
 		}
 		for _, c := range p.Conditions {
 			cc := c

--- a/apix/v1alpha2/inferencepool_conversion.go
+++ b/apix/v1alpha2/inferencepool_conversion.go
@@ -105,14 +105,17 @@ func convertStatusToV1(src *InferencePoolStatus) (*v1.InferencePoolStatus, error
 		ps := v1.ParentStatus{
 			ParentRef: toV1ParentRef(p.GatewayRef),
 		}
-		for _, c := range p.Conditions {
+		if p.Conditions != nil {
+			ps.Conditions = make([]metav1.Condition, len(p.Conditions))
+		}
+		for idx, c := range p.Conditions {
 			cc := c
 			// v1alpha2: "Accepted" -> v1: "SupportedByParent"
 			if cc.Type == string(v1.InferencePoolConditionAccepted) &&
 				cc.Reason == string(InferencePoolReasonAccepted) {
 				cc.Reason = string(v1.InferencePoolReasonAccepted)
 			}
-			ps.Conditions = append(ps.Conditions, cc)
+			ps.Conditions[idx] = cc
 		}
 		out.Parents = append(out.Parents, ps)
 	}
@@ -133,14 +136,17 @@ func convertStatusFromV1(src *v1.InferencePoolStatus) (*InferencePoolStatus, err
 		ps := PoolStatus{
 			GatewayRef: fromV1ParentRef(p.ParentRef),
 		}
-		for _, c := range p.Conditions {
+		if p.Conditions != nil {
+			ps.Conditions = make([]metav1.Condition, len(p.Conditions))
+		}
+		for idx, c := range p.Conditions {
 			cc := c
 			// v1: "SupportedByParent" -> v1alpha2: "Accepted"
 			if cc.Type == string(v1.InferencePoolConditionAccepted) &&
 				cc.Reason == string(v1.InferencePoolReasonAccepted) {
 				cc.Reason = string(InferencePoolReasonAccepted)
 			}
-			ps.Conditions = append(ps.Conditions, cc)
+			ps.Conditions[idx] = cc
 		}
 		out.Parents = append(out.Parents, ps)
 	}

--- a/apix/v1alpha2/inferencepool_conversion_test.go
+++ b/apix/v1alpha2/inferencepool_conversion_test.go
@@ -73,6 +73,12 @@ func TestInferencePoolConvertTo(t *testing.T) {
 						{
 							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
 							Conditions: []metav1.Condition{
+								{ // v1alpha2 default condition is skipped from conversion.
+									Type:               string(v1.InferencePoolConditionAccepted),
+									Status:             metav1.ConditionUnknown,
+									Reason:             string(InferencePoolReasonPending),
+									LastTransitionTime: timestamp,
+								},
 								{
 									Type:               string(InferencePoolConditionAccepted),
 									Status:             metav1.ConditionTrue,
@@ -127,7 +133,7 @@ func TestInferencePoolConvertTo(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "conversion from v1alpha2 to v1 with empty extensionRef and nil status condition",
+			name: "conversion from v1alpha2 to v1 with empty extensionRef and default v1alpha2 status condition",
 			src: &InferencePool{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "InferencePool",
@@ -147,6 +153,14 @@ func TestInferencePoolConvertTo(t *testing.T) {
 					Parents: []PoolStatus{
 						{
 							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
+							Conditions: []metav1.Condition{
+								{
+									Type:               string(v1.InferencePoolConditionAccepted),
+									Status:             metav1.ConditionUnknown,
+									Reason:             string(InferencePoolReasonPending),
+									LastTransitionTime: timestamp,
+								},
+							},
 						},
 					},
 				},
@@ -172,60 +186,6 @@ func TestInferencePoolConvertTo(t *testing.T) {
 					Parents: []v1.ParentStatus{
 						{
 							ParentRef: v1.ParentReference{Name: "my-gateway"},
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "conversion from v1alpha2 to v1 with empty extensionRef and empty status condition",
-			src: &InferencePool{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "InferencePool",
-					APIVersion: GroupVersion.String(),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pool",
-					Namespace: "test-ns",
-				},
-				Spec: InferencePoolSpec{
-					Selector: map[LabelKey]LabelValue{
-						"app": "my-model-server",
-					},
-					TargetPortNumber: 8080,
-				},
-				Status: InferencePoolStatus{
-					Parents: []PoolStatus{
-						{
-							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
-							Conditions: []metav1.Condition{},
-						},
-					},
-				},
-			},
-			want: &v1.InferencePool{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "InferencePool",
-					APIVersion: v1.GroupVersion.String(),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pool",
-					Namespace: "test-ns",
-				},
-				Spec: v1.InferencePoolSpec{
-					Selector: v1.LabelSelector{
-						MatchLabels: map[v1.LabelKey]v1.LabelValue{
-							"app": "my-model-server",
-						},
-					},
-					TargetPorts: []v1.Port{{Number: v1.PortNumber(int32(8080))}},
-				},
-				Status: v1.InferencePoolStatus{
-					Parents: []v1.ParentStatus{
-						{
-							ParentRef:  v1.ParentReference{Name: "my-gateway"},
-							Conditions: []metav1.Condition{},
 						},
 					},
 				},

--- a/apix/v1alpha2/inferencepool_conversion_test.go
+++ b/apix/v1alpha2/inferencepool_conversion_test.go
@@ -127,7 +127,7 @@ func TestInferencePoolConvertTo(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "conversion from v1alpha2 to v1 with empty extensionRef and empty status condition",
+			name: "conversion from v1alpha2 to v1 with empty extensionRef and nil status condition",
 			src: &InferencePool{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "InferencePool",
@@ -172,6 +172,60 @@ func TestInferencePoolConvertTo(t *testing.T) {
 					Parents: []v1.ParentStatus{
 						{
 							ParentRef: v1.ParentReference{Name: "my-gateway"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "conversion from v1alpha2 to v1 with empty extensionRef and empty status condition",
+			src: &InferencePool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "InferencePool",
+					APIVersion: GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "test-ns",
+				},
+				Spec: InferencePoolSpec{
+					Selector: map[LabelKey]LabelValue{
+						"app": "my-model-server",
+					},
+					TargetPortNumber: 8080,
+				},
+				Status: InferencePoolStatus{
+					Parents: []PoolStatus{
+						{
+							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
+							Conditions: []metav1.Condition{},
+						},
+					},
+				},
+			},
+			want: &v1.InferencePool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "InferencePool",
+					APIVersion: v1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "test-ns",
+				},
+				Spec: v1.InferencePoolSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "my-model-server",
+						},
+					},
+					TargetPorts: []v1.Port{{Number: v1.PortNumber(int32(8080))}},
+				},
+				Status: v1.InferencePoolStatus{
+					Parents: []v1.ParentStatus{
+						{
+							ParentRef:  v1.ParentReference{Name: "my-gateway"},
+							Conditions: []metav1.Condition{},
 						},
 					},
 				},
@@ -284,7 +338,7 @@ func TestInferencePoolConvertFrom(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "conversion from v1 to v1alpha2 with empty extensionRef and empty status condition",
+			name: "conversion from v1 to v1alpha2 with empty extensionRef and nil status condition",
 			src: &v1.InferencePool{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "InferencePool",
@@ -329,6 +383,60 @@ func TestInferencePoolConvertFrom(t *testing.T) {
 					Parents: []PoolStatus{
 						{
 							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "conversion from v1 to v1alpha2 with empty extensionRef and empty status condition",
+			src: &v1.InferencePool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "InferencePool",
+					APIVersion: v1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "test-ns",
+				},
+				Spec: v1.InferencePoolSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "my-model-server",
+						},
+					},
+					TargetPorts: []v1.Port{{Number: v1.PortNumber(int32(8080))}},
+				},
+				Status: v1.InferencePoolStatus{
+					Parents: []v1.ParentStatus{
+						{
+							ParentRef:  v1.ParentReference{Name: "my-gateway"},
+							Conditions: []metav1.Condition{},
+						},
+					},
+				},
+			},
+			want: &InferencePool{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "InferencePool",
+					APIVersion: GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "test-ns",
+				},
+				Spec: InferencePoolSpec{
+					Selector: map[LabelKey]LabelValue{
+						"app": "my-model-server",
+					},
+					TargetPortNumber: 8080,
+				},
+				Status: InferencePoolStatus{
+					Parents: []PoolStatus{
+						{
+							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
+							Conditions: []metav1.Condition{},
 						},
 					},
 				},

--- a/apix/v1alpha2/inferencepool_conversion_test.go
+++ b/apix/v1alpha2/inferencepool_conversion_test.go
@@ -127,7 +127,7 @@ func TestInferencePoolConvertTo(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "conversion from v1alpha2 to v1 with empty extensionRef",
+			name: "conversion from v1alpha2 to v1 with empty extensionRef and empty status condition",
 			src: &InferencePool{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "InferencePool",
@@ -147,14 +147,6 @@ func TestInferencePoolConvertTo(t *testing.T) {
 					Parents: []PoolStatus{
 						{
 							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
-							Conditions: []metav1.Condition{
-								{
-									Type:               string(InferencePoolConditionAccepted),
-									Status:             metav1.ConditionTrue,
-									Reason:             string(InferencePoolReasonAccepted),
-									LastTransitionTime: timestamp,
-								},
-							},
 						},
 					},
 				},
@@ -180,14 +172,6 @@ func TestInferencePoolConvertTo(t *testing.T) {
 					Parents: []v1.ParentStatus{
 						{
 							ParentRef: v1.ParentReference{Name: "my-gateway"},
-							Conditions: []metav1.Condition{
-								{
-									Type:               string(v1.InferencePoolConditionAccepted),
-									Status:             metav1.ConditionTrue,
-									Reason:             string(v1.InferencePoolReasonAccepted),
-									LastTransitionTime: timestamp,
-								},
-							},
 						},
 					},
 				},
@@ -300,7 +284,7 @@ func TestInferencePoolConvertFrom(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "conversion from v1 to v1alpha2 with empty extensionRef",
+			name: "conversion from v1 to v1alpha2 with empty extensionRef and empty status condition",
 			src: &v1.InferencePool{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "InferencePool",
@@ -322,14 +306,6 @@ func TestInferencePoolConvertFrom(t *testing.T) {
 					Parents: []v1.ParentStatus{
 						{
 							ParentRef: v1.ParentReference{Name: "my-gateway"},
-							Conditions: []metav1.Condition{
-								{
-									Type:               string(v1.InferencePoolConditionAccepted),
-									Status:             metav1.ConditionTrue,
-									Reason:             string(v1.InferencePoolReasonAccepted),
-									LastTransitionTime: timestamp,
-								},
-							},
 						},
 					},
 				},
@@ -353,14 +329,6 @@ func TestInferencePoolConvertFrom(t *testing.T) {
 					Parents: []PoolStatus{
 						{
 							GatewayRef: ParentGatewayReference{Name: "my-gateway"},
-							Conditions: []metav1.Condition{
-								{
-									Type:               string(InferencePoolConditionAccepted),
-									Status:             metav1.ConditionTrue,
-									Reason:             string(InferencePoolReasonAccepted),
-									LastTransitionTime: timestamp,
-								},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
While doing v1alpha2 and v1 infPool conversion, if the condition slice is empty we are always adding an empty placeholder slice. However, this is not consistent with the "omitempty"
```
	// +optional
	// +listType=map
	// +listMapKey=type
	// +kubebuilder:validation:MaxItems=8
	Conditions []metav1.Condition `json:"conditions,omitempty"`
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
