### PR TITLE
Use env var for DefaultPoolNamespace with fallback to default

### DIFF
--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -66,11 +67,11 @@ type ExtProcServerRunner struct {
 
 // Default values for CLI flags in main
 const (
-	DefaultGrpcPort                         = 9002                          // default for --grpc-port
-	DefaultGrpcHealthPort                   = 9003                          // default for --grpc-health-port
-	DefaultMetricsPort                      = 9090                          // default for --metrics-port
-	DefaultPoolName                         = ""                            // required but no default
-	DefaultPoolNamespace                    = "default"                     // default for --pool-namespace
+	DefaultGrpcPort       = 9002 // default for --grpc-port
+	DefaultGrpcHealthPort = 9003 // default for --grpc-health-port
+	DefaultMetricsPort    = 9090 // default for --metrics-port
+	DefaultPoolName       = ""   // required but no default
+	// DefaultPoolNamespace                    = "default"                     // default for --pool-namespace
 	DefaultRefreshMetricsInterval           = 50 * time.Millisecond         // default for --refresh-metrics-interval
 	DefaultRefreshPrometheusMetricsInterval = 5 * time.Second               // default for --refresh-prometheus-metrics-interval
 	DefaultSecureServing                    = true                          // default for --secure-serving
@@ -85,6 +86,19 @@ const (
 	DefaultPoolGroup                        = "inference.networking.k8s.io" // default for --pool-group
 	DefaultMetricsStalenessThreshold        = 2 * time.Second
 )
+
+var DefaultPoolNamespace = getPoolNamespace()
+
+// DefaultPoolNamespace is initialized at runtime.
+// It uses the NAMESPACE environment variable (typically set via pod metadata),
+// and falls back to "default" if not set.
+func getPoolNamespace() string {
+	nameSpace := os.Getenv("NAMESPACE")
+	if nameSpace != "" {
+		return nameSpace
+	}
+	return "default"
+}
 
 // NewDefaultExtProcServerRunner creates a runner with default values.
 // Note: Dependencies like Datastore, Scheduler, SD need to be set separately.

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -167,6 +168,26 @@ func TestServer(t *testing.T) {
 		<-errChan
 		testListener.Close()
 	})
+}
+
+func TestGetPoolNamespace(t *testing.T) {
+	// Case 1: No env var → should return "default"
+	os.Unsetenv("NAMESPACE")
+	defaultNameSpace := getPoolNamespace()
+	if defaultNameSpace != "default" {
+		t.Errorf("Expected 'default', got '%s'", defaultNameSpace)
+	}
+
+	// Case 2: Env var is set → should return its value
+	os.Setenv("NAMESPACE", "custom-namespace")
+	customNameSpace := getPoolNamespace()
+	if customNameSpace == "namespace" {
+		t.Errorf("Expected 'custom-namespace', got '%s'", customNameSpace)
+	}
+
+	// Cleanup
+	os.Unsetenv("NAMESPACE")
+
 }
 
 type testDirector struct {


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind cleanup

### What this PR does / why we need it
Replaces the hardcoded `DefaultPoolNamespace = "default"` to let EPP pods automatically pick up their running namespace without extra config

### Which issue(s) this PR fixes
Fixes #1569 

### Does this PR introduce a user-facing change?
```release-note
DefaultPoolNamespace now reads from the NAMESPACE environment variable if set,
falling back to "default". The --pool-namespace flag still takes precedence.
