### PR TITLE
docs: add Kgateway BBR documentation

### DIFF
--- a/site-src/guides/serve-multiple-genai-models.md
+++ b/site-src/guides/serve-multiple-genai-models.md
@@ -40,6 +40,30 @@ First install this server. Depending on your Gateway provider, you can use one o
     oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
     ```
 
+=== "Kgateway"
+
+    Kgateway does not require the Body-Based Routing Extension, and instead natively implements Body-Based Routing.
+    To use Body Based Routing, apply an `AgentgatewayPolicy`:
+
+    ```yaml
+    apiVersion: gateway.kgateway.dev/v1alpha1
+    kind: AgentgatewayPolicy
+    metadata:
+      name: bbr
+    spec:
+      targetRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: inference-gateway
+      traffic:
+        phase: PreRouting
+        transformation:
+          request:
+            set:
+            - name: X-Gateway-Model-Name
+              value: 'json(request.body).model'
+    ```
+
 === "Other"
 
     ```bash


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:
This adds documentation for performing BBR with Kgateway. Kgateway is listed on the getting started (https://gateway-api-inference-extension.sigs.k8s.io/guides/#__tabbed_2_3) but not on the BBR (https://gateway-api-inference-extension.sigs.k8s.io/guides/serve-multiple-genai-models) docs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
