### PR TITLE
add controllerName validation for InferencePool parent status

### DIFF
--- a/conformance/tests/inferencepool_controllername.go
+++ b/conformance/tests/inferencepool_controllername.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+
+	"sigs.k8s.io/gateway-api-inference-extension/conformance/resources"
+	k8sutils "sigs.k8s.io/gateway-api-inference-extension/conformance/utils/kubernetes"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, InferencePoolControllerName)
+}
+
+var InferencePoolControllerName = suite.ConformanceTest{
+	ShortName:   "InferencePoolControllerName",
+	Description: "InferencePool status parents should include controllerName",
+	Manifests:   []string{"tests/inferencepool_accepted.yaml"},
+	Features: []features.FeatureName{
+		features.FeatureName("SupportInferencePool"),
+		features.SupportGateway,
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		poolNN := resources.PrimaryInferencePoolNN
+
+		t.Run("InferencePool parent status reports controllerName", func(t *testing.T) {
+			k8sutils.InferencePoolMustHaveControllerName(t, s.Client, poolNN)
+		})
+	},
+}

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -224,6 +224,35 @@ func InferencePoolMustHaveNoParents(t *testing.T, c client.Reader, poolNN types.
 	t.Logf("Successfully verified that InferencePool %s has no parent statuses.", poolNN.String())
 }
 
+func InferencePoolMustHaveControllerName(
+	t *testing.T,
+	client client.Client,
+	poolNN types.NamespacedName,
+) {
+	t.Helper()
+
+	var pool inferenceapi.InferencePool
+
+	require.Eventually(t, func() bool {
+		err := client.Get(context.Background(), poolNN, &pool)
+		if err != nil {
+			return false
+		}
+
+		if len(pool.Status.Parents) == 0 {
+			return false
+		}
+
+		for _, parent := range pool.Status.Parents {
+			if parent.ControllerName == "" {
+				return false
+			}
+		}
+
+		return true
+	}, time.Minute, time.Second)
+}
+
 // HTTPRouteMustBeAcceptedAndResolved waits for the specified HTTPRoute
 // to be Accepted and have its references resolved by the specified Gateway.
 // It uses the upstream Gateway API's HTTPRouteMustHaveCondition helper.


### PR DESCRIPTION
This PR adds a new conformance test that validates controllerName is populated in InferencePool.status.parents.

Closes #1655