### PR TITLE
feat: Configure LRUCacheSize using the numGPUBlocks for approximate prefix cache

### DIFF
--- a/pkg/epp/backend/metrics/metrics.go
+++ b/pkg/epp/backend/metrics/metrics.go
@@ -38,6 +38,7 @@ const (
 	LoraInfoMaxAdaptersMetricName     = "max_lora"
 
 	CacheConfigBlockSizeInfoMetricName = "block_size"
+	CacheConfigNumGPUBlocksMetricName  = "num_gpu_blocks"
 )
 
 type PodMetricsClientImpl struct {
@@ -148,12 +149,16 @@ func (p *PodMetricsClientImpl) promToPodMetrics(
 			errs = multierr.Append(errs, err)
 		} else {
 			for _, v := range cacheMetrics.GetLabel() {
-				if v.GetName() == CacheConfigBlockSizeInfoMetricName {
+				switch v.GetName() {
+				case CacheConfigBlockSizeInfoMetricName:
 					updated.CacheBlockSize, err = strconv.Atoi(v.GetValue())
 					if err != nil {
 						errs = multierr.Append(errs, err)
-					} else {
-						break
+					}
+				case CacheConfigNumGPUBlocksMetricName:
+					updated.CacheNumGPUBlocks, err = strconv.Atoi(v.GetValue())
+					if err != nil {
+						errs = multierr.Append(errs, err)
 					}
 				}
 			}

--- a/pkg/epp/datalayer/metrics.go
+++ b/pkg/epp/datalayer/metrics.go
@@ -33,6 +33,8 @@ type Metrics struct {
 	KVCacheUsagePercent     float64
 	KvCacheMaxTokenCapacity int
 	CacheBlockSize          int
+	// Number of GPU blocks in the model server for KV Cache.
+	CacheNumGPUBlocks int
 
 	// UpdateTime records the last time when the metrics were updated.
 	UpdateTime time.Time
@@ -77,6 +79,7 @@ func (m *Metrics) Clone() *Metrics {
 		KVCacheUsagePercent:     m.KVCacheUsagePercent,
 		KvCacheMaxTokenCapacity: m.KvCacheMaxTokenCapacity,
 		CacheBlockSize:          m.CacheBlockSize,
+		CacheNumGPUBlocks:       m.CacheNumGPUBlocks,
 		UpdateTime:              m.UpdateTime,
 	}
 }

--- a/pkg/epp/datalayer/metrics/extractor.go
+++ b/pkg/epp/datalayer/metrics/extractor.go
@@ -39,6 +39,7 @@ const (
 	LoraInfoMaxAdaptersMetricName     = "max_lora"
 
 	CacheConfigBlockSizeInfoMetricName = "block_size"
+	CacheConfigNumGPUBlocksMetricName  = "num_gpu_blocks"
 )
 
 // Extractor implements the metrics extraction based on the model
@@ -161,11 +162,19 @@ func populateLoRAMetrics(clone *datalayer.Metrics, metric *dto.Metric, errs *[]e
 func populateCacheInfoMetrics(clone *datalayer.Metrics, metric *dto.Metric, errs *[]error) {
 	clone.CacheBlockSize = 0
 	for _, label := range metric.GetLabel() {
-		if label.GetName() == CacheConfigBlockSizeInfoMetricName {
+		switch label.GetName() {
+		case CacheConfigBlockSizeInfoMetricName:
 			if label.GetValue() != "" {
 				if val, err := strconv.Atoi(label.GetValue()); err == nil {
 					clone.CacheBlockSize = val
-					break
+				} else {
+					*errs = append(*errs, err)
+				}
+			}
+		case CacheConfigNumGPUBlocksMetricName:
+			if label.GetValue() != "" {
+				if val, err := strconv.Atoi(label.GetValue()); err == nil {
+					clone.CacheNumGPUBlocks = val
 				} else {
 					*errs = append(*errs, err)
 				}

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/indexer_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/indexer_test.go
@@ -23,25 +23,28 @@ import (
 )
 
 func TestIndexer_AddAndGet(t *testing.T) {
-	i := newIndexer(context.Background(), 2)
+	server := Server{
+		ServerID:       ServerID{Namespace: "default", Name: "server1"},
+		numOfGPUBlocks: 2,
+	}
+	i := newIndexer(context.Background(), 3) // Initialize with an lruSize greater than server.numOfGPUBlocks to verify server-defined limits take precedence.
 
 	hash1 := BlockHash(1)
-	server := ServerID{Namespace: "default", Name: "server1"}
 	// Add an entry to the cache
 	i.Add([]BlockHash{hash1}, server)
 
 	// Retrieve the entry
-	assert.Equal(t, 1, i.podToLRU[server].Len(), "Cache size should be 1 after adding an entry")
+	assert.Equal(t, 1, i.podToLRU[server.ServerID].Len(), "Cache size should be 1 after adding an entry")
 	servers := i.Get(hash1)
-	assert.Contains(t, servers, server, "Cache should contain the added server")
+	assert.Contains(t, servers, server.ServerID, "Cache should contain the added server")
 
 	// Add another entry to the cache, the cache size should be incremented to 2.
 	i.Add([]BlockHash{BlockHash(2)}, server)
-	assert.Equal(t, 2, i.podToLRU[server].Len(), "Cache size should  be 2 after adding an entry")
+	assert.Equal(t, 2, i.podToLRU[server.ServerID].Len(), "Cache size should  be 2 after adding an entry")
 
 	// Add another entry to the cache, which should evict the first one due to max size.
 	i.Add([]BlockHash{BlockHash(3)}, server)
-	assert.Equal(t, 2, i.podToLRU[server].Len(), "Cache size should still be 2 after adding an entry")
+	assert.Equal(t, 2, i.podToLRU[server.ServerID].Len(), "Cache size should still be 2 after adding an entry")
 
 	servers = i.Get(BlockHash(4))
 	assert.Empty(t, servers, "Cache should not contain non-existent hash")
@@ -52,8 +55,8 @@ func TestIndexer_RemovePodAndEviction(t *testing.T) {
 
 	i := newIndexer(context.Background(), indexerSize)
 
-	server1 := ServerID{Namespace: "default", Name: "server1"}
-	server2 := ServerID{Namespace: "default", Name: "server2"}
+	server1 := Server{ServerID: ServerID{Namespace: "default", Name: "server1"}}
+	server2 := Server{ServerID: ServerID{Namespace: "default", Name: "server2"}}
 
 	// Add indexerSize hashes to both servers
 	var hashes []BlockHash
@@ -65,15 +68,15 @@ func TestIndexer_RemovePodAndEviction(t *testing.T) {
 	}
 
 	// Ensure all entries are added
-	assert.Equal(t, indexerSize, i.podToLRU[server1].Len(), "server1 should have 10 entries")
-	assert.Equal(t, indexerSize, i.podToLRU[server2].Len(), "server2 should have 10 entries")
+	assert.Equal(t, indexerSize, i.podToLRU[server1.ServerID].Len(), "server1 should have 10 entries")
+	assert.Equal(t, indexerSize, i.podToLRU[server2.ServerID].Len(), "server2 should have 10 entries")
 
 	// Ensure each hash in hashToPods maps to both server1 and server2
 	for _, h := range hashes {
 		pods := i.hashToPods[h]
 		assert.Len(t, pods, 2, "Each hash should be associated with exactly 2 pods")
-		assert.Contains(t, pods, server1, "hash should be associated with server1")
-		assert.Contains(t, pods, server2, "hash should be associated with server2")
+		assert.Contains(t, pods, server1.ServerID, "hash should be associated with server1")
+		assert.Contains(t, pods, server2.ServerID, "hash should be associated with server2")
 	}
 
 	// Add indexerSize hash to server1 → should evict BlockHash(0)
@@ -82,25 +85,25 @@ func TestIndexer_RemovePodAndEviction(t *testing.T) {
 	i.Add([]BlockHash{newHash}, server1)
 
 	// server1 LRU should still be at max capacity
-	assert.Equal(t, indexerSize, i.podToLRU[server1].Len(), "server1 LRU should maintain max size")
+	assert.Equal(t, indexerSize, i.podToLRU[server1.ServerID].Len(), "server1 LRU should maintain max size")
 
 	// BlockHash(0) should no longer have server1 in hashToPods
 	pods := i.Get(evictedHash)
-	assert.NotContains(t, pods, server1, "server1 should be evicted from hashToPods for hash 0")
-	assert.Contains(t, pods, server2, "server2 should still have hash 0")
+	assert.NotContains(t, pods, server1.ServerID, "server1 should be evicted from hashToPods for hash 0")
+	assert.Contains(t, pods, server2.ServerID, "server2 should still have hash 0")
 
 	// Remove server2
-	i.RemovePod(server2)
+	i.RemovePod(server2.ServerID)
 
 	// hashToPods for hash 0 should now be empty
 	pods = i.Get(evictedHash)
-	assert.NotContains(t, pods, server2, "server2 should be removed from hash 0")
+	assert.NotContains(t, pods, server2.ServerID, "server2 should be removed from hash 0")
 	assert.Empty(t, pods, "hash 0 should have no pods after both eviction and removal")
 
 	// All remaining hashes should map only to server1
 	for hash, pods := range i.hashToPods {
 		assert.Len(t, pods, 1, "hash %v should have only 1 pod after server2 removal", hash)
-		assert.Contains(t, pods, server1, "hash %v should only contain server1", hash)
+		assert.Contains(t, pods, server1.ServerID, "hash %v should only contain server1", hash)
 	}
 
 	// Ensure hashToPods contains exactly indexerSize hashes (post-eviction and server2 removal)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind feature

**What this PR does / why we need it**:
This change introduces the ability to configure the `numGPUBlocks` for the approximate prefix cache.

Key changes:
  - The `indexer` now considers `numOfGPUBlocks` from the server's metrics when creating a new LRU cache. This allows the cache size to be dynamically adjusted based on the server's capacity.
  - If `numOfGPUBlocks` is not available, a default LRU size is used.
  - The `Add` method in the `indexer` now accepts a `Server` struct, which includes both the `ServerID` and `numOfGPUBlocks`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially #1304
Fixes #1512

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
feat: configure LRUCacheSize using the numGPUBlocks for approximate prefix cache scorer
```
