### PR TITLE
fix: [Flow Control]: Optionally disable endpoint subset filtering while dispatching requests

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -308,10 +308,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// --- Admission Control Initialization ---
 	var admissionController requestcontrol.AdmissionController
 	var locator contracts.PodLocator
-	locatorCfg := requestcontrol.PodLocatorConfig {
-		DisableEndpointSubsetFilter: opts.DisableEndpointSubsetFilter,
-	}
-	locator = requestcontrol.NewDatastorePodLocator(ds, locatorCfg)
+	locator = requestcontrol.NewDatastorePodLocator(ds, requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter))
 	if r.featureGates[flowcontrol.FeatureGate] {
 		locator = requestcontrol.NewCachedPodLocator(ctx, locator, time.Millisecond*50)
 		setupLog.Info("Initializing experimental Flow Control layer")

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -659,7 +659,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				}
 				config = config.WithAdmissionPlugins(newMockAdmissionPlugin("test-admit-plugin", test.admitRequestDenialError))
 
-				locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds, PodLocatorConfig{}), time.Minute)
+				locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
 				director := NewDirectorWithConfig(ds, mockSched, test.mockAdmissionController, locator, config)
 				if test.name == "successful request with model rewrite" {
 					mockDs := &mockDatastore{
@@ -667,7 +667,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 						rewrites: []*v1alpha2.InferenceModelRewrite{rewrite},
 					}
 					director.datastore = mockDs
-					director.podLocator = NewCachedPodLocator(context.Background(), NewDatastorePodLocator(mockDs, PodLocatorConfig{}), time.Minute)
+					director.podLocator = NewCachedPodLocator(context.Background(), NewDatastorePodLocator(mockDs), time.Minute)
 				}
 
 				reqCtx := &handlers.RequestContext{
@@ -956,7 +956,7 @@ func TestDirector_ApplyWeightedModelRewrite(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockDs := &mockDatastore{rewrites: test.rewrites}
-			locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(mockDs, PodLocatorConfig{}), time.Minute)
+			locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(mockDs), time.Minute)
 			director := NewDirectorWithConfig(mockDs, &mockScheduler{}, &mockAdmissionController{}, locator, NewConfig())
 
 			reqCtx := &handlers.RequestContext{
@@ -1057,7 +1057,7 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	ds := datastore.NewDatastore(t.Context(), nil, 0)
 	mockSched := &mockScheduler{}
-	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds, PodLocatorConfig{}), time.Minute)
+	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
 	director := NewDirectorWithConfig(
 		ds,
 		mockSched,
@@ -1101,7 +1101,7 @@ func TestDirector_HandleResponseStreaming(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	ds := datastore.NewDatastore(t.Context(), nil, 0)
 	mockSched := &mockScheduler{}
-	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds, PodLocatorConfig{}), time.Minute)
+	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
 	director := NewDirectorWithConfig(ds, mockSched, nil, locator, NewConfig().WithResponseStreamingPlugins(ps1))
 
 	reqCtx := &handlers.RequestContext{
@@ -1138,7 +1138,7 @@ func TestDirector_HandleResponseComplete(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	ds := datastore.NewDatastore(t.Context(), nil, 0)
 	mockSched := &mockScheduler{}
-	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds, PodLocatorConfig{}), time.Minute)
+	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
 	director := NewDirectorWithConfig(ds, mockSched, nil, locator, NewConfig().WithResponseCompletePlugins(pc1))
 
 	reqCtx := &handlers.RequestContext{

--- a/pkg/epp/requestcontrol/locator.go
+++ b/pkg/epp/requestcontrol/locator.go
@@ -56,6 +56,16 @@ type PodLocatorConfig struct {
 	DisableEndpointSubsetFilter bool
 }
 
+// LocatorOption is a function that configures the PodLocatorConfig.
+type LocatorOption func(*PodLocatorConfig)
+
+// WithDisableEndpointSubsetFilter sets the DisableEndpointSubsetFilter flag.
+func WithDisableEndpointSubsetFilter(disable bool) LocatorOption {
+	return func(c *PodLocatorConfig) {
+		c.DisableEndpointSubsetFilter = disable
+	}
+}
+
 // DatastorePodLocator implements contracts.PodLocator by querying the EPP Datastore.
 // It centralizes the logic for resolving candidate pods based on request metadata (specifically Envoy subset filters).
 type DatastorePodLocator struct {
@@ -66,7 +76,13 @@ type DatastorePodLocator struct {
 var _ contracts.PodLocator = &DatastorePodLocator{}
 
 // NewDatastorePodLocator creates a new DatastorePodLocator.
-func NewDatastorePodLocator(ds Datastore, cfg PodLocatorConfig) *DatastorePodLocator {
+func NewDatastorePodLocator(ds Datastore, opts ...LocatorOption) *DatastorePodLocator {
+	cfg := PodLocatorConfig{
+		DisableEndpointSubsetFilter: false,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	return &DatastorePodLocator{
 		datastore: ds,
 		config:    cfg,

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -168,9 +168,7 @@ func NewTestHarness(t *testing.T, ctx context.Context) *TestHarness {
 		MetricsStalenessThreshold: utilizationdetector.DefaultMetricsStalenessThreshold,
 	}
 	runner.SaturationDetector = utilizationdetector.NewDetector(sdConfig, logger.WithName("sd"))
-	locator := requestcontrol.NewDatastorePodLocator(runner.Datastore, requestcontrol.PodLocatorConfig {
-		DisableEndpointSubsetFilter: false,
-	})
+	locator := requestcontrol.NewDatastorePodLocator(runner.Datastore)
 	runner.Director = requestcontrol.NewDirectorWithConfig(
 		runner.Datastore,
 		scheduling.NewSchedulerWithConfig(schedulerConfig),


### PR DESCRIPTION
Fixes a bug where queued requests during Scale-from-Zero fail to be dispatched due to stale `x-gateway-destination-endpoint-subset` metadata.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind bug
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
This PR adds an option to disable subset filtering in EPP. If we don't disable subset filtering, all requests sent during SFZ will timeout and fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2117

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
It introduces a user-facing option that can be configured to disable subset filtering.

```
