### PR TITLE
feat: Allow request control plugins to return ext_proc dynamic metadata

### DIFF
--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"maps"
 	"strconv"
 	"time"
 
@@ -98,6 +99,14 @@ func (s *StreamingServer) generateRequestHeaderResponse(ctx context.Context, req
 	// The Endpoint Picker supports two approaches to communicating the target endpoint, as a request header
 	// and as an unstructure ext-proc response metadata key/value pair. This enables different integration
 	// options for gateway providers.
+	dynamicMetadata := s.generateMetadata(reqCtx.TargetEndpoint)
+	if reqCtx.Response.DynamicMetadata != nil {
+		if dynamicMetadata.Fields == nil {
+			dynamicMetadata.Fields = make(map[string]*structpb.Value)
+		}
+		maps.Copy(dynamicMetadata.Fields, reqCtx.Response.DynamicMetadata.Fields)
+	}
+
 	return &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestHeaders{
 			RequestHeaders: &extProcPb.HeadersResponse{
@@ -109,7 +118,7 @@ func (s *StreamingServer) generateRequestHeaderResponse(ctx context.Context, req
 				},
 			},
 		},
-		DynamicMetadata: s.generateMetadata(reqCtx.TargetEndpoint),
+		DynamicMetadata: dynamicMetadata,
 	}
 }
 

--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -23,6 +23,7 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
@@ -105,4 +106,47 @@ func TestGenerateHeaders_Sanitization(t *testing.T) {
 	assert.NotContains(t, gotHeaders, metadata.ObjectiveKey)
 	assert.Equal(t, "1.2.3.4:8080", gotHeaders[metadata.DestinationEndpointKey])
 	assert.Equal(t, "123", gotHeaders["Content-Length"])
+}
+
+func TestGenerateRequestHeaderResponse_MergeMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := &StreamingServer{}
+	reqCtx := &RequestContext{
+		TargetEndpoint: "1.2.3.4:8080",
+		Request: &Request{
+			Headers: make(map[string]string),
+		},
+		Response: &Response{
+			DynamicMetadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"existing_namespace": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"existing_key": {Kind: &structpb.Value_StringValue{StringValue: "existing_value"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp := server.generateRequestHeaderResponse(context.Background(), reqCtx)
+
+	// Check that the existing metadata is preserved
+	existingNamespace, ok := resp.DynamicMetadata.Fields["existing_namespace"]
+	assert.True(t, ok, "Expected existing_namespace to be in DynamicMetadata")
+	existingKey, ok := existingNamespace.GetStructValue().Fields["existing_key"]
+	assert.True(t, ok, "Expected existing_key to be in existing_namespace")
+	assert.Equal(t, "existing_value", existingKey.GetStringValue(), "Unexpected value for existing_key")
+
+	// Check that the new metadata is added
+	endpointNamespace, ok := resp.DynamicMetadata.Fields[metadata.DestinationEndpointNamespace]
+	assert.True(t, ok, "Expected DestinationEndpointNamespace to be in DynamicMetadata")
+	endpointKey, ok := endpointNamespace.GetStructValue().Fields[metadata.DestinationEndpointKey]
+	assert.True(t, ok, "Expected DestinationEndpointKey to be in DestinationEndpointNamespace")
+	assert.Equal(t, "1.2.3.4:8080", endpointKey.GetStringValue(), "Unexpected value for DestinationEndpointKey")
 }

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
+	handlerstypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
@@ -46,7 +47,7 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 	}
 	if response["usage"] != nil {
 		usg := response["usage"].(map[string]any)
-		usage := Usage{
+		usage := handlerstypes.Usage{
 			PromptTokens:     int(usg["prompt_tokens"].(float64)),
 			CompletionTokens: int(usg["completion_tokens"].(float64)),
 			TotalTokens:      int(usg["total_tokens"].(float64)),
@@ -54,7 +55,7 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 		if usg["prompt_token_details"] != nil {
 			detailsMap := usg["prompt_token_details"].(map[string]any)
 			if cachedTokens, ok := detailsMap["cached_tokens"]; ok {
-				usage.PromptTokenDetails = &PromptTokenDetails{
+				usage.PromptTokenDetails = &handlerstypes.PromptTokenDetails{
 					CachedTokens: int(cachedTokens.(float64)),
 				}
 			}
@@ -203,14 +204,7 @@ func parseRespForUsage(ctx context.Context, responseText string) ResponseBody {
 }
 
 type ResponseBody struct {
-	Usage Usage `json:"usage"`
-}
-
-type Usage struct {
-	PromptTokens       int                 `json:"prompt_tokens"`
-	CompletionTokens   int                 `json:"completion_tokens"`
-	TotalTokens        int                 `json:"total_tokens"`
-	PromptTokenDetails *PromptTokenDetails `json:"prompt_token_details,omitempty"`
+	Usage handlerstypes.Usage `json:"usage"`
 }
 
 type PromptTokenDetails struct {

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -31,10 +31,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
+	handlerstypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
 	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
@@ -82,7 +84,7 @@ type RequestContext struct {
 	RequestReceivedTimestamp  time.Time
 	ResponseCompleteTimestamp time.Time
 	RequestSize               int
-	Usage                     Usage
+	Usage                     handlerstypes.Usage
 	ResponseSize              int
 	ResponseComplete          bool
 	ResponseStatusCode        string
@@ -111,7 +113,8 @@ type Request struct {
 	Metadata map[string]any
 }
 type Response struct {
-	Headers map[string]string
+	Headers         map[string]string
+	DynamicMetadata *structpb.Struct
 }
 type StreamRequestState int
 

--- a/pkg/epp/handlers/types/types.go
+++ b/pkg/epp/handlers/types/types.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+type Usage struct {
+	PromptTokens       int                 `json:"prompt_tokens"`
+	CompletionTokens   int                 `json:"completion_tokens"`
+	TotalTokens        int                 `json:"total_tokens"`
+	PromptTokenDetails *PromptTokenDetails `json:"prompt_token_details,omitempty"`
+}
+
+type PromptTokenDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -314,8 +314,10 @@ func (d *Director) HandleResponseBodyComplete(ctx context.Context, reqCtx *handl
 	logger := log.FromContext(ctx).WithValues("stage", "bodyChunk")
 	logger.V(logutil.DEBUG).Info("Entering HandleResponseBodyComplete")
 	response := &Response{
-		RequestId: reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
-		Headers:   reqCtx.Response.Headers,
+		RequestId:       reqCtx.Request.Headers[requtil.RequestIdHeaderKey],
+		Headers:         reqCtx.Response.Headers,
+		DynamicMetadata: reqCtx.Response.DynamicMetadata,
+		Usage:           reqCtx.Usage,
 	}
 
 	d.runResponseCompletePlugins(ctx, reqCtx.SchedulingRequest, response, reqCtx.TargetPod)

--- a/pkg/epp/requestcontrol/types.go
+++ b/pkg/epp/requestcontrol/types.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package requestcontrol
 
+import (
+	"google.golang.org/protobuf/types/known/structpb"
+	handlerstypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers/types"
+)
+
 // Response contains information from the response received to be passed to the Response requestcontrol plugins
 type Response struct {
 	// RequestId is the Envoy generated Id for the request being processed
@@ -32,4 +37,9 @@ type Response struct {
 	// It is populated with Envoy's dynamic metadata when ext_proc is processing ProcessingRequest_ResponseHeaders.
 	// Currently, this is only used by conformance test.
 	ReqMetadata map[string]any
+	// Token usage counts parsed from the response body.
+	Usage handlerstypes.Usage
+	// DynamicMetadata is a map of metadata that can be passed to the Envoy. It is populated into the dynamic
+	// metadata when processing ProcessingResponse_RequestHeaders.
+	DynamicMetadata *structpb.Struct
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Here we create a mechanism to pass in the usage struct to the `ResponseBodyComplete` callback and also a mechanism for returning dynamic_metadata out of the callback and into the ext_proc's `ProcessingResponse` object. This will be used by the new plugin introduced in https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2114.

See https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2019 for more details.

**Which issue(s) this PR fixes:**

This contributes to https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2019, but does not fix it.

**Does this PR introduce a user-facing change?**:

No user-facing change.
