### PR TITLE
[metrics]: Allow EPP to register metrics from extension

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -143,6 +143,7 @@ func NewRunner() *Runner {
 type Runner struct {
 	requestControlConfig *requestcontrol.Config
 	schedulerConfig      *scheduling.SchedulerConfig
+	customCollectors     []prometheus.Collector
 }
 
 func (r *Runner) WithRequestControlConfig(requestControlConfig *requestcontrol.Config) *Runner {
@@ -152,6 +153,11 @@ func (r *Runner) WithRequestControlConfig(requestControlConfig *requestcontrol.C
 
 func (r *Runner) WithSchedulerConfig(schedulerConfig *scheduling.SchedulerConfig) *Runner {
 	r.schedulerConfig = schedulerConfig
+	return r
+}
+
+func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runner {
+	r.customCollectors = collectors
 	return r
 }
 
@@ -205,6 +211,9 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// --- Setup Metrics Server ---
 	customCollectors := []prometheus.Collector{collectors.NewInferencePoolMetricsCollector(datastore)}
+	if r.customCollectors != nil {
+		customCollectors = append(customCollectors, r.customCollectors...)
+	}
 	metrics.Register(customCollectors...)
 	metrics.RecordInferenceExtensionInfo(version.CommitSHA, version.BuildRef)
 	// Register metrics handler.


### PR DESCRIPTION
The motivation is
https://github.com/llm-d/llm-d-inference-scheduler/issues/386 that we would like to have more metrics from llm-d inference scheduler plugin.

The current metrics implementation is bundled in the runner of EPP, so this PR extends the runner to allow extension to register prometheus metrics collector.

See https://github.com/llm-d/llm-d-inference-scheduler/pull/405 for a draft PR of how metrics are going to be implemented in the plugin.

I have tested locally that both EPP and inference scheduler metrics can be exported through the pod /metrics endpoint.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

https://github.com/llm-d/llm-d-inference-scheduler/issues/386

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->

```release-note
Inference Gateway now allows extension to register prometheus metrics collector.
```
