### PR TITLE
Rename part three

### DIFF
--- a/pkg/epp/backend/metrics/metrics_state.go
+++ b/pkg/epp/backend/metrics/metrics_state.go
@@ -20,10 +20,5 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 )
 
-// NewMetricsState initializes a new MetricsState and returns its pointer.
-func NewMetricsState() *MetricsState {
-	return datalayer.NewMetrics()
-}
-
 // MetricsState holds the latest state of the metrics that were scraped from a pod.
 type MetricsState = datalayer.Metrics

--- a/pkg/epp/backend/metrics/types.go
+++ b/pkg/epp/backend/metrics/types.go
@@ -63,7 +63,7 @@ func (f *PodMetricsFactory) NewEndpoint(parentCtx context.Context, metadata *dat
 		logger:    log.FromContext(parentCtx).WithValues("endpoint", metadata.NamespacedName),
 	}
 	pm.metadata.Store(metadata)
-	pm.metrics.Store(NewMetricsState())
+	pm.metrics.Store(datalayer.NewMetrics())
 
 	pm.startRefreshLoop(parentCtx)
 	return pm

--- a/pkg/epp/metrics/collectors/inference_pool_test.go
+++ b/pkg/epp/metrics/collectors/inference_pool_test.go
@@ -43,7 +43,7 @@ var (
 		},
 	}
 	pod1NamespacedName = types.NamespacedName{Name: pod1.Name + "-rank-0", Namespace: pod1.Namespace}
-	pod1Metrics        = &backendmetrics.MetricsState{
+	pod1Metrics        = &datalayer.Metrics{
 		WaitingQueueSize:    100,
 		KVCacheUsagePercent: 0.2,
 		MaxActiveModels:     2,
@@ -70,7 +70,7 @@ func TestNoMetricsCollected(t *testing.T) {
 }
 
 func TestMetricsCollected(t *testing.T) {
-	metrics := map[types.NamespacedName]*backendmetrics.MetricsState{
+	metrics := map[types.NamespacedName]*datalayer.Metrics{
 		pod1NamespacedName: pod1Metrics,
 	}
 	period := time.Millisecond

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -271,9 +271,9 @@ func (d *Director) toSchedulerPodMetrics(pods []backendmetrics.PodMetrics) []sch
 	pm := make([]schedulingtypes.Endpoint, len(pods))
 	for i, pod := range pods {
 		if pod.GetAttributes() != nil {
-			pm[i] = &schedulingtypes.PodMetrics{EndpointMetadata: pod.GetMetadata().Clone(), MetricsState: pod.GetMetrics().Clone(), AttributeMap: pod.GetAttributes().Clone()}
+			pm[i] = &schedulingtypes.PodMetrics{EndpointMetadata: pod.GetMetadata().Clone(), Metrics: pod.GetMetrics().Clone(), AttributeMap: pod.GetAttributes().Clone()}
 		} else {
-			pm[i] = &schedulingtypes.PodMetrics{EndpointMetadata: pod.GetMetadata().Clone(), MetricsState: pod.GetMetrics().Clone(), AttributeMap: datalayer.NewAttributes()}
+			pm[i] = &schedulingtypes.PodMetrics{EndpointMetadata: pod.GetMetadata().Clone(), Metrics: pod.GetMetrics().Clone(), AttributeMap: datalayer.NewAttributes()}
 		}
 	}
 

--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	dplugins "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer/plugins/approximateprefix"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/plugins"
@@ -46,9 +45,9 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	}
 	plugin := New(context.Background(), config)
 
-	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, MetricsState: backendmetrics.NewMetricsState()}
-	endpoint2 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, MetricsState: backendmetrics.NewMetricsState()}
-	endpoint3 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, MetricsState: backendmetrics.NewMetricsState()}
+	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: datalayer.NewMetrics()}
+	endpoint2 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, Metrics: datalayer.NewMetrics()}
+	endpoint3 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, Metrics: datalayer.NewMetrics()}
 	endpoints := []types.Endpoint{endpoint1, endpoint2, endpoint3}
 
 	// First request.
@@ -215,7 +214,7 @@ func TestPrefixPluginChatCompletions(t *testing.T) {
 	}
 	plugin := New(context.Background(), config)
 
-	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, MetricsState: &backendmetrics.MetricsState{}}
+	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: &datalayer.Metrics{}}
 	endpoints := []types.Endpoint{endpoint1}
 
 	// Test with chat completions request
@@ -249,8 +248,8 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 	}
 	plugin := New(context.Background(), config)
 
-	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, MetricsState: &backendmetrics.MetricsState{}}
-	endpoint2 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, MetricsState: &backendmetrics.MetricsState{}}
+	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: &datalayer.Metrics{}}
+	endpoint2 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, Metrics: &datalayer.Metrics{}}
 	endpoints := []types.Endpoint{endpoint1, endpoint2}
 
 	// First request with initial conversation
@@ -479,7 +478,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	podName := "pod-autotune"
 	endpoint := &types.PodMetrics{
 		EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: podName}},
-		MetricsState: &backendmetrics.MetricsState{
+		Metrics: &datalayer.Metrics{
 			CacheBlockSize:    16,   // 16 tokens * 4 chars/token = 64 chars per block
 			CacheNumGPUBlocks: 1000, // 1000 blocks capacity
 		},
@@ -587,8 +586,8 @@ func TestPrepareRequestData(t *testing.T) {
 	}
 	plugin := New(context.Background(), config)
 
-	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, MetricsState: backendmetrics.NewMetricsState(), AttributeMap: datalayer.NewAttributes()}
-	endpoint2 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, MetricsState: backendmetrics.NewMetricsState(), AttributeMap: datalayer.NewAttributes()}
+	endpoint1 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: datalayer.NewMetrics(), AttributeMap: datalayer.NewAttributes()}
+	endpoint2 := &types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, Metrics: datalayer.NewMetrics(), AttributeMap: datalayer.NewAttributes()}
 	endpoints := []types.Endpoint{endpoint1, endpoint2}
 
 	// First request to populate cache.

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/latencypredictor_helper.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/latencypredictor_helper.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -49,7 +49,7 @@ func refreshLastSeenMetrics(ctx context.Context, sloCtx *sloRequestContext) {
 }
 
 // getLatestMetricsForProfile retrieves the latest metrics for prediction from sloCtx.LastSeenMetrics.
-func getLatestMetricsForProfile(sloCtx *sloRequestContext) (*backendmetrics.MetricsState, error) {
+func getLatestMetricsForProfile(sloCtx *sloRequestContext) (*datalayer.Metrics, error) {
 	if len(sloCtx.lastSeenMetrics) == 0 {
 		return nil, errors.New("no last seen metrics available for prediction")
 	}
@@ -164,7 +164,7 @@ func recordTTFTTrainingData(
 	ctx context.Context,
 	predictor latencypredictor.PredictorInterface,
 	sloCtx *sloRequestContext,
-	m *backendmetrics.MetricsState,
+	m *datalayer.Metrics,
 	now time.Time,
 	prefixCacheScore float64,
 ) {
@@ -311,7 +311,7 @@ func processTokenForLatencyPrediction(
 func bulkPredictWithMetrics(
 	ctx context.Context,
 	predictor latencypredictor.PredictorInterface,
-	metricsStates []*backendmetrics.MetricsState,
+	metricsStates []*datalayer.Metrics,
 	prompts []string,
 	generatedTokenCounts []int,
 	prefixCacheScores []float64,

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/latencypredictor_helper_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/latencypredictor_helper_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 )
 
@@ -35,7 +35,7 @@ func TestBulkPredictWithMetrics(t *testing.T) {
 		},
 	}
 
-	metricsStates := []*backendmetrics.MetricsState{
+	metricsStates := []*datalayer.Metrics{
 		{KVCacheUsagePercent: 0.5},
 		{KVCacheUsagePercent: 0.6},
 	}
@@ -58,7 +58,7 @@ func TestBulkPredictWithMetrics_Error(t *testing.T) {
 		err: errors.New("prediction failed"),
 	}
 
-	metricsStates := []*backendmetrics.MetricsState{
+	metricsStates := []*datalayer.Metrics{
 		{KVCacheUsagePercent: 0.5},
 	}
 	prompts := []string{"prompt1"}
@@ -73,7 +73,7 @@ func TestBulkPredictWithMetrics_Error(t *testing.T) {
 
 func TestBulkPredictWithMetrics_InputMismatch(t *testing.T) {
 	mockPredictor := &mockPredictor{}
-	metricsStates := []*backendmetrics.MetricsState{{}}
+	metricsStates := []*datalayer.Metrics{{}}
 	prompts := []string{"prompt1", "prompt2"} // Mismatch length
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}
@@ -87,7 +87,7 @@ func TestBulkPredictWithMetrics_InputMismatch(t *testing.T) {
 
 func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
 	mockPredictor := &mockPredictor{}
-	metricsStates := []*backendmetrics.MetricsState{nil} // Nil metrics state
+	metricsStates := []*datalayer.Metrics{nil} // Nil metrics state
 	prompts := []string{"prompt1"}
 	generatedTokenCounts := []int{1}
 	prefixCacheScores := []float64{0.0}

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/prediction.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/prediction.go
@@ -21,7 +21,7 @@ import (
 	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
@@ -46,7 +46,7 @@ func (s *SLOAwareRouter) generatePredictions(ctx context.Context, request *sched
 	predictions := make([]endpointPredictionResult, 0, len(candidateEndpoints))
 
 	// Prepare inputs for bulk prediction
-	metricsStates := make([]*backendmetrics.MetricsState, len(candidateEndpoints))
+	metricsStates := make([]*datalayer.Metrics, len(candidateEndpoints))
 	prompts := make([]string, len(candidateEndpoints))
 	generatedTokenCounts := make([]int, len(candidateEndpoints))
 	prefixCacheScores := make([]float64, len(candidateEndpoints))

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/requestcontrol_hooks.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/requestcontrol_hooks.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/apimachinery/pkg/types"
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
@@ -44,7 +43,7 @@ type sloRequestContext struct {
 	schedulingRequest         schedulingtypes.LLMRequest
 	targetMetadata            *datalayer.EndpointMetadata
 	schedulingResult          *schedulingtypes.SchedulingResult
-	lastSeenMetrics           map[string]*backendmetrics.MetricsState
+	lastSeenMetrics           map[string]*datalayer.Metrics
 	lastTokenTimestamp        time.Time
 	requestReceivedTimestamp  time.Time
 	generatedTokenCount       int
@@ -74,7 +73,7 @@ type sloRequestContext struct {
 func newSLORequestContext(request *schedulingtypes.LLMRequest) *sloRequestContext {
 	return &sloRequestContext{
 		schedulingRequest:             *request,
-		lastSeenMetrics:               make(map[string]*backendmetrics.MetricsState),
+		lastSeenMetrics:               make(map[string]*datalayer.Metrics),
 		prefixCacheScoresForEndpoints: make(map[string]float64),
 		predictionsForScheduling:      make([]endpointPredictionResult, 0),
 	}

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/requestcontrol_hooks_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/requestcontrol_hooks_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
@@ -340,12 +339,12 @@ func TestSLOAwareRouter_ResponseStreaming_FirstToken(t *testing.T) {
 	sloCtx.predictedTTFT = 80.0
 	sloCtx.avgPredictedTPOT = 30.0
 	// ADD THIS - populate metrics
-	sloCtx.lastSeenMetrics["prefill"] = &backendmetrics.MetricsState{
+	sloCtx.lastSeenMetrics["prefill"] = &datalayer.Metrics{
 		KVCacheUsagePercent: 0.5,
 		WaitingQueueSize:    1,
 		RunningRequestsSize: 1,
 	}
-	sloCtx.lastSeenMetrics["default"] = &backendmetrics.MetricsState{
+	sloCtx.lastSeenMetrics["default"] = &datalayer.Metrics{
 		KVCacheUsagePercent: 0.5,
 		WaitingQueueSize:    1,
 		RunningRequestsSize: 1,
@@ -391,12 +390,12 @@ func TestSLOAwareRouter_ResponseStreaming_SubsequentTokens(t *testing.T) {
 	sloCtx.predictedTTFT = 80.0
 	sloCtx.avgPredictedTPOT = 30.0
 	// ADD THIS - populate metrics
-	sloCtx.lastSeenMetrics["prefill"] = &backendmetrics.MetricsState{
+	sloCtx.lastSeenMetrics["prefill"] = &datalayer.Metrics{
 		KVCacheUsagePercent: 0.5,
 		WaitingQueueSize:    1,
 		RunningRequestsSize: 1,
 	}
-	sloCtx.lastSeenMetrics["default"] = &backendmetrics.MetricsState{
+	sloCtx.lastSeenMetrics["default"] = &datalayer.Metrics{
 		KVCacheUsagePercent: 0.5,
 		WaitingQueueSize:    1,
 		RunningRequestsSize: 1,
@@ -669,7 +668,7 @@ func TestSLORequestContext_UpdateMetrics(t *testing.T) {
 	ctx := newSLORequestContext(request)
 
 	// Add some metrics
-	metricsState := &backendmetrics.MetricsState{
+	metricsState := &datalayer.Metrics{
 		KVCacheUsagePercent: 0.5,
 		WaitingQueueSize:    3,
 	}

--- a/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/scorer_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/slo_aware_router/scorer_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
@@ -111,7 +110,7 @@ func createTestEndpoint(name string, kvCacheUsage float64, runningRequestsSize, 
 				Namespace: "default",
 			},
 		},
-		MetricsState: &backendmetrics.MetricsState{
+		Metrics: &datalayer.Metrics{
 			KVCacheUsagePercent: kvCacheUsage,
 			RunningRequestsSize: runningRequestsSize,
 			WaitingQueueSize:    waitingQueueSize,

--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache_utilization_test.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache_utilization_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
@@ -36,9 +35,9 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 		{
 			name: "Different KV cache utilization",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.8}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.5}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.8}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.0}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.2, // Highest KV cache usage (0.8) gets lowest score (1-0.8=0.2)
@@ -49,8 +48,8 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 		{
 			name: "Same KV cache utilization",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.6}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.6}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.6}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.6}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.4, // Both get same score (1-0.6=0.4)
@@ -60,8 +59,8 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 		{
 			name: "Zero KV cache utilization",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.0}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.0}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 1.0, // No KV cache usage gets highest score
@@ -71,8 +70,8 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 		{
 			name: "Full KV cache utilization",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 1.0}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 1.0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.0, // Full KV cache (1.0) gets lowest score (1-1=0)

--- a/pkg/epp/scheduling/framework/plugins/scorer/lora_affinity_test.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/lora_affinity_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
@@ -41,7 +40,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-1": 1},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 5,
@@ -58,7 +57,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 2},
 						WaitingModels:   map[string]int{"active-model-1": 1},
 						MaxActiveModels: 2,
@@ -75,7 +74,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 2},
 						WaitingModels:   map[string]int{"active-model-3": 1},
 						MaxActiveModels: 2,
@@ -83,7 +82,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 0,
@@ -101,7 +100,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-1": 1},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 5,
@@ -109,7 +108,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 4},
 						WaitingModels:   map[string]int{"active-model-1": 1},
 						MaxActiveModels: 5,
@@ -117,7 +116,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-2": 1},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 2,
@@ -125,7 +124,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod4"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-3": 1},
 						WaitingModels:   map[string]int{"active-model-1": 1},
 						MaxActiveModels: 2,
@@ -133,7 +132,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod5"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						ActiveModels:    map[string]int{"active-model-4": 1, "active-model-5": 1},
 						WaitingModels:   map[string]int{},
 						MaxActiveModels: 2,

--- a/pkg/epp/scheduling/framework/plugins/scorer/queue_test.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/queue_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
@@ -36,9 +35,9 @@ func TestQueueScorer(t *testing.T) {
 		{
 			name: "Different queue sizes",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 10}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 5}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 10}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 0}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.0, // Longest queue (10) gets lowest score
@@ -49,8 +48,8 @@ func TestQueueScorer(t *testing.T) {
 		{
 			name: "Same queue sizes",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 5}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 5}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 1.0, // When all pods have the same queue size, they get the same neutral score
@@ -60,8 +59,8 @@ func TestQueueScorer(t *testing.T) {
 		{
 			name: "Zero queue sizes",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 0}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{WaitingQueueSize: 0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{WaitingQueueSize: 0}},
 			},
 			expectedScoresEndpoint: map[int]float64{
 				0: 1.0,

--- a/pkg/epp/scheduling/framework/plugins/scorer/running_test.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/running_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 )
@@ -36,9 +35,9 @@ func TestRunningRequestsSizeScorer(t *testing.T) {
 		{
 			name: "Different running queue sizes",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 10}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 5}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 10}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 0}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 0.0, // Longest queue (10) gets lowest score
@@ -49,8 +48,8 @@ func TestRunningRequestsSizeScorer(t *testing.T) {
 		{
 			name: "Same running queue sizes",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 5}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 5}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 1.0, // When all pods have the same queue size, they get the same neutral score
@@ -60,8 +59,8 @@ func TestRunningRequestsSizeScorer(t *testing.T) {
 		{
 			name: "Zero running queue sizes",
 			endpoints: []types.Endpoint{
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 0}},
-				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, MetricsState: &backendmetrics.MetricsState{RunningRequestsSize: 0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 0}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{RunningRequestsSize: 0}},
 			},
 			expectedScoresPod: map[int]float64{
 				0: 1.0,

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/uuid"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics" // Import config for thresholds
+	// Import config for thresholds
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/multi/prefix"
@@ -81,7 +81,7 @@ func TestSchedule(t *testing.T) {
 			input: []types.Endpoint{
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
 						MaxActiveModels:     2,
@@ -93,7 +93,7 @@ func TestSchedule(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						WaitingQueueSize:    0,
 						KVCacheUsagePercent: 0.2,
 						MaxActiveModels:     2,
@@ -105,7 +105,7 @@ func TestSchedule(t *testing.T) {
 				},
 				&types.PodMetrics{
 					EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}},
-					MetricsState: &backendmetrics.MetricsState{
+					Metrics: &datalayer.Metrics{
 						WaitingQueueSize:    10,
 						KVCacheUsagePercent: 0.8,
 						MaxActiveModels:     2,
@@ -122,7 +122,7 @@ func TestSchedule(t *testing.T) {
 							&types.ScoredEndpoint{
 								Endpoint: &types.PodMetrics{
 									EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-									MetricsState: &backendmetrics.MetricsState{
+									Metrics: &datalayer.Metrics{
 										WaitingQueueSize:    0,
 										KVCacheUsagePercent: 0.2,
 										MaxActiveModels:     2,

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 )
 
@@ -189,7 +188,7 @@ func (mc Content) PlainText() string {
 
 type Endpoint interface {
 	GetMetadata() *datalayer.EndpointMetadata
-	GetMetrics() *backendmetrics.MetricsState
+	GetMetrics() *datalayer.Metrics
 	String() string
 	Get(string) (datalayer.Cloneable, bool)
 	Put(string, datalayer.Cloneable)
@@ -213,13 +212,13 @@ func (pm *PodMetrics) GetMetadata() *datalayer.EndpointMetadata {
 	return pm.EndpointMetadata
 }
 
-func (pm *PodMetrics) GetMetrics() *backendmetrics.MetricsState {
-	return pm.MetricsState
+func (pm *PodMetrics) GetMetrics() *datalayer.Metrics {
+	return pm.Metrics
 }
 
 type PodMetrics struct {
 	*datalayer.EndpointMetadata
-	*backendmetrics.MetricsState
+	*datalayer.Metrics
 	datalayer.AttributeMap
 }
 

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -48,6 +48,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/requestcontrol"
@@ -246,7 +247,7 @@ func (h *TestHarness) WithBaseResources() *TestHarness {
 // WithPods creates pod objects in the API server and configures the fake metrics client.
 func (h *TestHarness) WithPods(pods []podState) *TestHarness {
 	h.t.Helper()
-	metricsMap := make(map[types.NamespacedName]*backendmetrics.MetricsState)
+	metricsMap := make(map[types.NamespacedName]*datalayer.Metrics)
 
 	// Pre-calculate metrics and register them with the fake client.
 	for _, p := range pods {
@@ -256,7 +257,7 @@ func (h *TestHarness) WithPods(pods []podState) *TestHarness {
 			activeModelsMap[m] = 1
 		}
 
-		metricsMap[types.NamespacedName{Namespace: h.Namespace, Name: metricsKeyName}] = &backendmetrics.MetricsState{
+		metricsMap[types.NamespacedName{Namespace: h.Namespace, Name: metricsKeyName}] = &datalayer.Metrics{
 			WaitingQueueSize:    p.queueSize,
 			KVCacheUsagePercent: p.kvCacheUsage,
 			ActiveModels:        activeModelsMap,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR is a third PR in a set of PRs that is attempting to cleanup the code base WRT to Pods vs Model Server Endpoints and the old "backendmetrics" and the new DataLayer..

It does this by reducing the references to the struct pkg/epp/metrics/MetricsState and instead reference the aliased struct pkg/epp/datalayer/Metrics.

As Model Servers evolve, vLLM or others, one can not assume that there is a one to one relationship between pods and Model Servers. That is a pod may contain multiple Model Servers each. on its own port, such as vLLM's Data Parallel support. On the other hand Model Servers may do there own internal multi-pod routing as well.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
