### PR TITLE
revert BBR chunked request_response

### DIFF
--- a/pkg/bbr/handlers/request.go
+++ b/pkg/bbr/handlers/request.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
@@ -134,17 +133,22 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestBodyBytes []byte)
 }
 
 func addStreamedBodyResponse(responses []*eppb.ProcessingResponse, requestBodyBytes []byte) []*eppb.ProcessingResponse {
-	commonResponses := common.BuildChunkedBodyResponses(requestBodyBytes, true)
-	for _, commonResp := range commonResponses {
-		responses = append(responses, &eppb.ProcessingResponse{
-			Response: &eppb.ProcessingResponse_RequestBody{
-				RequestBody: &eppb.BodyResponse{
-					Response: commonResp,
+	return append(responses, &eppb.ProcessingResponse{
+		Response: &eppb.ProcessingResponse_RequestBody{
+			RequestBody: &eppb.BodyResponse{
+				Response: &eppb.CommonResponse{
+					BodyMutation: &eppb.BodyMutation{
+						Mutation: &eppb.BodyMutation_StreamedResponse{
+							StreamedResponse: &eppb.StreamedBodyResponse{
+								Body:        requestBodyBytes,
+								EndOfStream: true,
+							},
+						},
+					},
 				},
 			},
-		})
-	}
-	return responses
+		},
+	})
 }
 
 // HandleRequestHeaders handles request headers.

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -201,7 +201,6 @@ func TestHandleRequestBody(t *testing.T) {
 					"prompt": strings.Repeat("a", 70000),
 				}
 				b, _ := json.Marshal(m)
-				limit := 62000
 				return []*extProcPb.ProcessingResponse{
 					{
 						Response: &extProcPb.ProcessingResponse_RequestHeaders{
@@ -235,23 +234,7 @@ func TestHandleRequestBody(t *testing.T) {
 									BodyMutation: &extProcPb.BodyMutation{
 										Mutation: &extProcPb.BodyMutation_StreamedResponse{
 											StreamedResponse: &extProcPb.StreamedBodyResponse{
-												Body:        b[:limit],
-												EndOfStream: false,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Response: &extProcPb.ProcessingResponse_RequestBody{
-							RequestBody: &extProcPb.BodyResponse{
-								Response: &extProcPb.CommonResponse{
-									BodyMutation: &extProcPb.BodyMutation{
-										Mutation: &extProcPb.BodyMutation_StreamedResponse{
-											StreamedResponse: &extProcPb.StreamedBodyResponse{
-												Body:        b[limit:],
+												Body:        b,
 												EndOfStream: true,
 											},
 										},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

with chunked request response(https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2058) in BBR, sometimes the upstream server(either EPP or model server) will receive request_body with wrong EoS field.
Reverting the chunked request_response for now to fix issue.

one example is: 
<img width="1689" height="632" alt="image" src="https://github.com/user-attachments/assets/b7a21c68-eeca-4ebc-a4d5-e1723c1c321c" />

also Envoy may have potential issue in chaining ext_proc in full_duplex_streamed mode: https://github.com/envoyproxy/envoy/issues/41654


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
