### PR TITLE
cleanup: resolve technical debt and link tracking issues

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -94,7 +94,9 @@ const (
 	EnvSdMetricsStalenessThreshold = "SD_METRICS_STALENESS_THRESHOLD"
 )
 
-// TODO: This is a bad pattern. Remove this once we hook Flow Control into the config loading path.
+// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1794):
+// Remove this static initialization helper once Flow Control is integrated
+// into the EPP YAML-based plugin configuration path.
 func must[T any](t T, err error) T {
 	if err != nil {
 		panic(fmt.Sprintf("static initialization failed: %v", err))
@@ -102,7 +104,9 @@ func must[T any](t T, err error) T {
 	return t
 }
 
-// TODO: This is hardcoded for POC only. This needs to be hooked up to our text-based config story.
+// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1794):
+// Remove hardcoded configuration. Priorities, fairness policies, and limits should be loaded from the standard EPP
+// configuration system.
 var flowControlConfig = flowcontrol.Config{
 	Controller: fccontroller.Config{},        // Use all defaults.
 	Registry:   must(fcregistry.NewConfig()), // Use all defaults.

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -279,7 +279,7 @@ func (fr *FlowRegistry) prepareNewFlow(key types.FlowKey) (*flowState, error) {
 	}
 
 	for i, shard := range fr.allShards {
-		shard.synchronizeFlow(types.FlowSpecification{Key: key}, components[i].policy, components[i].queue)
+		shard.synchronizeFlow(key, components[i].policy, components[i].queue)
 	}
 
 	fr.logger.Info("Successfully prepared and synchronized new flow instance",
@@ -538,7 +538,7 @@ func (fr *FlowRegistry) executeScaleUpLocked(newTotalActive int) error {
 	// Commit (Infallible):
 	for i, shard := range newShards {
 		for key, components := range allComponents {
-			shard.synchronizeFlow(types.FlowSpecification{Key: key}, components[i].policy, components[i].queue)
+			shard.synchronizeFlow(key, components[i].policy, components[i].queue)
 		}
 	}
 	fr.activeShards = append(fr.activeShards, newShards...)

--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -298,14 +298,12 @@ func (s *registryShard) Stats() contracts.ShardStats {
 // synchronizeFlow is the internal administrative method for creating a flow instance on this shard.
 // It is an idempotent "create if not exists" operation.
 func (s *registryShard) synchronizeFlow(
-	spec types.FlowSpecification,
+	key types.FlowKey,
 	policy framework.IntraFlowDispatchPolicy,
 	q framework.SafeQueue,
 ) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	key := spec.Key
 
 	val, _ := s.priorityBands.Load(key.Priority)
 	band := val.(*priorityBand)
@@ -323,7 +321,7 @@ func (s *registryShard) synchronizeFlow(
 		return s.isDraining.Load()
 	}
 
-	mq := newManagedQueue(q, policy, spec.Key, s.logger, s.propagateStatsDelta, isDrainingFunc)
+	mq := newManagedQueue(q, policy, key, s.logger, s.propagateStatsDelta, isDrainingFunc)
 	band.queues[key.ID] = mq
 }
 

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -91,12 +91,11 @@ func newShardTestHarness(t *testing.T) *shardTestHarness {
 // synchronizeFlow simulates the registry synchronizing a flow with a real queue.
 func (h *shardTestHarness) synchronizeFlow(key types.FlowKey) {
 	h.t.Helper()
-	spec := types.FlowSpecification{Key: key}
 	policy, err := intraflow.NewPolicyFromName(defaultIntraFlowDispatchPolicy)
 	assert.NoError(h.t, err, "Helper synchronizeFlow: failed to create real intra-flow policy for synchronization")
 	q, err := queue.NewQueueFromName(defaultQueue, policy.Comparator())
 	assert.NoError(h.t, err, "Helper synchronizeFlow: failed to create real queue for synchronization")
-	h.shard.synchronizeFlow(spec, policy, q)
+	h.shard.synchronizeFlow(key, policy, q)
 }
 
 // addItem adds an item to a specific flow's queue on the shard.

--- a/pkg/epp/flowcontrol/types/flow.go
+++ b/pkg/epp/flowcontrol/types/flow.go
@@ -60,19 +60,3 @@ func (k FlowKey) Compare(other FlowKey) int {
 	}
 	return strings.Compare(k.ID, other.ID)
 }
-
-// FlowSpecification defines the complete configuration for a single logical flow instance, which is uniquely identified
-// by its immutable `Key`.
-//
-// It is the primary data contract used by the `contracts.FlowRegistry` to register or update a flow instance. The
-// registry manages one flow instance for each unique `FlowKey`. While the `Key` itself is immutable, the specification
-// can be updated via `RegisterOrUpdateFlow` to modify configurable parameters (e.g., policies, capacity limits) for the
-// existing flow instance (when these update stories are supported).
-type FlowSpecification struct {
-	// Key is the unique, immutable identifier for the flow instance this specification describes.
-	Key FlowKey
-
-	// TODO: Add other flow-scoped configuration fields here, such as:
-	// - IntraFlowDispatchPolicy intra.RegisteredPolicyName
-	// - CapacityBytes uint64
-}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -67,9 +67,10 @@ type StreamingServer struct {
 }
 
 // RequestContext stores context information during the life time of an HTTP request.
-// TODO: The requestContext is gathering a ton of fields. A future refactor needs to tease these fields apart.
-// Specifically, there are fields related to the ext-proc protocol, and then fields related to the lifecycle of the request.
-// We should split these apart as this monolithic object exposes too much data to too many layers.
+//
+// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2082):
+// Refactor this monolithic struct. Fields related to the Envoy ext-proc protocol should be decoupled from the internal
+// request lifecycle state.
 type RequestContext struct {
 	TargetPod                 *backend.Pod
 	TargetEndpoint            string

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -42,7 +42,9 @@ import (
 )
 
 const (
-	// TODO: Make these configurable per plugin via config.
+	// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2081):
+	// Make this timeout configurable per-plugin or globally via the Director configuration to support plugins with
+	// varying latency profiles.
 	prepareDataTimeout = 400 * time.Millisecond
 )
 

--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -57,7 +57,9 @@ type ResponseStreaming interface {
 //
 // Plugins should assume this is the final cleanup hook for a request.
 //
-// TODO: Consider passing an error or success bool; however, this is a breaking change and is deffered for now.
+// TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2079):
+// Update signature to pass error/termination state. This is a breaking change required for plugins to distinguish
+// between success, errors, and disconnects.
 type ResponseComplete interface {
 	plugins.Plugin
 	ResponseComplete(ctx context.Context, request *types.LLMRequest, response *Response, targetPod *backend.Pod)

--- a/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector.go
+++ b/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector.go
@@ -21,12 +21,6 @@ limitations under the License.
 // primarily based on backend queue depths and KV cache utilization, reflecting
 // the saturation signals previously used by the Scheduler before the
 // introduction of the FlowController.
-//
-// TODO: Explore more advanced saturation signals in the future, such as:
-//   - Latency-objective-based saturation.
-//   - Predictive saturation based on trends.
-//   - Hysteresis bands or other smoothing techniques to prevent rapid
-//     oscillations of the saturation signal.
 package utilizationdetector
 
 import (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This PR addresses outstanding technical debt comments across the handler and flow control stack by linking them to specific tracking issues or refactoring them where appropriate.

**Changes:**
1.  **Linked Tracking Issues:** Updated `TODO` comments with links to new tracking issues for future refactors:
    *   `RequestContext` refactor (#2082).
    *   Configurable `PrepareData` timeout (#2081).
    *   `ResponseComplete` signature update (#2079).
    *   Flow Control configuration unification (#1794).
2.  **Refactored `FlowRegistry`:** Removed the redundant `FlowSpecification` struct. The registry now synchronizes flows directly using the immutable `FlowKey`, simplifying the internal API surface.
3.  **Doc Cleanup:** Removed vague TODO in `utilizationdetector` that were aspirational rather than actionable technical debt and already well tracked i #1793.

**Which issue(s) this PR fixes**:
Ref: #2082, #2081, #2079, #1794, #1793

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```