### PR TITLE
Update steps to run conformance tests against gateway

### DIFF
--- a/conformance/reports/v1.0.0/gateway/kgateway/README.md
+++ b/conformance/reports/v1.0.0/gateway/kgateway/README.md
@@ -45,33 +45,39 @@ In order to run the conformance tests, the following prerequisites must be met:
    make kind-setup
    ```
 
-4. Install the kgateway CRDs:
+4. Build and load the images:
+
+   ```sh
+   make kind-build-and-load
+   ```
+
+5. Install the kgateway CRDs:
 
    ```sh
    helm upgrade -i --create-namespace --namespace kgateway-system \
    --version $VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
    ```
 
-5. Install kgateway with Inference Extension enabled:
+6. Install kgateway with Inference Extension enabled:
 
    ```sh
    helm upgrade -i --namespace kgateway-system --version $VERSION \
    kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set inferenceExtension.enabled=true
    ```
 
-6. Wait for the kgateway rollout to complete:
+7. Wait for the kgateway rollout to complete:
 
    ```sh
    kubectl rollout status deploy/kgateway -n kgateway-system
    ```
 
-7. Run the conformance tests:
+8. Run the conformance tests:
 
    ```sh
    make gie-conformance
    ```
 
-8. View and verify the conformance report:
+9. View and verify the conformance report:
 
    ```sh
    cat _test/conformance/inference-$VERSION-report.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**

Add one of the following kinds:
/kind documentation


**What this PR does / why we need it**:
This adds the missing step to build and load the images when running the conformance tests against kgateway

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
