### PR TITLE
chore: remove unneeded logging before returning error

### DIFF
--- a/internal/runnable/grpc.go
+++ b/internal/runnable/grpc.go
@@ -37,8 +37,7 @@ func GRPCServer(name string, srv *grpc.Server, port int) manager.Runnable {
 		// Start listening.
 		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err != nil {
-			log.Error(err, "gRPC server failed to listen")
-			return err
+			return fmt.Errorf("gRPC server failed to listen - %w", err)
 		}
 
 		log.Info("gRPC server listening", "port", port)
@@ -59,8 +58,7 @@ func GRPCServer(name string, srv *grpc.Server, port int) manager.Runnable {
 
 		// Keep serving until terminated.
 		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
-			log.Error(err, "gRPC server failed")
-			return err
+			return fmt.Errorf("gRPC server failed - %w", err)
 		}
 		log.Info("gRPC server terminated")
 		return nil

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -61,9 +61,6 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			return nil
 		}
 		if recvErr != nil {
-			// This error occurs very frequently, though it doesn't seem to have any impact.
-			// TODO Figure out if we can remove this noise.
-			loggerVerbose.Error(recvErr, "Cannot receive stream request")
 			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", recvErr)
 		}
 

--- a/pkg/bbr/server/runserver.go
+++ b/pkg/bbr/server/runserver.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/go-logr/logr"
@@ -54,8 +55,7 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		if r.SecureServing {
 			cert, err := tlsutil.CreateSelfSignedTLSCertificate(logger)
 			if err != nil {
-				logger.Error(err, "Failed to create self signed certificate")
-				return err
+				return fmt.Errorf("failed to create self signed certificate - %w", err)
 			}
 			creds := credentials.NewTLS(&tls.Config{Certificates: []tls.Certificate{cert}})
 			srv = grpc.NewServer(grpc.Creds(creds))

--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,8 +49,7 @@ func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.R
 	notFound := false
 	if err := c.Get(ctx, req.NamespacedName, infObjective); err != nil {
 		if !errors.IsNotFound(err) {
-			logger.Error(err, "Unable to get InferenceObjective")
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("unable to get InferenceObjective - %w", err)
 		}
 		notFound = true
 	}

--- a/pkg/epp/controller/inferencepool_reconciler.go
+++ b/pkg/epp/controller/inferencepool_reconciler.go
@@ -56,9 +56,7 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		obj = &v1alpha2.InferencePool{}
 	default:
 		// Handle unsupported groups gracefully.
-		err := fmt.Errorf("unsupported API group: %s", c.PoolGKNN.Group)
-		logger.Error(err, "Cannot reconcile InferencePool")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("cannot reconcile InferencePool - unsupported API group: %s", c.PoolGKNN.Group)
 	}
 
 	// 2. Perform a single, generic fetch for the object.
@@ -68,8 +66,7 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			c.Datastore.Clear()
 			return ctrl.Result{}, nil
 		}
-		logger.Error(err, "Unable to get InferencePool")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("unable to get InferencePool - %w", err)
 	}
 
 	// 3. Perform common checks using the client.Object interface.
@@ -90,16 +87,14 @@ func (c *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		var err error
 		err = pool.ConvertTo(v1infPool)
 		if err != nil {
-			logger.Error(err, "Failed to convert XInferencePool to InferencePool")
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to convert XInferencePool to InferencePool - %w", err)
 		}
 	default:
 		return ctrl.Result{}, fmt.Errorf("unsupported API group: %s", c.PoolGKNN.Group)
 	}
 
 	if err := c.Datastore.PoolSet(ctx, c.Reader, v1infPool); err != nil {
-		logger.Error(err, "Failed to update datastore")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to update datastore - %w", err)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/epp/controller/pod_reconciler.go
+++ b/pkg/epp/controller/pod_reconciler.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -55,8 +56,7 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			c.Datastore.PodDelete(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
-		logger.V(logutil.DEFAULT).Error(err, "Unable to get pod")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("unable to get pod - %w", err)
 	}
 
 	c.updateDatastore(logger, pod)

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -39,8 +40,7 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 	logger := log.FromContext(ctx)
 	responseBytes, err := json.Marshal(response)
 	if err != nil {
-		logger.V(logutil.DEFAULT).Error(err, "error marshalling responseBody")
-		return reqCtx, err
+		return reqCtx, fmt.Errorf("error marshalling responseBody - %w", err)
 	}
 	if response["usage"] != nil {
 		usg := response["usage"].(map[string]any)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -177,9 +177,6 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			return nil
 		}
 		if recvErr != nil {
-			// This error occurs very frequently, though it doesn't seem to have any impact.
-			// TODO Figure out if we can remove this noise.
-			logger.V(logutil.DEFAULT).Error(err, "Cannot receive stream request")
 			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", err)
 		}
 

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -157,8 +157,7 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 				cert, err = tlsutil.CreateSelfSignedTLSCertificate(logger)
 			}
 			if err != nil {
-				logger.Error(err, "Failed to create self signed certificate")
-				return err
+				return fmt.Errorf("failed to create self signed certificate - %w", err)
 			}
 
 			creds := credentials.NewTLS(&tls.Config{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove unneeded logging right before returning error.

How I decide which logging is useful:
- Useful: logging with extra info
https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/8b154baffd35e1c4ad1dcd131f1cbcac04ddc304/cmd/bbr/main.go#L98-L99
- Not useful: logging which say "something failed"

Would be great if you can feedback if my decision is reasonable. Thanks team.

**Which issue(s) this PR fixes**:
Fixes #334

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
