### PR TITLE
Adds PATCH Variable to Release Script

### DIFF
--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -18,13 +18,14 @@ set -euo pipefail
 # -----------------------------------------------------------------------------
 # Environment variables (defaults)
 # -----------------------------------------------------------------------------
-# MAJOR and MINOR are required (defaults provided here if not already set)
+# MAJOR, MINOR, and PATCH are required (defaults provided here if not already set)
 MAJOR="${MAJOR:-0}"
 MINOR="${MINOR:-1}"
+PATCH="${PATCH:-0}"
 
 # If RC is defined (non-empty) then include the rc suffix; otherwise omit it.
 if [[ -z "${RC-}" ]]; then
-  RELEASE_TAG="v${MAJOR}.${MINOR}.0"
+  RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}"
 else
   RELEASE_TAG="v${MAJOR}.${MINOR}.0-rc.${RC}"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

Adds a `PATCH` variable to the release script since it's missing and required to following the release workflow.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The `PATCH` env var is set by the `.github/ISSUE_TEMPLATE/new-release.md` release workflow, but is not consumed by the release script. This causes the patch release to end in `.0` instead of the applicable patch release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
