### PR TITLE
Add non-streaming response to approximate prefix cache.

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -304,6 +304,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 						break
 					}
 
+					reqCtx.Response.Body = body
 					reqCtx, responseErr = s.HandleResponseBody(ctx, reqCtx, responseBody)
 					if responseErr != nil {
 						if logger.V(logutil.DEBUG).Enabled() {

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -288,13 +288,7 @@ func (d *Director) HandleResponseBodyComplete(ctx context.Context, reqCtx *handl
 		logger.Error(err, "HandleResponseBodyComplete: failed to convert the response to LLMResponse.")
 		return reqCtx, err
 	}
-	response := &Response{
-		RequestId: requestID,
-		Headers:   reqCtx.Response.Headers,
-		// Currently use the first choice as the response body to process.
-		Body: llmResponse.GetFirstChoiceContent(),
-	}
-	d.runResponseCompletePlugins(ctx, reqCtx.SchedulingRequest, response, reqCtx.TargetPod)
+	d.runResponseCompletePlugins(ctx, reqCtx.SchedulingRequest, llmResponse, reqCtx.TargetPod)
 
 	logger.V(logutil.DEBUG).Info("Exiting HandleResponseBodyComplete")
 	return reqCtx, nil
@@ -344,7 +338,7 @@ func (d *Director) runResponseStreamingPlugins(ctx context.Context, request *sch
 	}
 }
 
-func (d *Director) runResponseCompletePlugins(ctx context.Context, request *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {
+func (d *Director) runResponseCompletePlugins(ctx context.Context, request *schedulingtypes.LLMRequest, response *schedulingtypes.LLMResponse, targetPod *backend.Pod) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.responseCompletePlugins {
 		loggerDebug.Info("Running ResponseComplete plugin", "plugin", plugin.TypedName())

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -55,5 +55,5 @@ type ResponseStreaming interface {
 // ResponseComplete is called by the director after the complete response is sent.
 type ResponseComplete interface {
 	plugins.Plugin
-	ResponseComplete(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)
+	ResponseComplete(ctx context.Context, request *types.LLMRequest, response *types.LLMResponse, targetPod *backend.Pod)
 }

--- a/pkg/epp/scheduling/types/types_test.go
+++ b/pkg/epp/scheduling/types/types_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMarshalMessagesToJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		messages []Message
+		want     []byte
+		wantErr  bool
+	}{
+		{
+			name:     "empty messages",
+			messages: []Message{},
+			want:     []byte{},
+			wantErr:  false,
+		},
+		{
+			name: "single message",
+			messages: []Message{
+				{Role: "user", Content: Content{Raw: "Hello"}},
+			},
+			want:    []byte(`{"role":"user","content":"Hello"},`),
+			wantErr: false,
+		},
+		{
+			name: "multiple messages",
+			messages: []Message{
+				{Role: "user", Content: Content{Raw: "Hello"}},
+				{Role: "assistant", Content: Content{Raw: "Hi there!"}},
+			},
+			want:    []byte(`{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi there!"},`),
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := MarshalMessagesToJSON(tc.messages...)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("MarshalMessagesToJSON() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("MarshalMessagesToJSON() got = %s, want %s", string(got), string(tc.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind feature

**What this PR does / why we need it**:

Add non streaming response to prefix cache, several points to pay attention:
1. This is only for non-streaming response, streaming response will be added in a followup PR.
2. The PR is based on #1661
  * Also changed the `ResponseComplete` to accept a `*types.LLMResponse` which has richer structure.
4. The response will be concatenated to the previous request. 
5. The encoding of `ChatCompletions` messages for prefix caching is now standardized via `MarshalMessagesToJSON` to improve caching accuracy for multi-turn conversations.
6. Currently only the first choice and the content will be prefix cached. (not role is added but could be a follow up)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes Partially [#971](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/971)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
