### PR TITLE
update make target naming in helm chart pushs commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,11 +339,11 @@ uninstall: generate kustomize ## Uninstall CRDs from the K8s cluster specified i
 
 ##@ Helm
 .PHONY: inferencepool-helm-chart-push
-inferencepool-helm-chart-push: yq helm
+inferencepool-helm-chart-push: yq helm-install
 	CHART=inferencepool EXTRA_TAG="$(EXTRA_TAG)" IMAGE_REGISTRY="$(IMAGE_REGISTRY)" YQ="$(YQ)" HELM="$(HELM)" ./hack/push-chart.sh
 
 .PHONY: bbr-helm-chart-push
-bbr-helm-chart-push: yq helm
+bbr-helm-chart-push: yq helm-install
 	CHART=body-based-routing EXTRA_TAG="$(EXTRA_TAG)" IMAGE_REGISTRY="$(IMAGE_REGISTRY)" YQ="$(YQ)" HELM="$(HELM)" ./hack/push-chart.sh
 
 ##@ Release


### PR DESCRIPTION
/kind bug

I busted the builds when I renamed `helm` -> `helm-install`. Needed to update the helm chart push commands. This PR does that.