### PR TITLE
Helm: Adds `istio` as a `provider`-scoped value for the inferencepool Chart

### DIFF
--- a/config/charts/inferencepool/templates/istio.yaml
+++ b/config/charts/inferencepool/templates/istio.yaml
@@ -1,16 +1,22 @@
 {{- if eq .Values.provider.name "istio" }}
+{{- /* Prefer .Values.provider.istio, fallback to legacy .Values.istio, then {} */ -}}
+{{- $provIstio := (index .Values "provider" "istio") -}}
+{{- $legacyIstio := .Values.istio -}}
+{{- $istio := coalesce $provIstio $legacyIstio (dict) -}}
+{{- $dr := (index $istio "destinationRule") | default (dict) -}}
+
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: {{ include "gateway-api-inference-extension.name" . }}
 spec:
-  host: {{ .Values.istio.destinationRule.host | default (printf "%s.%s.svc.cluster.local" (include "gateway-api-inference-extension.name" .) .Release.Namespace) }}
+  host: {{ (index $dr "host") | default (printf "%s.%s.svc.cluster.local" (include "gateway-api-inference-extension.name" .) .Release.Namespace) }}
   trafficPolicy:
     tls:
       mode: SIMPLE
       insecureSkipVerify: true
-    {{- if .Values.istio.destinationRule.trafficPolicy.connectionPool }}
-    connectionPool: 
-      {{- .Values.istio.destinationRule.trafficPolicy.connectionPool | toYaml | nindent 6 }}
+    {{- with (index (index $dr "trafficPolicy") "connectionPool") }}
+    connectionPool:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/config/charts/inferencepool/values.yaml
+++ b/config/charts/inferencepool/values.yaml
@@ -85,10 +85,23 @@ provider:
     # Set to true if the cluster is an Autopilot cluster.
     autopilot: false
 
+  # Istio-specific configuration.
+  # This block is only used if name is "istio".
+  istio:
+    destinationRule:
+      # Provide a way to override the default calculated host
+      host: ""
+      # Optional: Enables customization of the traffic policy
+      trafficPolicy: {}
+        # connectionPool:
+        #   http:
+        #     maxRequestsPerConnection: 256000
+
+# DEPRECATED and will be removed in v1.3. Instead, use `provider.istio.*`.
 istio:
   destinationRule:
     # Provide a way to override the default calculated host
-    host: "" 
+    host: ""
     # Optional: Enables customization of the traffic policy
     trafficPolicy: {}
       # connectionPool:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds `istio` as a `provider`-scoped value since Istio is considered a provider. The current top-level `istio` value is preserved for backwards compatibility while the new scope takes precedence. The top-scoped `istio` value should be removed in the v.1.3 release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1829

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Helm: Adds `istio` as a `provider`-scoped value of the inferencepool chart. 
```
