### PR TITLE
fix: harden header sanitization and handling logic

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -155,8 +155,11 @@ func (s *StreamingServer) generateResponseHeaders(reqCtx *RequestContext) []*con
 		},
 	}
 
-	// include all headers
+	// Include any non-system-owned headers.
 	for key, value := range reqCtx.Response.Headers {
+		if request.IsSystemOwnedHeader(key) {
+			continue
+		}
 		headers = append(headers, &configPb.HeaderValueOption{
 			Header: &configPb.HeaderValue{
 				Key:      key,

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
@@ -297,4 +298,31 @@ func TestHandleResponseBodyModelStreaming_TokenAccumulation(t *testing.T) {
 			assert.True(t, reqCtx.ResponseComplete, "Response should be marked complete after [DONE]")
 		})
 	}
+}
+
+func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
+	server := &StreamingServer{}
+	reqCtx := &RequestContext{
+		Response: &Response{
+			Headers: map[string]string{
+				"x-backend-server":              "vllm-v0.6.3",            // should passthrough
+				metadata.ObjectiveKey:           "sensitive-objective-id", // should be stripped
+				metadata.DestinationEndpointKey: "10.2.0.5:8080",          // should be stripped
+				"content-length":                "500",                    // hould be stripped
+			},
+		},
+	}
+
+	results := server.generateResponseHeaders(reqCtx)
+
+	gotHeaders := make(map[string]string)
+	for _, h := range results {
+		gotHeaders[h.Header.Key] = string(h.Header.RawValue)
+	}
+
+	assert.Contains(t, gotHeaders, "x-backend-server")
+	assert.Contains(t, gotHeaders, "x-went-into-resp-headers")
+	assert.NotContains(t, gotHeaders, metadata.ObjectiveKey)
+	assert.NotContains(t, gotHeaders, metadata.DestinationEndpointKey)
+	assert.NotContains(t, gotHeaders, "content-length")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR hardens the HTTP header handling logic within the extension to ensure strict ownership of protocol and system metadata headers.

Previously, the header generation logic in `generateHeaders` (Request) and `generateResponseHeaders` (Response) acted as a transparent passthrough, appending user-supplied headers to the outgoing message.

**Changes:**
*   Strict Blocklist: Introduces `requtil.IsSystemOwnedHeader` to define a specific set of headers (Protocol, Routing, and Control) that must be managed exclusively by the extension.
*   Sanitization: Updates the header generation loops to silently drop any external values for these keys.

**Reasoning:**
These changes are necessary to prevent ambiguity in downstream proxies (Envoy) and backends. For example, internal routing headers should not be influenceable by external input.

**Which issue(s) this PR fixes**:
Fixes #1624

**Does this PR introduce a user-facing change?**:
```release-note
Harden header handling logic to enforce strict ownership of system and protocol headers, preventing potential ambiguity in backend routing and response processing.
```