### PR TITLE
Use spf13/pflag instead of Go's standard flag package

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"flag"
+	goflag "flag"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -34,6 +34,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+	flag "github.com/spf13/pflag"
 	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -200,7 +201,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	opts := zap.Options{
 		Development: true,
 	}
-	opts.BindFlags(flag.CommandLine)
+	gfs := goflag.NewFlagSet("zap", goflag.ExitOnError)
+	opts.BindFlags(gfs) // zap expects a standard Go FlagSet and pflag.FlagSet is not compatible.
+	flag.CommandLine.AddGoFlagSet(gfs)
 	flag.Parse()
 	initLogging(&opts)
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,10 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-require github.com/go-logr/zapr v1.3.0
+require (
+	github.com/go-logr/zapr v1.3.0
+	github.com/spf13/pflag v1.0.7
+)
 
 require (
 	cel.dev/expr v0.24.0 // indirect
@@ -95,7 +98,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
-	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/pkg/epp/datalayer/metrics/factories.go
+++ b/pkg/epp/datalayer/metrics/factories.go
@@ -18,9 +18,10 @@ package metrics
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"strconv"
+
+	flag "github.com/spf13/pflag"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use `spf13/pflag` instead of Go's standard `flag` package, to align with rest of k8s.
The `pflag` package is a superset of the standard `flag` package, so no user visible change is expected.

**Which issue(s) this PR fixes**:
Ref #1947 for context.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
