### PR TITLE
Increase default FlowGCTimeout to 1h to prevent premature GC

### DIFF
--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -46,7 +46,9 @@ const (
 	defaultInitialShardCount int = 1
 	// defaultFlowGCTimeout is the default duration of inactivity after which an idle flow is garbage collected.
 	// This also serves as the interval for the periodic garbage collection scan.
-	defaultFlowGCTimeout time.Duration = 5 * time.Minute
+	// TODO:(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1982) revert to 5m once this GC
+	// race condition is properly resolved.
+	defaultFlowGCTimeout time.Duration = 1 * time.Hour
 	// defaultEventChannelBufferSize is the default size of the buffered channel for control plane events.
 	defaultEventChannelBufferSize int = 4096
 )
@@ -127,7 +129,7 @@ type Config struct {
 
 	// FlowGCTimeout defines the interval at which the registry scans for and garbage collects idle flows.
 	// A flow is collected if it has been observed to be Idle for at least one full scan interval.
-	// Optional: Defaults to `defaultFlowGCTimeout` (5 minutes).
+	// Optional: Defaults to `defaultFlowGCTimeout` (1 hour).
 	FlowGCTimeout time.Duration
 
 	// EventChannelBufferSize defines the size of the buffered channel used for internal control plane events.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR increases the default `FlowGCTimeout` to **1 hour**.

**Context**

Currently, the Flow Registry's garbage collector relies on a `leaseCount` that tracks the distribution phase but not the queueing phase. If a request sits in the queue waiting for a backend (e.g., waiting for a Pod to spin up) longer than the configured GC timeout (and no new traffic for the flow arrives during this time), the Registry mistakenly identifies the flow as "Idle" and deletes the queue resources, causing the request to be orphaned. This is difficult to trigger under normal load, but it is relevant for Scale from Zero.

**The Fix**

By increasing the default timeout to `1h`, we ensure that the GC timeout is strictly larger than any realistic queueing duration (which will likely hit client timeouts or other limits first). This makes the race condition unreachable in practice without requiring complex architectural changes in the release candidate.

A full architectural fix (switching to optimistic concurrency and lifecycle-aware leasing) is targeted for the next release cycle.

**Which issue(s) this PR fixes**:
Hack for #1982

**Does this PR introduce a user-facing change?**:
```release-note
Increased the default Flow Control garbage collection timeout to 1 hour. This prevents the accidental deletion of active flows during long queueing periods, improving stability during scale-from-zero.
```