### PR TITLE
Revert "uniquely name CRBAC (#1545)"

### DIFF
--- a/config/charts/inferencepool/templates/_helpers.tpl
+++ b/config/charts/inferencepool/templates/_helpers.tpl
@@ -17,15 +17,6 @@ Inference extension name
 {{- end -}}
 
 {{/*
-Cluster RBAC unique name
-*/}}
-{{- define "gateway-api-inference-extension.cluster-rbac-name" -}}
-{{- $base := .Release.Name | default "default-pool" | lower | trim | trunc 40 -}}
-{{- $base := .Release.Namespace | default "default" | lower | trim | trunc 40 - }}
-{{ printf "%s-%s-epp" $rn $ns | quote | trunc 84 }}
-{{- end -}}
-
-{{/*
 Selector labels
 */}}
 {{- define "gateway-api-inference-extension.selectorLabels" -}}

--- a/config/charts/inferencepool/templates/rbac.yaml
+++ b/config/charts/inferencepool/templates/rbac.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
+  name: {{ include "gateway-api-inference-extension.name" . }}
   labels:
     {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
 rules:
@@ -21,7 +21,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
+  name: {{ include "gateway-api-inference-extension.name" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "gateway-api-inference-extension.name" . }}
@@ -29,7 +29,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "gateway-api-inference-extension.cluster-rbac-name" . }}
+  name: {{ include "gateway-api-inference-extension.name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Reversion PR, allowing merging to main instead in #1564 

Relates to:

- https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1545#issuecomment-3275563940
- https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1563#issuecomment-3275577370
- https://llm-d.slack.com/archives/C08SBNRRSBD/p1757519952731199

cc @kfswain @ahg-g @liu-cong 