### PR TITLE
add kaushikmitr as appoved of slo aware routing plugin

### DIFF
--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/OWNERS
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kaushikmitr


### PR DESCRIPTION
This pull request adds ownership information to the `pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/OWNERS` file, designating `kaushikmitr` as an approver for this component.