### PR TITLE
fix(conformance): remove the inferenceObjective dependency compeletely.

### DIFF
--- a/conformance/resources/resourcename.go
+++ b/conformance/resources/resourcename.go
@@ -34,8 +34,6 @@ const (
 
 	ModelServerPodReplicas    = 3
 	EndPointPickerPodReplicas = 1
-
-	InferenceObjName = "conformance-fake-model-server"
 )
 
 var (

--- a/conformance/tests/epp_unavailable_fail_open.go
+++ b/conformance/tests/epp_unavailable_fail_open.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/conformance/utils/config"
 	k8sutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/kubernetes"
 	trafficutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/traffic"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/test"
 )
 
@@ -80,7 +79,6 @@ var EppUnAvailableFailOpen = suite.ConformanceTest{
 					Path: path,
 					Headers: map[string]string{
 						test.HeaderTestEppEndPointSelectionKey: targetPodIP,
-						metadata.ObjectiveKey:                  resources.InferenceObjName,
 					},
 					Method:    http.MethodPost,
 					Body:      requestBody,
@@ -108,7 +106,6 @@ var EppUnAvailableFailOpen = suite.ConformanceTest{
 					Path: path,
 					Headers: map[string]string{
 						test.HeaderTestEppEndPointSelectionKey: targetPodIP,
-						metadata.ObjectiveKey:                  resources.InferenceObjName,
 					},
 					Method:    http.MethodPost,
 					Body:      requestBody,

--- a/conformance/tests/epp_unavailable_fail_open.yaml
+++ b/conformance/tests/epp_unavailable_fail_open.yaml
@@ -1,15 +1,3 @@
-# --- InferenceObjective Definition ---
-# TODO: remove inferenceObjective dependency https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1002
-apiVersion: inference.networking.x-k8s.io/v1alpha2
-kind: InferenceObjective
-metadata:
-  name: conformance-fake-model-server
-  namespace: gateway-conformance-app-backend
-spec:
-  criticality: 2 # Mark criticality high enough to bypass the saturation check since the model server is fake and don't have such metrics. 
-  poolRef:
-    name: secondary-inference-pool
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/conformance/tests/gateway_following_epp_routing.go
+++ b/conformance/tests/gateway_following_epp_routing.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/conformance/resources"
 	k8sutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api-inference-extension/conformance/utils/traffic"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/test"
 )
 
@@ -97,7 +96,6 @@ var GatewayFollowingEPPRouting = suite.ConformanceTest{
 					Path: path,
 					Headers: map[string]string{
 						test.HeaderTestEppEndPointSelectionKey: podIPs[i],
-						metadata.ObjectiveKey:                  resources.InferenceObjName,
 					},
 					Method:    http.MethodPost,
 					Body:      requestBody,
@@ -134,7 +132,6 @@ var GatewayFollowingEPPRouting = suite.ConformanceTest{
 				eppHeaderValue := strings.Join(tc.podIPsToBeReturnedByEPP, ",")
 				headers := map[string]string{
 					test.HeaderTestEppEndPointSelectionKey: eppHeaderValue,
-					metadata.ObjectiveKey:                  resources.InferenceObjName,
 				}
 
 				t.Logf("Sending request to %s with EPP header '%s: %s'", gwAddr, test.HeaderTestEppEndPointSelectionKey, eppHeaderValue)

--- a/conformance/tests/gateway_following_epp_routing.yaml
+++ b/conformance/tests/gateway_following_epp_routing.yaml
@@ -1,16 +1,3 @@
-# --- InferenceObjective Definition ---
-# Service for the infra-backend-deployment.
-apiVersion: inference.networking.x-k8s.io/v1alpha2
-kind: InferenceObjective
-metadata:
-  name: conformance-fake-model-server
-  namespace: gateway-conformance-app-backend
-spec:
-  criticality: 2 # Mark criticality high enough to bypass the saturation check since the model server is fake and don't have such metrics.
-  poolRef:
-    name: primary-inference-pool
----
-# --- HTTPRoute for Primary Gateway ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind bug
/area conformance-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
1. Now the main inferenceObjective is using `priority` instead of `criticality` so currently the inferenceObjective is never applied successfully.
2. the inferenceObjective and the header is not needed since this change(https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/38462653aa0531e287f0ba79b863603c950b9155/pkg/epp/requestcontrol/director.go#L219-L222) is introduced in EPP. The default priority will be 0 which will bypass the saturation check natively.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1002

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->

