### PR TITLE
Flow Control: Ordering Policy Migration (Phase 1)

### DIFF
--- a/pkg/epp/flowcontrol/framework/doc.go
+++ b/pkg/epp/flowcontrol/framework/doc.go
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package framework defines the core plugin interfaces for extending the `controller.FlowController`.
+// Package framework defines the core plugin interfaces for extending the Flow Control layer.
 //
 // It establishes the contracts that custom logic, such as queueing disciplines and dispatching policies, must adhere
-// to. By building on these interfaces, the Flow Control system can be extended and customized without modifying the
+// to. By building on these interfaces, the Flow Control layer can be extended and customized without modifying the
 // core controller logic.
 //
 // The primary contracts are:
-//   - `SafeQueue`: An interface for concurrent-safe queue implementations.
-//   - `IntraFlowDispatchPolicy`: An interface for policies that decide which item to select from within a single flow's
-//     queue.
-//   - `ItemComparator`: An interface vended by policies to make their internal item-ordering logic explicit and
-//     available to other components.
+//   - SafeQueue: An interface for concurrent-safe queue implementations.
+//   - FairnessPolicy: The interface for policies that govern the competition between flows.
+//   - OrderingPolicy: The interface for policies that decide the strict sequence of service within a flow.
+//   - IntraFlowDispatchPolicy: (Deprecated) Legacy interface for intra-flow ordering. Replaced by OrderingPolicy.
+//   - ItemComparator: (Deprecated) Legacy interface for exposing ordering logic. Replaced by OrderingPolicy.
 //
-// These components are linked by `QueueCapability`, which allows policies to declare their queue requirements (e.g.,
+// These components are linked by QueueCapability, which allows policies to declare their queue requirements (e.g.,
 // FIFO or priority-based ordering).
 package framework

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/doc.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/doc.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package intraflow provides the standard implementations of the OrderingPolicy interface.
+//
+// # Context: The 3-Tier Dispatch Hierarchy
+//
+// The Flow Control system manages traffic using a strict three-tier decision hierarchy.
+// This package implements Tier 3.
+//
+//  1. Priority (Band Selection):
+//     The system first strictly selects the highest-priority Band that has pending work.
+//
+//  2. Fairness (Flow Selection):
+//     Once a Band is selected, the FairnessPolicy (interflow) determines which Flow within that band gets the next
+//     dispatch opportunity.
+//
+//  3. Ordering (Item Selection) - [THIS PACKAGE]:
+//     Once a Flow is selected, the OrderingPolicy determines which Request from that specific flow's queue is
+//     dispatched. This governs the "internal discipline" of the flow (e.g., whether to serve oldest requests first or
+//     most urgent).
+//
+// # Architecture: The Flyweight Pattern
+//
+// Ordering Policies are Singletons. A single instance handles the ordering logic for all queues in a Priority Band.
+// To support this efficiently, the policy follows the Flyweight pattern:
+//
+//  1. The Plugin Instance (e.g., FCFS) is a Singleton. It defines the Logic (Less).
+//  2. The Logic (Less) acts as a pure function (or comparator) that operates on the queue's items.
+//
+// # Standard Implementations
+//
+// This package includes the following core strategies:
+//
+//   - FCFS ("First-Come, First-Served") ("fcfs-ordering-policy"): Orders requests by their logical arrival time.
+//     This is the default and most "intuitive" ordering.
+//
+//   - EDF ("Earliest Deadline First") ("edf-ordering-policy"): Orders requests by their absolute deadline
+//     (EnqueueTime + TTL).
+//     This maximizes the number of requests served before their deadlines expire.
+//
+// TODO: Rename directory and package to "ordering".
+package intraflow

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/edf_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/edf_test.go
@@ -32,7 +32,7 @@ import (
 func TestEDFPolicy_Name(t *testing.T) {
 	t.Parallel()
 	policy := newEDFPolicy()
-	assert.Equal(t, EDFPolicyName, policy.Name())
+	assert.Equal(t, EDFOrderingPolicyType, policy.Name())
 }
 
 func TestEDFPolicy_RequiredQueueCapabilities(t *testing.T) {
@@ -60,7 +60,8 @@ func TestEDFPolicy_SelectItem(t *testing.T) {
 
 func TestEDFComparator_Func(t *testing.T) {
 	t.Parallel()
-	comparator := &edfComparator{}
+	policy := newEDFPolicy()
+	comparator := policy.Comparator()
 	compareFunc := comparator.Func()
 	require.NotNil(t, compareFunc)
 
@@ -124,7 +125,8 @@ func TestEDFComparator_Func(t *testing.T) {
 
 func TestEDFComparator_ScoreType(t *testing.T) {
 	t.Parallel()
-	comparator := &edfComparator{}
+	policy := newEDFPolicy()
+	comparator := policy.Comparator()
 	assert.Equal(t, string(framework.EDFPriorityScoreType), comparator.ScoreType())
 }
 

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/factory.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/factory.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dispatch provides the factory and registration mechanism for all `framework.IntraFlowDispatchPolicy`
-// implementations.
-// It allows new policies to be added to the system and instantiated by name.
 package intraflow
 
 import (

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/fcfs_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/fcfs_test.go
@@ -34,7 +34,7 @@ var testFlowKey = types.FlowKey{ID: "test-flow", Priority: 0}
 func TestFCFS_Name(t *testing.T) {
 	t.Parallel()
 	policy := newFCFS()
-	assert.Equal(t, FCFSPolicyName, policy.Name())
+	assert.Equal(t, FCFSOrderingPolicyType, policy.Name())
 }
 
 func TestFCFS_RequiredQueueCapabilities(t *testing.T) {
@@ -63,7 +63,8 @@ func TestFCFS_SelectItem(t *testing.T) {
 
 func TestEnqueueTimeComparator_Func(t *testing.T) {
 	t.Parallel()
-	comparator := &enqueueTimeComparator{} // Test the internal comparator directly
+	policy := newFCFS()
+	comparator := policy.Comparator()
 	compareFunc := comparator.Func()
 	require.NotNil(t, compareFunc)
 
@@ -102,6 +103,7 @@ func TestEnqueueTimeComparator_Func(t *testing.T) {
 
 func TestEnqueueTimeComparator_ScoreType(t *testing.T) {
 	t.Parallel()
-	comparator := &enqueueTimeComparator{}
+	policy := newFCFS()
+	comparator := policy.Comparator()
 	assert.Equal(t, string(framework.EnqueueTimePriorityScoreType), comparator.ScoreType())
 }

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -38,7 +38,7 @@ const (
 	// It is set to 1 GB.
 	defaultPriorityBandMaxBytes uint64 = 1_000_000_000
 	// defaultIntraFlowDispatchPolicy is the default policy for selecting items within a single flow's queue.
-	defaultIntraFlowDispatchPolicy intraflow.RegisteredPolicyName = intraflow.FCFSPolicyName
+	defaultIntraFlowDispatchPolicy intraflow.RegisteredPolicyName = intraflow.FCFSOrderingPolicyType
 	// defaultFairnessPolicyRef is the default policy for selecting which flow's queue to service next.
 	defaultFairnessPolicyRef string = interflow.GlobalStrictFairnessPolicyType
 	// defaultQueue is the default queue implementation for flows.

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -298,7 +298,7 @@ func TestNewConfig(t *testing.T) {
 			name: "ShouldError_WhenDefaultRuntimeCheckerDetectsUnknownQueue",
 			opts: []ConfigOption{
 				WithPriorityBand(mustBand(t, 1, "BadBand",
-					WithIntraFlowPolicy(intraflow.FCFSPolicyName),
+					WithIntraFlowPolicy(intraflow.FCFSOrderingPolicyType),
 					WithQueue("non-existent-queue"),
 				)),
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind cleanup

**What this PR does / why we need it**:

This PR implements Phase 1 of the Flow Control Layer's migration from `IntraFlowDispatchPolicy` to the new `OrderingPolicy` interface.

**Changes:**

- Defines `framework.OrderingPolicy` in `plugins.go`, which uses a `Less(a, b)` method instead of the legacy `SelectItem` indirection.
- Updates `FCFS` and `EDF` policies to implement the new interface while maintaining strict backward compatibility with the existing `IntraFlowDispatchPolicy`.
- Renames policy constants to `...OrderingPolicyType` for consistency with the EPP Plugin Architecture (matching `interflow` patterns).

**Migration Strategy:**

This is an additive change only. It sets the stage for Phase 2, where `ManagedQueue` and `Registry` will be updated to purely use the new interface.

**Which issue(s) this PR fixes**:

Part of #1715

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```