### PR TITLE
fix flake in weighted random picker

### DIFF
--- a/pkg/epp/scheduling/framework/plugins/picker/picker_test.go
+++ b/pkg/epp/scheduling/framework/plugins/picker/picker_test.go
@@ -18,6 +18,7 @@ package picker
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -138,8 +139,8 @@ func TestPickMaxScorePicker(t *testing.T) {
 
 func TestPickWeightedRandomPicker(t *testing.T) {
 	const (
-		testIterations = 1000
-		tolerance      = 0.2 // 20% tolerance in [0,1] range
+		testIterations = 10000
+		tolerance      = 0.05 // Verify within tolerance ±5%
 	)
 
 	pod1 := &types.PodMetrics{Pod: &backend.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}}
@@ -197,14 +198,14 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			picker := NewWeightedRandomPicker(test.maxPods)
-			selectionCounts := make(map[string]int)
 
-			// Calculate expected probabilities based on scores
+			// Summarize the total score of all pods
 			totalScore := 0.0
 			for _, pod := range test.input {
 				totalScore += pod.Score
 			}
 
+			// Calculate expected probabilities based on scores
 			expectedProbabilities := make(map[string]float64)
 			for _, pod := range test.input {
 				podName := pod.GetPod().NamespacedName.Name
@@ -216,20 +217,19 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 			}
 
 			// Initialize selection counters for each pod
+			selectionCounts := make(map[string]int)
 			for _, pod := range test.input {
 				podName := pod.GetPod().NamespacedName.Name
 				selectionCounts[podName] = 0
 			}
 
 			// Run multiple iterations to gather statistical data
-			for i := 0; i < testIterations; i++ {
+			for range testIterations {
 				result := picker.Pick(context.Background(), types.NewCycleState(), test.input)
 
 				// Count selections for probability analysis
-				if len(result.TargetPods) > 0 {
-					selectedPodName := result.TargetPods[0].GetPod().NamespacedName.Name
-					selectionCounts[selectedPodName]++
-				}
+				selectedPodName := result.TargetPods[0].GetPod().NamespacedName.Name
+				selectionCounts[selectedPodName]++
 			}
 
 			// Verify probability distribution
@@ -237,11 +237,7 @@ func TestPickWeightedRandomPicker(t *testing.T) {
 				actualCount := selectionCounts[podName]
 				actualProb := float64(actualCount) / float64(testIterations)
 
-				toleranceValue := expectedProb * tolerance
-				lowerBound := expectedProb - toleranceValue
-				upperBound := expectedProb + toleranceValue
-
-				if actualProb < lowerBound || actualProb > upperBound {
+				if math.Abs(actualProb-expectedProb) > tolerance {
 					t.Errorf("Pod %s: expected probability %.3f ±%.1f%%, got %.3f (count: %d/%d)",
 						podName, expectedProb, tolerance*100, actualProb, actualCount, testIterations)
 				} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
Fix a test flake of random weighted picker.
This fix is based on expected probabilities with some tolerance to make sure the actual random sampling is close enough to the expected results. more on the numbers:

🔹 Setup
- Suppose expected probability = 𝑝.
- Number of trials = 𝑛 = 10000
- The observed count follows a binomial distribution:
𝑋∼Binomial(𝑛,𝑝)
- Observed frequency = 𝑋/𝑛
- Standard deviation (σ) of observed frequency is:
𝜎=_sqrt_(𝑝(1−𝑝)/𝑛)

🔹 Example: worst-case variance

The variance is largest at 𝑝=0.5

𝜎=_sqrt_(0.5⋅0.5/10000)≈0.005

So the natural “jitter” is about ±0.5 percentage points.

🔹 With tolerance = ±5% (0.05)

- Allowed range = expected ±0.05.
- That is 10× wider than σ.

In normal distribution terms, that’s a 10σ bound.
The probability of going beyond 10σ is about 10^-23 — practically impossible in the lifetime of the universe.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1538

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
