### PR TITLE
fix tracing configuration in helm epp-deployment template

### DIFF
--- a/config/charts/inferencepool/templates/epp-deployment.yaml
+++ b/config/charts/inferencepool/templates/epp-deployment.yaml
@@ -62,11 +62,10 @@ spec:
         - "--{{ .name }}"
         - "{{ .value }}"
         {{- end }}
-        - "--tracing"
         {{- if .Values.inferenceExtension.tracing.enabled }}
-        - "true"
+        - --tracing=true
         {{- else }}
-        - "false"
+        - --tracing=false
         {{- end }}
         {{- if not .Values.inferenceExtension.monitoring.prometheus.enabled }}
         - --metrics-endpoint-auth=false


### PR DESCRIPTION
**What this PR does / why we need it**:
  
## Fix: Correct boolean flag syntax for --tracing argument

  ### Problem
  The `--tracing` flag was incorrectly split into two separate arguments:
  - `"--tracing"`
  - `"false"`

  Go's `flag` package interprets this as setting `--tracing=true` with `"false"` being ignored as a positional argument.

  ### Solution
  Changed to use the correct `--flag=value` syntax:
  - `--tracing=true` (when enabled)
  - `--tracing=false` (when disabled)

**What type of PR is this?**

/kind bug

