### PR TITLE
fix missing GCPBakendPolicy.

### DIFF
--- a/config/charts/inferencepool/templates/gke.yaml
+++ b/config/charts/inferencepool/templates/gke.yaml
@@ -39,6 +39,7 @@ spec:
     timeoutSec: 300    # 5-minute timeout (adjust as needed)
     logging:
       enabled: true    # log all requests by default
+---
 {{- if .Values.inferenceExtension.monitoring.gke.enabled }}
 {{- $metricsReadSA := printf "%s-metrics-reader-sa" .Release.Name -}}
 {{- $metricsReadSecretName := printf "%s-metrics-reader-secret" .Release.Name -}}
@@ -54,7 +55,6 @@ spec:
 {{-   $gmpNamespace = "gke-gmp-system" -}}
 {{- end -}}
 {{- $gmpCollectorRoleBindingName := printf "%s:collector:%s-%s-metrics-reader-secret-read" $gmpNamespace .Release.Namespace .Release.Name -}}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

This is discovered by the Lohi Pipline, where we always use the main helm to install inferencePool and it failed at finding GCPBackendPolicy:  
<img width="1094" height="503" alt="image" src="https://github.com/user-attachments/assets/f32c212b-f8f2-4733-b104-1ca8323a49ba" />


Current inferecePool Helm install will return warning and missing the GCPBackendPolicy for logging. The following as an exmple.

```
❯ export NAMESPACE=inference-demo
export HELM_RELEASE_NAME=infpool-gemma-2b
❯ helm upgrade -i $HELM_RELEASE_NAME \
  config/charts/inferencepool \
  -n $NAMESPACE \
  --create-namespace \
  --set inferencePool.modelServers.matchLabels.app=vllm-gemma2b \
  --set provider.name=gke \
  --set inferenceExtension.monitoring.gke.enabled=true
Release "infpool-gemma-2b" does not exist. Installing it now.
**I0920 00:19:58.644743 1622628 warnings.go:110] "Warning: unknown field \"spec\""**
NAME: infpool-gemma-2b
LAST DEPLOYED: Sat Sep 20 00:19:56 2025
NAMESPACE: inference-demo
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
InferencePool infpool-gemma-2b deployed.
```

W/ the change in this PR, the warning is gone and GCPBackendPolicy is creating again

```
❯ helm upgrade -i $HELM_RELEASE_NAME \
  config/charts/inferencepool \
  -n $NAMESPACE \
  --create-namespace \
  --set inferencePool.modelServers.matchLabels.app=vllm-gemma2b \
  --set provider.name=gke \
  --set inferenceExtension.monitoring.gke.enabled=true
Release "infpool-gemma-2b" has been upgraded. Happy Helming!
NAME: infpool-gemma-2b
LAST DEPLOYED: Sat Sep 20 00:39:38 2025
NAMESPACE: inference-demo
STATUS: deployed
REVISION: 6
TEST SUITE: None
NOTES:
InferencePool infpool-gemma-2b deployed.
❯ helm status infpool-gemma-2b -n inference-demo --show-resources
NAME: infpool-gemma-2b
LAST DEPLOYED: Sat Sep 20 00:39:38 2025
NAMESPACE: inference-demo
STATUS: deployed
REVISION: 6
RESOURCES:
==> v1/Secret
NAME                                     TYPE                                  DATA   AGE
infpool-gemma-2b-metrics-reader-secret   kubernetes.io/service-account-token   3      19m

==> v1/ConfigMap
NAME                   DATA   AGE
infpool-gemma-2b-epp   1      19m

==> v1/Role
NAME                                          CREATED AT
infpool-gemma-2b-metrics-reader-secret-read   2025-09-20T00:19:58Z
infpool-gemma-2b-epp   2025-09-20T00:19:58Z

==> v1/Service
NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
infpool-gemma-2b-epp   ClusterIP   34.118.228.139   <none>        9002/TCP,9090/TCP   19m

==> v1/Deployment
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
infpool-gemma-2b-epp   1/1     1            1           19m

==> v1/Pod(related)
NAME                                    READY   STATUS    RESTARTS   AGE
infpool-gemma-2b-epp-845d58797f-858v8   1/1     Running   0          19m

==> v1/HealthCheckPolicy
NAME               AGE
infpool-gemma-2b   104s

==> v1/ServiceAccount
NAME                                 SECRETS   AGE
infpool-gemma-2b-metrics-reader-sa   0         19m
infpool-gemma-2b-epp   0     19m

==> v1/ClusterRole
NAME                                             CREATED AT
inference-demo-infpool-gemma-2b-metrics-reader   2025-09-20T00:19:58Z
infpool-gemma-2b-inference-demo-epp   2025-09-20T00:19:58Z

==> v1/ClusterRoleBinding
NAME                                                          ROLE                                                         AGE
inference-demo-infpool-gemma-2b-metrics-reader-role-binding   ClusterRole/inference-demo-infpool-gemma-2b-metrics-reader   19m
infpool-gemma-2b-inference-demo-epp   ClusterRole/infpool-gemma-2b-inference-demo-epp   19m

==> v1/RoleBinding
NAME                                                                              ROLE                                               AGE
gmp-system:collector:inference-demo-infpool-gemma-2b-metrics-reader-secret-read   Role/infpool-gemma-2b-metrics-reader-secret-read   19m
infpool-gemma-2b-epp   Role/infpool-gemma-2b-epp   19m

==> v1/GCPBackendPolicy
NAME               AGE
infpool-gemma-2b   104s

==> v1/InferencePool
infpool-gemma-2b   19m

==> v1/PodMonitoring
infpool-gemma-2b   19m


TEST SUITE: None
NOTES:
InferencePool infpool-gemma-2b deployed.
````



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
