### PR TITLE
remove duplicate lora adapter scorer entry in docs

### DIFF
--- a/site-src/guides/epp-configuration/config-text.md
+++ b/site-src/guides/epp-configuration/config-text.md
@@ -292,16 +292,6 @@ available to serve new request).
 - *Type*: queue-scorer
 - *Parameters*: none
 
-
-#### **LoraAffinityScorer**
-
-Scores list of candidate pods based on the LoRA adapters loaded on the pod. 
-Pods with the adapter already loaded or able to be actively loaded will be 
-scored higher (since it's more available to serve new request).
-
-- *Type*: lora-affinity-scorer
-- *Parameters*: none
-
 ## Saturation Detector configuration
 
 The Saturation Detector is used to determine if the the cluster is overloaded, i.e. saturated. When


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind documentation

**What this PR does / why we need it**:
This PR removes a duplicate entry for the LoRAAffinityScorer in the EPP Config documentation.

First entry:
https://gateway-api-inference-extension.sigs.k8s.io/guides/epp-configuration/config-text/#loraaffinityscorer

Second Entry:
https://gateway-api-inference-extension.sigs.k8s.io/guides/epp-configuration/config-text/#loraaffinityscorer_1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
