### PR TITLE
Move prefix cache update from PreRequest to ResponseReceived

### DIFF
--- a/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
+++ b/pkg/epp/scheduling/framework/plugins/multi/prefix/plugin_test.go
@@ -81,6 +81,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req1, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req1, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 
 	// Second request doesn't share any prefix with first one. It should be added to the cache but
@@ -113,6 +114,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req2, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req2, nil, endpoint2.GetMetadata())
 	plugin.wg.Wait()
 
 	// Third request shares partial prefix with first one.
@@ -144,6 +146,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req3, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req3, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 
 	// 4th request is same as req3 except the model is different, still no match.
@@ -174,6 +177,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req4, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req4, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 
 	// 5th request shares partial prefix with 3rd one.
@@ -204,6 +208,7 @@ func TestPrefixPluginCompletion(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req5, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req5, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 }
 
@@ -284,6 +289,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req1, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req1, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 
 	// Second request adds assistant response and new user message (conversation grows)
@@ -317,6 +323,7 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 
 	// Simulate pod1 was picked again
 	plugin.PreRequest(context.Background(), req2, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req2, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 
 	// Third request continues the conversation even further
@@ -528,6 +535,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 			},
 		}
 		plugin.PreRequest(context.Background(), req, schedulingResult)
+		plugin.ResponseReceived(context.Background(), req, nil, endpoint.GetMetadata())
 		plugin.wg.Wait()
 
 		// Check indexer state
@@ -563,6 +571,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 			},
 		}
 		plugin.PreRequest(context.Background(), req, schedulingResult)
+		plugin.ResponseReceived(context.Background(), req, nil, endpoint.GetMetadata())
 		plugin.wg.Wait()
 
 		assert.Contains(t, plugin.indexer.Pods(), ServerID(endpoint.GetMetadata().NamespacedName))
@@ -609,6 +618,7 @@ func TestPrepareRequestData(t *testing.T) {
 		},
 	}
 	plugin.PreRequest(context.Background(), req1, schedulingResult)
+	plugin.ResponseReceived(context.Background(), req1, nil, endpoint1.GetMetadata())
 	plugin.wg.Wait()
 
 	// Second request that shares a prefix.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:

This PR updates the prefixCacheScorer plugin to defer updating the cache index and recording metrics until
the ResponseReceived phase. This will prevent the case when request is shedded the prefix cache index is still updated.

See: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/971#issuecomment-3728007924 and https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/971#issuecomment-3728046693

Changes:
1. Moved the indexer update logic from PreRequest to ResponseReceived to ensure only served requests update
     the cache (avoiding updates from shedded requests).
2. Updated SchedulingContextState for prefixCacheScorer to persist selected servers and metric stats across the request lifecycle for ResponseReceived to process. This will prevent a larger refactor since the interface of `ResponseReceived` only have `targetPod *datalayer.EndpointMetadata`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially #971

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Almost none, delayed the prefix cache update just after response is received.
```
