### PR TITLE
feat(docs): enable content tab linking in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ theme:
     - navigation.tabs
     - navigation.top
     - navigation.expand
+    - content.tabs.link
   palette:
     primary: custom
   custom_dir: site-src/overrides


### PR DESCRIPTION
fixes #2157

enabled https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#linked-content-tabs feature 