### PR TITLE
fix(inferenceModelRewrites): conditionally skip watching InferenceModelRewrite and InferenceObjective

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -204,9 +204,11 @@ func (r *Runner) Run(ctx context.Context) error {
 		setupLog.Error(err, "Failed to extract GKNN")
 		return err
 	}
-	disableK8sCrdReconcile := *endpointSelector != ""
-	controllerCfg := runserver.NewControllerConfig(disableK8sCrdReconcile)
-	ds, err := setupDatastore(setupLog, ctx, epf, int32(opts.ModelServerMetricsPort), disableK8sCrdReconcile,
+
+	startCrdReconcilers := opts.EndpointSelector == "" // If endpointSelector is empty, it means it's not in the standalone mode. Then we should start the inferencePool and other CRD Reconciler.
+	controllerCfg := runserver.NewControllerConfig(startCrdReconcilers)
+
+	ds, err := setupDatastore(setupLog, ctx, epf, int32(opts.ModelServerMetricsPort), startCrdReconcilers,
 		opts.PoolName, opts.PoolNamespace, opts.EndpointSelector, opts.EndpointTargetPorts)
 	if err != nil {
 		setupLog.Error(err, "Failed to setup datastore")
@@ -329,7 +331,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		GrpcPort:                         opts.GRPCPort,
 		GKNN:                             *gknn,
 		Datastore:                        ds,
-		DisableK8sCrdReconcile:           controllerCfg,
+		ControllerCfg:                    controllerCfg,
 		SecureServing:                    opts.SecureServing,
 		HealthChecking:                   opts.HealthChecking,
 		CertPath:                         opts.CertPath,
@@ -368,8 +370,8 @@ func (r *Runner) Run(ctx context.Context) error {
 }
 
 func setupDatastore(setupLog logr.Logger, ctx context.Context, epFactory datalayer.EndpointFactory, modelServerMetricsPort int32,
-	disableK8sCrdReconcile bool, namespace, name, endpointSelector string, endpointTargetPorts []int) (datastore.Datastore, error) {
-	if !disableK8sCrdReconcile {
+	startCrdReconcilers bool, namespace, name, endpointSelector string, endpointTargetPorts []int) (datastore.Datastore, error) {
+	if startCrdReconcilers {
 		return datastore.NewDatastore(ctx, epFactory, modelServerMetricsPort), nil
 	} else {
 		endpointPool := datalayer.NewEndpointPool(namespace, name)

--- a/pkg/epp/server/controller_config.go
+++ b/pkg/epp/server/controller_config.go
@@ -25,19 +25,19 @@ import (
 )
 
 type ControllerConfig struct {
-	disableK8sCrdReconcile    bool
+	startCrdReconcilers       bool
 	hasInferenceObjective     bool
 	hasInferenceModelRewrites bool
 }
 
-func NewControllerConfig(disableK8sCrdReconcile bool) ControllerConfig {
+func NewControllerConfig(startCrdReconcilers bool) ControllerConfig {
 	return ControllerConfig{
-		disableK8sCrdReconcile: disableK8sCrdReconcile,
+		startCrdReconcilers: startCrdReconcilers,
 	}
 }
 
 func (cc *ControllerConfig) PopulateControllerConfig(cfg *rest.Config) error {
-	if cc.disableK8sCrdReconcile {
+	if !cc.startCrdReconcilers {
 		return nil
 	}
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)

--- a/pkg/epp/server/controller_config_test.go
+++ b/pkg/epp/server/controller_config_test.go
@@ -27,13 +27,13 @@ import (
 
 func TestNewControllerConfig(t *testing.T) {
 	c := NewControllerConfig(true)
-	if !c.disableK8sCrdReconcile {
-		t.Error("expected disableK8sCrdReconcile to be true")
+	if !c.startCrdReconcilers {
+		t.Error("expected startCrdReconcilers to be true")
 	}
 
 	c = NewControllerConfig(false)
-	if c.disableK8sCrdReconcile {
-		t.Error("expected disableK8sCrdReconcile to be false")
+	if c.startCrdReconcilers {
+		t.Error("expected startCrdReconcilers to be false")
 	}
 }
 
@@ -96,7 +96,7 @@ func TestPopulateWithDiscovery(t *testing.T) {
 }
 
 func TestPopulateControllerConfig_Disable(t *testing.T) {
-	c := NewControllerConfig(true)
+	c := NewControllerConfig(false)
 	err := c.PopulateControllerConfig(nil)
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)

--- a/pkg/epp/server/controller_manager.go
+++ b/pkg/epp/server/controller_manager.go
@@ -59,7 +59,7 @@ func defaultManagerOptions(cfg ControllerConfig, gknn common.GKNN, metricsServer
 		},
 		Metrics: metricsServerOptions,
 	}
-	if !cfg.disableK8sCrdReconcile {
+	if cfg.startCrdReconcilers {
 		if cfg.hasInferenceObjective {
 			opt.Cache.ByObject[&v1alpha2.InferenceObjective{}] = cache.ByObject{Namespaces: map[string]cache.Config{
 				gknn.Namespace: {},

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -84,7 +84,7 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 	return &ExtProcServerRunner{
 		GrpcPort:                         opts.GRPCPort,
 		GKNN:                             gknn,
-		ControllerCfg:                    ControllerConfig{false, true, true},
+		ControllerCfg:                    ControllerConfig{true, true, true},
 		SecureServing:                    opts.SecureServing,
 		HealthChecking:                   opts.HealthChecking,
 		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
@@ -96,7 +96,7 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 // SetupWithManager sets up the runner with the given manager.
 func (r *ExtProcServerRunner) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	// Create the controllers and register them with the manager
-	if !r.ControllerCfg.disableK8sCrdReconcile {
+	if r.ControllerCfg.startCrdReconcilers {
 		if err := (&controller.InferencePoolReconciler{
 			Datastore: r.Datastore,
 			Reader:    mgr.GetClient(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug
/kind cleanup

**What this PR does / why we need it**:

This fixes an issue where the controller manager would fail to start if the InferenceModelRewrite or InferenceObjective CRDs were missing. This change introduces a dynamic check for the existence of these CRDs before attempting to set up reconcilers or adding them to the cache. This allows the controller to gracefully handle environments where these optional CRDs are not installed, even when CRD reconciliation is generally enabled.

Tested with deleting the `inferenceModelRewrites CRD` and start the EPP successfully.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Make InferenceModelRewrite and InferenceObjective optional to install
```
