### PR TITLE
Add `pod_type` categorical feature to latency prediction models

### DIFF
--- a/sidecars/latencypredictorasync/types.go
+++ b/sidecars/latencypredictorasync/types.go
@@ -133,6 +133,7 @@ type TrainingEntry struct {
 	ActualTTFT         float64   `json:"actual_ttft_ms"`
 	ActualTPOT         float64   `json:"actual_tpot_ms"`
 	PrefixCacheScore   float64   `json:"prefix_cache_score"`
+	PodType            string    `json:"pod_type,omitempty"` // "prefill", "decode", or "" for monolithic
 	Timestamp          time.Time `json:"timestamp"`
 }
 
@@ -147,6 +148,7 @@ type PredictionRequest struct {
 	NumRequestRunning  int     `json:"num_request_running"`
 	NumTokensGenerated int     `json:"num_tokens_generated"`
 	PrefixCacheScore   float64 `json:"prefix_cache_score"`
+	PodType            string  `json:"pod_type,omitempty"` // "prefill", "decode", or "" for monolithic
 }
 
 type PredictionResponse struct {


### PR DESCRIPTION
 Add `pod_type` support for prefill-decode (PD) disaggregated serving:

  - Added `pod_type` categorical feature (''=monolithic, 'prefill', 'decode') to both TTFT and TPOT prediction models
  - Implemented `pod_type_cat` encoding in feature preparation with proper categorical handling
  - Updated Bayesian Ridge models to one-hot encode pod_type (can't handle categoricals directly)
  - Modified XGBoost monotone constraints from 5 -> 6 features, with no constraint on pod_type
  - Added pod_type field to API models (PredictionRequest, TrainingEntry) in Python and Go
  - Ensured backward compatibility by defaulting to '' (monolithic) when pod_type is missing

Resolves: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1923

Links to related PRs:
https://github.com/llm-d/llm-d/pull/596
https://github.com/llm-d/llm-d-inference-scheduler/pull/564