### PR TITLE
fix: ensure ResponseComplete hook always executes

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -96,10 +96,6 @@ func (s *StreamingServer) HandleResponseBodyModelStreaming(ctx context.Context, 
 			cachedToken = reqCtx.Usage.PromptTokenDetails.CachedTokens
 		}
 		metrics.RecordPromptCachedTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, cachedToken)
-		_, err := s.director.HandleResponseBodyComplete(ctx, reqCtx)
-		if err != nil {
-			logger.Error(err, "error in HandleResponseBodyComplete")
-		}
 	}
 }
 

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -165,6 +165,17 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		if reqCtx.RequestRunning {
 			metrics.DecRunningRequests(reqCtx.IncomingModelName)
 		}
+
+		// If we scheduled a pod (TargetPod != nil) but never marked the response  as complete (e.g. error, disconnect,
+		// panic), force the completion hooks to run.
+		if reqCtx.TargetPod != nil && !reqCtx.ResponseComplete {
+			// Use a fresh context as the request context might be canceled (Client Disconnect).
+			// We only need logging from the original context.
+			cleanupCtx := log.IntoContext(context.Background(), logger)
+			if _, err := s.director.HandleResponseBodyComplete(cleanupCtx, reqCtx); err != nil {
+				logger.Error(err, "error in HandleResponseBodyComplete")
+			}
+		}
 	}(err, reqCtx)
 
 	for {
@@ -275,6 +286,10 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				s.HandleResponseBodyModelStreaming(ctx, reqCtx, responseText)
 				if v.ResponseBody.EndOfStream {
 					loggerTrace.Info("stream completed")
+					reqCtx.ResponseComplete = true
+					if _, err := s.director.HandleResponseBodyComplete(ctx, reqCtx); err != nil {
+						logger.Error(err, "error in HandleResponseBodyComplete")
+					}
 
 					reqCtx.ResponseCompleteTimestamp = time.Now()
 					metrics.RecordRequestLatencies(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -52,7 +52,12 @@ type ResponseStreaming interface {
 	ResponseStreaming(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)
 }
 
-// ResponseComplete is called by the director after the complete response is sent.
+// ResponseComplete is called by the director when the request lifecycle terminates.
+// This occurs after a response is fully sent, OR if the request fails/disconnects after a pod was scheduled.
+//
+// Plugins should assume this is the final cleanup hook for a request.
+//
+// TODO: Consider passing an error or success bool; however, this is a breaking change and is deffered for now.
 type ResponseComplete interface {
 	plugins.Plugin
 	ResponseComplete(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR ensures that the `ResponseComplete` plugin hook is always executed if a request was scheduled to a pod, regardless of how the request terminates (success, error, or client disconnect).

**The Problem:**
Stateful plugins (like the upcoming Concurrency Saturation Detector) rely on strict symmetry between `PreRequest` (increment) and `ResponseComplete` (decrement). Previously, several edge cases could break this symmetry, causing capacity leaks where the system believed it was saturated when it was actually empty:

1.  **Errors & Disconnects:** If `json.Marshal` failed or the client context was canceled after scheduling but before response generation, the function would return early, skipping the completion hook.
2.  **Split Streaming Chunks:** The streaming logic relied on string parsing (`strings.Contains(..., "[DONE]")`) to detect the end of a stream. If the TCP/Envoy chunk boundary split this message across two reads, the completion signal was missed.

**The Fix:**
1.  **Safety Defer:** Added a `defer` block in `server.Process` that checks if a `TargetPod` was assigned but `ResponseComplete` was never called. If so, it forces the completion hook to run.
2.  **Authoritative Streaming Signal:** Moved the streaming completion trigger out of the content-parsing utility and into the main loop, relying on the gRPC `EndOfStream` boolean. This makes the logic robust against split chunks.

**Which issue(s) this PR fixes**:

Prerequisite for #1793 

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where client disconnects, internal errors, or split streaming chunks could cause request capacity to leak, potentially leading to false saturation signals in the Flow Control layer.
```