### PR TITLE
feat: Add a FirstTokenReceived plugin interface

### DIFF
--- a/pkg/epp/requestcontrol/plugins.go
+++ b/pkg/epp/requestcontrol/plugins.go
@@ -25,11 +25,10 @@ import (
 )
 
 const (
-	PreRequestExtensionPoint          = "PreRequest"
-	ResponseReceivedExtensionPoint    = "ResponseReceived"
-	ResponseStreamingExtensionPoint   = "ResponseStreaming"
-	ResponseCompleteExtensionPoint    = "ResponseComplete"
-	FirstTokenReceivedExtensionPoint  = "FirstTokenReceived"
+	PreRequestExtensionPoint        = "PreRequest"
+	ResponseReceivedExtensionPoint  = "ResponseReceived"
+	ResponseStreamingExtensionPoint = "ResponseStreaming"
+	ResponseCompleteExtensionPoint  = "ResponseComplete"
 )
 
 // PreRequest is called by the director after a getting result from scheduling layer and
@@ -64,14 +63,6 @@ type ResponseStreaming interface {
 type ResponseComplete interface {
 	plugins.Plugin
 	ResponseComplete(ctx context.Context, request *types.LLMRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
-}
-
-// FirstTokenReceived is called by the director when the first token of a streaming response is received.
-// This is useful for plugins that need to perform actions at the time-to-first-token (TTFT) moment,
-// such as marking prefill completion in disaggregated inference architectures.
-type FirstTokenReceived interface {
-	plugins.Plugin
-	FirstTokenReceived(ctx context.Context, request *types.LLMRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
 // PrepareRequestData is called by the director before scheduling requests.

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -23,25 +23,23 @@ import (
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
-		admissionPlugins:          []AdmissionPlugin{},
-		prepareDataPlugins:        []PrepareDataPlugin{},
-		preRequestPlugins:         []PreRequest{},
-		responseReceivedPlugins:   []ResponseReceived{},
-		responseStreamingPlugins:  []ResponseStreaming{},
-		responseCompletePlugins:   []ResponseComplete{},
-		firstTokenReceivedPlugins: []FirstTokenReceived{},
+		admissionPlugins:         []AdmissionPlugin{},
+		prepareDataPlugins:       []PrepareDataPlugin{},
+		preRequestPlugins:        []PreRequest{},
+		responseReceivedPlugins:  []ResponseReceived{},
+		responseStreamingPlugins: []ResponseStreaming{},
+		responseCompletePlugins:  []ResponseComplete{},
 	}
 }
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
-	admissionPlugins          []AdmissionPlugin
-	prepareDataPlugins        []PrepareDataPlugin
-	preRequestPlugins         []PreRequest
-	responseReceivedPlugins   []ResponseReceived
-	responseStreamingPlugins  []ResponseStreaming
-	responseCompletePlugins   []ResponseComplete
-	firstTokenReceivedPlugins []FirstTokenReceived
+	admissionPlugins         []AdmissionPlugin
+	prepareDataPlugins       []PrepareDataPlugin
+	preRequestPlugins        []PreRequest
+	responseReceivedPlugins  []ResponseReceived
+	responseStreamingPlugins []ResponseStreaming
+	responseCompletePlugins  []ResponseComplete
 }
 
 // WithPreRequestPlugins sets the given plugins as the PreRequest plugins.
@@ -69,13 +67,6 @@ func (c *Config) WithResponseStreamingPlugins(plugins ...ResponseStreaming) *Con
 // If the Config has ResponseComplete plugins already, this call replaces the existing plugins with the given ones.
 func (c *Config) WithResponseCompletePlugins(plugins ...ResponseComplete) *Config {
 	c.responseCompletePlugins = plugins
-	return c
-}
-
-// WithFirstTokenReceivedPlugins sets the given plugins as the FirstTokenReceived plugins.
-// If the Config has FirstTokenReceived plugins already, this call replaces the existing plugins with the given ones.
-func (c *Config) WithFirstTokenReceivedPlugins(plugins ...FirstTokenReceived) *Config {
-	c.firstTokenReceivedPlugins = plugins
 	return c
 }
 
@@ -107,9 +98,6 @@ func (c *Config) AddPlugins(pluginObjects ...plugins.Plugin) {
 		}
 		if responseCompletePlugin, ok := plugin.(ResponseComplete); ok {
 			c.responseCompletePlugins = append(c.responseCompletePlugins, responseCompletePlugin)
-		}
-		if firstTokenReceivedPlugin, ok := plugin.(FirstTokenReceived); ok {
-			c.firstTokenReceivedPlugins = append(c.firstTokenReceivedPlugins, firstTokenReceivedPlugin)
 		}
 		if prepareDataPlugin, ok := plugin.(PrepareDataPlugin); ok {
 			c.prepareDataPlugins = append(c.prepareDataPlugins, prepareDataPlugin)

--- a/pkg/epp/requestcontrol/types.go
+++ b/pkg/epp/requestcontrol/types.go
@@ -26,6 +26,10 @@ type Response struct {
 	Body string
 	// IsStreaming indicates whether or not the response is being streamed by the model
 	IsStreaming bool
+	// IsFirstToken when true indicates this is the first chunk of a streaming response.
+	// This is useful for plugins that need to perform actions at the time-to-first-token (TTFT) moment,
+	// such as marking prefill completion in disaggregated inference architectures.
+	IsFirstToken bool
 	// EndOfStream when true indicates that this invocation contains the last chunk of the response
 	EndOfStream bool
 	// ReqMetadata is a map of metadata that can be passed from Envoy.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
During Disag serving the EPP needs to know when the first token was received so that the kv-router can receive the Prefill Complete event and do book keeping like decrement the token count. 
If we were to add the IsFirstToken field to the Response struct we can then use it in the ResponseStreaming interface implementation of the Scorer plugin to trigger the book keeping operation as below:

func (k *KVAwareScorer) ResponseStreaming(
    ctx context.Context,
    request *schedtypes.LLMRequest,
    response *rc.Response,
    targetPod *datalayer.EndpointMetadata,
) {
    if response.IsFirstToken {
        CallMarkPrefillComplete(request.RequestId)
    }
}

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
