### PR TITLE
Add support for video/audio formats for multimodal inputs

### DIFF
--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -134,12 +134,23 @@ type Content struct {
 }
 
 type ContentBlock struct {
-	Type     string     `json:"type"`
-	Text     string     `json:"text,omitempty"`
-	ImageURL ImageBlock `json:"image_url,omitempty"`
+	Type       string     `json:"type"`
+	Text       string     `json:"text,omitempty"`
+	ImageURL   ImageBlock `json:"image_url,omitempty"`
+	InputAudio AudioBlock `json:"input_audio,omitempty"`
+	VideoURL   VideoBlock `json:"video_url,omitempty"`
 }
 
 type ImageBlock struct {
+	Url string `json:"url,omitempty"`
+}
+
+type AudioBlock struct {
+	Data   string `json:"data,omitempty"`
+	Format string `json:"format,omitempty"`
+}
+
+type VideoBlock struct {
 	Url string `json:"url,omitempty"`
 }
 

--- a/pkg/epp/util/request/body_test.go
+++ b/pkg/epp/util/request/body_test.go
@@ -115,6 +115,50 @@ func TestExtractRequestData(t *testing.T) {
 			},
 		},
 		{
+			name: "chat completions request body with audio and video content",
+			body: map[string]any{
+				"model": "test",
+				"messages": []any{
+					map[string]any{
+						"role": "user",
+						"content": []map[string]any{
+							{
+								"type": "input_audio",
+								"input_audio": map[string]any{
+									"data":   "base64data",
+									"format": "wav",
+								},
+							},
+							{
+								"type": "video_url",
+								"video_url": map[string]any{
+									"url": "https://example.com/video.mp4",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &types.LLMRequestBody{
+				ChatCompletions: &types.ChatCompletionsRequest{
+					Messages: []types.Message{
+						{Role: "user", Content: types.Content{
+							Structured: []types.ContentBlock{
+								{
+									Type:       "input_audio",
+									InputAudio: types.AudioBlock{Data: "base64data", Format: "wav"},
+								},
+								{
+									Type:     "video_url",
+									VideoURL: types.VideoBlock{Url: "https://example.com/video.mp4"},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+		{
 			name: "chat completions with all optional fields",
 			body: map[string]any{
 				"model": "test",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

Presently, only image is supported for multimodal inputs. vllm supports video/audio formats as well: https://docs.vllm.ai/en/stable/features/multimodal_inputs/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses #1980

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Support for video and audio formats for multimodal models.
```
