### PR TITLE
Correct the InferencePoolResolvedRefsCondition  conformance tests.

### DIFF
--- a/conformance/tests/inferencepool_resolvedrefs_condition.go
+++ b/conformance/tests/inferencepool_resolvedrefs_condition.go
@@ -36,10 +36,10 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, InferencePoolParentStatus)
+	ConformanceTests = append(ConformanceTests, InferencePoolResolvedRefsCondition)
 }
 
-var InferencePoolParentStatus = suite.ConformanceTest{
+var InferencePoolResolvedRefsCondition = suite.ConformanceTest{
 	ShortName:   "InferencePoolResolvedRefsCondition",
 	Description: "Verify that an InferencePool correctly updates its parent-specific status (e.g., Accepted condition) when referenced by HTTPRoutes attached to shared Gateways, and clears parent statuses when no longer referenced.",
 	Manifests:   []string{"tests/inferencepool_resolvedrefs_condition.yaml"},
@@ -98,16 +98,16 @@ var InferencePoolParentStatus = suite.ConformanceTest{
 				t,
 				s.RoundTripper,
 				s.TimeoutConfig,
-				gwPrimaryAddr,
+				gwSecondaryAddr,
 				gwhttp.ExpectedResponse{
 					Request: gwhttp.Request{
 						Host: hostnameSecondaryGw,
 						Path: pathSecondaryGw,
 					},
 					Response: gwhttp.Response{
-						StatusCodes: []int{http.StatusNotFound},
+						StatusCodes: []int{http.StatusOK},
 					},
-					Backend:   resources.PrimaryModelServerDeploymentName,
+					Backend:   resources.PrimaryModelServerDeploymentName, // Primary because in this test, both primary and secondary httpRoute is backnedRef the primary InferecePool.
 					Namespace: resources.AppBackendNamespace,
 				},
 			)
@@ -139,7 +139,7 @@ var InferencePoolParentStatus = suite.ConformanceTest{
 					Response: gwhttp.Response{
 						StatusCodes: []int{http.StatusOK},
 					},
-					Backend:   resources.PrimaryModelServerDeploymentName,
+					Backend:   resources.PrimaryModelServerDeploymentName, // Primary because in this test, both primary and secondary httpRoute is backnedRef the primary InferecePool.
 					Namespace: resources.AppBackendNamespace,
 				},
 			)
@@ -178,7 +178,7 @@ var InferencePoolParentStatus = suite.ConformanceTest{
 				t,
 				s.RoundTripper,
 				s.TimeoutConfig,
-				gwPrimaryAddr,
+				gwSecondaryAddr,
 				gwhttp.ExpectedResponse{
 					Request: gwhttp.Request{
 						Host: hostnameSecondaryGw,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:
The PR https://github.com/kubernetes-sigs/gateway-api-inference-extension/commit/0707d2fb276e1a8366fa693a3337081d7d763a57#diff-4fff24a24347da2990a6a84ae376c39de10be47f0b08f5f5ac480230dc723ee4 accidentally changed the verification a little bit and it can still pass the conformance test. But that's not what we want to test.
<img width="2846" height="1384" alt="image" src="https://github.com/user-attachments/assets/69217bec-46bd-4b9b-914c-b2337e8b07d1" />


Run the test agianst GKE to make sure it still passes

```
go test -v ./conformance -args -debug -gateway-class gke-l7-regional-external-managed -cleanup-base-resources=false -allow-crds-mismatch=true -run-test InferencePoolResolvedRefsCondition

--- PASS: TestConformance (186.87s)
    --- SKIP: TestConformance/EppUnAvailableFailOpen (0.00s)
    --- SKIP: TestConformance/GatewayFollowingEPPRouting (0.00s)
    --- SKIP: TestConformance/GatewayWeightedAcrossTwoInferencePools (0.00s)
    --- SKIP: TestConformance/HTTPRouteInvalidInferencePoolRef (0.00s)
    --- SKIP: TestConformance/HTTPRouteMultipleGatewaysDifferentPools (0.00s)
    --- SKIP: TestConformance/InferencePoolAccepted (0.00s)
    --- SKIP: TestConformance/InferencePoolHTTPRoutePortValidation (0.00s)
    --- SKIP: TestConformance/InferencePoolInvalidEPPService (0.00s)
    --- SKIP: TestConformance/HTTPRouteMultipleRulesDifferentPools (0.00s)
    --- PASS: TestConformance/InferencePoolResolvedRefsCondition (180.54s)
        --- PASS: TestConformance/InferencePoolResolvedRefsCondition/InferencePool_should_show_Accepted:True_by_parents_and_be_routable_via_multiple_HTTPRoutes (51.25s)
        --- PASS: TestConformance/InferencePoolResolvedRefsCondition/Delete_httproute-for-primary-gw_and_verify_InferencePool_status_and_routing_via_secondary_gw (27.29s)
        --- PASS: TestConformance/InferencePoolResolvedRefsCondition/Delete_httproute-for-secondary-gw_and_verify_InferencePool_has_no_parent_statuses_and_is_not_routable (56.12s)
PASS
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
