### PR TITLE
Removed duplicated field in log message

### DIFF
--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -404,13 +404,12 @@ func (sp *ShardProcessor) runCleanupSweep(ctx context.Context) {
 // memory.
 func (sp *ShardProcessor) sweepFinalizedItems() {
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
-		key := managedQ.FlowQueueAccessor().FlowKey()
 		predicate := func(itemAcc types.QueueItemAccessor) bool {
 			return itemAcc.(*FlowItem).FinalState() != nil
 		}
 		removedItems := managedQ.Cleanup(predicate)
 		logger.V(logutil.DEBUG).Info("Swept finalized items and released capacity.",
-			"flowKey", key, "count", len(removedItems))
+			"count", len(removedItems))
 	}
 	sp.processAllQueuesConcurrently("sweepFinalizedItems", processFn)
 }
@@ -461,7 +460,7 @@ func (sp *ShardProcessor) evictAll() {
 			// Finalization is idempotent; safe to call even if already finalized externally.
 			item.FinalizeWithOutcome(outcome, errShutdown)
 			logger.V(logutil.TRACE).Info("Item evicted during shutdown.",
-				"flowKey", key, "reqID", item.OriginalRequest().ID())
+				"reqID", item.OriginalRequest().ID())
 		}
 	}
 	sp.processAllQueuesConcurrently("evictAll", processFn)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Two log messages in the FlowControl component repeat a data field.

Here is an example log message with the issue:
```json
{"level":"Level(-4)","ts":"2026-01-13T15:55:57Z","logger":"flow-controller.sweepFinalizedItems","caller":"internal/processor.go:412","msg":"Swept finalized items and released capacity.","shardID":"shard-0000","flowKey":"default-flow:0","flowID":"default-flow","flowPriority":0,"flowKey":"default-flow:0","count":0}
```

The flowKey field is repeated twice.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
