### PR TITLE
cleanup(flowcontrol): Refactor registry with generic leasing and atomic GC

### DIFF
--- a/pkg/epp/flowcontrol/registry/leasing.go
+++ b/pkg/epp/flowcontrol/registry/leasing.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// leasedState implements a reference-counted "Leasing" pattern.
+// Resources are active when leaseCount > 0 and idle when leaseCount == 0.
+type leasedState struct {
+	// mu protects the lifecycle fields.
+	mu sync.Mutex
+
+	// leaseCount tracks the number of active references to this resource.
+	leaseCount int
+
+	// becameIdleAt tracks when the resource became idle.
+	// A zero value indicates the resource is currently active.
+	becameIdleAt time.Time
+
+	// markedForDeletion indicates the GC has selected this resource for deletion.
+	markedForDeletion bool
+}
+
+// tryPin acquires a lease if the resource is not marked for deletion.
+func (ls *leasedState) tryPin() bool {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if ls.markedForDeletion {
+		return false
+	}
+	ls.leaseCount++
+	ls.becameIdleAt = time.Time{} // Mark as active.
+	return true
+}
+
+// unpin releases a lease, marking the resource as idle if the count drops to zero.
+func (ls *leasedState) unpin(now time.Time) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	ls.leaseCount--
+	if ls.leaseCount == 0 {
+		ls.becameIdleAt = now
+	}
+}
+
+// leasable is an interface for resources that embed leasedState.
+type leasable interface {
+	tryPin() bool
+	unpin(now time.Time)
+	isActive() bool
+	checkAndMarkForDeletion(timeout time.Duration, now time.Time) bool
+}
+
+// isActive checks if the resource has any active leases.
+func (ls *leasedState) isActive() bool {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	return ls.leaseCount > 0
+}
+
+// checkAndMarkForDeletion returns true if the resource is idle and has exceeded the timeout.
+func (ls *leasedState) checkAndMarkForDeletion(timeout time.Duration, now time.Time) bool {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	active := ls.leaseCount > 0
+	if active {
+		if !ls.becameIdleAt.IsZero() {
+			ls.becameIdleAt = time.Time{}
+		}
+		return false
+	}
+
+	if ls.becameIdleAt.IsZero() {
+		ls.becameIdleAt = now
+		return false
+	}
+
+	if now.Sub(ls.becameIdleAt) < timeout {
+		return false
+	}
+
+	ls.markedForDeletion = true
+	return true
+}
+
+// collectLeasedResources removes idle resources from the map and returns them for cleanup.
+func collectLeasedResources[K any, V interface {
+	leasable
+	comparable
+}](
+	m *sync.Map,
+	timeout time.Duration,
+	clock clock.Clock,
+) []V {
+	var resourcesToClean []V
+	now := clock.Now()
+
+	m.Range(func(key, value any) bool {
+		k := key.(K)
+		v := value.(V)
+
+		if v.checkAndMarkForDeletion(timeout, now) {
+			if val, loaded := m.LoadAndDelete(k); loaded {
+				deletedVal := val.(V)
+				resourcesToClean = append(resourcesToClean, deletedVal)
+			}
+		}
+		return true
+	})
+
+	return resourcesToClean
+}
+
+// pinLeasedResource is a generic helper to perform the CAS loop for pinning a leased resource.
+func pinLeasedResource[K any, V interface {
+	leasable
+	comparable
+}](
+	m *sync.Map,
+	key K,
+	createFn func() V,
+	clock clock.Clock,
+) (V, bool) {
+	for {
+		val, ok := m.Load(key)
+		if !ok {
+			val, ok = m.LoadOrStore(key, createFn())
+		}
+		state := val.(V)
+		isNew := !ok
+
+		if state.tryPin() {
+			// Did the GC delete this object while we were acquiring it?
+			currentVal, ok := m.Load(key)
+			if !ok || currentVal != state {
+				// We acquired a "stale" object. Back off and retry.
+				state.unpin(clock.Now())
+				continue
+			}
+			return state, isNew
+		}
+
+		// The GC has marked this resource for deletion. Back off and allow it to die.
+		// We yield the processor to allow the GC goroutine to run and complete LoadAndDelete.
+		runtime.Gosched()
+		continue
+	}
+}

--- a/pkg/epp/flowcontrol/registry/leasing_test.go
+++ b/pkg/epp/flowcontrol/registry/leasing_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	testclock "k8s.io/utils/clock/testing"
+)
+
+// testResource is a simple struct that embeds leasedState for testing purposes.
+type testResource struct {
+	id string
+	leasedState
+}
+
+func TestLeasedState_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	clock := testclock.NewFakeClock(time.Now())
+	r := &testResource{}
+
+	// 1. Initial State
+	assert.False(t, r.isActive(), "new resource should not be active")
+	assert.True(t, r.becameIdleAt.IsZero(), "new resource should have zero becameIdleAt")
+
+	// 2. Pin
+	success := r.tryPin()
+	require.True(t, success, "tryPin should succeed")
+	assert.True(t, r.isActive(), "resource should be active after pin")
+	assert.Equal(t, 1, r.leaseCount)
+
+	// 3. Unpin
+	r.unpin(clock.Now())
+	assert.False(t, r.isActive(), "resource should not be active after unpin")
+	assert.Equal(t, 0, r.leaseCount)
+	assert.Equal(t, clock.Now(), r.becameIdleAt, "becameIdleAt should be set to now")
+
+	// 4. Re-Pin (Resurrection)
+	clock.Step(1 * time.Minute)
+	success = r.tryPin()
+	require.True(t, success, "re-pin should succeed")
+	assert.True(t, r.becameIdleAt.IsZero(), "becameIdleAt should be cleared after re-pin")
+}
+
+func TestCollectLeasedResources(t *testing.T) {
+	t.Parallel()
+
+	clock := testclock.NewFakeClock(time.Now())
+	timeout := 10 * time.Minute
+	m := &sync.Map{}
+
+	add := func(id string) *testResource {
+		r := &testResource{id: id}
+		m.Store(id, r)
+		return r
+	}
+
+	// Scenario 1: Active Resource
+	active := add("active")
+	active.tryPin()
+
+	// Scenario 2: Idle Resource (Just became idle)
+	idleFresh := add("idle-fresh")
+
+	// Scenario 3: Expired Resource
+	expired := add("expired")
+	expired.becameIdleAt = clock.Now().Add(-20 * time.Minute) // Way past timeout
+
+	// Run GC (First Pass)
+	deleted := collectLeasedResources[string, *testResource](m, timeout, clock)
+
+	require.Len(t, deleted, 1, "should delete exactly one resource (expired)")
+	assert.Equal(t, expired.id, deleted[0].id, "expired resource should be deleted")
+
+	_, exists := m.Load(idleFresh.id)
+	assert.True(t, exists, "idleFresh should still exist")
+	assert.False(t, idleFresh.becameIdleAt.IsZero(), "idleFresh should be marked with becameIdleAt")
+	assert.Equal(t, clock.Now(), idleFresh.becameIdleAt)
+
+	_, exists = m.Load(active.id)
+	assert.True(t, exists, "active should still exist")
+}
+
+func TestCollectLeasedResources_Integration(t *testing.T) {
+	t.Parallel()
+	clock := testclock.NewFakeClock(time.Now())
+	timeout := 10 * time.Second
+	m := &sync.Map{}
+
+	r1 := &testResource{id: "r1"} // Will stay active
+	r1.tryPin()
+	m.Store("r1", r1)
+
+	r2 := &testResource{id: "r2"} // Will be idle, then expire
+	m.Store("r2", r2)
+
+	r3 := &testResource{id: "r3"} // Will be idle, but not expire
+	m.Store("r3", r3)
+
+	// Pass 1: Mark r2 and r3 as idle.
+	results := collectLeasedResources[string, *testResource](m, timeout, clock)
+	assert.Empty(t, results)
+	assert.False(t, r2.becameIdleAt.IsZero())
+	assert.False(t, r3.becameIdleAt.IsZero())
+
+	// Advance time by 5 seconds (less than timeout).
+	clock.Step(5 * time.Second)
+	results = collectLeasedResources[string, *testResource](m, timeout, clock)
+	assert.Empty(t, results)
+
+	// Advance time by another 6 seconds (total 11s > 10s timeout).
+	clock.Step(6 * time.Second)
+
+	// Pin r3 before the GC runs to save it.
+	r3.tryPin()
+
+	results = collectLeasedResources[string, *testResource](m, timeout, clock)
+
+	// r2 should be deleted.
+	require.Len(t, results, 1)
+	assert.Equal(t, "r2", results[0].id)
+	_, exists := m.Load("r2")
+	assert.False(t, exists, "r2 should be removed from map")
+
+	// r3 should be safe and becameIdleAt cleared.
+	_, exists = m.Load("r3")
+	assert.True(t, exists, "r3 should remain")
+	assert.True(t, r3.becameIdleAt.IsZero(), "r3 should be unmarked")
+}
+
+func TestCollectLeasedResources_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	// Verify that pinLeasedResource and collectLeasedResources are safe to use concurrently.
+	// Specifically, we want to ensure:
+	// 1. No data races.
+	// 2. Objects are not double-deleted or deleted while active.
+	// 3. Resurrected objects (pinned during GC) are NOT deleted.
+
+	clock := testclock.NewFakeClock(time.Now())
+	timeout := 10 * time.Millisecond
+	m := &sync.Map{}
+
+	const numGoroutines = 100
+	const iterations = 1000
+
+	var (
+		resurrectedCount atomic.Int64
+		deletedCount     atomic.Int64
+	)
+
+	// Create a single resource that we will fight over.
+	key := "contended-resource"
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Start goroutines that randomly Pin/Unpin or Run GC.
+	for i := range numGoroutines {
+		go func(id int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(id)))
+
+			for range iterations {
+				action := rng.Intn(3) // 0: Pin/Unpin, 1: GC, 2: Access
+
+				switch action {
+				case 0:
+					// Simulates a request coming in: Pin -> Sleep -> Unpin.
+					val, _ := pinLeasedResource(
+						m,
+						key,
+						func() *testResource { return &testResource{id: key} },
+						clock,
+					)
+
+					// Invariant Check: pinLeasedResource must never return an object that is marked for deletion.
+					val.mu.Lock()
+					isMarked := val.markedForDeletion
+					val.mu.Unlock()
+					if isMarked {
+						t.Error("Invariant Violation: pinLeasedResource returned an object marked for deletion")
+					}
+
+					// Simulate "Work"
+					time.Sleep(time.Duration(rng.Intn(100)) * time.Microsecond)
+
+					val.unpin(clock.Now())
+
+				case 1:
+					// Simulate Background GC.
+					// Advance clock slightly to allow timeouts to eventually trigger.
+					if rng.Intn(100) == 0 {
+						clock.Step(5 * time.Millisecond) // Half timeout
+					}
+
+					deleted := collectLeasedResources[string, *testResource](m, timeout, clock)
+					deletedCount.Add(int64(len(deleted)))
+					for _, d := range deleted {
+						if d.id != key {
+							t.Errorf("GC deleted unexpected key: %s", d.id)
+						}
+					}
+
+				case 2:
+					// Simulate "Resurrection" check.
+					// If it exists, try to pin it specifically.
+					if val, ok := m.Load(key); ok {
+						r := val.(*testResource)
+						if r.tryPin() {
+							resurrectedCount.Add(1)
+							r.unpin(clock.Now())
+						}
+					}
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Final Consistency Check:
+	// If the resource remains in the map, it MUST be valid (not marked for deletion).
+	// A marked-for-deletion object should have been removed by collectLeasedResources.
+	if val, ok := m.Load(key); ok {
+		r := val.(*testResource)
+		r.mu.Lock()
+		isMarked := r.markedForDeletion
+		r.mu.Unlock()
+
+		assert.False(t, isMarked, "Invariant Violation: Found object in map that is marked for deletion")
+	}
+}

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -23,7 +23,6 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/utils/clock"
@@ -48,29 +47,9 @@ type bandStats struct {
 }
 
 // flowState tracks the lifecycle and usage of a specific flow instance.
-//
-// It uses a mutex-protected reference counter to arbitrate between active request processing and garbage collection.
-// This structure allows the registry to safely determine if a flow is currently in use or eligible for deletion.
 type flowState struct {
+	leasedState
 	key types.FlowKey
-
-	// mu protects the lifecycle fields (leaseCount, becameIdleAt, closing).
-	// We use a mutex instead of independent atomics to ensure that state transitions (e.g., Active -> Idle) are atomic
-	// and consistent.
-	mu sync.Mutex
-
-	// leaseCount tracks the number of concurrent, in-flight connections using this flow.
-	// - count > 0: Active. The flow is pinned and cannot be garbage collected.
-	// - count == 0: Idle. The flow is eligible for garbage collection if the timeout is exceeded.
-	leaseCount int
-
-	// becameIdleAt tracks the timestamp when leaseCount last dropped to zero.
-	// A zero value (time.Time{}) indicates the flow is currently Active.
-	becameIdleAt time.Time
-
-	// markedForDeletion indicates that the Garbage Collector has selected this flow for deletion.
-	// If true, incoming requests must back off and allow the flow to be cleaned up.
-	markedForDeletion bool
 
 	// initialized ensures that the heavy-weight infrastructure provisioning (creating queues on shards) happens exactly
 	// once per flowState instance.
@@ -80,36 +59,9 @@ type flowState struct {
 }
 
 // priorityBandState tracks the lifecycle state for a dynamically provisioned priority band.
-// Unlike flowState, which tracks individual flows, this tracks an entire priority level and persists
-// after all flows at that priority are garbage collected to enforce idle timeout before band deletion.
-//
-// It uses the same mutex-protected reference counter (leaseCount) pattern as flowState to arbitrate between
-// active flows and garbage collection. Leases represent active FLOWS, not individual requests, and are held
-// from flow creation until flow destruction.
 type priorityBandState struct {
+	leasedState
 	priority int
-
-	// mu protects the lifecycle fields (leaseCount, becameIdleAt, markedForDeletion).
-	// We use a mutex instead of independent atomics to ensure that state transitions (e.g., Active -> Idle) are atomic
-	// and consistent, following the same pattern as flowState.
-	mu sync.Mutex
-
-	// leaseCount tracks the number of active flows at this priority level.
-	// Each flow contributes exactly one lease, acquired when the flow is created (pinActiveFlow) and
-	// released when the flow is destroyed (gcFlows) or JIT provisioning fails.
-	// This is more efficient than per-request leasing as it avoids atomic updates on the hot path.
-	// - count > 0: Active. The band is pinned and cannot be garbage collected.
-	// - count == 0: May be eligible for GC if also empty (see markPriorityBands).
-	leaseCount int
-
-	// becameIdleAt tracks the timestamp when the band became truly idle (both empty and leaseCount == 0).
-	// A zero value (time.Time{}) indicates the band is currently Active (has flows).
-	// This field is managed by markPriorityBands, which verifies both conditions.
-	becameIdleAt time.Time
-
-	// markedForDeletion indicates that the Garbage Collector has selected this band for deletion.
-	// If true, incoming flow creation operations must back off and allow the band to be cleaned up.
-	markedForDeletion bool
 }
 
 // FlowRegistry is the concrete implementation of the contracts.FlowRegistry interface.
@@ -238,14 +190,24 @@ func (fr *FlowRegistry) WithConnection(key types.FlowKey, fn func(conn contracts
 	}
 
 	// 1. Acquire lease: Pin the flow state in memory.
-	state, isNewFlow := fr.pinActiveFlow(key)
+	state, isNewFlow := pinLeasedResource(
+		&fr.flowStates,
+		key,
+		func() *flowState { return &flowState{key: key} },
+		fr.clock,
+	)
 	if isNewFlow {
 		// If this is a newly created flow, increment the band's lease count.
 		// Band leases track the number of active *flows* (not requests).
 		// Every flow in the map holds exactly one band lease.
-		fr.pinActivePriorityBand(key.Priority)
+		pinLeasedResource(
+			&fr.priorityBandStates,
+			key.Priority,
+			func() *priorityBandState { return &priorityBandState{priority: key.Priority} },
+			fr.clock,
+		)
 	}
-	defer fr.releaseFlow(state)
+	defer state.unpin(fr.clock.Now())
 
 	// 2. JIT provisioning: Ensure physical resources exist on shards.
 	// We use sync.Once to ensure we only pay the initialization cost (building components, locking shards) exactly once
@@ -264,8 +226,7 @@ func (fr *FlowRegistry) WithConnection(key types.FlowKey, fn func(conn contracts
 		// If JIT provisioning fails for a new flow, we must release that lease to prevent leaking band leases.
 		if isNewFlow {
 			if bandVal, ok := fr.priorityBandStates.Load(key.Priority); ok {
-				bandState := bandVal.(*priorityBandState)
-				fr.releasePriorityBand(bandState)
+				bandVal.(*priorityBandState).unpin(fr.clock.Now())
 			}
 		}
 
@@ -275,108 +236,6 @@ func (fr *FlowRegistry) WithConnection(key types.FlowKey, fn func(conn contracts
 	// 3. Execute callback.
 	// The flow lease is held throughout the execution of fn, preventing GC.
 	return fn(&connection{registry: fr, key: key})
-}
-
-// pinActiveFlow locates or creates the flow state and increments its lease count.
-//
-// It uses an optimistic loop to handle race conditions where the Garbage Collector might delete the object from the map
-// concurrently. It ensures that the returned state object is both authoritative (present in the map) and leased
-// (count > 0).
-//
-// Returns the flow state and a boolean indicating whether this call created a new flow.
-func (fr *FlowRegistry) pinActiveFlow(key types.FlowKey) (*flowState, bool) {
-	for {
-		val, ok := fr.flowStates.Load(key) // Optimization: Check Load first to avoid allocation on the hot path.
-		if !ok {
-			val, ok = fr.flowStates.LoadOrStore(key, &flowState{key: key})
-		}
-		state := val.(*flowState)
-		isNewFlow := !ok
-
-		state.mu.Lock()
-		if state.markedForDeletion {
-			// The GC has marked this flow for deletion.
-			// We must back off and let it die. We will retry and create a fresh one.
-			state.mu.Unlock()
-			continue
-		}
-		state.leaseCount++
-		state.becameIdleAt = time.Time{} // Mark as Active
-		state.mu.Unlock()
-
-		// Did the GC delete this object while we were acquiring it?
-		currentVal, ok := fr.flowStates.Load(key)
-		if !ok || currentVal != state {
-			// We acquired a "stale" object. Back off and retry.
-			fr.releaseFlow(state)
-			continue
-		}
-
-		return state, isNewFlow
-	}
-}
-
-// releaseFlow decrements the lease count for a flow.
-// If the lease count reaches zero, the flow is marked as idle with the current timestamp.
-func (fr *FlowRegistry) releaseFlow(state *flowState) {
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	state.leaseCount--
-	if state.leaseCount == 0 {
-		state.becameIdleAt = fr.clock.Now()
-	}
-}
-
-// pinActivePriorityBand locates or creates the priority band state and increments its lease count.
-//
-// This is called from pinActiveFlow when creating a NEW flow to establish the invariant:
-// bandState.leaseCount = number of active flows at this priority.
-//
-// It uses an optimistic loop to handle race conditions where the Garbage Collector might delete the band
-// concurrently. It ensures that the returned state object is both authoritative (present in the map) and leased
-// (count > 0).
-func (fr *FlowRegistry) pinActivePriorityBand(priority int) *priorityBandState {
-	for {
-		val, ok := fr.priorityBandStates.Load(priority)
-		if !ok {
-			val, _ = fr.priorityBandStates.LoadOrStore(priority, &priorityBandState{priority: priority})
-		}
-		state := val.(*priorityBandState)
-
-		state.mu.Lock()
-		if state.markedForDeletion {
-			// The GC has marked this band for deletion.
-			// We must back off and let it die. We will retry and create a fresh one.
-			state.mu.Unlock()
-			continue
-		}
-		state.leaseCount++
-		state.becameIdleAt = time.Time{} // Mark as Active
-		state.mu.Unlock()
-
-		// Did the GC delete this object while we were acquiring it?
-		currentVal, ok := fr.priorityBandStates.Load(priority)
-		if !ok || currentVal != state {
-			// We acquired a "stale" object. Back off and retry.
-			fr.releasePriorityBand(state)
-			continue
-		}
-		return state
-	}
-}
-
-// releasePriorityBand decrements the lease count for a priority band.
-//
-// Unlike releaseFlow, we do NOT automatically set becameIdleAt when leaseCount reaches zero.
-// A band is idle only when BOTH conditions are met:
-//  1. leaseCount == 0 (no active flows)
-//  2. isBandEmpty() == true (no buffered items or queues)
-//
-// The becameIdleAt timestamp is managed by markPriorityBands, which checks both conditions.
-func (fr *FlowRegistry) releasePriorityBand(state *priorityBandState) {
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	state.leaseCount--
 }
 
 // ensureFlowInfrastructure guarantees that the Priority Band exists and that the flow's queues are synchronized across
@@ -447,59 +306,10 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 	return nil
 }
 
-// isBandActive returns true if the priority band has any flows or buffered items across all shards.
-func (fr *FlowRegistry) isBandActive(priority int) bool {
-	// Get stable shard snapshot
-	fr.mu.RLock()
-	shards := fr.allShards
-	fr.mu.RUnlock()
-
-	for _, shard := range shards {
-		// If the band doesn't exist on this shard it is not partitioned here.
-		if val, ok := shard.priorityBands.Load(priority); ok {
-			band := val.(*priorityBand)
-
-			// Check queue count under lock
-			shard.mu.RLock()
-			queueCount := len(band.queues)
-			shard.mu.RUnlock()
-
-			if queueCount > 0 {
-				return true
-			}
-
-			// Check atomic statistics (lock-free)
-			if band.len.Load() > 0 || band.byteSize.Load() > 0 {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // deletePriorityBand removes a priority band from the registry and all shards.
-// This method should only be called after verifying the band is safe to delete (empty across all shards).
-// Follows locking order: FlowRegistry.mu → registryShard.mu
 func (fr *FlowRegistry) deletePriorityBand(priority int) {
-	fr.mu.Lock()
-	defer fr.mu.Unlock()
-
-	// Delete from registry config
-	delete(fr.config.PriorityBands, priority)
-
-	// Delete from stats tracking
-	fr.perPriorityBandStats.Delete(priority)
-
-	// Delete from all shards (both active and draining)
-	for _, shard := range fr.allShards {
-		shard.deletePriorityBand(priority)
-	}
-
-	// Delete lifecycle state
-	fr.priorityBandStates.Delete(priority)
-
-	fr.logger.Info("Successfully deleted priority band", "priority", priority)
+	fr.priorityBandStates.Delete(priority)           // Logical delete
+	fr.cleanupPriorityBandResources([]int{priority}) // Physical cleanup
 }
 
 // --- `contracts.FlowRegistryObserver` Implementation ---
@@ -557,60 +367,27 @@ func (fr *FlowRegistry) executeGCCycle() {
 	fr.sweepDrainingShards()
 }
 
-// gcFlows performs the Mark-and-Sweep of Idle flows.
-//
-// It iterates through all tracked flows and identifies candidates that have zero active leases and have exceeded the
-// configured idle timeout. These flows are first removed from the internal map (Logical Delete), their corresponding
-// priority band leases are released, and then they are cleaned up from the shards (Physical Delete).
+// gcFlows removes idle flows.
 func (fr *FlowRegistry) gcFlows() {
-	var flowsToClean []types.FlowKey
-	fr.flowStates.Range(func(key, value interface{}) bool {
-		state := value.(*flowState)
-		state.mu.Lock()
+	deletedFlows := collectLeasedResources[types.FlowKey, *flowState](
+		&fr.flowStates,
+		fr.config.FlowGCTimeout,
+		fr.clock,
+	)
 
-		// 1. Check Lease.
-		if state.leaseCount > 0 {
-			state.mu.Unlock()
-			return true
-		}
-
-		// 2. Check Idle Timeout.
-		if state.becameIdleAt.IsZero() || fr.clock.Since(state.becameIdleAt) < fr.config.FlowGCTimeout {
-			state.mu.Unlock()
-			return true // Not yet expired or active.
-		}
-
-		// 3. Mark for Deletion.
-		state.markedForDeletion = true
-		idleTime := state.becameIdleAt // Captured for logging
-		priority := state.key.Priority // Captured for band lease release
-		state.mu.Unlock()
-
-		// 4. Logical Delete.
-		// Normally we may assume that only one GC loop is running globally: the following check is defensive.
-		// Concurrent GC might happen in test cases if a GC cycle is triggered concurrently with a background GC loop.
-		// In the case of concurrent GC execution, both GC cycles might see the same flow in their Range() snapshots.
-		// Only the first one to delete it should release the band lease. This prevents double-release bugs.
-		if _, existed := fr.flowStates.LoadAndDelete(key); existed {
-			flowsToClean = append(flowsToClean, key.(types.FlowKey))
-			fr.logger.V(logging.VERBOSE).Info("Garbage collecting flow", "flowKey", key, "becameIdleAt", idleTime)
-
-			// 5. Release the band lease.
-			// Every flow in the map holds exactly one band lease. This flow is being destroyed,
-			// so decrement the band's flow count.
-			if bandVal, ok := fr.priorityBandStates.Load(priority); ok {
-				bandState := bandVal.(*priorityBandState)
-				fr.releasePriorityBand(bandState)
+	if len(deletedFlows) > 0 {
+		var keysToClean []types.FlowKey
+		for _, v := range deletedFlows {
+			fr.logger.V(logging.VERBOSE).Info("Garbage collecting flow", "flowKey", v.key, "becameIdleAt", v.becameIdleAt)
+			// Release the band lease.
+			// Every flow in the map holds exactly one band lease.
+			if bandVal, ok := fr.priorityBandStates.Load(v.key.Priority); ok {
+				bandVal.(*priorityBandState).unpin(fr.clock.Now())
 			}
+			keysToClean = append(keysToClean, v.key)
 		}
 
-		return true
-	})
-
-	// 6. Physical Cleanup.
-	// Performed outside the map iteration to avoid blocking or complex lock interactions.
-	if len(flowsToClean) > 0 {
-		fr.cleanupFlowResources(flowsToClean)
+		fr.cleanupFlowResources(keysToClean)
 	}
 }
 
@@ -629,61 +406,22 @@ func (fr *FlowRegistry) cleanupFlowResources(keys []types.FlowKey) {
 	}
 }
 
-// gcPriorityBands performs garbage collection of idle priority bands.
-// It follows the same pattern as gcFlows: verify and mark inside Range, then physical cleanup outside.
+// gcPriorityBands removes idle priority bands.
 func (fr *FlowRegistry) gcPriorityBands() {
-	var bandsToClean []int
-	fr.priorityBandStates.Range(func(priority, value interface{}) bool {
-		prio := priority.(int)
-		state := value.(*priorityBandState)
+	deletedBands := collectLeasedResources[int, *priorityBandState](
+		&fr.priorityBandStates,
+		fr.config.PriorityBandGCTimeout,
+		fr.clock,
+	)
 
-		state.mu.Lock()
-
-		// 1. Check if band is active: has buffered items OR active flows (leaseCount > 0).
-		if fr.isBandActive(prio) || state.leaseCount > 0 {
-			// Band is active - reset idle timestamp if previously idle.
-			if !state.becameIdleAt.IsZero() {
-				state.becameIdleAt = time.Time{}
-				fr.logger.V(logging.DEBUG).Info("Priority band became active again", "priority", prio)
-			}
-			state.mu.Unlock()
-			return true
+	if len(deletedBands) > 0 {
+		var keysToClean []int
+		for _, v := range deletedBands {
+			fr.logger.V(logging.VERBOSE).Info("Garbage collecting priority band",
+				"priority", v.priority, "becameIdleAt", v.becameIdleAt)
+			keysToClean = append(keysToClean, v.priority)
 		}
-
-		// 2. Band is idle - mark idle timestamp on first detection.
-		// This requires at least TWO GC cycles before collection (grace period).
-		if state.becameIdleAt.IsZero() {
-			state.becameIdleAt = fr.clock.Now()
-			fr.logger.V(logging.DEBUG).Info("Priority band became idle",
-				"priority", prio, "becameIdleAt", state.becameIdleAt)
-			state.mu.Unlock()
-			return true // Come back next GC cycle to check timeout.
-		}
-
-		// 3. Band has been idle for a while - check if timeout expired.
-		if fr.clock.Since(state.becameIdleAt) < fr.config.PriorityBandGCTimeout {
-			state.mu.Unlock()
-			return true // Still within grace period.
-		}
-
-		// 4. Timeout expired - mark for deletion.
-		state.markedForDeletion = true
-		idleTime := state.becameIdleAt // Captured for logging
-		state.mu.Unlock()
-
-		// 5. Logical Delete.
-		// Remove from the map. Concurrent pinActivePriorityBand calls will now create a fresh instance.
-		fr.priorityBandStates.Delete(prio)
-		bandsToClean = append(bandsToClean, prio)
-		fr.logger.V(logging.VERBOSE).Info("Garbage collecting priority band", "priority", prio, "becameIdleAt", idleTime)
-
-		return true
-	})
-
-	// 6. Physical Cleanup.
-	// Performed outside the map iteration to avoid blocking or complex lock interactions.
-	if len(bandsToClean) > 0 {
-		fr.cleanupPriorityBandResources(bandsToClean)
+		fr.cleanupPriorityBandResources(keysToClean)
 	}
 }
 

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -811,8 +811,15 @@ func TestFlowRegistry_Concurrency(t *testing.T) {
 			}()
 		}
 
-		// Let workers create some bands before GC starts collecting
-		time.Sleep(50 * time.Millisecond)
+		// Wait for at least one band to be created.
+		require.Eventually(t, func() bool {
+			count := 0
+			h.fr.priorityBandStates.Range(func(_, _ any) bool {
+				count++
+				return true
+			})
+			return count > 0
+		}, 5*time.Second, 10*time.Millisecond, "Dynamic bands should be created")
 
 		// Check bands were created before GC collects them all
 		bandCount := 0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind test

**What this PR does / why we need it**:

This PR refactors the `FlowRegistry` to extract the optimistic resource leasing and garbage collection logic into a dedicated, generic `leasing.go` file.  Previously, the "Check-Pin-Retry" loops and "Mark-and-Sweep" GC logic were duplicated for both Flows and Priority Bands. This duplication obscured the critical concurrency safety invariants.

**Key Changes:**

- Introduced `leasedState` and `pinLeasedResource`. This encapsulates the complex lock-free retry loops, `sync.Once` handling, etc. into a single, reusable primitive.
- Leveraged generics to deduplicate the GC logic (`collectLeasedResources`). This ensures that Flows and Priority Bands adhere to identical lifecycle safety contracts.
- Added `leasing_test.go` with unit tests for the `leasedState` state machine and a high-contention chaos test verifying that "Pin vs GC" races result in deterministic behavior without data corruption.

**Which issue(s) this PR fixes**:

Cleanup following #2127 and #2097. Pure refactoring for maintainability, not tracked in any issue.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```