### PR TITLE
Use actual platform architecture when building images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ SHELL = /usr/bin/env bash -o pipefail
 
 GIT_COMMIT_SHA ?= "$(shell git rev-parse HEAD 2>/dev/null)"
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
-PLATFORMS ?= linux/amd64
+TARGETARCH ?= $(shell go env GOARCH)
+PLATFORMS ?= linux/$(TARGETARCH)
 DOCKER_BUILDX_CMD ?= docker buildx
 IMAGE_BUILD_CMD ?= $(DOCKER_BUILDX_CMD) build
 IMAGE_BUILD_EXTRA_OPTS ?=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Makes it easier to develop on non AMD64 based computers, such as the M* Macs

**Does this PR introduce a user-facing change?**:
```release-note
- By default when running the various make targets that build images, the image will be built for the Linux O/S for the architecture of the machine running the build. This behavior can be overridden using the PLATFORMS environment variable.
```
