### PR TITLE
fix: [Flow Control]: Cleanup: Remove PriorityName from PriorityBandConfig

### DIFF
--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -219,9 +219,6 @@ type ShardStats struct {
 type PriorityBandStats struct {
 	// Priority is the numerical priority level this struct describes.
 	Priority int
-	// PriorityName is a human-readable name for the priority band (e.g., "Critical", "Sheddable").
-	// The registry configuration requires this field, so it is guaranteed to be non-empty.
-	PriorityName string
 	// CapacityBytes is the configured maximum total byte size for this priority band.
 	// When viewed via `AggregateStats`, this is the global limit. When viewed via `ShardStats`, this is the partitioned
 	// value for that specific shard.

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -592,19 +592,7 @@ func TestShardProcessor(t *testing.T) {
 						assert.ErrorIs(t, item.FinalState().Err, testErr, "The underlying error should be preserved")
 					},
 				},
-				{
-					name: "should reject item on registry priority band lookup failure",
-					setupHarness: func(h *testHarness) {
-						h.addQueue(testFlow)
-						h.PriorityBandAccessorFunc = func(int) (framework.PriorityBandAccessor, error) { return nil, testErr }
-					},
-					assert: func(t *testing.T, h *testHarness, item *FlowItem) {
-						assert.Equal(t, types.QueueOutcomeRejectedOther, item.FinalState().Outcome,
-							"Outcome should be RejectedOther")
-						require.Error(t, item.FinalState().Err, "An error should be returned")
-						assert.ErrorIs(t, item.FinalState().Err, testErr, "The underlying error should be preserved")
-					},
-				},
+
 				{
 					name: "should reject item on queue add failure",
 					setupHarness: func(h *testHarness) {

--- a/pkg/epp/flowcontrol/framework/accessors.go
+++ b/pkg/epp/flowcontrol/framework/accessors.go
@@ -55,9 +55,6 @@ type PriorityBandAccessor interface {
 	// Priority returns the numerical priority level of this group.
 	Priority() int
 
-	// PriorityName returns the human-readable name of this priority band.
-	PriorityName() string
-
 	// FlowKeys returns the list of identities for every flow currently active within this group.
 	// The caller can use the ID field from each key to look up a specific queue via the Queue(id) method.
 	// The order of keys is not guaranteed unless specified by the implementation.

--- a/pkg/epp/flowcontrol/framework/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/framework/mocks/mocks.go
@@ -72,16 +72,14 @@ var _ framework.FlowQueueAccessor = &MockFlowQueueAccessor{}
 // This avoids collision with the interface method of the same name.
 type MockPriorityBandAccessor struct {
 	PriorityV         int
-	PriorityNameV     string
 	PolicyStateV      any
 	FlowKeysFunc      func() []types.FlowKey
 	QueueFunc         func(flowID string) framework.FlowQueueAccessor
 	IterateQueuesFunc func(callback func(flow framework.FlowQueueAccessor) (keepIterating bool))
 }
 
-func (m *MockPriorityBandAccessor) Priority() int        { return m.PriorityV }
-func (m *MockPriorityBandAccessor) PriorityName() string { return m.PriorityNameV }
-func (m *MockPriorityBandAccessor) PolicyState() any     { return m.PolicyStateV }
+func (m *MockPriorityBandAccessor) Priority() int    { return m.PriorityV }
+func (m *MockPriorityBandAccessor) PolicyState() any { return m.PolicyStateV }
 
 func (m *MockPriorityBandAccessor) FlowKeys() []types.FlowKey {
 	if m.FlowKeysFunc != nil {

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -429,7 +429,6 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 
 	newBand := *fr.config.DefaultPriorityBand
 	newBand.Priority = priority
-	newBand.PriorityName = fmt.Sprintf("Dynamic-%d", priority)
 	fr.config.PriorityBands[priority] = &newBand
 
 	fr.perPriorityBandStats.LoadOrStore(priority, &bandStats{})
@@ -524,7 +523,6 @@ func (fr *FlowRegistry) Stats() contracts.AggregateStats {
 		bandCfg := fr.config.PriorityBands[priority]
 		stats.PerPriorityBandStats[priority] = contracts.PriorityBandStats{
 			Priority:      priority,
-			PriorityName:  bandCfg.PriorityName,
 			CapacityBytes: bandCfg.MaxBytes,
 			ByteSize:      uint64(bandStats.byteSize.Load()),
 			Len:           uint64(bandStats.len.Load()),

--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -300,7 +300,6 @@ func (s *registryShard) Stats() contracts.ShardStats {
 
 		stats.PerPriorityBandStats[priority] = contracts.PriorityBandStats{
 			Priority:      priority,
-			PriorityName:  band.config.PriorityName,
 			CapacityBytes: band.config.MaxBytes, // This is the partitioned capacity.
 			ByteSize:      uint64(band.byteSize.Load()),
 			Len:           uint64(band.len.Load()),
@@ -409,13 +408,6 @@ func (a *priorityBandAccessor) Priority() int {
 	a.shard.mu.RLock()
 	defer a.shard.mu.RUnlock()
 	return a.band.config.Priority
-}
-
-// PriorityName returns the human-readable name of this priority band.
-func (a *priorityBandAccessor) PriorityName() string {
-	a.shard.mu.RLock()
-	defer a.shard.mu.RUnlock()
-	return a.band.config.PriorityName
 }
 
 // PolicyState returns the opaque, mutable state for the fairness policy scoped to this band.


### PR DESCRIPTION
## Summary
This PR fixes #2013

## Changes
- `pkg/epp/flowcontrol/config_test.go`
- `pkg/epp/flowcontrol/contracts/registry.go`
- `pkg/epp/flowcontrol/controller/internal/processor.go`
- `pkg/epp/flowcontrol/framework/mocks/mocks.go`
- `pkg/epp/flowcontrol/framework/policies.go`
- `pkg/epp/flowcontrol/registry/config.go`
- `pkg/epp/flowcontrol/registry/config_test.go`
- `pkg/epp/flowcontrol/registry/registry.go`
- `pkg/epp/flowcontrol/registry/registry_test.go`
- `pkg/epp/flowcontrol/registry/shard.go`
- `pkg/epp/flowcontrol/registry/shard_test.go`
