### PR TITLE
fix: decouple streaming usage parsing from [DONE] signal to handle network fragmentation

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -80,15 +80,19 @@ func (s *StreamingServer) HandleResponseBodyModelStreaming(ctx context.Context, 
 	if err != nil {
 		logger.Error(err, "error in HandleResponseBodyStreaming")
 	}
+
+	// Parse usage on EVERY chunk to catch split streams (where usage and [DONE] are in different chunks).
+	if resp := parseRespForUsage(ctx, responseText); resp.Usage.TotalTokens > 0 {
+		reqCtx.Usage = resp.Usage
+	}
+
 	if strings.Contains(responseText, streamingEndMsg) {
 		reqCtx.ResponseComplete = true
-		resp := parseRespForUsage(ctx, responseText)
-		reqCtx.Usage = resp.Usage
-		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, resp.Usage.PromptTokens)
-		metrics.RecordOutputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, resp.Usage.CompletionTokens)
+		metrics.RecordInputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Usage.PromptTokens)
+		metrics.RecordOutputTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Usage.CompletionTokens)
 		cachedToken := 0
-		if resp.Usage.PromptTokenDetails != nil {
-			cachedToken = resp.Usage.PromptTokenDetails.CachedTokens
+		if reqCtx.Usage.PromptTokenDetails != nil {
+			cachedToken = reqCtx.Usage.PromptTokenDetails.CachedTokens
 		}
 		metrics.RecordPromptCachedTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, cachedToken)
 		_, err := s.director.HandleResponseBodyComplete(ctx, reqCtx)
@@ -181,8 +185,8 @@ func parseRespForUsage(ctx context.Context, responseText string) ResponseBody {
 	response := ResponseBody{}
 	logger := log.FromContext(ctx)
 
-	lines := strings.Split(responseText, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(responseText, "\n")
+	for line := range lines {
 		if !strings.HasPrefix(line, streamingRespPrefix) {
 			continue
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR ensures streaming token metrics (Prompt/Completion tokens) are accurately captured by decoupling usage parsing from the stream termination signal. 

**The Problem:**
The [OpenAI streaming protocol](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options) delivers the `usage` object and the `[DONE]` signal as two distinct SSE events (separated by `\n\n`). 

The previous implementation assumed these two events would always arrive within the same `HttpBody` chunk from Envoy. However, because they are separate logical messages, the underlying transport (TCP/TLS) or Envoy's buffering can split them into separate frames:
- **Chunk A:** `data: {"usage": {...}, "choices": []}`
- **Chunk B:** `data: [DONE]`

In this scenario, the old logic would ignore Chunk A (because it lacks the `[DONE]` string) and then fail to find usage data in Chunk B. This results in metrics being recorded as **zero** whenever network fragmentation occurs.

```go
// Old Logic (Fragile)
if strings.Contains(text, "[DONE]") {
    usage := parse(text) // <--- Fails if usage was in the PREVIOUS chunk
    record(usage)
}
```

**The Fix:**
Changes the handler to a stateful approach that persists usage data across the lifetime of the request context:
1.  **Continuous Parsing:** Attempts to parse the `usage` field on **every** incoming chunk.
2.  **State Persistence:** If valid usage data is found, it is stored in the `RequestContext`.
3.  **Deferred Recording:** Metrics are only recorded when the `[DONE]` signal is detected, using the most recently captured usage data from the context.

This ensures 100% reliability regardless of how the network or upstream provider fragments the SSE stream.

**Which issue(s) this PR fixes**:
Fixes #1626 

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a potential race condition where streaming inference metrics could report 0 tokens if the usage data and completion signal arrived in separate network packets.
```