### PR TITLE
Fix indention error for latency predictor

### DIFF
--- a/config/charts/inference-extension/templates/_deployment.yaml
+++ b/config/charts/inference-extension/templates/_deployment.yaml
@@ -165,7 +165,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-        {{- include "gateway-api-inference-extension.latencyPredictor.env" . | nindent 8 }}
+        {{- include "gateway-api-inference-extension.latencyPredictor.env" . | nindent 12 }}
         {{- if .Values.inferenceExtension.tracing.enabled }}
             - name: OTEL_SERVICE_NAME
               value: "gateway-api-inference-extension"
@@ -191,26 +191,26 @@ spec:
               value: {{ .Values.inferenceExtension.tracing.sampling.samplerArg | quote }}
         {{- end }}
         {{- if .Values.inferenceExtension.env }}
-        {{- toYaml .Values.inferenceExtension.env | nindent 8 }}
+        {{- toYaml .Values.inferenceExtension.env | nindent 12 }}
         {{- end }}
           volumeMounts:
             - name: plugins-config-volume
               mountPath: "/config"
         {{- if .Values.inferenceExtension.volumeMounts }}
-        {{- toYaml .Values.inferenceExtension.volumeMounts | nindent 8 }}
+        {{- toYaml .Values.inferenceExtension.volumeMounts | nindent 12 }}
         {{- end }}
-      {{- include "gateway-api-inference-extension.latencyPredictor.containers" . | nindent 6 }}
+      {{- include "gateway-api-inference-extension.latencyPredictor.containers" . | nindent 8 }}
       volumes:
       {{- if .Values.inferenceExtension.volumes }}
-      {{- toYaml .Values.inferenceExtension.volumes | nindent 6 }}
+      {{- toYaml .Values.inferenceExtension.volumes | nindent 8 }}
       {{- end }}
       {{- if .Values.inferenceExtension.sidecar.volumes }}
-      {{- tpl (toYaml .Values.inferenceExtension.sidecar.volumes) $ | nindent 6 }}
+      {{- tpl (toYaml .Values.inferenceExtension.sidecar.volumes) $ | nindent 8 }}
       {{- end }}
-      - name: plugins-config-volume
-        configMap:
-          name: {{ include "gateway-api-inference-extension.name" . }}
-      {{- include "gateway-api-inference-extension.latencyPredictor.volumes" . | nindent 6 }}
+        - name: plugins-config-volume
+          configMap:
+            name: {{ include "gateway-api-inference-extension.name" . }}
+      {{- include "gateway-api-inference-extension.latencyPredictor.volumes" . | nindent 8 }}
       {{- if .Values.inferenceExtension.affinity }}
       affinity:
         {{- toYaml .Values.inferenceExtension.affinity | nindent 8 }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
There is a bug when  latency predictor is enabled.

```
❯ helm template latency-predictor \
./inferencepool \
--set inferencePool.modelServers.matchLabels.drepperyaolabel=drpepperyaokey \
--set provider.name=$GATEWAY_PROVIDER \
--set inferenceExtension.monitoring.prometheus.enabled=true \
--set inferenceExtension.latencyPredictor.enabled=true
Error: YAML parse error on inferencepool/templates/epp-deployment.yaml: error converting YAML to JSON: yaml: line 88: did not find expected key

Use --debug flag to render out invalid YAML
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
