### PR TITLE
add scoring preference to scorer interface.

### DIFF
--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -408,12 +408,22 @@ func (m *mockPlugin) TypedName() plugins.TypedName { return m.t }
 // Mock Scorer
 type mockScorer struct{ mockPlugin }
 
+// compile-time type assertion
+var _ framework.Scorer = &mockScorer{}
+
+func (m *mockScorer) Category() framework.ScorerCategory {
+	return framework.Distribution
+}
+
 func (m *mockScorer) Score(context.Context, *types.CycleState, *types.LLMRequest, []types.Endpoint) map[types.Endpoint]float64 {
 	return nil
 }
 
 // Mock Picker
 type mockPicker struct{ mockPlugin }
+
+// compile-time type assertion
+var _ framework.Picker = &mockPicker{}
 
 func (m *mockPicker) Pick(context.Context, *types.CycleState, []*types.ScoredEndpoint) *types.ProfileRunResult {
 	return nil
@@ -422,21 +432,15 @@ func (m *mockPicker) Pick(context.Context, *types.CycleState, []*types.ScoredEnd
 // Mock Handler
 type mockHandler struct{ mockPlugin }
 
-func (m *mockHandler) Pick(
-	context.Context,
-	*types.CycleState,
-	*types.LLMRequest,
-	map[string]*framework.SchedulerProfile,
-	map[string]*types.ProfileRunResult,
-) map[string]*framework.SchedulerProfile {
+// compile-time type assertion
+var _ framework.ProfileHandler = &mockHandler{}
+
+func (m *mockHandler) Pick(context.Context, *types.CycleState, *types.LLMRequest, map[string]*framework.SchedulerProfile,
+	map[string]*types.ProfileRunResult) map[string]*framework.SchedulerProfile {
 	return nil
 }
-func (m *mockHandler) ProcessResults(
-	context.Context,
-	*types.CycleState,
-	*types.LLMRequest,
-	map[string]*types.ProfileRunResult,
-) (*types.SchedulingResult, error) {
+func (m *mockHandler) ProcessResults(context.Context, *types.CycleState, *types.LLMRequest,
+	map[string]*types.ProfileRunResult) (*types.SchedulingResult, error) {
 	return nil, nil
 }
 

--- a/pkg/epp/scheduling/framework/plugins.go
+++ b/pkg/epp/scheduling/framework/plugins.go
@@ -31,6 +31,22 @@ const (
 	ProcessProfilesResultsExtensionPoint = "ProcessProfilesResults"
 )
 
+// ScorerCategory marks the preference a scorer applies when scoring candidate endpoints.
+type ScorerCategory string
+
+const (
+	// Affinity indicates a scorer that prefers endpoints with existing locality, such as kv-cache or session-related state,
+	// and therefore tends to give higher scores to the same endpoints.
+	Affinity ScorerCategory = "Affinity"
+
+	// Distribution indicates a scorer that prefers spreading requests evenly across all candidate endpoints to avoid
+	// hotspots and improve overall utilization.
+	Distribution ScorerCategory = "Distribution"
+
+	// Balance indicates a scorer that its preference is balanced between Affinity and Distribution.
+	Balance ScorerCategory = "Balance"
+)
+
 // ProfileHandler defines the extension points for handling multi SchedulerProfile instances.
 // More specifically, this interface defines the 'Pick' and 'ProcessResults' extension points.
 type ProfileHandler interface {
@@ -60,6 +76,7 @@ type Filter interface {
 // If a scorer returns value lower than 0, it will be treated as score 0.
 type Scorer interface {
 	plugins.Plugin
+	Category() ScorerCategory
 	Score(ctx context.Context, cycleState *types.CycleState, request *types.LLMRequest, pods []types.Endpoint) map[types.Endpoint]float64
 }
 

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin.go
@@ -207,6 +207,11 @@ func (p *Plugin) TypedName() plugins.TypedName {
 	return p.typedName
 }
 
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (p *Plugin) Category() framework.ScorerCategory {
+	return framework.Affinity
+}
+
 // WithName sets the name of the plugin.
 func (p *Plugin) WithName(name string) *Plugin {
 	p.typedName.Name = name

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/scorer.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/scorer.go
@@ -186,6 +186,11 @@ func (s *SLOAwareRouter) TypedName() plugins.TypedName {
 	return s.typedName
 }
 
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *SLOAwareRouter) Category() framework.ScorerCategory {
+	return framework.Balance
+}
+
 func (s *SLOAwareRouter) WithName(name string) *SLOAwareRouter {
 	s.typedName.Name = name
 	return s

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache_utilization.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache_utilization.go
@@ -55,6 +55,11 @@ func (s *KVCacheUtilizationScorer) TypedName() plugins.TypedName {
 	return s.typedName
 }
 
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *KVCacheUtilizationScorer) Category() framework.ScorerCategory {
+	return framework.Distribution
+}
+
 // Consumes returns the list of data that is consumed by the plugin.
 func (s *KVCacheUtilizationScorer) Consumes() map[string]any {
 	return map[string]any{

--- a/pkg/epp/scheduling/framework/plugins/scorer/lora_affinity.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/lora_affinity.go
@@ -55,6 +55,11 @@ func (s *LoraAffinityScorer) TypedName() plugins.TypedName {
 	return s.typedName
 }
 
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *LoraAffinityScorer) Category() framework.ScorerCategory {
+	return framework.Affinity
+}
+
 // Consumes returns the list of data that is consumed by the plugin.
 func (s *LoraAffinityScorer) Consumes() map[string]any {
 	return map[string]any{

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue.go
@@ -57,6 +57,11 @@ func (s *QueueScorer) TypedName() plugins.TypedName {
 	return s.typedName
 }
 
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *QueueScorer) Category() framework.ScorerCategory {
+	return framework.Distribution
+}
+
 // Consumes returns the list of data that is consumed by the plugin.
 func (s *QueueScorer) Consumes() map[string]any {
 	return map[string]any{

--- a/pkg/epp/scheduling/framework/plugins/scorer/running.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/running.go
@@ -57,6 +57,11 @@ func (s *RunningRequestsSizeScorer) TypedName() plugins.TypedName {
 	return s.typedName
 }
 
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *RunningRequestsSizeScorer) Category() framework.ScorerCategory {
+	return framework.Distribution
+}
+
 // Consumes returns the list of data that is consumed by the plugin.
 func (s *RunningRequestsSizeScorer) Consumes() map[string]any {
 	return map[string]any{

--- a/pkg/epp/scheduling/framework/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/framework/scheduler_profile_test.go
@@ -201,6 +201,10 @@ func (tp *testPlugin) TypedName() plugins.TypedName {
 	return tp.typedName
 }
 
+func (tp *testPlugin) Category() ScorerCategory {
+	return Distribution
+}
+
 func (tp *testPlugin) Filter(_ context.Context, _ *types.CycleState, _ *types.LLMRequest, endpoints []types.Endpoint) []types.Endpoint {
 	tp.FilterCallCount++
 	return findEndpoints(endpoints, tp.FilterRes...)


### PR DESCRIPTION
this is a pre-req for adapting scorer weights

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
This is a pre-req for experimenting with #1992.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
When implementing a scorer, the developer should declare if the scorer preference is affinity based on some cache or other state, or even load distribution.
Not changing anything in the user experience, only for the developer of scorers.
```

/cc @kfswain @vMaroon 