### PR TITLE
fix both error propogation and priority band fullness

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -218,7 +218,8 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
-				// Body stream complete. Allocate empty slice for response to use.
+				// Body stream complete. Capture raw size for flow control.
+				reqCtx.RequestSize = len(body)
 				body = []byte{}
 
 				reqCtx, err = s.director.HandleRequest(ctx, reqCtx)
@@ -227,12 +228,14 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
-				// Populate the ExtProc protocol responses for the request body.
-				requestBodyBytes, err := json.Marshal(reqCtx.Request.Body)
+				// Marshal after HandleRequest to include modifications (e.g., model rewriting).
+				var requestBodyBytes []byte
+				requestBodyBytes, err = json.Marshal(reqCtx.Request.Body)
 				if err != nil {
 					logger.V(logutil.DEFAULT).Error(err, "Error marshalling request body")
 					break
 				}
+				// Update RequestSize to match marshalled body for Content-Length header.
 				reqCtx.RequestSize = len(requestBodyBytes)
 				reqCtx.reqHeaderResp = s.generateRequestHeaderResponse(reqCtx)
 				reqCtx.reqBodyResp = s.generateRequestBodyResponses(requestBodyBytes)


### PR DESCRIPTION
Testing the experimental flow control layer and found that it was not properly load shedding requests when setting the maximum byte size of a flow queue. Bisected it down to a shadowing bug, this PR fixes this and also the fact that the size of the queue was not properly tracked.