### PR TITLE
LatencyPredictor requests handle Completions and ChatCompletions format

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/latencypredictor_helper.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/latencypredictor_helper.go
@@ -85,7 +85,7 @@ func processPreRequestForLatencyPrediction(
 
 	in := latencypredictor.PredictionRequest{
 		KVCachePercentage:  m.KVCacheUsagePercent,
-		InputTokenLength:   len(strings.Fields(predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt)),
+		InputTokenLength:   len(strings.Fields(requtil.GetPromptText(&predictedLatencyCtx.schedulingRequest))),
 		NumRequestWaiting:  m.WaitingQueueSize,
 		NumRequestRunning:  m.RunningRequestsSize,
 		NumTokensGenerated: 0,
@@ -172,7 +172,7 @@ func recordTTFTTrainingData(
 	// Train TTFT
 	entry := latencypredictor.TrainingEntry{
 		KVCachePercentage:  m.KVCacheUsagePercent,
-		InputTokenLength:   len(strings.Fields(predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt)),
+		InputTokenLength:   len(strings.Fields(requtil.GetPromptText(&predictedLatencyCtx.schedulingRequest))),
 		ActualTTFT:         predictedLatencyCtx.ttft,
 		ActualTPOT:         0,
 		Timestamp:          now,
@@ -202,7 +202,7 @@ func predictFirstTPOT(
 	// Predict first TPOT
 	in := latencypredictor.PredictionRequest{
 		KVCachePercentage:  m.KVCacheUsagePercent,
-		InputTokenLength:   len(strings.Fields(predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt)),
+		InputTokenLength:   len(strings.Fields(requtil.GetPromptText(&predictedLatencyCtx.schedulingRequest))),
 		NumRequestWaiting:  m.WaitingQueueSize,
 		NumRequestRunning:  m.RunningRequestsSize,
 		NumTokensGenerated: predictedLatencyCtx.generatedTokenCount,
@@ -260,7 +260,7 @@ func processTokenForLatencyPrediction(
 	// Record actual TPOT
 	entry := latencypredictor.TrainingEntry{
 		KVCachePercentage:  m.KVCacheUsagePercent,
-		InputTokenLength:   len(strings.Fields(predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt)),
+		InputTokenLength:   len(strings.Fields(requtil.GetPromptText(&predictedLatencyCtx.schedulingRequest))),
 		ActualTTFT:         0,
 		ActualTPOT:         latencyMs,
 		Timestamp:          now,
@@ -277,7 +277,7 @@ func processTokenForLatencyPrediction(
 	if predictedLatencyCtx.tokenSampler.shouldPredict(predictedLatencyCtx.generatedTokenCount) {
 		in := latencypredictor.PredictionRequest{
 			KVCachePercentage:  m.KVCacheUsagePercent,
-			InputTokenLength:   len(strings.Fields(predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt)),
+			InputTokenLength:   len(strings.Fields(requtil.GetPromptText(&predictedLatencyCtx.schedulingRequest))),
 			NumRequestWaiting:  m.WaitingQueueSize,
 			NumRequestRunning:  m.RunningRequestsSize,
 			NumTokensGenerated: predictedLatencyCtx.generatedTokenCount,

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/prediction.go
@@ -21,9 +21,11 @@ import (
 	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
 )
 
@@ -60,7 +62,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, request *sch
 		logger.V(logutil.DEBUG).Info("Prefix cache score for pod", "pod", endpoint.GetMetadata().String(), "prefixCacheScore", prefixCacheScore)
 
 		metricsStates[i] = endpoint.GetMetrics()
-		prompts[i] = request.Body.Completions.Prompt
+		prompts[i] = requtil.GetPromptText(request)
 		generatedTokenCounts[i] = 1
 		prefixCacheScores[i] = prefixCacheScore
 	}

--- a/pkg/epp/util/request/body.go
+++ b/pkg/epp/util/request/body.go
@@ -126,3 +126,36 @@ func validateChatCompletionsMessages(messages []types.Message) error {
 
 	return nil
 }
+
+// GetPromptText extracts the prompt text from either Completions or ChatCompletions format.
+// For completions requests, it returns the prompt string directly.
+// For chat completions requests, it concatenates all message contents.
+// Returns empty string if the request body is invalid or missing.
+func GetPromptText(request *types.LLMRequest) string {
+	if request == nil || request.Body == nil {
+		return ""
+	}
+
+	// Try Completions format first (assumed to be valid if not nil)
+	if request.Body.Completions != nil {
+		return request.Body.Completions.Prompt
+	}
+
+	// Must be ChatCompletions request at this point
+	if request.Body.ChatCompletions != nil && len(request.Body.ChatCompletions.Messages) > 0 {
+		// Concatenate all message contents
+		var result string
+		for i, msg := range request.Body.ChatCompletions.Messages {
+			text := msg.Content.PlainText()
+			if text != "" {
+				if i > 0 && result != "" {
+					result += " "
+				}
+				result += text
+			}
+		}
+		return result
+	}
+
+	return ""
+}


### PR DESCRIPTION
Issue: Currently Latency Predictor assumes the SchedulingRequest to be in the Completions format. 
Solution: Adds support for ChatCompletions format