### PR TITLE
Fix LabelSelector validation markers for map field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ help: ## Display this help.
 .PHONY: generate
 generate: controller-gen code-generator ## Generate WebhookConfiguration, ClusterRole, CustomResourceDefinition objects, code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate/boilerplate.generatego.txt" paths="./..."
+	$(CONTROLLER_GEN) crd output:dir="./config/crd/bases" paths="./..."
 	./hack/update-codegen.sh
 
 # Use same code-generator version as k8s.io/api

--- a/api/v1/shared_types.go
+++ b/api/v1/shared_types.go
@@ -137,7 +137,7 @@ type LabelSelector struct {
 	// The matching logic is an AND operation on all entries.
 	//
 	// +required
-	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:MinProperties=1
+	// +kubebuilder:validation:MaxProperties=64
 	MatchLabels map[LabelKey]LabelValue `json:"matchLabels,omitempty"`
 }

--- a/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
@@ -147,6 +147,8 @@ spec:
                       MatchLabels contains a set of required {key,value} pairs.
                       An object must match every label in this map to be selected.
                       The matching logic is an AND operation on all entries.
+                    maxProperties: 64
+                    minProperties: 1
                     type: object
                 required:
                 - matchLabels


### PR DESCRIPTION
Backport of PR #1679

* Fix LabelSelector validation markers for map field

  Changed MinItems/MaxItems to MinProperties/MaxProperties for the MatchLabels field in LabelSelector, as it is a map type, not an array. This resolves controller-gen CRD generation errors.



* Add CRD generation to make generate target

Add controller-gen crd to the generate target to validate kubebuilder markers during development and CI runs.

Previously, make generate only ran controller-gen object, which generates DeepCopy methods but does not validate CRD markers like MinItems, MaxItems, MinProperties, etc. This meant invalid markers could be merged without detection, only to cause failures in downstream projects that run full CRD generation.

By adding CRD generation to the generate target:
- Invalid kubebuilder markers are caught immediately during development
- CI will fail if markers are incorrect or CRDs are out of sync
- Prevents downstream projects from encountering CRD generation errors
- Aligns with the target's existing documentation which states it generates CustomResourceDefinition objects

This change would have caught the MinItems/MaxItems issue fixed in commit 40cecfd before it was merged.



* Regenerate CRDs with updated validation markers

This regenerates the CRDs to include the MinProperties/MaxProperties validation for the MatchLabels map field.

The generated CRD now includes:
- minProperties: 1
- maxProperties: 64

These properties correctly validate the map field, replacing the incorrect MinItems/MaxItems markers that were causing controller-gen failures.



---------

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
