### PR TITLE
refactor: flow control config

### DIFF
--- a/pkg/epp/flowcontrol/config.go
+++ b/pkg/epp/flowcontrol/config.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/controller"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/registry"
+)
+
+// Config is the top-level configuration for the entire flow control module.
+// It embeds the configurations for the controller and the registry, providing a single point of entry for validation
+// and initialization.
+type Config struct {
+	Controller controller.Config
+	Registry   registry.Config
+}
+
+// ValidateAndApplyDefaults checks the configuration for validity and populates any empty fields with system defaults.
+// It delegates validation to the underlying controller and registry configurations.
+// It returns a new, validated `Config` object and does not mutate the receiver.
+func (c *Config) ValidateAndApplyDefaults() (*Config, error) {
+	validatedControllerCfg, err := c.Controller.ValidateAndApplyDefaults()
+	if err != nil {
+		return nil, fmt.Errorf("controller config validation failed: %w", err)
+	}
+	validatedRegistryCfg, err := c.Registry.ValidateAndApplyDefaults()
+	if err != nil {
+		return nil, fmt.Errorf("registry config validation failed: %w", err)
+	}
+	return &Config{
+		Controller: *validatedControllerCfg,
+		Registry:   *validatedRegistryCfg,
+	}, nil
+}

--- a/pkg/epp/flowcontrol/config_test.go
+++ b/pkg/epp/flowcontrol/config_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/controller"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/registry"
+)
+
+func TestConfig_ValidateAndApplyDefaults(t *testing.T) {
+	t.Parallel()
+
+	// A minimal valid registry config, which is required for the success case.
+	validRegistryConfig := registry.Config{
+		PriorityBands: []registry.PriorityBandConfig{
+			{Priority: 1, PriorityName: "TestBand"},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		input         Config
+		expectErr     bool
+		expectedErrIs error
+	}{
+		{
+			name: "ShouldSucceed_WhenSubConfigsAreValid",
+			input: Config{
+				Controller: controller.Config{},
+				Registry:   validRegistryConfig,
+			},
+			expectErr: false,
+		},
+		{
+			name: "ShouldFail_WhenControllerConfigIsInvalid",
+			input: Config{
+				Controller: controller.Config{
+					DefaultRequestTTL: -1 * time.Second,
+				},
+				Registry: validRegistryConfig,
+			},
+			expectErr: true,
+		},
+		{
+			name: "ShouldFail_WhenRegistryConfigIsInvalid",
+			input: Config{
+				Controller: controller.Config{},
+				Registry: registry.Config{
+					PriorityBands: []registry.PriorityBandConfig{},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			originalInput := tc.input
+			validatedCfg, err := tc.input.ValidateAndApplyDefaults()
+
+			if tc.expectErr {
+				require.Error(t, err, "expected an error but got nil")
+			} else {
+				require.NoError(t, err, "expected no error but got: %v", err)
+				require.NotNil(t, validatedCfg, "validatedCfg should not be nil on success")
+			}
+
+			assert.Equal(t, originalInput, tc.input, "input config should not be mutated")
+		})
+	}
+}

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -53,46 +53,38 @@ type Config struct {
 	EnqueueChannelBufferSize int
 }
 
-// newConfig performs validation and initialization, returning a guaranteed-valid `Config` object.
-// This is the required constructor for creating a new configuration.
-// It does not mutate the input `cfg`.
-func newConfig(cfg Config) (*Config, error) {
-	newCfg := cfg.deepCopy()
-	if err := newCfg.validateAndApplyDefaults(); err != nil {
-		return nil, err
-	}
-	return newCfg, nil
-}
+// ValidateAndApplyDefaults checks the global configuration for validity and then creates a new `Config` object,
+// populating any empty fields with system defaults.
+// It does not mutate the receiver.
+func (c *Config) ValidateAndApplyDefaults() (*Config, error) {
+	cfg := c.deepCopy()
 
-// validateAndApplyDefaults checks the global configuration for validity and then mutates the receiver to populate any
-// empty fields with system defaults.
-func (c *Config) validateAndApplyDefaults() error {
 	// --- Validation ---
-	if c.DefaultRequestTTL < 0 {
-		return fmt.Errorf("DefaultRequestTTL cannot be negative, but got %v", c.DefaultRequestTTL)
+	if cfg.DefaultRequestTTL < 0 {
+		return nil, fmt.Errorf("DefaultRequestTTL cannot be negative, but got %v", cfg.DefaultRequestTTL)
 	}
-	if c.ExpiryCleanupInterval < 0 {
-		return fmt.Errorf("ExpiryCleanupInterval cannot be negative, but got %v", c.ExpiryCleanupInterval)
+	if cfg.ExpiryCleanupInterval < 0 {
+		return nil, fmt.Errorf("ExpiryCleanupInterval cannot be negative, but got %v", cfg.ExpiryCleanupInterval)
 	}
-	if c.ProcessorReconciliationInterval < 0 {
-		return fmt.Errorf("ProcessorReconciliationInterval cannot be negative, but got %v",
-			c.ProcessorReconciliationInterval)
+	if cfg.ProcessorReconciliationInterval < 0 {
+		return nil, fmt.Errorf("ProcessorReconciliationInterval cannot be negative, but got %v",
+			cfg.ProcessorReconciliationInterval)
 	}
-	if c.EnqueueChannelBufferSize < 0 {
-		return fmt.Errorf("EnqueueChannelBufferSize cannot be negative, but got %d", c.EnqueueChannelBufferSize)
+	if cfg.EnqueueChannelBufferSize < 0 {
+		return nil, fmt.Errorf("EnqueueChannelBufferSize cannot be negative, but got %d", cfg.EnqueueChannelBufferSize)
 	}
 
 	// --- Defaulting ---
-	if c.ExpiryCleanupInterval == 0 {
-		c.ExpiryCleanupInterval = defaultExpiryCleanupInterval
+	if cfg.ExpiryCleanupInterval == 0 {
+		cfg.ExpiryCleanupInterval = defaultExpiryCleanupInterval
 	}
-	if c.ProcessorReconciliationInterval == 0 {
-		c.ProcessorReconciliationInterval = defaultProcessorReconciliationInterval
+	if cfg.ProcessorReconciliationInterval == 0 {
+		cfg.ProcessorReconciliationInterval = defaultProcessorReconciliationInterval
 	}
-	if c.EnqueueChannelBufferSize == 0 {
-		c.EnqueueChannelBufferSize = defaultEnqueueChannelBufferSize
+	if cfg.EnqueueChannelBufferSize == 0 {
+		cfg.EnqueueChannelBufferSize = defaultEnqueueChannelBufferSize
 	}
-	return nil
+	return cfg, nil
 }
 
 // deepCopy creates a deep copy of the `Config` object.

--- a/pkg/epp/flowcontrol/controller/config_test.go
+++ b/pkg/epp/flowcontrol/controller/config_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewConfig(t *testing.T) {
+func TestConfig_ValidateAndApplyDefaults(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -88,7 +88,7 @@ func TestNewConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			originalInput := tc.input.deepCopy()
-			validatedCfg, err := newConfig(tc.input)
+			validatedCfg, err := tc.input.ValidateAndApplyDefaults()
 
 			if tc.expectErr {
 				require.Error(t, err, "expected an error but got nil")

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -118,13 +118,8 @@ func NewFlowController(
 	logger logr.Logger,
 	opts ...flowControllerOption,
 ) (*FlowController, error) {
-	validatedConfig, err := newConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("invalid flow controller configuration: %w", err)
-	}
-
 	fc := &FlowController{
-		config:             *validatedConfig,
+		config:             *config.deepCopy(),
 		registry:           registry,
 		saturationDetector: sd,
 		clock:              clock.RealClock{},

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -796,6 +796,7 @@ func TestFlowController_Concurrency(t *testing.T) {
 		// Use a generous buffer to prevent flakes in the test due to transient queuing delays.
 		EnqueueChannelBufferSize: numRequests,
 		DefaultRequestTTL:        1 * time.Second,
+		ExpiryCleanupInterval:    100 * time.Millisecond,
 	}, mockRegistry)
 
 	var wg sync.WaitGroup

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -273,23 +273,6 @@ func newTestRequest(ctx context.Context, key types.FlowKey) *typesmocks.MockFlow
 
 // --- Test Cases ---
 
-func TestNewFlowController(t *testing.T) {
-	t.Parallel()
-
-	t.Run("ErrorOnInvalidConfig", func(t *testing.T) {
-		t.Parallel()
-		invalidCfg := Config{ProcessorReconciliationInterval: -1 * time.Second}
-		_, err := NewFlowController(
-			context.Background(),
-			invalidCfg,
-			&mockRegistryClient{},
-			&mocks.MockSaturationDetector{},
-			logr.Discard(),
-		)
-		require.Error(t, err, "NewFlowController must return an error for invalid configuration")
-	})
-}
-
 func TestFlowController_EnqueueAndWait(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -112,7 +112,7 @@ type Config struct {
 // that operate at this priority level.
 type PriorityBandConfig struct {
 	// Priority is the unique numerical priority level for this band.
-	// Convention: Lower numerical values indicate lower priority.
+	// Convention: Highest numeric value corresponds to highest priority (centered on 0).
 	// Required.
 	Priority int
 
@@ -138,20 +138,6 @@ type PriorityBandConfig struct {
 	// MaxBytes defines the maximum total byte size for this priority band, aggregated across all shards.
 	// Optional: Defaults to `defaultPriorityBandMaxBytes` (1 GB).
 	MaxBytes uint64
-}
-
-// NewConfig performs validation and initialization, returning a guaranteed-valid `Config` object.
-// This is the required constructor for creating a new configuration. It applies provided functional options (primarily
-// for testing) and does not mutate the input `cfg`.
-func NewConfig(cfg Config, opts ...configOption) (*Config, error) {
-	newCfg := cfg.deepCopy()
-	for _, opt := range opts {
-		opt(newCfg)
-	}
-	if err := newCfg.validateAndApplyDefaults(); err != nil {
-		return nil, err
-	}
-	return newCfg, nil
 }
 
 // =============================================================================
@@ -205,52 +191,55 @@ func (sc *ShardConfig) getBandConfig(priority int) (*ShardPriorityBandConfig, er
 
 // --- Validation and Defaulting ---
 
-// validateAndApplyDefaults checks the global configuration for validity (including plugin compatibility) and mutates
-// the receiver to populate any empty fields with system defaults. It also initializes internal lookup maps.
-func (c *Config) validateAndApplyDefaults() error {
+// ValidateAndApplyDefaults checks the global configuration for validity and then creates a new `Config` object,
+// populating any empty fields with system defaults.
+// It does not mutate the receiver.
+func (c *Config) ValidateAndApplyDefaults() (*Config, error) {
+	cfg := c.deepCopy()
+
 	// Apply defaults to top-level fields.
-	if c.InitialShardCount <= 0 {
-		c.InitialShardCount = defaultInitialShardCount
+	if cfg.InitialShardCount <= 0 {
+		cfg.InitialShardCount = defaultInitialShardCount
 	}
-	if c.FlowGCTimeout <= 0 {
-		c.FlowGCTimeout = defaultFlowGCTimeout
+	if cfg.FlowGCTimeout <= 0 {
+		cfg.FlowGCTimeout = defaultFlowGCTimeout
 	}
-	if c.EventChannelBufferSize <= 0 {
-		c.EventChannelBufferSize = defaultEventChannelBufferSize
+	if cfg.EventChannelBufferSize <= 0 {
+		cfg.EventChannelBufferSize = defaultEventChannelBufferSize
 	}
 
 	// Ensure the DI factories are initialized for production use if `NewConfig` was called without options.
-	if c.interFlowDispatchPolicyFactory == nil {
-		c.interFlowDispatchPolicyFactory = inter.NewPolicyFromName
+	if cfg.interFlowDispatchPolicyFactory == nil {
+		cfg.interFlowDispatchPolicyFactory = inter.NewPolicyFromName
 	}
-	if c.intraFlowDispatchPolicyFactory == nil {
-		c.intraFlowDispatchPolicyFactory = intra.NewPolicyFromName
+	if cfg.intraFlowDispatchPolicyFactory == nil {
+		cfg.intraFlowDispatchPolicyFactory = intra.NewPolicyFromName
 	}
-	if c.queueFactory == nil {
-		c.queueFactory = queue.NewQueueFromName
+	if cfg.queueFactory == nil {
+		cfg.queueFactory = queue.NewQueueFromName
 	}
 
-	if len(c.PriorityBands) == 0 {
-		return errors.New("config validation failed: at least one priority band must be defined")
+	if len(cfg.PriorityBands) == 0 {
+		return nil, errors.New("config validation failed: at least one priority band must be defined")
 	}
 
 	// Validate and default each priority band.
 	priorities := make(map[int]struct{})
 	priorityNames := make(map[string]struct{})
-	c.priorityBandMap = make(map[int]*PriorityBandConfig, len(c.PriorityBands))
+	cfg.priorityBandMap = make(map[int]*PriorityBandConfig, len(cfg.PriorityBands))
 
-	for i := range c.PriorityBands {
-		band := &c.PriorityBands[i]
+	for i := range cfg.PriorityBands {
+		band := &cfg.PriorityBands[i]
 		if _, exists := priorities[band.Priority]; exists {
-			return fmt.Errorf("config validation failed: duplicate priority level %d found", band.Priority)
+			return nil, fmt.Errorf("config validation failed: duplicate priority level %d found", band.Priority)
 		}
 		priorities[band.Priority] = struct{}{}
 
 		if band.PriorityName == "" {
-			return fmt.Errorf("config validation failed: PriorityName is required for priority band %d", band.Priority)
+			return nil, fmt.Errorf("config validation failed: PriorityName is required for priority band %d", band.Priority)
 		}
 		if _, exists := priorityNames[band.PriorityName]; exists {
-			return fmt.Errorf("config validation failed: duplicate priority name %q found", band.PriorityName)
+			return nil, fmt.Errorf("config validation failed: duplicate priority name %q found", band.PriorityName)
 		}
 		priorityNames[band.PriorityName] = struct{}{}
 
@@ -267,12 +256,12 @@ func (c *Config) validateAndApplyDefaults() error {
 			band.MaxBytes = defaultPriorityBandMaxBytes
 		}
 
-		if err := c.validateBandCompatibility(*band); err != nil {
-			return err
+		if err := cfg.validateBandCompatibility(*band); err != nil {
+			return nil, err
 		}
-		c.priorityBandMap[band.Priority] = band
+		cfg.priorityBandMap[band.Priority] = band
 	}
-	return nil
+	return cfg, nil
 }
 
 // validateBandCompatibility verifies that a band's configured queue type has the necessary capabilities.
@@ -423,6 +412,18 @@ func withQueueFactory(factory queueFactory) configOption {
 	}
 }
 
+// newConfig creates a new validated and defaulted `Config` object.
+// It applies provided test-only functional options before validation and defaulting.
+// It does not mutate the input `cfg`.
+// test-only
+func newConfig(cfg Config, opts ...configOption) (*Config, error) {
+	newCfg := cfg.deepCopy()
+	for _, opt := range opts {
+		opt(newCfg)
+	}
+	return newCfg.ValidateAndApplyDefaults()
+}
+
 // --- Internal Utilities ---
 
 // deepCopy creates a deep copy of the `Config` object.
@@ -436,7 +437,6 @@ func (c *Config) deepCopy() *Config {
 		FlowGCTimeout:                  c.FlowGCTimeout,
 		EventChannelBufferSize:         c.EventChannelBufferSize,
 		PriorityBands:                  make([]PriorityBandConfig, len(c.PriorityBands)),
-		priorityBandMap:                make(map[int]*PriorityBandConfig, len(c.PriorityBands)),
 		interFlowDispatchPolicyFactory: c.interFlowDispatchPolicyFactory,
 		intraFlowDispatchPolicyFactory: c.intraFlowDispatchPolicyFactory,
 		queueFactory:                   c.queueFactory,
@@ -445,11 +445,14 @@ func (c *Config) deepCopy() *Config {
 	// PriorityBandConfig contains only value types, so a slice copy is sufficient for a deep copy.
 	copy(newCfg.PriorityBands, c.PriorityBands)
 
-	// Crucial: We must rebuild the map and take the address of the elements within the new slice (`newCfg.PriorityBands`)
-	// to ensure the map pointers are correct for the newly created `Config` instance.
-	for i := range newCfg.PriorityBands {
-		band := &newCfg.PriorityBands[i]
-		newCfg.priorityBandMap[band.Priority] = band
+	if c.priorityBandMap != nil {
+		newCfg.priorityBandMap = make(map[int]*PriorityBandConfig, len(c.PriorityBands))
+		// Crucial: We must rebuild the map and take the address of the elements within the new slice (`newCfg.PriorityBands`)
+		// to ensure the map pointers are correct for the newly created `Config` instance.
+		for i := range newCfg.PriorityBands {
+			band := &newCfg.PriorityBands[i]
+			newCfg.priorityBandMap[band.Priority] = band
+		}
 	}
 	return newCfg
 }

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -59,7 +59,7 @@ type shardTestHarness struct {
 // newShardTestHarness initializes a `shardTestHarness` with a default configuration.
 func newShardTestHarness(t *testing.T) *shardTestHarness {
 	t.Helper()
-	globalConfig, err := NewConfig(Config{
+	globalConfig, err := newConfig(Config{
 		PriorityBands: []PriorityBandConfig{
 			{Priority: highPriority, PriorityName: "High"},
 			{Priority: lowPriority, PriorityName: "Low"},
@@ -146,7 +146,7 @@ func TestShard_New(t *testing.T) {
 
 	t.Run("ShouldFail_WhenInterFlowPolicyFactoryFails", func(t *testing.T) {
 		t.Parallel()
-		shardConfig, _ := NewConfig(Config{PriorityBands: []PriorityBandConfig{
+		shardConfig, _ := newConfig(Config{PriorityBands: []PriorityBandConfig{
 			{Priority: highPriority, PriorityName: "High"},
 		}})
 		failingFactory := func(inter.RegisteredPolicyName) (framework.InterFlowDispatchPolicy, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR refactors the configuration handling within the `pkg/epp/flowcontrol` package and its sub-packages (`controller`, `registry`) to improve robustness, consistency, and clarity.

The core of the refactoring replaces the `newConfig` factory function pattern with a public `ValidateAndApplyDefaults` method on the configuration structs. This change:
- Makes the validation and defaulting logic more explicit and discoverable.
- Promotes immutability by returning a new, validated configuration object instead of mutating the receiver.
- Simplifies the constructors for `FlowController` and `FlowRegistry`, as they now expect a pre-validated configuration.
- Introduces a new top-level `flowcontrol.Config` to provide a single, unified entry point for the entire module's configuration (simplifies wiring this layer into the rest of EPP).

Overall, these changes lead to a more maintainable and less error-prone configuration system.

**Which issue(s) this PR fixes**:

Tracks #674 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

cc @rahulgurnani 