### PR TITLE
fix: streaming metrics and header parsing bugs

### DIFF
--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -32,7 +32,11 @@ func ExtractHeaderValue(req *extProcPb.ProcessingRequest_RequestHeaders, headerK
 	if req != nil && req.RequestHeaders != nil && req.RequestHeaders.Headers != nil {
 		for _, headerKv := range req.RequestHeaders.Headers.Headers {
 			if strings.ToLower(headerKv.Key) == headerKeyInLower {
-				return string(headerKv.RawValue)
+				// Per the Envoy API, a header's value can be in either the `RawValue` (bytes) or `Value` (string) field.
+				if len(headerKv.RawValue) > 0 {
+					return string(headerKv.RawValue)
+				}
+				return headerKv.Value
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

This PR addresses several critical bugs in the endpoint picker that were discovered during refactoring work. These fixes are essential for stability, reliability, and observability.

The key changes are:

1.  **Fixes Critical Streaming Metrics Bug:** For `text/event-stream` responses, token usage metrics are being undercounted. The logic only parsed the final `[DONE]` message for a `usage` block, failing to accumulate token counts from earlier messages. Furthermore, a context corruption bug caused the `model_name` label in Prometheus to be empty, rendering the metric unusable for per-model monitoring. This PR corrects the logic to accumulate tokens across the entire stream and ensures all metric labels are correctly populated.

2.  **Fixes Header Parsing Reliability:** The EPP was brittle in how it parsed headers, exclusively checking the `RawValue` field and ignoring the `Value` field. This could lead to two severe production issues:
    *   **Streaming Detection Failure:** If a client sent `content-type: text/event-stream` using the `Value` field, the EPP would fail to detect the stream and attempt to buffer the entire response, risking high memory usage and OOM kills.
    *   **Broken Distributed Tracing:** The `x-request-id` header could be missed, breaking the distributed trace and hindering debugging.
    This PR makes all header parsing robust by correctly checking both fields.

3.  **Complete Hermetic Test Overhaul:** The integration test suite has been refactored to be significantly more robust and maintainable. The previous shared-state, table-driven test has been replaced with a `testHarness` structure that provides full resource and state isolation for each test case, eliminating flakes and improving clarity.

**Which issue(s) this PR fixes**:
Fixes #1624
Fixes #1626 

**Does this PR introduce a user-facing change?**:
```release-note
- Fixes a critical bug where token usage metrics for streaming responses were undercounted and recorded with a missing `model_name` label.
- Fixes a bug that could cause the gateway to buffer streaming responses incorrectly.
- Improves the robustness of header parsing to prevent dropped `x-request-id` headers, ensuring distributed traces remain intact.
```
