### PR TITLE
controller: extend flow lease scope to fix orphaned queues #1982

### DIFF
--- a/pkg/epp/flowcontrol/registry/connection.go
+++ b/pkg/epp/flowcontrol/registry/connection.go
@@ -21,8 +21,9 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 )
 
-// connection is the concrete, un-exported implementation of the `contracts.ActiveFlowConnection` interface.
-// It is a temporary handle created for the duration of a single `WithConnection` call.
+// connection is the concrete, un-exported implementation of the contracts.ActiveFlowConnection interface.
+// It represents a scoped lease that pins the flow state in memory, preventing garbage collection for the duration of
+// the session.
 type connection struct {
 	registry *FlowRegistry
 	key      types.FlowKey
@@ -41,4 +42,9 @@ func (c *connection) ActiveShards() []contracts.RegistryShard {
 		shardsCopy[i] = s
 	}
 	return shardsCopy
+}
+
+// FlowKey returns the immutable identity of the flow this connection is pinned to.
+func (c *connection) FlowKey() types.FlowKey {
+	return c.key
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes a race condition (Issue #1982) where the Flow Registry Garbage Collector could delete a Flow while it still had active requests waiting in a queue.

**The Bug**

Previously, `EnqueueAndWait` only acquired a Registry lease during the *distribution phase* (selecting a shard). Once the request was submitted to a shard's queue, the lease was released. In scenarios like "Scale from Zero," where requests sit in queues for longer than `FlowGCTimeout` without new incoming traffic, the Registry would see the flow as "Idle" (0 leases) and delete it. This orphaned the queues, causing requests to time out silently.

**The Fix**

We now extend the scope of `WithConnection` to cover the entire request lifecycle, from distribution until finalization (dispatch or timeout).
*   The flow remains "pinned" in memory as long as at least one request is active or queued.
*   The GC will correctly skip these flows during its sweep phase.

**Safety Note**
This change is only safe because of **PR #2127** (Optimistic Concurrency).
*   **Old Behavior (Mutex):** Holding a lease for minutes would have blocked the GC's Write Lock, which would have blocked all subsequent Read Locks, causing a total DoS on the system.
*   **New Behavior (Atomic):** We can hold the lease indefinitely. The GC simply sees `leaseCount > 0` via an atomic load and skips the flow without blocking.

**Which issue(s) this PR fixes**:
Fixes #1982

_Reviewer Notes:_

*   This PR must not be merged until **PR #2127** is merged.
*   **Interface Change:** Added `FlowKey()` to the `ActiveFlowConnection` contract. While not strictly necessary, this allows us to pass just the connection object down the stack, enforcing encapsulation.
*   **Testing:** Added `Regression_LeaseHeldDuringQueueing` to `controller_test.go`, which uses channels to deterministically prove the lease is not released while the processor is blocked.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug where flows could be garbage collected while requests were still queued during long wait times with no new traffic (e.g., scale-from-zero).
```

/hold
Waiting for PR #2127