### PR TITLE
A transitional PR towards pluggable BBR Framework

### DIFF
--- a/cmd/bbr/runner/runner.go
+++ b/cmd/bbr/runner/runner.go
@@ -41,6 +41,8 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/internal/runnable"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/datastore"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
+	bbr "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
+	routing "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/routing"
 	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/server"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/profiling"
@@ -48,6 +50,7 @@ import (
 )
 
 var (
+	// Flags
 	grpcPort            = flag.Int("grpc-port", 9004, "The gRPC port used for communicating with Envoy proxy")
 	grpcHealthPort      = flag.Int("grpc-health-port", 9005, "The port used for gRPC liveness and readiness probes")
 	metricsPort         = flag.Int("metrics-port", 9090, "The metrics port")
@@ -57,7 +60,12 @@ var (
 	logVerbosity        = flag.Int("v", logutil.DEFAULT, "number for the log level verbosity")
 	enablePprof         = flag.Bool("enable-pprof", true, "Enables pprof handlers. Defaults to true. Set to false to disable pprof handlers.")
 
+	// Logging
 	setupLog = ctrl.Log.WithName("setup")
+
+	// Contains the BBR plugins specs specified via repeated flags:
+	//   --plugin <type>:<name>[:<json>]
+	pluginSpecs bbr.BBRPluginSpecs
 )
 
 func NewRunner() *Runner {
@@ -69,6 +77,10 @@ func NewRunner() *Runner {
 // Runner is used to run bbr with its plugins
 type Runner struct {
 	bbrExecutableName string
+
+	// The slice of BBR plugin instances executed by the request handler,
+	// in the same order the plugin flags are provided.
+	bbrPluginInstances []bbr.BBRPlugin
 }
 
 // WithExecutableName sets the name of the executable containing the runner.
@@ -82,6 +94,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	setupLog.Info(r.bbrExecutableName+" build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
+
+	flag.Var(&pluginSpecs, "plugin", `Repeatable. --plugin <type>:<name>[:<json>]`)
 	flag.Parse()
 	initLogging(&opts)
 
@@ -150,12 +164,44 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
+	// Register factories for all known in-tree BBR plugins
+	r.registerInTreePlugins()
+
+	// Construct BBR plugin instances for the in tree plugins that are (1) registered and (2) requested via the --plugin flags
+	if len(pluginSpecs) == 0 {
+		setupLog.Info("No BBR plugins are specified. Running BBR with the default behavior.")
+
+		// Append a default BBRPlugin to the slice of the BBRPlugin instances using regular registered factory mechanism.
+		factory := bbr.Registry[routing.DefaultPluginType]
+		defaultPlugin, err := factory("", nil)
+		if err != nil {
+			setupLog.Error(err, "Failed to create default plugin")
+			return err
+		}
+		r.withPlugin(defaultPlugin)
+	} else {
+		setupLog.Info("BBR plugins are specified. Running BBR with the specified plugins.")
+
+		for _, s := range pluginSpecs {
+			factory, ok := bbr.Registry[s.Type]
+			if !ok {
+				setupLog.Error(err, fmt.Sprintf("unknown plugin type %q (no factory registered)\n", s.Type))
+			}
+			instance, err := factory(s.Name, s.JSON)
+			if err != nil {
+				setupLog.Error(err, fmt.Sprintf("invalid %s#%s: %v\n", s.Type, s.Name, err))
+			}
+			r.withPlugin(instance)
+		}
+	}
+
 	// Setup ExtProc Server Runner
 	serverRunner := &runserver.ExtProcServerRunner{
-		GrpcPort:      *grpcPort,
-		Datastore:     ds,
-		SecureServing: *secureServing,
-		Streaming:     *streaming,
+		GrpcPort:        *grpcPort,
+		Datastore:       ds,
+		SecureServing:   *secureServing,
+		Streaming:       *streaming,
+		PluginInstances: r.bbrPluginInstances,
 	}
 	if err := serverRunner.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to setup BBR controllers")
@@ -181,6 +227,15 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	setupLog.Info("Manager terminated")
 	return nil
+}
+
+// registerInTreePlugins registers the factory functions of all known BBR plugins
+func (r *Runner) registerInTreePlugins() {
+	bbr.Register(routing.DefaultPluginType, routing.DefaultPluginFactory)
+}
+
+func (r *Runner) withPlugin(p bbr.BBRPlugin) {
+	r.bbrPluginInstances = append(r.bbrPluginInstances, p)
 }
 
 // registerHealthServer adds the Health gRPC server as a Runnable to the given manager.

--- a/config/charts/body-based-routing/templates/bbr.yaml
+++ b/config/charts/body-based-routing/templates/bbr.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         app: {{ .Values.bbr.name }}
     spec:
-      serviceAccountName: {{ .Values.bbr.name}}-{{ .Release.Name }}
+      serviceAccountName: {{ .Values.bbr.name }}-{{ .Release.Name }}
       containers:
       - name: bbr
         image: {{ .Values.bbr.image.hub }}/{{ .Values.bbr.image.name }}:{{ .Values.bbr.image.tag }}
@@ -24,6 +24,14 @@ spec:
         {{- range $key, $value := .Values.bbr.flags }}
         - --{{ $key }}
         - "{{ $value }}"
+        {{- end }}      
+        {{- range .Values.bbr.plugins }}
+        - --plugin
+        {{- if .json }}
+        - {{ printf "%s:%s:%s" .type .name (toJson .json) | quote }}
+        {{- else }}
+        - {{ printf "%s:%s" .type .name | quote }}
+        {{- end }}
         {{- end }}
         {{- if not .Values.bbr.multiNamespace }}
         env:

--- a/config/charts/body-based-routing/values.yaml
+++ b/config/charts/body-based-routing/values.yaml
@@ -14,6 +14,12 @@ bbr:
     # Log verbosity
     v: 3
 
+  # Plugin configuration (transitional - currently runs no-op default plugin)
+  plugins:
+    - type: default-bbr
+      name: default-bbr
+      json: {"v":0, "no-op":true}
+
 provider:
   name: none
 

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -30,6 +30,7 @@ import (
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
+	bbr "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
@@ -267,7 +268,7 @@ func TestHandleRequestBody(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			server := NewServer(test.streaming, &fakeDatastore{})
+			server := NewServer(test.streaming, &fakeDatastore{}, []bbr.BBRPlugin{})
 			bodyBytes, _ := json.Marshal(test.body)
 			resp, err := server.HandleRequestBody(ctx, bodyBytes)
 			if err != nil {

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -29,24 +29,28 @@ import (
 
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
+
+	bbr "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 )
 
 type Datastore interface {
 	GetBaseModel(modelName string) string
 }
 
-func NewServer(streaming bool, ds Datastore) *Server {
+func NewServer(streaming bool, ds Datastore, bbrPluginInstances []bbr.BBRPlugin) *Server {
 	return &Server{
-		streaming: streaming,
-		ds:        ds,
+		streaming:       streaming,
+		ds:              ds,
+		pluginInstances: bbrPluginInstances,
 	}
 }
 
 // Server implements the Envoy external processing server.
 // https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto
 type Server struct {
-	streaming bool
-	ds        Datastore
+	streaming       bool
+	ds              Datastore
+	pluginInstances []bbr.BBRPlugin
 }
 
 func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {

--- a/pkg/bbr/handlers/server_test.go
+++ b/pkg/bbr/handlers/server_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	bbr "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
@@ -139,7 +140,7 @@ func TestProcessRequestBody(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			srv := NewServer(tc.streaming, &fakeDatastore{})
+			srv := NewServer(tc.streaming, &fakeDatastore{}, []bbr.BBRPlugin{})
 			streamedBody := &streamedBody{}
 			for i, body := range tc.bodys {
 				got, err := srv.processRequestBody(context.Background(), body, streamedBody, log.FromContext(ctx))

--- a/pkg/bbr/plugins/plugins.go
+++ b/pkg/bbr/plugins/plugins.go
@@ -23,9 +23,10 @@ import (
 type BBRPlugin interface {
 	plugin.Plugin
 
-	// Execute runs the plugin logic on the request body and a map of headers.
-	// A plugin's imnplementation logic CAN mutate the body of the message.
+	// Execute runs the plugin's logic on the request body.
+	// A plugin's implementation logic CAN mutate the body of the message.
 	// A plugin's implementation MUST return a map of headers.
 	// If no headers are set by the implementation, the return headers map is nil.
-	Execute(requestBodyBytes []byte, requestHeaders map[string][]string) (mutatedBodyBytes []byte, headers map[string][]string, err error)
+	// In the future, a headers map can be added to the plugin interface to allow different plugins on a chain to share information on the headers.
+	Execute(requestBodyBytes []byte) (mutatedBodyBytes []byte, headers map[string][]string, err error)
 }

--- a/pkg/bbr/routing/default.go
+++ b/pkg/bbr/routing/default.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routing
+
+import (
+	"encoding/json"
+
+	bbr "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
+	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+)
+
+const (
+	DefaultPluginType = "no-op-plugin"
+)
+
+// compile-time type validation
+var _ bbr.BBRPlugin = &DefaultPlugin{}
+
+type DefaultPlugin struct {
+	typedName epp.TypedName
+}
+
+// DefaultPluginFactory defines the factory function for DefaultPlugin.
+// The name and rawParameters are ignored as the plugin uses the default configuration.
+func DefaultPluginFactory(_ string, _ json.RawMessage) (bbr.BBRPlugin, error) {
+	return NewDefaultPlugin(), nil
+}
+
+// NewDefaultPlugin returns a concrete *DefaultPlugin.
+func NewDefaultPlugin() *DefaultPlugin {
+	return &DefaultPlugin{
+		typedName: epp.TypedName{Type: DefaultPluginType, Name: DefaultPluginType},
+	}
+}
+
+// The current default plugin is a no-op and returns the request body unchanged.
+// After integration, "no-op-plugin" will be replaced by "default-plugin",
+// which will extract the model name, map it to a base model, and set the
+// necessary request headers.
+func (p *DefaultPlugin) Execute(requestBodyBytes []byte) ([]byte, map[string][]string, error) {
+	return requestBodyBytes, nil, nil
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *DefaultPlugin) TypedName() epp.TypedName {
+	return p.typedName
+}
+
+// WithName sets the name of the default BBR plugin
+func (p *DefaultPlugin) WithName(name string) *DefaultPlugin {
+	p.typedName.Name = name
+	return p
+}

--- a/pkg/bbr/server/runserver.go
+++ b/pkg/bbr/server/runserver.go
@@ -33,14 +33,16 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/controller"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/datastore"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/handlers"
+	bbr "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 )
 
 // ExtProcServerRunner provides methods to manage an external process server.
 type ExtProcServerRunner struct {
-	GrpcPort      int
-	Datastore     datastore.Datastore
-	SecureServing bool
-	Streaming     bool
+	GrpcPort        int
+	Datastore       datastore.Datastore
+	SecureServing   bool
+	Streaming       bool
+	PluginInstances []bbr.BBRPlugin
 }
 
 func NewDefaultExtProcServerRunner(port int, streaming bool) *ExtProcServerRunner {
@@ -81,7 +83,7 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 			srv = grpc.NewServer()
 		}
 
-		extProcPb.RegisterExternalProcessorServer(srv, handlers.NewServer(r.Streaming, r.Datastore))
+		extProcPb.RegisterExternalProcessorServer(srv, handlers.NewServer(r.Streaming, r.Datastore, r.PluginInstances))
 
 		// Forward to the gRPC runnable.
 		return runnable.GRPCServer("ext-proc", srv, r.GrpcPort).Start(ctx)


### PR DESCRIPTION
/kind feature

What this PR does / why we need it:

This PR is the next development step, extending PR #2121 

Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1963

Main changes/additions:

1. BBRPlugins are specified using a repeatable `--plugin` flag and are executed in the order in which they are specified
2. No-op plugin for testing
3. BBRPlugin slice containing only this plugin
4. Helm chart for BBR with no-op `--plugin` updated
5. `Execute` method in BBRPlugin interface is made narrower, as there is no use case for header manipulation at the moment
6. The full path from plugin specification to registration to execution in the request handler is implemented with the no-op plugin

Converting the BBR default implementation into the plugin form is handled in the next PR following this development step.

Known issues:

1. Add comprehensive unit tests
2. In the longer term, the headers map might be returned to the BBRPlugin interface. Also need to figure out how to receive the header information in the request handler


Does this PR introduce a user-facing change?:

-->

NONE
