### PR TITLE
bbr configmap reconciler and bbr datastore 

### DIFF
--- a/pkg/bbr/controller/configmap_reconciler.go
+++ b/pkg/bbr/controller/configmap_reconciler.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/datastore"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
+)
+
+type ConfigMapReconciler struct {
+	client.Reader
+	Datastore datastore.Datastore
+}
+
+func (c *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).V(logutil.DEFAULT)
+	ctx = ctrl.LoggerInto(ctx, logger)
+
+	logger.Info("Reconciling ConfigMap")
+
+	configmap := &corev1.ConfigMap{}
+	err := c.Get(ctx, req.NamespacedName, configmap)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("unable to get ConfigMap - %w", err)
+	}
+
+	if errors.IsNotFound(err) || !configmap.DeletionTimestamp.IsZero() {
+		// ConfigMap object got deleted or is marked for deletion.
+		c.Datastore.ConfigMapDelete(configmap)
+		return ctrl.Result{}, nil
+	}
+
+	// otherwise, add or update the entries of the configmap
+	if err := c.Datastore.ConfigMapUpdateOrAddIfNotExist(configmap); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to add or update ConfigMap - %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *ConfigMapReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		Complete(c)
+}

--- a/pkg/bbr/datastore/datastore.go
+++ b/pkg/bbr/datastore/datastore.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastore
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	baseModelKey = "baseModel"
+	adaptersKey  = "adapters"
+)
+
+// The bbr datastore stores a mapping between a LoRA adapter and its corresponding base model.
+// Each ConfigMap object stores a mapping between base model and a set of LoRA adapters and datastore translates this into an in-memory cache.
+// In case the number of LoRA adapters is extremely large, it's possible to use multiple ConfigMap objects, each storing a slice of the mapping.
+// Base models are not stored in the cache.
+type Datastore interface {
+	ConfigMapUpdateOrAddIfNotExist(configmap *corev1.ConfigMap) error
+	ConfigMapDelete(configmap *corev1.ConfigMap)
+}
+
+// NewDatastore creates a new bbr data store.
+func NewDatastore() Datastore {
+	return &datastore{
+		loraAdapterToBaseModel: map[string]string{},
+		configmapAdapters:      map[types.NamespacedName]sets.Set[string]{}, // map from configmap namespaced name to its adapters
+		lock:                   sync.RWMutex{},
+	}
+}
+
+type datastore struct {
+	loraAdapterToBaseModel map[string]string // a mapping between a lora adapter and its corresponding base model
+	configmapAdapters      map[types.NamespacedName]sets.Set[string]
+	lock                   sync.RWMutex
+}
+
+func (ds *datastore) ConfigMapUpdateOrAddIfNotExist(configmap *corev1.ConfigMap) error {
+	baseModel, newAdapters, err := ds.parseConfigMap(configmap)
+	if err != nil {
+		return fmt.Errorf("failed to parse configmap - %w", err)
+	}
+
+	configmapNamespacedName := types.NamespacedName{Namespace: configmap.GetNamespace(), Name: configmap.GetName()}
+	existingAdapters := sets.Set[string]{}
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	if previousAdapters, found := ds.configmapAdapters[configmapNamespacedName]; found {
+		existingAdapters = previousAdapters
+	}
+	adaptersToRemove := existingAdapters.Difference(newAdapters) // adapters in existingAdapters but not in newAdapters.
+	// update loraAdapterToBaseModel mapping
+	for adapterToUpdate := range newAdapters {
+		ds.loraAdapterToBaseModel[adapterToUpdate] = baseModel
+	}
+	for adapterToRemove := range adaptersToRemove {
+		delete(ds.loraAdapterToBaseModel, adapterToRemove)
+	}
+	// update configmap NamespacedName to current set of adapters mapping
+	ds.configmapAdapters[configmapNamespacedName] = newAdapters
+
+	return nil
+}
+
+func (ds *datastore) ConfigMapDelete(configmap *corev1.ConfigMap) {
+	configmapNamespacedName := types.NamespacedName{Namespace: configmap.GetNamespace(), Name: configmap.GetName()}
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+	// delete adapters from loraAdapterToBaseModel mapping
+	adapters := ds.configmapAdapters[configmapNamespacedName]
+	for adapter := range adapters {
+		delete(ds.loraAdapterToBaseModel, adapter)
+	}
+	// delete configmap NamespacedName to current set of adapters mapping
+	delete(ds.configmapAdapters, configmapNamespacedName)
+}
+
+// parseConfigMap returns a tuple consisting (base model, set of adapters, error)
+// error is set in case the configmap data section is not in the expected format.
+func (ds *datastore) parseConfigMap(configmap *corev1.ConfigMap) (string, sets.Set[string], error) {
+	// parse base model
+	baseModel, ok := configmap.Data[baseModelKey]
+	if !ok || strings.TrimSpace(baseModel) == "" {
+		return "", nil, fmt.Errorf("missing or empty baseModel in ConfigMap %s/%s", configmap.Namespace, configmap.Name)
+	}
+
+	adapters := sets.Set[string]{}
+	// parse adapters
+	if raw, ok := configmap.Data[adaptersKey]; ok && strings.TrimSpace(raw) != "" {
+		var list []string
+		if err := yaml.Unmarshal([]byte(raw), &list); err != nil {
+			return "", nil, fmt.Errorf("failed to parse adapters: %w", err)
+		}
+
+		for _, adapter := range list {
+			if strings.TrimSpace(adapter) == "" {
+				continue // skip empty entries
+			}
+			adapters.Insert(adapter)
+		}
+	}
+
+	return baseModel, adapters, nil
+}


### PR DESCRIPTION
Add configmap reconciler and bbr datastore for storing mapping between adapters and base.
This is a prep for the multi inference pool management by bbr and is only a first PR out of a series of PRs.
the next PRs should include adding unit tests, plugging the controller into controller manager, adding env var to enable/disable this feature as experimental and enhancements to the bbr helm chart to apply the proper rbac. 

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
first step of #1812 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
