### PR TITLE
Fixed epp pod starting but not working when using multiple schedulingProfiles

### DIFF
--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/profile"
 )
 
 var scheme = runtime.NewScheme()
@@ -111,6 +112,10 @@ func loadSchedulerConfig(configProfiles []configapi.SchedulingProfile, handle pl
 	}
 	if profileHandler == nil {
 		return nil, errors.New("no profile handler was specified")
+	}
+
+	if profileHandler.TypedName().Type == profile.SingleProfileHandlerType && len(profiles) > 1 {
+		return nil, errors.New("single profile handler is intended to be used with a single profile, but multiple profiles were specified")
 	}
 
 	return scheduling.NewSchedulerConfig(profileHandler, profiles), nil

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -420,6 +420,11 @@ func TestLoadConfig(t *testing.T) {
 			configText: errorNoProfileHandlersText,
 			wantErr:    true,
 		},
+		{
+			name:       "errorMultiProfilesUseSingleProfileHandler",
+			configText: errorMultiProfilesUseSingleProfileHandlerText,
+			wantErr:    true,
+		},
 	}
 
 	registerNeededPlgugins()
@@ -880,6 +885,26 @@ const errorNoProfileHandlersText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+- name: prof2
+  plugins:
+  - pluginRef: maxScore
+`
+
+// multiple profiles using SingleProfileHandler
+//
+//nolint:dupword
+const errorMultiProfilesUseSingleProfileHandlerText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: profileHandler
+  type: single-profile-handler
 - name: maxScore
   type: max-score-picker
 schedulingProfiles:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

Fixed epp pod starting but not working when using multiple schedulingProfiles

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1697

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
