### PR TITLE
feat(conformance): add responseReceived plugin to support verifying destination endpoint.

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -58,6 +58,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics/collectors"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
+	testresponsereceived "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol/plugins/test/responsereceived"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/saturationdetector"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/multi/prefix"
@@ -408,6 +409,8 @@ func (r *Runner) registerInTreePlugins() {
 	plugins.Register(scorer.LoraAffinityScorerType, scorer.LoraAffinityScorerFactory)
 	// register filter for test purpose only (used in conformance tests)
 	plugins.Register(testfilter.HeaderBasedTestingFilterType, testfilter.HeaderBasedTestingFilterFactory)
+	// register response received plugin for test purpose only (used in conformance tests)
+	plugins.Register(testresponsereceived.DestinationEndpointServedVerifierType, testresponsereceived.DestinationEndpointServedVerifierFactory)
 }
 
 func (r *Runner) parsePluginsConfiguration(ctx context.Context, ds datastore.Datastore) error {

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -26,6 +26,8 @@ const (
 	DestinationEndpointNamespace = "envoy.lb"
 	// DestinationEndpointKey is the header and response metadata key used by Envoy to route to the appropriate pod.
 	DestinationEndpointKey = "x-gateway-destination-endpoint"
+	// DestinationEndpointServedKey is the metadata key used by Envoy to specify the endpoint that served the request.
+	DestinationEndpointServedKey = "x-gateway-destination-endpoint-served"
 	// FlowFairnessIDKey is the header key used to pass the fairness ID to be used in Flow Control.
 	FlowFairnessIDKey = "x-gateway-inference-fairness-id"
 	// ObjectiveKey is the header key used to specify the objective of an incoming request.

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -253,10 +253,10 @@ func (d *Director) toSchedulerPodMetrics(pods []backendmetrics.PodMetrics) []sch
 // HandleResponseReceived is called when the response headers are received.
 func (d *Director) HandleResponseReceived(ctx context.Context, reqCtx *handlers.RequestContext) (*handlers.RequestContext, error) {
 	response := &Response{
-		RequestId: reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
-		Headers:   reqCtx.Response.Headers,
+		RequestId:   reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
+		Headers:     reqCtx.Response.Headers,
+		ReqMetadata: reqCtx.Request.Metadata,
 	}
-
 	// TODO: to extend fallback functionality, handle cases where target pod is unavailable
 	// https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1224
 	d.runResponseReceivedPlugins(ctx, reqCtx.SchedulingRequest, response, reqCtx.TargetPod)

--- a/pkg/epp/requestcontrol/plugins/test/consts.go
+++ b/pkg/epp/requestcontrol/plugins/test/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+const (
+	// ConformanceTestResultHeader is the header key for the conformance test result.
+	ConformanceTestResultHeader = "x-conformance-test-served-endpoint"
+)

--- a/pkg/epp/requestcontrol/plugins/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/requestcontrol/plugins/test/responsereceived/destination_endpoint_served_verifier.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsereceived
+
+import (
+	"context"
+	"encoding/json"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol/plugins/test"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+const (
+	// DestinationEndpointServedVerifierType is the ResponseReceived type that is used in plugins registry.
+	DestinationEndpointServedVerifierType = "destination-endpoint-served-verifier"
+)
+
+var _ requestcontrol.ResponseReceived = &DestinationEndpointServedVerifier{}
+
+// DestinationEndpointServedVerifier is a test-only plugin for conformance tests.
+// It verifies that the request was served by the expected endpoint.
+// It works by reading Envoy's dynamic metadata, which is passed in the
+// Response.ReqMetadata field. This metadata should contain the
+// address of the backend endpoint that served the request. The verifier then
+// writes this address to the "x-conformance-test-served-endpoint" response header.
+// The conformance test client can then validate this header to ensure the request
+// was routed correctly.
+type DestinationEndpointServedVerifier struct {
+	typedName plugins.TypedName
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (f *DestinationEndpointServedVerifier) TypedName() plugins.TypedName {
+	return f.typedName
+}
+
+// WithName sets the name of the filter.
+func (f *DestinationEndpointServedVerifier) WithName(name string) *DestinationEndpointServedVerifier {
+	f.typedName.Name = name
+	return f
+}
+
+// DestinationEndpointServedVerifierFactory defines the factory function for DestinationEndpointServedVerifier.
+func DestinationEndpointServedVerifierFactory(name string, _ json.RawMessage, _ plugins.Handle) (plugins.Plugin, error) {
+	return NewDestinationEndpointServedVerifier().WithName(name), nil
+}
+
+func NewDestinationEndpointServedVerifier() *DestinationEndpointServedVerifier {
+	return &DestinationEndpointServedVerifier{}
+}
+
+// ResponseReceived is the handler for the ResponseReceived extension point.
+func (p *DestinationEndpointServedVerifier) ResponseReceived(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, _ *backend.Pod) {
+	logger := log.FromContext(ctx).WithName(p.TypedName().String())
+	logger.V(logging.DEBUG).Info("Verifying destination endpoint served")
+
+	reqMetadata := response.ReqMetadata
+	lbMetadata, ok := reqMetadata[metadata.DestinationEndpointNamespace].(map[string]any)
+	if !ok {
+		logger.V(logging.DEBUG).Info("Response does not contain envoy lb metadata, skipping verification")
+		response.Headers[test.ConformanceTestResultHeader] = "fail: missing envoy lb metadata"
+		return
+	}
+
+	actualEndpoint, ok := lbMetadata[metadata.DestinationEndpointServedKey].(string)
+	if !ok {
+		logger.V(logging.DEBUG).Info("Response does not contain destination endpoint served metadata, skipping verification")
+		response.Headers[test.ConformanceTestResultHeader] = "fail: missing destination endpoint served metadata"
+		return
+	}
+	response.Headers[test.ConformanceTestResultHeader] = actualEndpoint
+}

--- a/pkg/epp/requestcontrol/plugins/test/responsereceived/destination_endpoint_served_verifier_test.go
+++ b/pkg/epp/requestcontrol/plugins/test/responsereceived/destination_endpoint_served_verifier_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsereceived
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol/plugins/test"
+)
+
+func TestDestinationEndpointServedVerifier_ResponseReceived(t *testing.T) {
+	testCases := []struct {
+		name                string
+		response            *requestcontrol.Response
+		expectedHeaderValue string
+	}{
+		{
+			name: "success - endpoint is correctly reported",
+			response: &requestcontrol.Response{
+				Headers: make(map[string]string),
+				ReqMetadata: map[string]any{
+					metadata.DestinationEndpointNamespace: map[string]any{
+						metadata.DestinationEndpointServedKey: "10.0.0.1:8080",
+					},
+				},
+			},
+			expectedHeaderValue: "10.0.0.1:8080",
+		},
+		{
+			name: "failure - missing lb metadata",
+			response: &requestcontrol.Response{
+				Headers:     make(map[string]string),
+				ReqMetadata: map[string]any{},
+			},
+			expectedHeaderValue: "fail: missing envoy lb metadata",
+		},
+		{
+			name: "failure - missing served endpoint key",
+			response: &requestcontrol.Response{
+				Headers: make(map[string]string),
+				ReqMetadata: map[string]any{
+					metadata.DestinationEndpointNamespace: map[string]any{
+						"some-other-key": "some-value",
+					},
+				},
+			},
+			expectedHeaderValue: "fail: missing destination endpoint served metadata",
+		},
+		{
+			name: "failure - nil metadata",
+			response: &requestcontrol.Response{
+				Headers:     make(map[string]string),
+				ReqMetadata: nil,
+			},
+			expectedHeaderValue: "fail: missing envoy lb metadata",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := NewDestinationEndpointServedVerifier().WithName("test-verifier")
+
+			plugin.ResponseReceived(context.Background(), nil, tc.response, nil)
+
+			actualHeader, ok := tc.response.Headers[test.ConformanceTestResultHeader]
+			require.True(t, ok, "Expected header %s to be set", test.ConformanceTestResultHeader)
+			require.Equal(t, tc.expectedHeaderValue, actualHeader)
+		})
+	}
+}

--- a/pkg/epp/requestcontrol/types.go
+++ b/pkg/epp/requestcontrol/types.go
@@ -28,4 +28,8 @@ type Response struct {
 	IsStreaming bool
 	// EndOfStream when true indicates that this invocation contains the last chunk of the response
 	EndOfStream bool
+	// ReqMetadata is a map of metadata that can be passed from Envoy.
+	// It is populated with Envoy's dynamic metadata when ext_proc is processing ProcessingRequest_ResponseHeaders.
+	// Currently, this is only used by conformance test.
+	ReqMetadata map[string]any
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind test
/area conformance-machinery
/area conformance-test

**What this PR does / why we need it**:

  This PR introduces the necessary components within the Endpoint Picker (EPP) to support a new conformance test that
  verifies gateway compliance with the x-gateway-destination-endpoint-served metadata requirement.

Exposes the "x-conformance-test-served-endpoint"

following is an example
```
❯ curl -i http://${IP}/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "'"${MODEL_NAME}"'",
    "messages": [
      {
        "role": "user",
        "content": "hi"
      }
    ]
  }'
HTTP/1.1 200 OK
x-went-into-resp-headers: true
date: Thu, 13 Nov 2025 07:24:41 GMT
server: uvicorn
x-conformance-test-served-endpoint: 10.116.3.5:8000
content-type: application/json
via: 1.1 google
transfer-encoding: chunked

{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"annotations":null,"audio":null,"content":"\u003cthink\u003e\nOkay, the user said \"hi\". I need to respond appropriately. Let me think. A simple \"Hello!\" is a good start. But maybe they want a more personal message. I should check if they have any specific request in mind. If not, a general greeting is best. I should make sure the response is friendly and open to further conversation. Let me put that into a natural reply.\n\u003c/think\u003e\n\nHello! How can I assist you today? 😊","function_call":null,"reasoning_content":null,"refusal":null,"role":"assistant","tool_calls":[]},"stop_reason":null,"token_ids":null}],"created":1763018681,"id":"chatcmpl-0535f422-84f2-479c-93d5-ca6129e657bb","kv_transfer_params":null,"model":"Qwen/Qwen3-0.6B","object":"chat.completion","prompt_logprobs":null,"prompt_token_ids":null,"service_tier":null,"system_fingerprint":null,"usage":{"completion_tokens":97,"prompt_tokens":9,"prompt_tokens_details":null,"total_tokens":106}}% 
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially  #1670

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
A new plugin `destination-endpoint-served-verifier` for conformance tests can be adopted
```
