### PR TITLE
Updates gateway manifests for v1 InferencePool

### DIFF
--- a/config/manifests/gateway/agentgateway/httproute.yaml
+++ b/config/manifests/gateway/agentgateway/httproute.yaml
@@ -9,7 +9,7 @@ spec:
     name: inference-gateway
   rules:
   - backendRefs:
-    - group: inference.networking.x-k8s.io
+    - group: inference.networking.k8s.io
       kind: InferencePool
       name: vllm-llama3-8b-instruct
     matches:

--- a/config/manifests/gateway/envoyaigateway/httproute.yaml
+++ b/config/manifests/gateway/envoyaigateway/httproute.yaml
@@ -9,7 +9,7 @@ spec:
       name: inference-gateway
   rules:
     - backendRefs:
-        - group: inference.networking.x-k8s.io
+        - group: inference.networking.k8s.io
           kind: InferencePool
           name: vllm-llama3-8b-instruct
       matches:

--- a/config/manifests/gateway/istio/httproute.yaml
+++ b/config/manifests/gateway/istio/httproute.yaml
@@ -9,7 +9,7 @@ spec:
     name: inference-gateway
   rules:
   - backendRefs:
-    - group: inference.networking.x-k8s.io
+    - group: inference.networking.k8s.io
       kind: InferencePool
       name: vllm-llama3-8b-instruct
     matches:

--- a/config/manifests/gateway/kgateway/httproute.yaml
+++ b/config/manifests/gateway/kgateway/httproute.yaml
@@ -9,7 +9,7 @@ spec:
     name: inference-gateway
   rules:
   - backendRefs:
-    - group: inference.networking.x-k8s.io
+    - group: inference.networking.k8s.io
       kind: InferencePool
       name: vllm-llama3-8b-instruct
     matches:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->
Updates HTTPRoute manifests for all gateways other than GKE to use v1 InferencePool as a backendRef.

**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:

This PR is needed because a user cannot complete the quickstart guide for all gateways other than GKE. Additionally, we do not want to promote the alpha InferencePool API.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1602

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
