### PR TITLE
feat: add kvcache_utilization_normalized scorer.

### DIFF
--- a/pkg/epp/scheduling/framework/plugins/scorer/kvcache_utilization_test.go
+++ b/pkg/epp/scheduling/framework/plugins/scorer/kvcache_utilization_test.go
@@ -18,9 +18,11 @@ package scorer
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	types "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
@@ -29,11 +31,13 @@ import (
 func TestKvCacheUtilizationScorer(t *testing.T) {
 	tests := []struct {
 		name                   string
+		normalizeScore         bool
 		endpoints              []types.Endpoint
 		expectedScoresEndpoint map[int]float64 // Map of endpoint index to expected score
 	}{
 		{
-			name: "Different KV cache utilization",
+			name:           "Absolute: Different KV cache utilization",
+			normalizeScore: false,
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.8}},
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
@@ -46,7 +50,8 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 			},
 		},
 		{
-			name: "Same KV cache utilization",
+			name:           "Absolute: Same KV cache utilization",
+			normalizeScore: false,
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.6}},
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.6}},
@@ -57,7 +62,8 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 			},
 		},
 		{
-			name: "Zero KV cache utilization",
+			name:           "Absolute: Zero KV cache utilization",
+			normalizeScore: false,
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.0}},
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.0}},
@@ -68,7 +74,7 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 			},
 		},
 		{
-			name: "Full KV cache utilization",
+			name: "Absolute: Full KV cache utilization",
 			endpoints: []types.Endpoint{
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 1.0}},
 				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
@@ -78,15 +84,112 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 				1: 0.5, // Half KV cache (0.5) gets medium score (1-0.5=0.5)
 			},
 		},
+		{
+			name:           "Normalized: Different KV cache utilization",
+			normalizeScore: true,
+			endpoints: []types.Endpoint{
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.1}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.9}},
+			},
+			expectedScoresEndpoint: map[int]float64{
+				0: 1.0, // (0.9 - 0.1) / (0.9 - 0.1) = 1.0
+				1: 0.5, // (0.9 - 0.5) / (0.9 - 0.1) = 0.5
+				2: 0.0, // (0.9 - 0.9) / (0.9 - 0.1) = 0.0
+			},
+		},
+		{
+			name:           "Normalized: All same utilization",
+			normalizeScore: true,
+			endpoints: []types.Endpoint{
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
+			},
+			expectedScoresEndpoint: map[int]float64{
+				0: 1.0,
+				1: 1.0,
+			},
+		},
+		{
+			name:           "Normalized: Utilization smaller than tolerance",
+			normalizeScore: true,
+			endpoints: []types.Endpoint{
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.5}},
+				&types.PodMetrics{EndpointMetadata: &datalayer.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, Metrics: &datalayer.Metrics{KVCacheUsagePercent: 0.500001}},
+			},
+			expectedScoresEndpoint: map[int]float64{
+				0: 1.0,
+				1: 1.0,
+			},
+		},
+		{
+			name:                   "Normalized: Empty endpoints",
+			normalizeScore:         true,
+			endpoints:              []types.Endpoint{},
+			expectedScoresEndpoint: map[int]float64{},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scores := NewKVCacheUtilizationScorer().Score(context.Background(), types.NewCycleState(), &types.LLMRequest{}, test.endpoints)
+			scorer := NewKVCacheUtilizationScorer(test.normalizeScore)
+			scores := scorer.Score(context.Background(), types.NewCycleState(), &types.LLMRequest{}, test.endpoints)
 
 			for i, endpoint := range test.endpoints {
 				expectedScore := test.expectedScoresEndpoint[i]
 				assert.InDelta(t, expectedScore, scores[endpoint], 0.0001, "Endpoint %d should have score %f", i, expectedScore)
+			}
+		})
+	}
+}
+
+func TestKvCacheUtilizationScorerFactory(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     json.RawMessage
+		wantNorm bool
+		wantErr  bool
+	}{
+		{
+			name:     "Empty args (default)",
+			args:     nil,
+			wantNorm: false,
+			wantErr:  false,
+		},
+		{
+			name:     "Explicit normalize false",
+			args:     json.RawMessage(`{"normalizeScore": false}`),
+			wantNorm: false,
+			wantErr:  false,
+		},
+		{
+			name:     "Explicit normalize true",
+			args:     json.RawMessage(`{"normalizeScore": true}`),
+			wantNorm: true,
+			wantErr:  false,
+		},
+		{
+			name:    "Invalid JSON",
+			args:    json.RawMessage(`{invalid}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := KvCacheUtilizationScorerFactory(KvCacheUtilizationScorerType, tt.args, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KvCacheUtilizationScorerFactory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				scorer := p.(*KVCacheUtilizationScorer)
+				if scorer.normalizeScore != tt.wantNorm {
+					t.Errorf("expected normalizeScore %v, got %v", tt.wantNorm, scorer.normalizeScore)
+				}
+				if scorer.TypedName().Name != KvCacheUtilizationScorerType {
+					t.Errorf("expected name 'kv-cache-utilization-scorer', got %s", scorer.TypedName().Name)
+				}
 			}
 		})
 	}

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -35,7 +35,7 @@ import (
 
 // Tests the default scheduler configuration and expected behavior.
 func TestSchedule(t *testing.T) {
-	kvCacheUtilizationScorer := scorer.NewKVCacheUtilizationScorer()
+	kvCacheUtilizationScorer := scorer.NewKVCacheUtilizationScorer(false)
 	queueingScorer := scorer.NewQueueScorer()
 	prefixCacheScorer := prefix.New(context.Background(), prefix.DefaultConfig)
 	loraAffinityScorer := scorer.NewLoraAffinityScorer()

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -194,7 +194,7 @@ func NewTestHarness(t *testing.T, ctx context.Context, opts ...HarnessOption) *T
 
 	defaultProfile := framework.NewSchedulerProfile().
 		WithScorers(
-			framework.NewWeightedScorer(scorer.NewKVCacheUtilizationScorer(), 1),
+			framework.NewWeightedScorer(scorer.NewKVCacheUtilizationScorer(false), 1),
 			framework.NewWeightedScorer(scorer.NewQueueScorer(), 1),
 			framework.NewWeightedScorer(prefix.New(ctx, prefix.DefaultConfig), 1),
 			framework.NewWeightedScorer(scorer.NewLoraAffinityScorer(), 1),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
Add a new scorer kv-cache-utilization-normalized-scorer. It scores endpoints based on their KV cache utilization relative to **other** candidates.

The existing/old kv-cache-utilization-scorer:
1. unlike other existing scorers(prefix, queue, running), it's absolute scoring. Thus, the score is sensitive to workload. If the workload is high, the kv utilization is high. 
2. if all candidates have similar utilization (e.g., all are at ~90%), the score differences are
  negligible (e.g., 0.10 vs 0.11).



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add a normalize parameter to kv-cache-utilization-scorer

Now people can use to use normalized score for kv-cache-utilization-scorer


- type: kv-cache-utilization-scorer
  parameters:
    normalizeScore: true

# default to false
```
