### PR TITLE
fix: fix header parsing to prevent trace ID loss

### DIFF
--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
 
 const (
@@ -55,11 +56,7 @@ func (s *StreamingServer) HandleRequestHeaders(reqCtx *RequestContext, req *extP
 	}
 
 	for _, header := range req.RequestHeaders.Headers.Headers {
-		if header.RawValue != nil {
-			reqCtx.Request.Headers[header.Key] = string(header.RawValue)
-		} else {
-			reqCtx.Request.Headers[header.Key] = header.Value
-		}
+		reqCtx.Request.Headers[header.Key] = request.GetHeaderValue(header)
 		switch header.Key {
 		case metadata.FlowFairnessIDKey:
 			reqCtx.FairnessID = reqCtx.Request.Headers[header.Key]

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
 
 const (
@@ -100,11 +101,7 @@ func (s *StreamingServer) HandleResponseBodyModelStreaming(ctx context.Context, 
 
 func (s *StreamingServer) HandleResponseHeaders(ctx context.Context, reqCtx *RequestContext, resp *extProcPb.ProcessingRequest_ResponseHeaders) (*RequestContext, error) {
 	for _, header := range resp.ResponseHeaders.Headers.Headers {
-		if header.RawValue != nil {
-			reqCtx.Response.Headers[header.Key] = string(header.RawValue)
-		} else {
-			reqCtx.Response.Headers[header.Key] = header.Value
-		}
+		reqCtx.Response.Headers[header.Key] = request.GetHeaderValue(header)
 	}
 
 	reqCtx, err := s.director.HandleResponseReceived(ctx, reqCtx)

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -19,6 +19,7 @@ package request
 import (
 	"strings"
 
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 )
 
@@ -26,13 +27,23 @@ const (
 	RequestIdHeaderKey = "x-request-id"
 )
 
+// GetHeaderValue safely extracts the string value from an Envoy HeaderValue field.
+func GetHeaderValue(header *corev3.HeaderValue) string {
+	if len(header.RawValue) > 0 {
+		return string(header.RawValue)
+	}
+	return header.Value
+}
+
+// ExtractHeaderValue searches for a specific header key in the processing request and returns its value.
+// The lookup is case-insensitive.
+// Returns an empty string if the header is missing or if the request structure is nil.
 func ExtractHeaderValue(req *extProcPb.ProcessingRequest_RequestHeaders, headerKey string) string {
-	// header key should be case insensitive
 	headerKeyInLower := strings.ToLower(headerKey)
 	if req != nil && req.RequestHeaders != nil && req.RequestHeaders.Headers != nil {
 		for _, headerKv := range req.RequestHeaders.Headers.Headers {
 			if strings.ToLower(headerKv.Key) == headerKeyInLower {
-				return string(headerKv.RawValue)
+				return GetHeaderValue(headerKv)
 			}
 		}
 	}

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -54,6 +54,14 @@ func TestExtractHeaderValue(t *testing.T) {
 			key:      "x-request-id",
 			expected: "",
 		},
+		{
+			name: "String value fallback",
+			headers: []*corev3.HeaderValue{
+				{Key: "fallback-test", Value: "only-string"},
+			},
+			key:      "fallback-test",
+			expected: "only-string",
+		},
 	}
 
 	for _, tt := range tests {
@@ -69,6 +77,60 @@ func TestExtractHeaderValue(t *testing.T) {
 			result := ExtractHeaderValue(req, tt.key)
 			if result != tt.expected {
 				t.Errorf("ExtractHeaderValue() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetHeaderValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   *corev3.HeaderValue
+		expected string
+	}{
+		{
+			name: "Prefers RawValue when present",
+			header: &corev3.HeaderValue{
+				Key:      "x-test",
+				RawValue: []byte("raw-content"),
+				Value:    "string-content", // Should be ignored
+			},
+			expected: "raw-content",
+		},
+		{
+			name: "Falls back to Value when RawValue is nil",
+			header: &corev3.HeaderValue{
+				Key:      "x-test",
+				RawValue: nil,
+				Value:    "string-content",
+			},
+			expected: "string-content",
+		},
+		{
+			name: "Falls back to Value when RawValue is empty slice",
+			header: &corev3.HeaderValue{
+				Key:      "x-test",
+				RawValue: []byte{},
+				Value:    "string-content",
+			},
+			expected: "string-content",
+		},
+		{
+			name: "Returns empty if both are empty",
+			header: &corev3.HeaderValue{
+				Key:      "x-test",
+				RawValue: []byte{},
+				Value:    "",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetHeaderValue(tt.header)
+			if result != tt.expected {
+				t.Errorf("GetHeaderValue() = %v, want %v", result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes a defect in how the extension parses HTTP headers from Envoy's `HeaderValue` protobuf message.

Previously, the extension relied on brittle assumptions about which fields Envoy populates:
1.  Trace ID Loss: `ExtractHeaderValue` ignored the `Value` field entirely. If Envoy sent headers as strings, the extension would read an empty string, forcing the generation of a new Request ID and breaking distributed tracing.
2.  Possible Data Corruption: `HandleRequestHeaders` checked `if header.RawValue != nil`. Since an empty byte slice `[]byte{}` is not `nil`, this caused the code to overwrite valid string values in `header.Value` with empty strings.

Though, I am not sure if the latter is actually possible in practice.

**The Fix:**
*   Introduces a centralized helper `requtil.GetHeaderValue`.
*   Updates extraction logic to prioritize `RawValue` **only** if `len > 0`, ensuring a safe fallback to `Value`.
*   Adds comprehensive unit tests covering these edge cases.

**Which issue(s) this PR fixes**:
Part of #1624.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where HTTP headers (e.g., Request IDs for tracing) could be dropped or corrupted depending on the Envoy configuration.
```