### PR TITLE
fix config load error when picker is set before the scoerer w/o weight.

### DIFF
--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -420,6 +420,11 @@ func TestLoadConfig(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "successPickerWeightUnsetScorerText",
+			configText: successPickerWeightUnsetScorerText,
+			wantErr:    false,
+		},
+		{
 			name:       "errorBadYaml",
 			configText: errorBadYamlText,
 			wantErr:    true,
@@ -472,7 +477,7 @@ func TestLoadConfig(t *testing.T) {
 				t.Errorf("LoadConfigPhaseOne returned an unexpected error. error %v", err)
 			}
 			t.Logf("error was %s", err)
-		} else if test.wantErr {
+		} else {
 			handle := utils.NewTestHandle(context.Background())
 			_, err = LoadConfigPhaseTwo(rawConfig, handle, logger)
 			if err != nil {
@@ -943,6 +948,22 @@ schedulingProfiles:
 - name: default
   plugins:
   - pluginRef: maxScore
+`
+
+// success with picker and unset weight scorer
+//
+//nolint:dupword
+const successPickerWeightUnsetScorerText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: random-picker
+- type: prefix-cache-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: random-picker
+  - pluginRef: prefix-cache-scorer
 `
 
 // invalid parameter configuration for plugin (string passed, in expected)

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -145,7 +145,6 @@ func setDefaultsPhaseTwo(cfg *configapi.EndpointPickerConfig, handle plugins.Han
 				cfg.SchedulingProfiles[idx] = theProfile
 			} else if _, ok := referencedPlugin.(framework.Picker); ok {
 				hasPicker = true
-				break
 			}
 		}
 		if !hasPicker {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

W/o this PR, the following EPP scheduler config will get nil pointer `panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d12fc9]`

```
apiVersion: inference.networking.x-k8s.io/v1alpha1
    kind: EndpointPickerConfig
    plugins:
    - type: random-picker
    - type: queue-scorer
    - type: kv-cache-utilization-scorer
    - type: prefix-cache-scorer
    schedulingProfiles:
    - name: default
      plugins:
      - pluginRef: random-picker
      - pluginRef: queue-scorer
      - pluginRef: kv-cache-utilization-scorer
      - pluginRef: prefix-cache-scorer
```

We should not assume picker is always the last plugin. Thus, we should not break earlier before setting the defaults for all scorers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
