### PR TITLE
Datalayer refactoring: HTTP datasource and client

### DIFF
--- a/pkg/epp/datalayer/http/client.go
+++ b/pkg/epp/datalayer/http/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package httpds
+package http
 
 import (
 	"context"

--- a/pkg/epp/datalayer/http/datasource.go
+++ b/pkg/epp/datalayer/http/datasource.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package httpds
+package http
 
 import (
 	"context"

--- a/pkg/epp/datalayer/metrics/datasource_test.go
+++ b/pkg/epp/datalayer/metrics/datasource_test.go
@@ -25,11 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
-	httpds "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer/http"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer/http"
 )
 
 func TestDatasource(t *testing.T) {
-	source := httpds.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
+	source := http.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
 		"metrics-data-source", parseMetrics, PrometheusMetricType)
 	extractor, err := NewModelServerExtractor(defaultTotalQueuedRequestsMetric, "", "", "", "")
 	assert.Nil(t, err, "failed to create extractor")

--- a/pkg/epp/datalayer/metrics/factories.go
+++ b/pkg/epp/datalayer/metrics/factories.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/common/model"
 	flag "github.com/spf13/pflag"
 
-	httpds "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer/http"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer/http"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
 )
 
@@ -76,7 +76,7 @@ func MetricsDataSourceFactory(name string, parameters json.RawMessage, handle pl
 		}
 	}
 
-	ds := httpds.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify, MetricsDataSourceType,
+	ds := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify, MetricsDataSourceType,
 		name, parseMetrics, PrometheusMetricType)
 	return ds, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

This PR refactors metrics datasource and client into a general HTTP datasource and client, allowing code reuse in similar scenarios, e.g., gathering of models info.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
