### PR TITLE
Interfaces towards pluggable BBR framework (initial PR)

### DIFF
--- a/pkg/bbr/plugins/plugins.go
+++ b/pkg/bbr/plugins/plugins.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
+)
+
+type BBRPlugin interface {
+	plugins.Plugin
+
+	// Execute runs the plugin logic on the request body and a map of headers.
+	// A plugin's imnplementation logic CAN mutate the body of the message.
+	// A plugin's implementation MUST return a map of headers.
+	// If no headers are set by the implementation, the return headers map is nil.
+	Execute(requestBodyBytes []byte, requestHeaders map[string][]string) (mutatedBodyBytes []byte, headers map[string][]string, err error)
+}

--- a/pkg/bbr/plugins/registry.go
+++ b/pkg/bbr/plugins/registry.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import "encoding/json"
+
+// Any no-argument function that returns BBRPlugin can be assigned to this type (including a concrete factory function)
+type PluginFactoryFunc func(name string, parameters json.RawMessage) (BBRPlugin, error)
+
+// Registry is a simple mapping from the plugin name to the factory that creates this BBRPlugin
+var Registry = map[string]PluginFactoryFunc{}
+
+// Registers a plugin's factory
+func Register(pluginType string, factory PluginFactoryFunc) {
+	Registry[pluginType] = factory
+}

--- a/pkg/bbr/plugins/spec.go
+++ b/pkg/bbr/plugins/spec.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// BBRPluginSpec implements flag.Value interface and defines a repeatable configuration block specified in CLI: --plugin <type>:<name>:<json>
+type BBRPluginSpec struct {
+	Type string
+	Name string
+	JSON json.RawMessage // raw JSON representing parameters for the plugin factory
+	Raw  string          // original parameters string (for error messages)
+}
+
+// BBRPluginSpecs Slice (because the plugin flag is repeatable)
+type BBRPluginSpecs []BBRPluginSpec
+
+func (p *BBRPluginSpecs) Set(s string) error {
+	spec := BBRPluginSpec{Raw: s}
+
+	// Accept either:
+	//   <type>:<name>
+	//   <type>:<name>:<json>
+	segments := strings.SplitN(s, ":", 3)
+	if len(segments) < 2 {
+		return errors.New(`usage: --plugin <type>:<name>:<json>`)
+	}
+	spec.Type = strings.TrimSpace(segments[0])
+	spec.Name = strings.TrimSpace(segments[1])
+
+	if spec.Type == "" {
+		return errors.New("bbr plugin type cannot be empty")
+	}
+	if spec.Name == "" {
+		return errors.New("bbr plugin name cannot be empty")
+	}
+
+	// If the third segment is provided, validate JSON if non-empty.
+	if len(segments) == 3 {
+		jsonSegment := strings.TrimSpace(segments[2])
+		// Allow empty JSON segment (means "no parameters").
+		if jsonSegment != "" {
+			if !json.Valid([]byte(jsonSegment)) {
+				return errors.New("invalid json")
+			}
+		}
+		spec.JSON = json.RawMessage(jsonSegment)
+	}
+
+	*p = append(*p, spec)
+	return nil
+}
+
+func (p *BBRPluginSpecs) String() string {
+	specs := *p
+	out := make([]string, 0, len(specs)) // preallocate memory
+
+	for _, s := range *p {
+		out = append(out, s.Raw)
+	}
+	return strings.Join(out, " ")
+}


### PR DESCRIPTION
/kind feature

What this PR does / why we need it:

Allows custom extensions to BBR functionality without requiring modifications to the IGW code base, as described in https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1964.

This PR is first in a series of PRs to implement this proposal incrementally.
This PR does not change the current BBR behavior. This PR only proposes interfaces. 
Following the reviewers' feedback on PR [#1981](https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1981), the interfaces are simplified and the uses case involves only a single BBR plugin that can be instantiated.

Which issue(s) this PR fixes:
Fixes #1963

Does this PR introduce a user-facing change?:

-->

NONE
