### PR TITLE
Adjust default scorer weights to favor more prefix cache affinity

### DIFF
--- a/config/charts/inferencepool/templates/epp-config.yaml
+++ b/config/charts/inferencepool/templates/epp-config.yaml
@@ -15,8 +15,11 @@ data:
     - name: default
       plugins:
       - pluginRef: queue-scorer
+        weight: 2
       - pluginRef: kv-cache-utilization-scorer
+        weight: 2
       - pluginRef: prefix-cache-scorer
+        weight: 3
   {{- if (hasKey .Values.inferenceExtension "pluginsCustomConfig") }}
   {{- .Values.inferenceExtension.pluginsCustomConfig | toYaml | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
This PR proposes changing the default scorer weights in helm.

Current: 
"111" `prefix-cache-scorer: 1, queue-scorer:1, kv-cache-utilization-scorer:1`

Proposed: 
"322":`prefix-cache-scorer: 3, queue-scorer:2, kv-cache-utilization-scorer:2`


The reason is that both `queue` and `kv cache` scorers reflect "load", and both combined can dilute the `prefix cache` affinity. Here are benchmark data to support this decision:

* In a "low cache" scenario, where the total active cache amount is low compared to the total cache capacity, both weights perform very similarly, this is shown in the initial benchmark of the prefix cache plugin: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/768.
* In a "high cache" scenario such as https://github.com/llm-d/llm-d-kv-cache-manager/blob/main/benchmarking/73-capacity/README.md, where the active cache is over 70% of the total capacity, the 322 configuration outperforms 111. NOTE initially we thought the the performance difference was due to the precise vs. estimate prefix scorers, however after adjusting the estimate scorer weight to be 322 (same as precise scorer), we found estimate and precise scorer perform similarly, highlighting that the main driver for performance is proper weights. Credits to @zetxqx for performing the [benchmark](https://docs.google.com/document/d/1c5RI4JSTNli0NJ6OauH1SzpinvxBTvZy_c86TxOxpFg/edit?tab=t.0#heading=h.y1ctn1dbe9nj).

In summary, this change should NOT cause regression in "low cache" scenario, but significantly improves performance for "high cache" scenario.

cc @vMaroon @ahg-g @zetxqx 
