### PR TITLE
improve the readable of test-unit make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,9 @@ test: generate fmt vet envtest image-build verify-crds ## Run tests.
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
-	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./pkg/... -race -coverprofile cover.out
+	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./pkg/... -race -coverprofile cover.out; \
+	go tool cover -func=cover.out; \
+	rm cover.out
 
 .PHONY: test-integration
 test-integration: envtest ## Run integration tests.


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

After this enhancement, `make test-unit` will finally print:
```
...
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing/wrappers.go:249:                                                               TargetPortNumber                                0.0%
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing/wrappers.go:254:                                                               ExtensionRef                                    0.0%
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing/wrappers.go:260:                                                               ObjRef                                          0.0%
sigs.k8s.io/gateway-api-inference-extension/pkg/generator/main.go:35:                                                                           main                                            0.0%
total:                                                                                                                                          (statements)                                    60.4%
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
