### PR TITLE
fix: correctly handle zero fresh pods in pool metrics

### DIFF
--- a/pkg/epp/backend/metrics/logger.go
+++ b/pkg/epp/backend/metrics/logger.go
@@ -87,7 +87,10 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 
 	podMetrics := datastore.PodList(PodsWithFreshMetrics(metricsStalenessThreshold))
 	logger.V(logutil.TRACE).Info("Refreshing Prometheus Metrics", "ReadyPods", len(podMetrics))
-	if len(podMetrics) == 0 {
+	podTotalCount := len(podMetrics)
+	metrics.RecordInferencePoolReadyPods(pool.Name, float64(podTotalCount))
+
+	if podTotalCount == 0 {
 		return
 	}
 
@@ -96,8 +99,6 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 		queueTotal += pod.GetMetrics().WaitingQueueSize
 	}
 
-	podTotalCount := len(podMetrics)
 	metrics.RecordInferencePoolAvgKVCache(pool.Name, kvCacheTotal/float64(podTotalCount))
 	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(queueTotal/podTotalCount))
-	metrics.RecordInferencePoolReadyPods(pool.Name, float64(podTotalCount))
 }

--- a/pkg/epp/datalayer/metrics/logger.go
+++ b/pkg/epp/datalayer/metrics/logger.go
@@ -109,17 +109,17 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 
 	podMetrics := datastore.PodList(podsWithFreshMetrics(stalenessThreshold))
 	logger.V(logutil.TRACE).Info("Refreshing Prometheus Metrics", "ReadyPods", len(podMetrics))
+	podCount := len(podMetrics)
+	metrics.RecordInferencePoolReadyPods(pool.Name, float64(podCount))
 
-	if len(podMetrics) == 0 {
+	if podCount == 0 {
 		return
 	}
 
 	totals := calculateTotals(podMetrics)
-	podCount := len(podMetrics)
 
 	metrics.RecordInferencePoolAvgKVCache(pool.Name, totals.kvCache/float64(podCount))
 	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(totals.queueSize/podCount))
-	metrics.RecordInferencePoolReadyPods(pool.Name, float64(podCount))
 }
 
 // totals holds aggregated metric values


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

- Always report inference_pool_ready_pods (including 0) to reflect true availability
- Skip AvgKVCache and AvgQueueSize metrics when no fresh pods exist,
  avoiding misleading zero values that mask outages

This ensures alerting on ready_pods==0 works reliably and prevents
false interpretation of average metrics during pod downtime or staleness.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
