### PR TITLE
Standardize plugins.TypedName field name from 'tn' to 'typedName'

### DIFF
--- a/pkg/epp/datalayer/datasource_test.go
+++ b/pkg/epp/datalayer/datasource_test.go
@@ -31,17 +31,17 @@ const (
 )
 
 type mockDataSource struct {
-	tn plugins.TypedName
+	typedName plugins.TypedName
 }
 
-func (m *mockDataSource) TypedName() plugins.TypedName                { return m.tn }
+func (m *mockDataSource) TypedName() plugins.TypedName                { return m.typedName }
 func (m *mockDataSource) Extractors() []string                        { return []string{} }
 func (m *mockDataSource) AddExtractor(_ Extractor) error              { return nil }
 func (m *mockDataSource) Collect(_ context.Context, _ Endpoint) error { return nil }
 
 func TestRegisterAndGetSource(t *testing.T) {
 	reg := DataSourceRegistry{}
-	ds := &mockDataSource{tn: plugins.TypedName{Type: testType, Name: testType}}
+	ds := &mockDataSource{typedName: plugins.TypedName{Type: testType, Name: testType}}
 
 	err := reg.Register(ds)
 	assert.NoError(t, err, "expected no error on first registration")

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -141,19 +141,19 @@ func newMockPrepareDataPlugin(name string) *mockPrepareDataPlugin {
 }
 
 type mockAdmissionPlugin struct {
-	tn          plugins.TypedName
+	typedName   plugins.TypedName
 	denialError error
 }
 
 func newMockAdmissionPlugin(name string, denialError error) *mockAdmissionPlugin {
 	return &mockAdmissionPlugin{
-		tn:          plugins.TypedName{Type: "mock-admit-data", Name: name},
+		typedName:   plugins.TypedName{Type: "mock-admit-data", Name: name},
 		denialError: denialError,
 	}
 }
 
 func (m *mockAdmissionPlugin) TypedName() plugins.TypedName {
-	return m.tn
+	return m.typedName
 }
 
 func (m *mockAdmissionPlugin) AdmitRequest(ctx context.Context, request *schedulingtypes.LLMRequest, pods []schedulingtypes.Pod) error {
@@ -1238,51 +1238,51 @@ const (
 )
 
 type testResponseReceived struct {
-	tn                      plugins.TypedName
+	typedName               plugins.TypedName
 	lastRespOnResponse      *Response
 	lastTargetPodOnResponse string
 }
 
 type testResponseStreaming struct {
-	tn                       plugins.TypedName
+	typedName                plugins.TypedName
 	lastRespOnStreaming      *Response
 	lastTargetPodOnStreaming string
 }
 
 type testResponseComplete struct {
-	tn                      plugins.TypedName
+	typedName               plugins.TypedName
 	lastRespOnComplete      *Response
 	lastTargetPodOnComplete string
 }
 
 func newTestResponseReceived(name string) *testResponseReceived {
 	return &testResponseReceived{
-		tn: plugins.TypedName{Type: testResponseReceivedType, Name: name},
+		typedName: plugins.TypedName{Type: testResponseReceivedType, Name: name},
 	}
 }
 
 func newTestResponseStreaming(name string) *testResponseStreaming {
 	return &testResponseStreaming{
-		tn: plugins.TypedName{Type: testPostStreamingType, Name: name},
+		typedName: plugins.TypedName{Type: testPostStreamingType, Name: name},
 	}
 }
 
 func newTestResponseComplete(name string) *testResponseComplete {
 	return &testResponseComplete{
-		tn: plugins.TypedName{Type: testPostCompleteType, Name: name},
+		typedName: plugins.TypedName{Type: testPostCompleteType, Name: name},
 	}
 }
 
 func (p *testResponseReceived) TypedName() plugins.TypedName {
-	return p.tn
+	return p.typedName
 }
 
 func (p *testResponseStreaming) TypedName() plugins.TypedName {
-	return p.tn
+	return p.typedName
 }
 
 func (p *testResponseComplete) TypedName() plugins.TypedName {
-	return p.tn
+	return p.typedName
 }
 
 func (p *testResponseReceived) ResponseReceived(_ context.Context, _ *schedulingtypes.LLMRequest, response *Response, targetPod *backend.Pod) {

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/scorer.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/scorer.go
@@ -37,7 +37,7 @@ import (
 )
 
 type SLOAwareRouter struct {
-	tn                  plugins.TypedName
+	typedName           plugins.TypedName
 	latencypredictor    latencypredictor.PredictorInterface
 	runningRequestLists map[types.NamespacedName]*requestPriorityQueue
 	sloContextStore     sync.Map // map[string]*SLORequestContext
@@ -108,7 +108,7 @@ func NewSLOAwareRouter(config Config, predictor latencypredictor.PredictorInterf
 	}
 
 	return &SLOAwareRouter{
-		tn:                  plugins.TypedName{Type: SLOAwareRouterPluginType, Name: SLOAwareRouterPluginType},
+		typedName:           plugins.TypedName{Type: SLOAwareRouterPluginType, Name: SLOAwareRouterPluginType},
 		latencypredictor:    predictor,
 		runningRequestLists: make(map[types.NamespacedName]*requestPriorityQueue),
 		sloContextStore:     sync.Map{},
@@ -132,11 +132,11 @@ func startPredictor(handle plugins.Handle) (latencypredictor.PredictorInterface,
 }
 
 func (s *SLOAwareRouter) TypedName() plugins.TypedName {
-	return s.tn
+	return s.typedName
 }
 
 func (s *SLOAwareRouter) WithName(name string) *SLOAwareRouter {
-	s.tn.Name = name
+	s.typedName.Name = name
 	return s
 }
 

--- a/pkg/epp/scheduling/framework/plugins/scorer/lora_affinity.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/lora_affinity.go
@@ -41,18 +41,18 @@ func LoraAffinityScorerFactory(name string, _ json.RawMessage, _ plugins.Handle)
 // NewLoraAffinityScorer initializes a new LoraAffinityScorer and returns its pointer.
 func NewLoraAffinityScorer() *LoraAffinityScorer {
 	return &LoraAffinityScorer{
-		tn: plugins.TypedName{Type: LoraAffinityScorerType, Name: LoraAffinityScorerType},
+		typedName: plugins.TypedName{Type: LoraAffinityScorerType, Name: LoraAffinityScorerType},
 	}
 }
 
 // LoraAffinityScorer scores list of candidate pods based on Lora affinity and availability.
 type LoraAffinityScorer struct {
-	tn plugins.TypedName
+	typedName plugins.TypedName
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
 func (s *LoraAffinityScorer) TypedName() plugins.TypedName {
-	return s.tn
+	return s.typedName
 }
 
 // Consumes returns the list of data that is consumed by the plugin.
@@ -65,7 +65,7 @@ func (s *LoraAffinityScorer) Consumes() map[string]any {
 
 // WithName sets the name of the scorer.
 func (s *LoraAffinityScorer) WithName(name string) *LoraAffinityScorer {
-	s.tn.Name = name
+	s.typedName.Name = name
 	return s
 }
 


### PR DESCRIPTION
- Change LoraAffinityScorer to use typedName
- Change SLOAwareRouter to use typedName
- Update test mocks: mockAdmissionPlugin, testResponseReceived, testResponseStreaming, testResponseComplete, mockDataSource
- Improves consistency across all plugin implementations

Fixes #1910

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This PR standardizes the variable naming for `plugins.TypedName` fields across the codebase. Previously, both `tn` and `typedName` were used inconsistently. This change adopts `typedName` as the standard variable name for better code readability and consistency.

Changes include:
- Change LoraAffinityScorer to use typedName
- Change SLOAwareRouter to use typedName
- Update test mocks: mockAdmissionPlugin, testResponseReceived, testResponseStreaming, testResponseComplete, mockDataSource
- Improves consistency across all plugin implementations

**Which issue(s) this PR fixes**:
Fixes #1910

**Does this PR introduce a user-facing change?**:
```release-note
NONE
