### PR TITLE
test: add hermetic coverage for standalone mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/spf13/pflag v1.0.10
+	go.opentelemetry.io/otel/trace v1.39.0
 	sigs.k8s.io/kustomize/api v0.21.0
 	sigs.k8s.io/kustomize/kyaml v0.21.0
 )
@@ -116,7 +117,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -27,6 +27,9 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 )
 
+// DefaultTestPort is the standard port used for mock model servers in tests.
+const DefaultTestPort = 8000
+
 // PodWrapper wraps a Pod.
 type PodWrapper struct {
 	corev1.Pod
@@ -51,7 +54,8 @@ func MakePod(podName string) *PodWrapper {
 	}
 }
 
-// Complete sets necessary fields for a Pod to make it not denied by the apiserver
+// Complete sets necessary fields for a Pod to make it not denied by the apiserver.
+// It applies a default container image and ensures the model server port is exposed.
 func (p *PodWrapper) Complete() *PodWrapper {
 	if p.Pod.Namespace == "" {
 		p.Namespace("default")
@@ -60,6 +64,13 @@ func (p *PodWrapper) Complete() *PodWrapper {
 		{
 			Name:  "mock-vllm",
 			Image: "mock-vllm:latest",
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "http",
+					ContainerPort: DefaultTestPort,
+					Protocol:      corev1.ProtocolTCP,
+				},
+			},
 		},
 	}
 	return p


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR adds hermetic integration test coverage for the EPP **Standalone Mode**.

Recently, a regression in Standalone mode startup logic (fixed in #2092) went undetected because existing integration tests only exercised the Standard (CRD-based) mode. This PR bridges that gap by:

1.  **Updating Test Harness:** Extending `test/integration/epp/harness.go` with `WithStandaloneMode()`. This simulates the CLI-based configuration path by injecting a static `EndpointPool` and disabling Gateway API CRD watchers.
2.  **Refactoring Hermetic Tests:** Updating `hermetic_test.go` to run test permutations in both `Standard` and `Standalone` modes using a table-driven approach.
3.  **Improving Test Infrastructure:** Centralizing default test ports in `wrappers.go` to ensure consistency between the harness and mock pod definitions.

**Which issue(s) this PR fixes**:

Fixes #2091

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```