### PR TITLE
refactor(flowcontrol): migrate interfaces to framework/interface/flowcontrol

### DIFF
--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -17,8 +17,8 @@ limitations under the License.
 package contracts
 
 import (
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 // FlowRegistry is the complete interface for the global flow control plane.
@@ -124,14 +124,14 @@ type RegistryShard interface {
 	// Returns:
 	//   - FairnessPolicy: The active policy instance.
 	//   - error: A wrapped ErrPriorityBandNotFound if the priority level is not configured on this shard.
-	FairnessPolicy(priority int) (framework.FairnessPolicy, error)
+	FairnessPolicy(priority int) (flowcontrol.FairnessPolicy, error)
 
 	// PriorityBandAccessor retrieves the read-only view of the "Flow Group" for a specific priority level.
 	// This accessor provides the state of all contending flows within the band (as seen by this shard) and serves as the
 	// primary input for FairnessPolicy execution.
 	//
 	// Returns an error wrapping ErrPriorityBandNotFound if the priority level is not configured.
-	PriorityBandAccessor(priority int) (framework.PriorityBandAccessor, error)
+	PriorityBandAccessor(priority int) (flowcontrol.PriorityBandAccessor, error)
 
 	// AllOrderedPriorityLevels returns all configured priority levels that this shard is aware of, sorted in descending
 	// numerical order. This order corresponds to highest priority (highest numeric value) to lowest priority (lowest
@@ -145,8 +145,8 @@ type RegistryShard interface {
 }
 
 // ManagedQueue defines the interface for a flow's queue on a specific shard.
-// It acts as a stateful decorator that *use an underlying framework.SafeQueue, augmenting it with statistics tracking
-// and lifecycle awareness (e.g., rejecting adds when a shard is draining).
+// It acts as a stateful decorator that *use an underlying SafeQueue, augmenting it with statistics tracking, and
+// lifecycle awareness (e.g., rejecting adds when a shard is draining).
 //
 // Conformance: Implementations MUST be goroutine-safe.
 type ManagedQueue interface {
@@ -159,14 +159,14 @@ type ManagedQueue interface {
 	Remove(handle types.QueueItemHandle) (types.QueueItemAccessor, error)
 
 	// Cleanup removes all items from the underlying queue that satisfy the predicate.
-	Cleanup(predicate framework.PredicateFunc) []types.QueueItemAccessor
+	Cleanup(predicate flowcontrol.PredicateFunc) []types.QueueItemAccessor
 
 	// Drain removes all items from the underlying queue.
 	Drain() []types.QueueItemAccessor
 
 	// FlowQueueAccessor returns a read-only, flow-aware accessor for this queue, used by policy plugins.
 	// Conformance: This method MUST NOT return nil.
-	FlowQueueAccessor() framework.FlowQueueAccessor
+	FlowQueueAccessor() flowcontrol.FlowQueueAccessor
 }
 
 // AggregateStats holds globally aggregated statistics for the entire `FlowRegistry`.

--- a/pkg/epp/flowcontrol/framework/plugins/interflow/besthead.go
+++ b/pkg/epp/flowcontrol/framework/plugins/interflow/besthead.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -82,17 +82,17 @@ func (p *globalStrict) NewState(_ context.Context) any {
 // as a strict comparison is impossible.
 func (p *globalStrict) Pick(
 	_ context.Context,
-	flowGroup framework.PriorityBandAccessor,
-) (framework.FlowQueueAccessor, error) {
+	flowGroup flowcontrol.PriorityBandAccessor,
+) (flowcontrol.FlowQueueAccessor, error) {
 	if flowGroup == nil {
 		return nil, nil
 	}
 
-	var bestQueue framework.FlowQueueAccessor
+	var bestQueue flowcontrol.FlowQueueAccessor
 	var bestItem types.QueueItemAccessor
 	var iterationErr error
 
-	flowGroup.IterateQueues(func(queue framework.FlowQueueAccessor) (keepIterating bool) {
+	flowGroup.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) (keepIterating bool) {
 		if queue == nil || queue.Len() == 0 {
 			return true
 		}
@@ -109,7 +109,7 @@ func (p *globalStrict) Pick(
 		}
 
 		if queue.OrderingPolicy().TypedName().Type != bestQueue.OrderingPolicy().TypedName().Type {
-			iterationErr = fmt.Errorf("%w: expected %q, got %q", framework.ErrIncompatiblePriorityType,
+			iterationErr = fmt.Errorf("%w: expected %q, got %q", flowcontrol.ErrIncompatiblePriorityType,
 				bestQueue.OrderingPolicy().TypedName().Type, queue.OrderingPolicy().TypedName().Type)
 			return false
 		}

--- a/pkg/epp/flowcontrol/framework/plugins/interflow/besthead_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/interflow/besthead_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
-	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -40,9 +40,9 @@ func newTestOrderingPolicy() *frameworkmocks.MockOrderingPolicy {
 	}
 }
 
-func newTestBand(queues ...framework.FlowQueueAccessor) *frameworkmocks.MockPriorityBandAccessor {
+func newTestBand(queues ...flowcontrol.FlowQueueAccessor) *frameworkmocks.MockPriorityBandAccessor {
 	flowKeys := make([]types.FlowKey, 0, len(queues))
-	queuesByID := make(map[string]framework.FlowQueueAccessor, len(queues))
+	queuesByID := make(map[string]flowcontrol.FlowQueueAccessor, len(queues))
 	for _, q := range queues {
 		key := q.FlowKey()
 		flowKeys = append(flowKeys, key)
@@ -50,10 +50,10 @@ func newTestBand(queues ...framework.FlowQueueAccessor) *frameworkmocks.MockPrio
 	}
 	return &frameworkmocks.MockPriorityBandAccessor{
 		FlowKeysFunc: func() []types.FlowKey { return flowKeys },
-		QueueFunc: func(id string) framework.FlowQueueAccessor {
+		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 			return queuesByID[id]
 		},
-		IterateQueuesFunc: func(iterator func(flow framework.FlowQueueAccessor) bool) {
+		IterateQueuesFunc: func(iterator func(flow flowcontrol.FlowQueueAccessor) bool) {
 			for _, key := range flowKeys {
 				if !iterator(queuesByID[key.ID]) {
 					break
@@ -104,7 +104,7 @@ func TestGlobalStrict_Pick(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		band            framework.PriorityBandAccessor
+		band            flowcontrol.PriorityBandAccessor
 		expectedQueueID string
 		expectedErr     error
 		shouldPanic     bool
@@ -150,7 +150,7 @@ func TestGlobalStrict_Pick(t *testing.T) {
 					},
 				},
 			),
-			expectedErr: framework.ErrIncompatiblePriorityType,
+			expectedErr: flowcontrol.ErrIncompatiblePriorityType,
 		},
 		{
 			name: "OrderingPolicyIsNil",

--- a/pkg/epp/flowcontrol/framework/plugins/interflow/roundrobin.go
+++ b/pkg/epp/flowcontrol/framework/plugins/interflow/roundrobin.go
@@ -23,8 +23,8 @@ import (
 	"slices"
 	"sync"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -77,8 +77,8 @@ func (p *roundRobin) NewState(_ context.Context) any {
 // It retrieves the band-specific state, locks it, and advances the cursor.
 func (p *roundRobin) Pick(
 	_ context.Context,
-	flowGroup framework.PriorityBandAccessor,
-) (framework.FlowQueueAccessor, error) {
+	flowGroup flowcontrol.PriorityBandAccessor,
+) (flowcontrol.FlowQueueAccessor, error) {
 	if flowGroup == nil {
 		return nil, nil
 	}

--- a/pkg/epp/flowcontrol/framework/plugins/interflow/roundrobin_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/interflow/roundrobin_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
-	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol/mocks"
 )
 
 var (
@@ -58,7 +58,7 @@ func TestRoundRobin_Pick_Logic(t *testing.T) {
 	mockBand := &frameworkmocks.MockPriorityBandAccessor{
 		PolicyStateV: state,
 		FlowKeysFunc: func() []types.FlowKey { return []types.FlowKey{flow3Key, flow1Key, flow2Key} }, // Unsorted to test sorting
-		QueueFunc: func(id string) framework.FlowQueueAccessor {
+		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 			switch id {
 			case "flow1":
 				return queue1
@@ -108,7 +108,7 @@ func TestRoundRobin_Pick_SkipsEmptyQueues(t *testing.T) {
 	mockBand := &frameworkmocks.MockPriorityBandAccessor{
 		PolicyStateV: state,
 		FlowKeysFunc: func() []types.FlowKey { return []types.FlowKey{flow1Key, flowEmptyKey, flow3Key} },
-		QueueFunc: func(id string) framework.FlowQueueAccessor {
+		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 			switch id {
 			case "flow1":
 				return queue1
@@ -150,7 +150,7 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	mockBand := &frameworkmocks.MockPriorityBandAccessor{
 		PolicyStateV: state,
 		FlowKeysFunc: func() []types.FlowKey { return []types.FlowKey{flow1Key, flow2Key} },
-		QueueFunc: func(id string) framework.FlowQueueAccessor {
+		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 			if id == "flow1" {
 				return queue1
 			}
@@ -167,7 +167,7 @@ func TestRoundRobin_Pick_HandlesDynamicFlows(t *testing.T) {
 	// --- Simulate adding a flow ---
 	queue3 := &frameworkmocks.MockFlowQueueAccessor{LenV: 1, FlowKeyV: flow3Key}
 	mockBand.FlowKeysFunc = func() []types.FlowKey { return []types.FlowKey{flow1Key, flow2Key, flow3Key} }
-	mockBand.QueueFunc = func(id string) framework.FlowQueueAccessor {
+	mockBand.QueueFunc = func(id string) flowcontrol.FlowQueueAccessor {
 		switch id {
 		case "flow1":
 			return queue1
@@ -222,7 +222,7 @@ func TestRoundRobin_Pick_Concurrency(t *testing.T) {
 			mockBand := &frameworkmocks.MockPriorityBandAccessor{
 				PolicyStateV: state,
 				FlowKeysFunc: func() []types.FlowKey { return []types.FlowKey{flow1Key, flow2Key, flow3Key} },
-				QueueFunc: func(id string) framework.FlowQueueAccessor {
+				QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
 					for _, q := range queues {
 						if q.FlowKey().ID == id {
 							return q

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/edf.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/edf.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -43,7 +43,7 @@ func init() {
 // See the documentation for the exported EDFOrderingPolicyType constant for detailed behavioral guarantees.
 type EDFPolicy struct{}
 
-var _ framework.OrderingPolicy = &EDFPolicy{}
+var _ flowcontrol.OrderingPolicy = &EDFPolicy{}
 
 func newEDFPolicy() *EDFPolicy {
 	return &EDFPolicy{}
@@ -55,8 +55,8 @@ func (p *EDFPolicy) Name() string {
 
 // RequiredQueueCapabilities returns the queue capabilities required by this policy.
 // It requires a priority-configurable queue (e.g., heap-based) to maintain items in deadline-sorted order.
-func (p *EDFPolicy) RequiredQueueCapabilities() []framework.QueueCapability {
-	return []framework.QueueCapability{framework.CapabilityPriorityConfigurable}
+func (p *EDFPolicy) RequiredQueueCapabilities() []flowcontrol.QueueCapability {
+	return []flowcontrol.QueueCapability{flowcontrol.CapabilityPriorityConfigurable}
 }
 
 // TypedName returns the type and name tuple of this plugin instance.

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/edf_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/edf_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 func TestEDFPolicy_Name(t *testing.T) {
@@ -39,7 +39,7 @@ func TestEDFPolicy_RequiredQueueCapabilities(t *testing.T) {
 	policy := newEDFPolicy()
 	caps := policy.RequiredQueueCapabilities()
 	require.Len(t, caps, 1)
-	assert.Equal(t, framework.CapabilityPriorityConfigurable, caps[0])
+	assert.Equal(t, flowcontrol.CapabilityPriorityConfigurable, caps[0])
 }
 
 func TestEDF_Less(t *testing.T) {

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/fcfs.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/fcfs.go
@@ -19,8 +19,8 @@ package intraflow
 import (
 	"encoding/json"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -30,8 +30,8 @@ import (
 //
 // # Behavior and Queue Pairing
 //
-// The behavioral guarantees of this policy are critically dependent on the capabilities of the `framework.SafeQueue` it
-// is paired with. The system distinguishes between:
+// The behavioral guarantees of this policy are critically dependent on the capabilities of the SafeQueue it is paired
+// with. The system distinguishes between:
 //   - "Logical Enqueue Time": The timestamp when a request first arrives at the `controller.FlowController`.
 //   - "Physical Enqueue Time": The timestamp when a request is added to a specific shard's queue, which happens later.
 //
@@ -41,7 +41,7 @@ import (
 //     This configuration ensures that requests are processed in the order they arrived at the controller, providing the
 //     most intuitive behavior.
 //   - Paired with a `CapabilityFIFO` queue, it provides approximate FCFS ordering based on physical arrival order at
-//     the `framework.SafeQueue`.
+//     the SafeQueue.
 //     This configuration offers higher performance at the cost of strict logical-time ordering, as the
 //     `controller.FlowController`'s "bounce-and-retry" mechanic for Draining shards means a bounced request may be
 //     processed after a request that logically arrived later.
@@ -63,7 +63,7 @@ func init() {
 // behavior.
 type fcfs struct{}
 
-var _ framework.OrderingPolicy = &fcfs{}
+var _ flowcontrol.OrderingPolicy = &fcfs{}
 
 // newFCFS creates a new `fcfs` policy instance.
 func newFCFS() *fcfs {
@@ -77,8 +77,8 @@ func (p *fcfs) Name() string {
 
 // RequiredQueueCapabilities returns an empty slice, indicating that this policy can operate with any queue.
 // See the `FCFSPolicyName` constant's documentation for details on the behavioral trade-offs.
-func (p *fcfs) RequiredQueueCapabilities() []framework.QueueCapability {
-	return []framework.QueueCapability{}
+func (p *fcfs) RequiredQueueCapabilities() []flowcontrol.QueueCapability {
+	return []flowcontrol.QueueCapability{}
 }
 
 // TypedName returns the type and name tuple of this plugin instance.

--- a/pkg/epp/flowcontrol/framework/plugins/intraflow/functional_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/intraflow/functional_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -46,7 +46,7 @@ func TestOrderingPolicyConformance(t *testing.T) {
 			plugin, err := factory(name, nil, nil)
 			require.NoError(t, err, "Factory failed for plugin %s", name)
 			require.NotNil(t, plugin, "Factory returned nil for plugin %s", name)
-			policy, ok := plugin.(framework.OrderingPolicy)
+			policy, ok := plugin.(flowcontrol.OrderingPolicy)
 			if !ok {
 				return
 			}

--- a/pkg/epp/flowcontrol/framework/plugins/queue/benchmark_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/benchmark_test.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 	"testing"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 var benchmarkFlowKey = types.FlowKey{ID: "benchmark-flow"}
@@ -63,7 +63,7 @@ func BenchmarkQueues(b *testing.B) {
 
 // benchmarkAddRemove measures the throughput of tightly coupled Add and Remove operations in parallel. This is a good
 // measure of the base overhead of the queue's data structure and locking mechanism.
-func benchmarkAddRemove(b *testing.B, q framework.SafeQueue) {
+func benchmarkAddRemove(b *testing.B, q flowcontrol.SafeQueue) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -81,7 +81,7 @@ func benchmarkAddRemove(b *testing.B, q framework.SafeQueue) {
 
 // benchmarkAddPeekRemove measures the throughput of a serial Add, PeekHead, and Remove sequence. This simulates a
 // common consumer pattern where a single worker peeks at an item before deciding to process and remove it.
-func benchmarkAddPeekRemove(b *testing.B, q framework.SafeQueue) {
+func benchmarkAddPeekRemove(b *testing.B, q flowcontrol.SafeQueue) {
 	// Pre-add one item so PeekHead doesn't fail on the first iteration.
 	initialItem := mocks.NewMockQueueItemAccessor(1, "initial", benchmarkFlowKey)
 	q.Add(initialItem)
@@ -107,7 +107,7 @@ func benchmarkAddPeekRemove(b *testing.B, q framework.SafeQueue) {
 
 // benchmarkBulkAddThenBulkRemove measures performance of filling the queue up with a batch of items and then draining
 // it. This can reveal performance characteristics related to how the data structure grows and shrinks.
-func benchmarkBulkAddThenBulkRemove(b *testing.B, q framework.SafeQueue) {
+func benchmarkBulkAddThenBulkRemove(b *testing.B, q flowcontrol.SafeQueue) {
 	b.ReportAllocs()
 
 	for i := 0; b.Loop(); i++ {
@@ -134,7 +134,7 @@ func benchmarkBulkAddThenBulkRemove(b *testing.B, q framework.SafeQueue) {
 
 // benchmarkAddPeekTailRemove measures the throughput of a serial Add, PeekTail, and Remove sequence. This is useful for
 // understanding the performance of accessing the lowest-priority item.
-func benchmarkAddPeekTailRemove(b *testing.B, q framework.SafeQueue) {
+func benchmarkAddPeekTailRemove(b *testing.B, q flowcontrol.SafeQueue) {
 	// Pre-add one item so PeekTail doesn't fail on the first iteration.
 	initialItem := mocks.NewMockQueueItemAccessor(1, "initial", benchmarkFlowKey)
 	q.Add(initialItem)
@@ -159,7 +159,7 @@ func benchmarkAddPeekTailRemove(b *testing.B, q framework.SafeQueue) {
 
 // benchmarkHighContention simulates a more realistic workload with multiple producers and consumers operating on the
 // queue concurrently.
-func benchmarkHighContention(b *testing.B, q framework.SafeQueue) {
+func benchmarkHighContention(b *testing.B, q flowcontrol.SafeQueue) {
 	// Pre-fill the queue to ensure consumers have work to do immediately.
 	for i := range 1000 {
 		item := mocks.NewMockQueueItemAccessor(1, fmt.Sprintf("prefill-%d", i), benchmarkFlowKey)

--- a/pkg/epp/flowcontrol/framework/plugins/queue/factory.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/factory.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package queue provides the factory and registration mechanism for all `framework.SafeQueue` implementations.
+// Package queue provides the factory and registration mechanism for all SafeQueue implementations.
 // It allows new queues to be added to the system and instantiated by name.
 package queue
 
@@ -22,14 +22,14 @@ import (
 	"fmt"
 	"sync"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 // RegisteredQueueName is the unique name under which a queue is registered.
 type RegisteredQueueName string
 
-// QueueConstructor defines the function signature for creating a `framework.SafeQueue`.
-type QueueConstructor func(policy framework.OrderingPolicy) (framework.SafeQueue, error)
+// QueueConstructor defines the function signature for creating a SafeQueue.
+type QueueConstructor func(policy flowcontrol.OrderingPolicy) (flowcontrol.SafeQueue, error)
 
 var (
 	// mu guards the registration map.
@@ -44,7 +44,7 @@ func MustRegisterQueue(name RegisteredQueueName, constructor QueueConstructor) {
 	mu.Lock()
 	defer mu.Unlock()
 	if _, ok := RegisteredQueues[name]; ok {
-		panic(fmt.Sprintf("framework.SafeQueue already registered with name %q", name))
+		panic(fmt.Sprintf("SafeQueue already registered with name %q", name))
 	}
 	RegisteredQueues[name] = constructor
 }
@@ -52,12 +52,12 @@ func MustRegisterQueue(name RegisteredQueueName, constructor QueueConstructor) {
 // NewQueueFromName creates a new SafeQueue given its registered name and the OrderingPolicy that will be optionally
 // used to configure the queue (provided it declares CapabilityPriorityConfigurable).
 // This is called by the FlowRegistry during initialization of a flow's ManagedQueue.
-func NewQueueFromName(name RegisteredQueueName, policy framework.OrderingPolicy) (framework.SafeQueue, error) {
+func NewQueueFromName(name RegisteredQueueName, policy flowcontrol.OrderingPolicy) (flowcontrol.SafeQueue, error) {
 	mu.RLock()
 	defer mu.RUnlock()
 	constructor, ok := RegisteredQueues[name]
 	if !ok {
-		return nil, fmt.Errorf("no framework.SafeQueue registered with name %q", name)
+		return nil, fmt.Errorf("no SafeQueue registered with name %q", name)
 	}
 	return constructor(policy)
 }

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
-	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/interflow"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/intraflow"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
@@ -65,10 +65,10 @@ func newTestPluginsHandle(t *testing.T) plugin.Handle {
 
 // mockCapabilityChecker is a test double for verifying that NewConfig correctly delegates compatibility checks.
 type mockCapabilityChecker struct {
-	checkCompatibilityFunc func(p framework.OrderingPolicy, q queue.RegisteredQueueName) error
+	checkCompatibilityFunc func(p flowcontrol.OrderingPolicy, q queue.RegisteredQueueName) error
 }
 
-func (m *mockCapabilityChecker) CheckCompatibility(p framework.OrderingPolicy, q queue.RegisteredQueueName) error {
+func (m *mockCapabilityChecker) CheckCompatibility(p flowcontrol.OrderingPolicy, q queue.RegisteredQueueName) error {
 	if m.checkCompatibilityFunc != nil {
 		return m.checkCompatibilityFunc(p, q)
 	}
@@ -176,7 +176,7 @@ func TestNewConfig(t *testing.T) {
 					Queue:        "CustomQueue",
 				}),
 				withCapabilityChecker(&mockCapabilityChecker{
-					checkCompatibilityFunc: func(framework.OrderingPolicy, queue.RegisteredQueueName) error { return nil },
+					checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error { return nil },
 				}),
 			},
 			handle: newTestPluginsHandle(t),
@@ -290,7 +290,7 @@ func TestNewConfig(t *testing.T) {
 			opts: []ConfigOption{
 				WithPriorityBand(mustBand(t, 1, "High")),
 				withCapabilityChecker(&mockCapabilityChecker{
-					checkCompatibilityFunc: func(framework.OrderingPolicy, queue.RegisteredQueueName) error {
+					checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error {
 						return contracts.ErrPolicyQueueIncompatible
 					},
 				}),

--- a/pkg/epp/flowcontrol/registry/doc.go
+++ b/pkg/epp/flowcontrol/registry/doc.go
@@ -23,6 +23,6 @@ limitations under the License.
 //     handling registration, garbage collection, and scaling operations.
 //   - `registryShard`: A slice of the data plane. It holds a partition of the total state and provides a
 //     read-optimized, concurrent-safe view for a single `controller.FlowController` worker.
-//   - `managedQueue`: A stateful decorator around a `framework.SafeQueue`. It is the fundamental unit of state,
+//   - `managedQueue`: A stateful decorator around a SafeQueue. It is the fundamental unit of state,
 //     responsible for atomically tracking statistics (e.g., length and byte size) and ensuring data consistency.
 package registry

--- a/pkg/epp/flowcontrol/registry/managedqueue_test.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
-	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	typesmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol/mocks"
 )
 
 // --- Test Harness and Mocks ---
@@ -61,7 +61,7 @@ func newRealMqHarness(t *testing.T, key types.FlowKey) *mqTestHarness {
 }
 
 // newMqHarness is the base constructor for the test harness.
-func newMqHarness(t *testing.T, queue framework.SafeQueue, key types.FlowKey, isDraining bool) *mqTestHarness {
+func newMqHarness(t *testing.T, queue flowcontrol.SafeQueue, key types.FlowKey, isDraining bool) *mqTestHarness {
 	t.Helper()
 
 	propagator := &mockStatsPropagator{}
@@ -249,7 +249,7 @@ func TestManagedQueue_Cleanup(t *testing.T) {
 		{
 			name: "ShouldSucceed_AndDecrementStats_WhenItemsRemoved",
 			setupMock: func(q *frameworkmocks.MockSafeQueue, items []types.QueueItemAccessor) {
-				q.CleanupFunc = func(_ framework.PredicateFunc) []types.QueueItemAccessor {
+				q.CleanupFunc = func(_ flowcontrol.PredicateFunc) []types.QueueItemAccessor {
 					return items
 				}
 			},
@@ -259,7 +259,7 @@ func TestManagedQueue_Cleanup(t *testing.T) {
 		{
 			name: "ShouldSucceed_AndNotChangeStats_WhenNoItemsRemoved",
 			setupMock: func(q *frameworkmocks.MockSafeQueue, items []types.QueueItemAccessor) {
-				q.CleanupFunc = func(_ framework.PredicateFunc) []types.QueueItemAccessor {
+				q.CleanupFunc = func(_ flowcontrol.PredicateFunc) []types.QueueItemAccessor {
 					return nil // Simulate no items matching predicate.
 				}
 			},
@@ -343,7 +343,7 @@ func TestManagedQueue_FlowQueueAccessor(t *testing.T) {
 		q.PeekHeadV = item
 		q.PeekTailV = item
 		q.NameV = "MockQueue"
-		q.CapabilitiesV = []framework.QueueCapability{framework.CapabilityFIFO}
+		q.CapabilitiesV = []flowcontrol.QueueCapability{flowcontrol.CapabilityFIFO}
 		require.NoError(t, harness.mq.Add(item), "Test setup: Adding an item must succeed")
 
 		accessor := harness.mq.FlowQueueAccessor()

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -30,9 +30,9 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 // propagateStatsDeltaFunc defines the callback function used to propagate statistics changes (deltas) up the hierarchy
@@ -842,8 +842,8 @@ func (fr *FlowRegistry) repartitionShardConfigsLocked() {
 
 // flowComponents holds the plugin instances created for a single flow on a single shard.
 type flowComponents struct {
-	policy framework.OrderingPolicy
-	queue  framework.SafeQueue
+	policy flowcontrol.OrderingPolicy
+	queue  flowcontrol.SafeQueue
 }
 
 // buildFlowComponents instantiates the necessary plugin components for a new flow instance.

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -30,10 +30,10 @@ import (
 	testclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 // --- Test Harness ---
@@ -188,7 +188,7 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 			handle,
 			WithPriorityBand(badBand),
 			withCapabilityChecker(&mockCapabilityChecker{
-				checkCompatibilityFunc: func(framework.OrderingPolicy, queue.RegisteredQueueName) error {
+				checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error {
 					return nil // Approve everything.
 				},
 			}),
@@ -204,7 +204,7 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 		})
 
 		require.Error(t, err, "WithConnection must return an error for a failed flow JIT registration")
-		assert.ErrorContains(t, err, "no framework.SafeQueue registered", "The returned error must propagate the reason")
+		assert.ErrorContains(t, err, "no SafeQueue registered", "The returned error must propagate the reason")
 	})
 
 	t.Run("Handle_Shards_ShouldReturnAllActiveShardsAndBeACopy", func(t *testing.T) {
@@ -1384,7 +1384,7 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	// This ensures NewConfig succeeds, but JIT (ensureFlowInfrastructure) fails when trying to instantiate the queue.
 	failQueueName := queue.RegisteredQueueName("NonExistentQueue")
 	mockChecker := &mockCapabilityChecker{
-		checkCompatibilityFunc: func(p framework.OrderingPolicy, q queue.RegisteredQueueName) error {
+		checkCompatibilityFunc: func(p flowcontrol.OrderingPolicy, q queue.RegisteredQueueName) error {
 			return nil // Bypass validation.
 		},
 	}

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types/mocks"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 )
 
 const (
@@ -273,7 +273,7 @@ func TestShard_PriorityBandAccessor(t *testing.T) {
 			t.Run("ShouldVisitAllQueuesInBand", func(t *testing.T) {
 				t.Parallel()
 				var iteratedKeys []types.FlowKey
-				accessor.IterateQueues(func(queue framework.FlowQueueAccessor) bool {
+				accessor.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
 					iteratedKeys = append(iteratedKeys, queue.FlowKey())
 					return true
 				})
@@ -285,7 +285,7 @@ func TestShard_PriorityBandAccessor(t *testing.T) {
 			t.Run("ShouldExitEarly_WhenCallbackReturnsFalse", func(t *testing.T) {
 				t.Parallel()
 				var iterationCount int
-				accessor.IterateQueues(func(queue framework.FlowQueueAccessor) bool {
+				accessor.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
 					iterationCount++
 					return false
 				})
@@ -305,7 +305,7 @@ func TestShard_PriorityBandAccessor(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					for i := 0; i < 100; i++ {
-						accessor.IterateQueues(func(queue framework.FlowQueueAccessor) bool {
+						accessor.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
 							// Accessing data should not panic or race.
 							_ = queue.FlowKey()
 							return true
@@ -341,7 +341,7 @@ func TestShard_PriorityBandAccessor(t *testing.T) {
 			assert.Empty(t, keys, "FlowKeys() on an empty band must return an empty slice")
 
 			var callbackExecuted bool
-			accessor.IterateQueues(func(queue framework.FlowQueueAccessor) bool {
+			accessor.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
 				callbackExecuted = true
 				return true
 			})
@@ -480,7 +480,7 @@ func TestShard_Concurrency_MixedWorkload(t *testing.T) {
 					for _, priority := range h.shard.AllOrderedPriorityLevels() {
 						accessor, err := h.shard.PriorityBandAccessor(priority)
 						if err == nil {
-							accessor.IterateQueues(func(q framework.FlowQueueAccessor) bool { return true })
+							accessor.IterateQueues(func(q flowcontrol.FlowQueueAccessor) bool { return true })
 						}
 					}
 				}

--- a/pkg/epp/flowcontrol/types/doc.go
+++ b/pkg/epp/flowcontrol/types/doc.go
@@ -31,9 +31,9 @@ limitations under the License.
 //     `QueueItemAccessor` interface. This is an enriched, read-only view used by policies and queues. It adds internal
 //     metadata like `EnqueueTime` and `EffectiveTTL`.
 //
-//  3. If the request is accepted and added to a `framework.SafeQueue`, the queue creates a `QueueItemHandle`. This is
-//     an opaque, queue-specific handle that the controller uses to perform targeted operations (like removal) without
-//     needing to know the queue's internal implementation details.
+//  3. If the request is accepted and added to a SafeQueue, the queue creates a `QueueItemHandle`. This is an opaque,
+//     queue-specific handle that the controller uses to perform targeted operations (like removal) without needing to
+//     know the queue's internal implementation details.
 //
 //  4. The `EnqueueAndWait` method blocks until the request reaches a terminal state. This final state is reported using
 //     a `QueueOutcome` enum and a corresponding `error`.

--- a/pkg/epp/flowcontrol/types/errors.go
+++ b/pkg/epp/flowcontrol/types/errors.go
@@ -40,7 +40,7 @@ var (
 
 // --- Pre-Enqueue Rejection Errors ---
 
-// The following errors can occur before a request is formally added to a `framework.SafeQueue`. When returned by
+// The following errors can occur before a request is formally added to a SafeQueue. When returned by
 // `FlowController.EnqueueAndWait()`, these specific errors will typically be wrapped by `ErrRejected`.
 var (
 	// ErrQueueAtCapacity indicates that a request could not be enqueued because queue capacity limits were met.
@@ -49,9 +49,8 @@ var (
 
 // --- Post-Enqueue Eviction Errors ---
 
-// The following errors occur when a request, already in a `framework.SafeQueue`, is removed for reasons other than
-// dispatch. When returned by `FlowController.EnqueueAndWait()`, these specific errors will typically be wrapped by
-// `ErrEvicted`.
+// The following errors occur when a request, already in a SafeQueue, is removed for reasons other than dispatch.
+// When returned by `FlowController.EnqueueAndWait()`, these specific errors will typically be wrapped by `ErrEvicted`.
 var (
 	// ErrTTLExpired indicates a request was evicted from a queue because its effective Time-To-Live expired.
 	ErrTTLExpired = errors.New("request TTL expired")

--- a/pkg/epp/flowcontrol/types/outcomes.go
+++ b/pkg/epp/flowcontrol/types/outcomes.go
@@ -34,7 +34,7 @@ const (
 	// The associated error from `FlowController.EnqueueAndWait()` will be nil.
 	QueueOutcomeDispatched
 
-	// --- Pre-Enqueue Rejection Outcomes (request never entered a `framework.SafeQueue`) ---
+	// --- Pre-Enqueue Rejection Outcomes (request never entered a SafeQueue) ---
 	// For these outcomes, the error from `FlowController.EnqueueAndWait()` will wrap `ErrRejected`.
 
 	// QueueOutcomeRejectedCapacity indicates rejection because queue capacity limits were met.
@@ -47,7 +47,7 @@ const (
 	// flow ID, or controller shutdown), which will be wrapped by `ErrRejected`.
 	QueueOutcomeRejectedOther
 
-	// --- Post-Enqueue Eviction Outcomes (request was in a `framework.SafeQueue` but not dispatched) ---
+	// --- Post-Enqueue Eviction Outcomes (request was in a SafeQueue but not dispatched) ---
 	// For these outcomes, the error from `FlowController.EnqueueAndWait()` will wrap `ErrEvicted`.
 
 	// QueueOutcomeEvictedTTL indicates eviction from a queue because the request's effective Time-To-Live expired.

--- a/pkg/epp/framework/interface/flowcontrol/accessors.go
+++ b/pkg/epp/framework/interface/flowcontrol/accessors.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package flowcontrol
 
 import "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 

--- a/pkg/epp/framework/interface/flowcontrol/doc.go
+++ b/pkg/epp/framework/interface/flowcontrol/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package framework defines the core plugin interfaces for extending the Flow Control layer.
+// Package flowcontrol defines the core plugin interfaces for extending the Flow Control layer.
 //
 // It establishes the contracts that custom logic, such as queueing disciplines and dispatching policies, must adhere
 // to. By building on these interfaces, the Flow Control layer can be extended and customized without modifying the
@@ -29,4 +29,4 @@ limitations under the License.
 //
 // These components are linked by QueueCapability, which allows policies to declare their queue requirements (e.g.,
 // FIFO or priority-based ordering).
-package framework
+package flowcontrol

--- a/pkg/epp/framework/interface/flowcontrol/errors.go
+++ b/pkg/epp/framework/interface/flowcontrol/errors.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package flowcontrol
 
 import (
 	"errors"

--- a/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
+++ b/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
@@ -19,8 +19,8 @@ package mocks
 import (
 	"context"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
@@ -34,16 +34,16 @@ type MockFlowQueueAccessor struct {
 	PeekHeadV       types.QueueItemAccessor
 	PeekTailV       types.QueueItemAccessor
 	FlowKeyV        types.FlowKey
-	OrderingPolicyV framework.OrderingPolicy
-	CapabilitiesV   []framework.QueueCapability
+	OrderingPolicyV flowcontrol.OrderingPolicy
+	CapabilitiesV   []flowcontrol.QueueCapability
 }
 
-func (m *MockFlowQueueAccessor) Name() string                              { return m.NameV }
-func (m *MockFlowQueueAccessor) Len() int                                  { return m.LenV }
-func (m *MockFlowQueueAccessor) ByteSize() uint64                          { return m.ByteSizeV }
-func (m *MockFlowQueueAccessor) OrderingPolicy() framework.OrderingPolicy  { return m.OrderingPolicyV }
-func (m *MockFlowQueueAccessor) FlowKey() types.FlowKey                    { return m.FlowKeyV }
-func (m *MockFlowQueueAccessor) Capabilities() []framework.QueueCapability { return m.CapabilitiesV }
+func (m *MockFlowQueueAccessor) Name() string                                { return m.NameV }
+func (m *MockFlowQueueAccessor) Len() int                                    { return m.LenV }
+func (m *MockFlowQueueAccessor) ByteSize() uint64                            { return m.ByteSizeV }
+func (m *MockFlowQueueAccessor) OrderingPolicy() flowcontrol.OrderingPolicy  { return m.OrderingPolicyV }
+func (m *MockFlowQueueAccessor) FlowKey() types.FlowKey                      { return m.FlowKeyV }
+func (m *MockFlowQueueAccessor) Capabilities() []flowcontrol.QueueCapability { return m.CapabilitiesV }
 
 func (m *MockFlowQueueAccessor) PeekHead() types.QueueItemAccessor {
 	return m.PeekHeadV
@@ -53,7 +53,7 @@ func (m *MockFlowQueueAccessor) PeekTail() types.QueueItemAccessor {
 	return m.PeekTailV
 }
 
-var _ framework.FlowQueueAccessor = &MockFlowQueueAccessor{}
+var _ flowcontrol.FlowQueueAccessor = &MockFlowQueueAccessor{}
 
 // MockPriorityBandAccessor is a behavioral mock for the PriorityBandAccessor interface.
 // Simple accessors are configured with public value fields (e.g., PriorityV).
@@ -66,8 +66,8 @@ type MockPriorityBandAccessor struct {
 	PriorityNameV     string
 	PolicyStateV      any
 	FlowKeysFunc      func() []types.FlowKey
-	QueueFunc         func(flowID string) framework.FlowQueueAccessor
-	IterateQueuesFunc func(callback func(flow framework.FlowQueueAccessor) (keepIterating bool))
+	QueueFunc         func(flowID string) flowcontrol.FlowQueueAccessor
+	IterateQueuesFunc func(callback func(flow flowcontrol.FlowQueueAccessor) (keepIterating bool))
 }
 
 func (m *MockPriorityBandAccessor) Priority() int        { return m.PriorityV }
@@ -81,41 +81,41 @@ func (m *MockPriorityBandAccessor) FlowKeys() []types.FlowKey {
 	return nil
 }
 
-func (m *MockPriorityBandAccessor) Queue(id string) framework.FlowQueueAccessor {
+func (m *MockPriorityBandAccessor) Queue(id string) flowcontrol.FlowQueueAccessor {
 	if m.QueueFunc != nil {
 		return m.QueueFunc(id)
 	}
 	return nil
 }
 
-func (m *MockPriorityBandAccessor) IterateQueues(callback func(flow framework.FlowQueueAccessor) bool) {
+func (m *MockPriorityBandAccessor) IterateQueues(callback func(flow flowcontrol.FlowQueueAccessor) bool) {
 	if m.IterateQueuesFunc != nil {
 		m.IterateQueuesFunc(callback)
 	}
 }
 
-var _ framework.PriorityBandAccessor = &MockPriorityBandAccessor{}
+var _ flowcontrol.PriorityBandAccessor = &MockPriorityBandAccessor{}
 
-// MockSafeQueue is a simple stub mock for the `framework.SafeQueue` interface.
+// MockSafeQueue is a simple stub mock for the SafeQueue interface.
 // It is used for tests that need to control the exact return values of a queue's methods without simulating the queue's
 // internal logic or state.
 type MockSafeQueue struct {
 	NameV         string
-	CapabilitiesV []framework.QueueCapability
+	CapabilitiesV []flowcontrol.QueueCapability
 	LenV          int
 	ByteSizeV     uint64
 	PeekHeadV     types.QueueItemAccessor
 	PeekTailV     types.QueueItemAccessor
 	AddFunc       func(item types.QueueItemAccessor)
 	RemoveFunc    func(handle types.QueueItemHandle) (types.QueueItemAccessor, error)
-	CleanupFunc   func(predicate framework.PredicateFunc) []types.QueueItemAccessor
+	CleanupFunc   func(predicate flowcontrol.PredicateFunc) []types.QueueItemAccessor
 	DrainFunc     func() []types.QueueItemAccessor
 }
 
-func (m *MockSafeQueue) Name() string                              { return m.NameV }
-func (m *MockSafeQueue) Capabilities() []framework.QueueCapability { return m.CapabilitiesV }
-func (m *MockSafeQueue) Len() int                                  { return m.LenV }
-func (m *MockSafeQueue) ByteSize() uint64                          { return m.ByteSizeV }
+func (m *MockSafeQueue) Name() string                                { return m.NameV }
+func (m *MockSafeQueue) Capabilities() []flowcontrol.QueueCapability { return m.CapabilitiesV }
+func (m *MockSafeQueue) Len() int                                    { return m.LenV }
+func (m *MockSafeQueue) ByteSize() uint64                            { return m.ByteSizeV }
 
 func (m *MockSafeQueue) PeekHead() types.QueueItemAccessor {
 	return m.PeekHeadV
@@ -138,7 +138,7 @@ func (m *MockSafeQueue) Remove(handle types.QueueItemHandle) (types.QueueItemAcc
 	return nil, nil
 }
 
-func (m *MockSafeQueue) Cleanup(predicate framework.PredicateFunc) []types.QueueItemAccessor {
+func (m *MockSafeQueue) Cleanup(predicate flowcontrol.PredicateFunc) []types.QueueItemAccessor {
 	if m.CleanupFunc != nil {
 		return m.CleanupFunc(predicate)
 	}
@@ -152,7 +152,7 @@ func (m *MockSafeQueue) Drain() []types.QueueItemAccessor {
 	return nil
 }
 
-var _ framework.SafeQueue = &MockSafeQueue{}
+var _ flowcontrol.SafeQueue = &MockSafeQueue{}
 
 // MockOrderingPolicy is a behavioral mock for the OrderingPolicy interface.
 // Simple accessors are configured with public value fields (e.g., TypedNameV).
@@ -160,7 +160,7 @@ var _ framework.SafeQueue = &MockSafeQueue{}
 type MockOrderingPolicy struct {
 	TypedNameV                 plugin.TypedName
 	LessFunc                   func(a, b types.QueueItemAccessor) bool
-	RequiredQueueCapabilitiesV []framework.QueueCapability
+	RequiredQueueCapabilitiesV []flowcontrol.QueueCapability
 }
 
 func (m *MockOrderingPolicy) TypedName() plugin.TypedName { return m.TypedNameV }
@@ -172,11 +172,11 @@ func (m *MockOrderingPolicy) Less(a, b types.QueueItemAccessor) bool {
 	return false
 }
 
-func (m *MockOrderingPolicy) RequiredQueueCapabilities() []framework.QueueCapability {
+func (m *MockOrderingPolicy) RequiredQueueCapabilities() []flowcontrol.QueueCapability {
 	return m.RequiredQueueCapabilitiesV
 }
 
-var _ framework.OrderingPolicy = &MockOrderingPolicy{}
+var _ flowcontrol.OrderingPolicy = &MockOrderingPolicy{}
 
 // MockFairnessPolicy is a behavioral mock for the FairnessPolicy interface.
 // Simple accessors are configured with public value fields (e.g., NameV).
@@ -184,7 +184,7 @@ var _ framework.OrderingPolicy = &MockOrderingPolicy{}
 type MockFairnessPolicy struct {
 	TypedNameV   plugin.TypedName
 	NewStateFunc func(ctx context.Context) any
-	PickFunc     func(ctx context.Context, flowGroup framework.PriorityBandAccessor) (framework.FlowQueueAccessor, error)
+	PickFunc     func(ctx context.Context, flowGroup flowcontrol.PriorityBandAccessor) (flowcontrol.FlowQueueAccessor, error)
 }
 
 func (m *MockFairnessPolicy) TypedName() plugin.TypedName { return m.TypedNameV }
@@ -196,11 +196,11 @@ func (m *MockFairnessPolicy) NewState(ctx context.Context) any {
 	return nil
 }
 
-func (m *MockFairnessPolicy) Pick(ctx context.Context, flowGroup framework.PriorityBandAccessor) (framework.FlowQueueAccessor, error) {
+func (m *MockFairnessPolicy) Pick(ctx context.Context, flowGroup flowcontrol.PriorityBandAccessor) (flowcontrol.FlowQueueAccessor, error) {
 	if m.PickFunc != nil {
 		return m.PickFunc(ctx, flowGroup)
 	}
 	return nil, nil
 }
 
-var _ framework.FairnessPolicy = &MockFairnessPolicy{}
+var _ flowcontrol.FairnessPolicy = &MockFairnessPolicy{}

--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package flowcontrol
 
 import (
 	"context"

--- a/pkg/epp/framework/interface/flowcontrol/queue.go
+++ b/pkg/epp/framework/interface/flowcontrol/queue.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package flowcontrol
 
 import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This improves discoverability and mitigates future import cycles.

**Which issue(s) this PR fixes**:

Part of #2190 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```