### PR TITLE
refactor: rename intraflow package to ordering

### DIFF
--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -21,7 +21,7 @@ import (
 
 	configapi "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/fairness"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/intraflow"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/ordering"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/framework/plugins/picker"
@@ -145,7 +145,7 @@ func ensureFlowControlLayer(
 	handle fwkplugin.Handle,
 	_ map[string]fwkplugin.Plugin,
 ) error {
-	if err := registerDefaultPlugin(cfg, handle, intraflow.FCFSOrderingPolicyType); err != nil {
+	if err := registerDefaultPlugin(cfg, handle, ordering.FCFSOrderingPolicyType); err != nil {
 		return err
 	}
 	return registerDefaultPlugin(cfg, handle, fairness.GlobalStrictFairnessPolicyType)

--- a/pkg/epp/flowcontrol/README.md
+++ b/pkg/epp/flowcontrol/README.md
@@ -100,7 +100,7 @@ their justifications, please refer to the detailed documentation within the rele
     requests to the backends. Its design focuses on high throughput and backpressure.
 
 2.  **Pluggable `Policy` Framework (`./framework`)**: This defines the core interfaces for all pluggable logic. It
-    features a two-tier policy system for `InterFlow` (decisions *between* different flows) and `IntraFlow`
+    features a two-tier policy system for `Fairness` (decisions *between* different flows) and `Ordering`
     (decisions *within* a single flow) logic, covering both request dispatch and displacement.
 
 3.  **Extensible `SafeQueue` System (`./framework`)**: This defines the `framework.SafeQueue` interface for

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -330,14 +330,14 @@ func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
 	return false
 }
 
-// selectItem applies the configured fairness and intra-flow dispatch policies to select a single item.
+// selectItem applies the configured fairness and ordering policies to select a single item.
 func (sp *ShardProcessor) selectItem(
 	ctx context.Context,
 	flowGroup flowcontrol.PriorityBandAccessor,
 ) (types.QueueItemAccessor, error) {
 	fairnessP, err := sp.shard.FairnessPolicy(flowGroup.Priority())
 	if err != nil {
-		return nil, fmt.Errorf("could not get InterFlowDispatchPolicy: %w", err)
+		return nil, fmt.Errorf("could not get FairnessPolicy: %w", err)
 	}
 	queue, err := fairnessP.Pick(ctx, flowGroup)
 	if err != nil {

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/doc.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package intraflow provides the standard implementations of the OrderingPolicy interface.
+// Package ordering provides the standard implementations of the OrderingPolicy interface.
 //
 // # Context: The 3-Tier Dispatch Hierarchy
 //
@@ -51,6 +51,4 @@ limitations under the License.
 //   - EDF ("Earliest Deadline First") ("edf-ordering-policy"): Orders requests by their absolute deadline
 //     (EnqueueTime + TTL).
 //     This maximizes the number of requests served before their deadlines expire.
-//
-// TODO: Rename directory and package to "ordering".
-package intraflow
+package ordering

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/edf.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/edf.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package intraflow
+package ordering
 
 import (
 	"encoding/json"

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/edf_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/edf_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package intraflow
+package ordering
 
 import (
 	"testing"

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package intraflow
+package ordering
 
 import (
 	"encoding/json"

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package intraflow
+package ordering
 
 import (
 	"testing"

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/functional_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/functional_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package intraflow
+package ordering
 
 import (
 	"testing"

--- a/pkg/epp/flowcontrol/framework/plugins/queue/README.md
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/README.md
@@ -7,7 +7,7 @@ defines core, self-contained queue data structures used by the `controller.FlowC
 
 The `controller.FlowController` manages requests by organizing them into queues. Each logical "flow" within a given
 priority band has its own `contracts.ManagedQueue` instance, which wraps a `framework.SafeQueue`. This design allows the
-`controller.FlowController` to apply policies at both the inter-flow (across different flows) and intra-flow (within a
+`controller.FlowController` to apply policies at both the fairness (across different flows) and ordering (within a
 single flow's queue) levels.
 
 The `framework.SafeQueue` interface abstracts the underlying data structure and its ordering logic. This pluggable

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -25,7 +25,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/fairness"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/intraflow"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/ordering"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
@@ -38,7 +38,7 @@ const (
 	// It is set to 1 GB.
 	defaultPriorityBandMaxBytes uint64 = 1_000_000_000
 	// defaultOrderingPolicyRef is the default policy for selecting items within a single flow's queue.
-	defaultOrderingPolicyRef string = intraflow.FCFSOrderingPolicyType
+	defaultOrderingPolicyRef string = ordering.FCFSOrderingPolicyType
 	// defaultFairnessPolicyRef is the default policy for selecting which flow's queue to service next.
 	defaultFairnessPolicyRef string = fairness.GlobalStrictFairnessPolicyType
 	// defaultQueue is the default queue implementation for flows.

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -25,7 +25,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/fairness"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/intraflow"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/ordering"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/queue"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol/mocks"
@@ -48,16 +48,16 @@ func newTestPluginsHandle(t *testing.T) plugin.Handle {
 			Name: fairness.RoundRobinFairnessPolicyType,
 		},
 	})
-	handle.AddPlugin(intraflow.FCFSOrderingPolicyType, &frameworkmocks.MockOrderingPolicy{
+	handle.AddPlugin(ordering.FCFSOrderingPolicyType, &frameworkmocks.MockOrderingPolicy{
 		TypedNameV: plugin.TypedName{
-			Type: intraflow.FCFSOrderingPolicyType,
-			Name: intraflow.FCFSOrderingPolicyType,
+			Type: ordering.FCFSOrderingPolicyType,
+			Name: ordering.FCFSOrderingPolicyType,
 		},
 	})
-	handle.AddPlugin(intraflow.EDFOrderingPolicyType, &frameworkmocks.MockOrderingPolicy{
+	handle.AddPlugin(ordering.EDFOrderingPolicyType, &frameworkmocks.MockOrderingPolicy{
 		TypedNameV: plugin.TypedName{
-			Type: intraflow.EDFOrderingPolicyType,
-			Name: intraflow.EDFOrderingPolicyType,
+			Type: ordering.EDFOrderingPolicyType,
+			Name: ordering.EDFOrderingPolicyType,
 		},
 	})
 	return handle
@@ -341,14 +341,14 @@ func TestNewPriorityBandConfig(t *testing.T) {
 		pb, err := NewPriorityBandConfig(handle, 1, "Custom",
 			WithQueue(queue.RegisteredQueueName("CustomQueue")),
 			WithBandMaxBytes(999),
-			WithOrderingPolicy(intraflow.EDFOrderingPolicyType, handle),
+			WithOrderingPolicy(ordering.EDFOrderingPolicyType, handle),
 			WithFairnessPolicy(fairness.RoundRobinFairnessPolicyType, handle),
 		)
 		require.NoError(t, err)
 		assert.Equal(t, queue.RegisteredQueueName("CustomQueue"), pb.Queue)
 		assert.Equal(t, uint64(999), pb.MaxBytes)
 		require.NotNil(t, pb.OrderingPolicy)
-		assert.Equal(t, intraflow.EDFOrderingPolicyType, pb.OrderingPolicy.TypedName().Name)
+		assert.Equal(t, ordering.EDFOrderingPolicyType, pb.OrderingPolicy.TypedName().Name)
 		require.NotNil(t, pb.FairnessPolicy)
 		assert.Equal(t, fairness.RoundRobinFairnessPolicyType, pb.FairnessPolicy.TypedName().Name)
 	})

--- a/pkg/epp/flowcontrol/registry/managedqueue_test.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue_test.go
@@ -357,7 +357,7 @@ func TestManagedQueue_FlowQueueAccessor(t *testing.T) {
 			"Accessor ByteSize() must reflect the managed queue's current byte size")
 		assert.Equal(t, flowKey, accessor.FlowKey(), "Accessor FlowKey() must return the correct identifier for the flow")
 		assert.Equal(t, harness.mockPolicy, accessor.OrderingPolicy(),
-			"Accessor OrderingPolicy() must return the policy provided by the configured intra-flow policy")
+			"Accessor OrderingPolicy() must return the policy provided by the configured ordering policy")
 
 		peekedHead := accessor.PeekHead()
 		assert.Same(t, item, peekedHead, "Accessor PeekHead() must return the exact item instance at the head")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind cleanup

**What this PR does / why we need it**:

Rename `pkg/epp/flowcontrol/framework/plugins/intraflow` to `pkg/epp/flowcontrol/framework/plugins/ordering`.

Update all references and package declarations. This aligns the implementation package name with the `OrderingPolicy` interface.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Cleanup from #1715 following #2188 and #2193.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
