### PR TITLE
allow overriding the runner's containing executable name

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -135,14 +135,14 @@ var (
 // NewRunner initializes a new EPP Runner and returns its pointer.
 func NewRunner() *Runner {
 	return &Runner{
-		eppExecutable:        "GIE",
+		eppExecutableName:    "GIE",
 		requestControlConfig: requestcontrol.NewConfig(), // default requestcontrol config has empty plugin list
 	}
 }
 
 // Runner is used to run epp with its plugins
 type Runner struct {
-	eppExecutable        string // the EPP executable name
+	eppExecutableName    string // the EPP executable name
 	requestControlConfig *requestcontrol.Config
 	schedulerConfig      *scheduling.SchedulerConfig
 	customCollectors     []prometheus.Collector
@@ -150,8 +150,8 @@ type Runner struct {
 
 // WithExecutableName sets the name of the executable containing the runner.
 // The name is used in the version log upon startup and is otherwise opaque.
-func (r *Runner) WithExecutableName(exe string) *Runner {
-	r.eppExecutable = exe
+func (r *Runner) WithExecutableName(exeName string) *Runner {
+	r.eppExecutableName = exeName
 	return r
 }
 
@@ -185,7 +185,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	setupLog.Info(r.eppExecutable+" build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
+	setupLog.Info(r.eppExecutableName+" build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
 
 	// Validate flags
 	if err := validateFlags(); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow setting of the runners executable name when logging the commit SHA and build informaiton.
Since `runner.Run` logs a fixed `GIE build`, this PR allows setting a containing executable name for the runner. The executable defaults to `GIE` as in the current code.

The IGW runner is reused outside of this repo (e.g., llm-d sidecar and inference-scheduler). The version values are set
via linker flags (`-X ....`) populating the values from the importing repo and not based on IGW's version being used.

A different option would be to extend the version struct to include an executable name directly (i.e., allow overriding via linker flags as well).

**Which issue(s) this PR fixes**:
NA

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
