### PR TITLE
Uniquely name crbac

### DIFF
--- a/config/charts/inferencepool/templates/_helpers.tpl
+++ b/config/charts/inferencepool/templates/_helpers.tpl
@@ -17,6 +17,15 @@ Inference extension name
 {{- end -}}
 
 {{/*
+Cluster RBAC unique name
+*/}}
+{{- define "gateway-api-inference-extension.cluster-rbac-name" -}}
+{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 -}}
+{{- $base := .Release.Namespace | default "default" | lower | trim | trunc 40 - }}
+{{ printf "%s-%s-epp" $rn $ns | quote | trunc 84 }}
+{{- end -}}
+
+{{/*
 Selector labels
 */}}
 {{- define "gateway-api-inference-extension.selectorLabels" -}}

--- a/config/charts/inferencepool/templates/rbac.yaml
+++ b/config/charts/inferencepool/templates/rbac.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "gateway-api-inference-extension.name" . }}
+  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
   labels:
     {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
 rules:
@@ -21,7 +21,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "gateway-api-inference-extension.name" . }}
+  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "gateway-api-inference-extension.name" . }}
@@ -29,7 +29,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "gateway-api-inference-extension.name" . }}
+  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
The root cause of #1393 as an alternative solution. The issue behind this is that you cannot install 2 releases of the GIE inferencepool chart with the same release name but in different namespaces because helm fights over the ownership of the cluster RBAC. This is a key issue we have in `llm-d` where people try to deploy similar examples in parallel but cannot.

**Does this PR introduce a user-facing change?**:
There are no API changes here, it simply creates a separate naming convention for cluster scoped RBAC so that multiple releases with the same name but different namespaces can co-exist.

cc @nirrozenbaum @ahg-g @kfswain @liu-cong This is one of the criteria for release in `llm-d` for version `v0.3.0`
