### PR TITLE
feat: Added Pre schedule plugin API

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -244,7 +244,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		runtime.SetBlockProfileRate(1)
 	}
 
-	err = r.parsePluginsConfiguration(ctx)
+	err = r.parsePluginsConfiguration(ctx, datastore)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse plugins configuration")
 		return err
@@ -321,7 +321,7 @@ func (r *Runner) registerInTreePlugins() {
 	plugins.Register(testfilter.HeaderBasedTestingFilterType, testfilter.HeaderBasedTestingFilterFactory)
 }
 
-func (r *Runner) parsePluginsConfiguration(ctx context.Context) error {
+func (r *Runner) parsePluginsConfiguration(ctx context.Context, datastore datastore.Datastore) error {
 	if *configText == "" && *configFile == "" {
 		return nil // configuring through code, not through file
 	}
@@ -340,7 +340,7 @@ func (r *Runner) parsePluginsConfiguration(ctx context.Context) error {
 	}
 
 	r.registerInTreePlugins()
-	handle := plugins.NewEppHandle(ctx)
+	handle := plugins.NewEppHandle(ctx, datastore)
 	config, err := loader.LoadConfig(configBytes, handle, logger)
 	if err != nil {
 		return fmt.Errorf("failed to load the configuration - %w", err)

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -303,7 +303,7 @@ func TestLoadRawConfigurationWithDefaults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		handle := utils.NewTestHandle(context.Background())
+		handle := utils.NewTestHandle(context.Background(), nil)
 
 		configBytes := []byte(test.configText)
 		if test.configFile != "" {
@@ -346,7 +346,7 @@ func checkError(t *testing.T, function string, test testStruct, err error) {
 }
 
 func TestInstantiatePlugins(t *testing.T) {
-	handle := utils.NewTestHandle(context.Background())
+	handle := utils.NewTestHandle(context.Background(), nil)
 	_, err := LoadConfig([]byte(successConfigText), handle, logging.NewTestLogger())
 	if err != nil {
 		t.Fatalf("LoadConfig returned unexpected error - %v", err)
@@ -360,7 +360,7 @@ func TestInstantiatePlugins(t *testing.T) {
 		t.Fatalf("loaded plugins returned test1 has the wrong type %#v", t1)
 	}
 
-	handle = utils.NewTestHandle(context.Background())
+	handle = utils.NewTestHandle(context.Background(), nil)
 	_, err = LoadConfig([]byte(errorBadPluginReferenceParametersText), handle, logging.NewTestLogger())
 	if err == nil {
 		t.Fatalf("LoadConfig did not return error as expected ")
@@ -426,7 +426,7 @@ func TestLoadConfig(t *testing.T) {
 
 	logger := logging.NewTestLogger()
 	for _, test := range tests {
-		handle := utils.NewTestHandle(context.Background())
+		handle := utils.NewTestHandle(context.Background(), nil)
 		_, err := LoadConfig([]byte(test.configText), handle, logger)
 		if err != nil {
 			if !test.wantErr {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -529,9 +529,7 @@ func TestGetCandidatePodsForScheduling(t *testing.T) {
 	ds := &mockDatastore{pods: testInput}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			director := NewDirectorWithConfig(ds, &mockScheduler{}, &mockSaturationDetector{}, NewConfig())
-
-			got := director.getCandidatePodsForScheduling(context.Background(), test.metadata)
+			got := GetCandidatePodsForScheduling(context.Background(), ds, test.metadata)
 
 			diff := cmp.Diff(test.output, got, cmpopts.SortSlices(func(a, b backendmetrics.PodMetrics) bool {
 				return a.GetPod().NamespacedName.String() < b.GetPod().NamespacedName.String()

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -20,14 +20,24 @@ import (
 	"context"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
 
 const (
+	PreScheduleExtensionPoint  = "PreSchedule"
 	PreRequestExtensionPoint   = "PreRequest"
 	PostResponseExtensionPoint = "PostResponse"
 )
+
+// PreSchedule is called by the director before sending the request to the scheduler.
+// It gets the set of candidate pods to be filtered and scored.
+type PreSchedule interface {
+	plugins.Plugin
+	GetCandidatePods(ctx context.Context, request *handlers.Request) []backendmetrics.PodMetrics
+}
 
 // PreRequest is called by the director after a getting result from scheduling layer and
 // before a request is sent to the selected model server.

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -23,6 +23,7 @@ import (
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
+		preSchedulePlugins:  []PreSchedule{},
 		preRequestPlugins:   []PreRequest{},
 		postResponsePlugins: []PostResponse{},
 	}
@@ -30,8 +31,16 @@ func NewConfig() *Config {
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
+	preSchedulePlugins  []PreSchedule
 	preRequestPlugins   []PreRequest
 	postResponsePlugins []PostResponse
+}
+
+// WithPreSchedulePlugins sets the given plugins as the PreSchedule plugins.
+// If the Config has PreSchedule plugins already, this call replaces the existing plugins with the given ones.
+func (c *Config) WithPreSchedulePlugins(plugins ...PreSchedule) *Config {
+	c.preSchedulePlugins = plugins
+	return c
 }
 
 // WithPreRequestPlugins sets the given plugins as the PreRequest plugins.
@@ -50,6 +59,9 @@ func (c *Config) WithPostResponsePlugins(plugins ...PostResponse) *Config {
 
 func (c *Config) AddPlugins(pluginObjects ...plugins.Plugin) {
 	for _, plugin := range pluginObjects {
+		if preSchedulePlugin, ok := plugin.(PreSchedule); ok {
+			c.preSchedulePlugins = append(c.preSchedulePlugins, preSchedulePlugin)
+		}
 		if preRequestPlugin, ok := plugin.(PreRequest); ok {
 			c.preRequestPlugins = append(c.preRequestPlugins, preRequestPlugin)
 		}

--- a/test/utils/handle.go
+++ b/test/utils/handle.go
@@ -26,6 +26,7 @@ import (
 type testHandle struct {
 	ctx context.Context
 	plugins.HandlePlugins
+	plugins.Datastore
 }
 
 // Context returns a context the plugins can use, if they need one
@@ -57,11 +58,12 @@ func (h *testHandlePlugins) GetAllPluginsWithNames() map[string]plugins.Plugin {
 	return h.plugins
 }
 
-func NewTestHandle(ctx context.Context) plugins.Handle {
+func NewTestHandle(ctx context.Context, datastore plugins.Datastore) plugins.Handle {
 	return &testHandle{
 		ctx: ctx,
 		HandlePlugins: &testHandlePlugins{
 			plugins: map[string]plugins.Plugin{},
 		},
+		Datastore: datastore,
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a new optional extension point, the PreSchedule plugin. This plugin when specified is invoked by the Director before the scheduler is invoked. In particular it is in charge of getting the candidate pods to be filtered and scored by the scheduling process.

The new PreSchedule plugin enables more sophisticated pod selection strategies.

This is particularly useful in cases where one is using an autoscaler in a cluster of many InferencePools that are "sharing" a set of GPUs. In periods of inactivity for some particular model, one might want to scale its InferencePool to zero and use the freed up GPU in another InferencePool. When requests for the model that was scaled to zero come in, one would want to scale that InferencePool up from zero, in order to process the requests.

**Does this PR introduce a user-facing change?**:
- A new extension point has been added, the PreSchedule plugin, which can be used for more sophisticated pod selection algorithms.
```release-note

```
