### PR TITLE
feat (reports): add infrastructure to run NGF conformance tests and i…

### DIFF
--- a/conformance/reports/v1.0.2/gateway/nginx-nginx-gateway-fabric/README.md
+++ b/conformance/reports/v1.0.2/gateway/nginx-nginx-gateway-fabric/README.md
@@ -1,0 +1,29 @@
+# Nginx NGINX Gateway Fabric
+
+## Table of Contents
+
+| Extension Version Tested | Profile Tested | Implementation Version | Mode    | Report                                                                     |
+|--------------------------|----------------|------------------------|---------|----------------------------------------------------------------------------|
+| v1.0.2                   | Gateway        | v2.2.0                 | default | [v2.2.0 report](./inference-v2.2.0-report.yaml)    
+
+## Reproduce
+
+To reproduce results, clone the NGF repository:
+
+```shell
+git clone https://github.com/nginx/nginx-gateway-fabric.git && cd nginx-gateway-fabric/tests
+```
+
+Follow the steps in the [NGINX Gateway Fabric Testing](https://github.com/nginx/nginx-gateway-fabric/blob/main/tests/README.md#conformance-testing) document to run the conformance tests. If you are running tests on the `edge` version, then you don't need to build any images. Otherwise, you'll need to check out the specific release tag that you want to test, and then build and load the images onto your cluster, per the steps in the README.
+
+Note: Enable this flag to install all CRDs and required resources:
+
+```shell
+export ENABLE_INFERENCE_EXTENSION=true
+```
+
+After running, see the conformance report:
+
+```shell
+cat conformance-profile-inference.yaml
+```

--- a/conformance/reports/v1.0.2/gateway/nginx-nginx-gateway-fabric/inference-v2.2.0-report.yaml
+++ b/conformance/reports/v1.0.2/gateway/nginx-nginx-gateway-fabric/inference-v2.2.0-report.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-10-28T14:18:58Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.3.0
+implementation:
+  contact:
+  - https://github.com/nginx/nginx-gateway-fabric/discussions/new/choose
+  organization: nginx
+  project: nginx-gateway-fabric
+  url: https://github.com/nginx/nginx-gateway-fabric
+  version: 2.2.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 9
+      Skipped: 0
+  name: Gateway
+  summary: Core tests succeeded.


### PR DESCRIPTION
What type of PR is this?
/kind documentation

Optionally add one or more of the following kinds if applicable:
/area conformance-test

What this PR does / why we need it:
Adds a v1.0.2 gateway inference conformance report for the Nginx Gateway Fabric implementation.

Which issue(s) this PR fixes:

N/A

Does this PR introduce a user-facing change?:

NONE