### PR TITLE
Docs: Updates HTTPRoute Refs for IGs

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -132,8 +132,11 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extens
       5. Deploy the HTTPRoute
 
          ```bash
-         kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/gateway/istio/httproute.yaml
+         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/heads/main/config/manifests/gateway/istio/httproute.yaml
          ```
+
+         **Note:** The above URL should be replaced with a tagged reference when [Issue 1741](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1741)
+         is fixed.
 
       6. Confirm that the HTTPRoute status conditions include `Accepted=True` and `ResolvedRefs=True`:
 
@@ -180,8 +183,11 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extens
       5. Deploy the HTTPRoute
 
          ```bash
-         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/tags/v1.0.1/config/manifests/gateway/kgateway/httproute.yaml
+         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/heads/main/config/manifests/gateway/kgateway/httproute.yaml
          ```
+
+         **Note:** The above URL should be replaced with a tagged reference when [Issue 1741](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1741)
+         is fixed.
 
       6. Confirm that the HTTPRoute status conditions include `Accepted=True` and `ResolvedRefs=True`:
 
@@ -227,8 +233,11 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extens
       5. Deploy the HTTPRoute
 
          ```bash
-         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/tags/v1.0.1/config/manifests/gateway/agentgateway/httproute.yaml
+         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/heads/main/config/manifests/gateway/agentgateway/httproute.yaml
          ```
+
+         **Note:** The above URL should be replaced with a tagged reference when [Issue 1741](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1741)
+         is fixed.
 
       6. Confirm that the HTTPRoute status conditions include `Accepted=True` and `ResolvedRefs=True`:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

Updates non-GKE inference gateways to use HTTPRoute manifest from the main branch until #1741 is fixed. This PR and #1741 should be closed if the v1.0.2 patch release is cut.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Needed b/c the quickstart is currently broken for all inference gateways other than GKE.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
