### PR TITLE
feat: add native TTFT, TPOT, ITL, and E2E latency tracking to framework

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -47,6 +48,9 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 
 	reqCtx.ResponseSize += len(responseBytes)
 
+	// Capture current timestamp for metrics calculation
+	now := time.Now()
+
 	parsedResp, err := s.parser.ParseResponse(ctx, responseBytes, reqCtx.Response.Headers, endOfStream)
 	if err != nil {
 		logger.Error(err, "parsing response")
@@ -58,7 +62,61 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 			metrics.RecordPromptCachedTokens(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Usage.PromptTokenDetails.CachedTokens)
 		}
 	}
+
+	// Track token generation timing for streaming responses
+	// Skip tracking for [DONE] markers which don't contain actual tokens
+	isDoneMarker := len(responseBytes) > 0 && string(responseBytes) == "data: [DONE]"
+	if len(responseBytes) > 0 && !isDoneMarker {
+		// Calculate TTFT (Time to First Token) - only on first chunk with content
+		if reqCtx.TTFT == 0 {
+			// TTFT from client perspective (request received to first token)
+			reqCtx.TTFT = now.Sub(reqCtx.RequestReceivedTimestamp).Seconds()
+			// TTFT from EPP perspective (scheduling complete to first token)
+			reqCtx.TTFTEPP = now.Sub(reqCtx.SchedulingCompleteTimestamp).Seconds()
+
+			logger.V(logutil.DEBUG).Info("First token received", "TTFT", reqCtx.TTFT, "TTFTEPP", reqCtx.TTFTEPP)
+		}
+
+		// Track inter-token timing for subsequent chunks
+		if !reqCtx.LastTokenTimestamp.IsZero() {
+			// Inter-Token Latency (ITL) - time between this chunk and previous chunk
+			itl := now.Sub(reqCtx.LastTokenTimestamp).Seconds()
+			logger.V(logutil.TRACE).Info("Inter-token latency", "ITL", itl)
+
+			// Increment token count for TPOT calculation
+			reqCtx.GeneratedTokenCount++
+		}
+
+		reqCtx.LastTokenTimestamp = now
+	}
+
 	if endOfStream {
+		// Record TTFT metrics
+		if reqCtx.TTFT > 0 {
+			metrics.RecordRequestTTFT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.TTFT)
+			logger.V(logutil.DEBUG).Info("Recorded TTFT", "TTFT", reqCtx.TTFT)
+		}
+
+		// Calculate and record TPOT (Time Per Output Token)
+		// TPOT = (Total decode time) / (number of token intervals)
+		if reqCtx.GeneratedTokenCount > 0 && reqCtx.TTFT > 0 {
+			// Calculate time from first token to last token (decode phase)
+			firstTokenTime := reqCtx.RequestReceivedTimestamp.Add(time.Duration(reqCtx.TTFT * float64(time.Second)))
+			decodeDuration := now.Sub(firstTokenTime).Seconds()
+
+			// Calculate average TPOT (time per output token during decode phase)
+			reqCtx.TPOT = decodeDuration / float64(reqCtx.GeneratedTokenCount)
+
+			// TPOT from EPP perspective
+			firstTokenTimeEPP := reqCtx.SchedulingCompleteTimestamp.Add(time.Duration(reqCtx.TTFTEPP * float64(time.Second)))
+			decodeDurationEPP := now.Sub(firstTokenTimeEPP).Seconds()
+			reqCtx.TPOTEPP = decodeDurationEPP / float64(reqCtx.GeneratedTokenCount)
+
+			metrics.RecordRequestTPOT(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.TPOT)
+			logger.V(logutil.DEBUG).Info("Recorded TPOT", "TPOT", reqCtx.TPOT, "tokenCount", reqCtx.GeneratedTokenCount, "decodeDuration", decodeDuration)
+		}
+
+		// Record existing metrics
 		metrics.RecordNormalizedTimePerOutputToken(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp, reqCtx.Usage.CompletionTokens)
 		metrics.RecordRequestLatencies(ctx, reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestReceivedTimestamp, reqCtx.ResponseCompleteTimestamp)
 		metrics.RecordResponseSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.ResponseSize)

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -409,6 +410,92 @@ func TestResponseSizeAccumulation(t *testing.T) {
 				server.HandleResponseBody(ctx, reqCtx, chunk, endOfStream)
 			}
 			assert.Equal(t, tt.wantResponseSize, reqCtx.ResponseSize)
+		})
+	}
+}
+
+func TestTTFTTPOTMetricsTracking(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	tests := []struct {
+		name                    string
+		chunks                  [][]byte
+		wantTTFTGreaterThanZero bool
+		wantTPOTGreaterThanZero bool
+		wantGeneratedTokenCount int
+	}{
+		{
+			name: "streaming response with multiple chunks",
+			chunks: [][]byte{
+				[]byte("data: {\"choices\":[{\"text\":\"Hello\"}]}\n"),
+				[]byte("data: {\"choices\":[{\"text\":\" world\"}]}\n"),
+				[]byte("data: {\"choices\":[{\"text\":\"!\"}]}\n"),
+				[]byte("data: [DONE]"),
+			},
+			wantTTFTGreaterThanZero: true,
+			wantTPOTGreaterThanZero: true,
+			wantGeneratedTokenCount: 2, // First chunk doesn't count, then 2 more chunks
+		},
+		{
+			name: "single chunk non-streaming response",
+			chunks: [][]byte{
+				[]byte(body),
+			},
+			wantTTFTGreaterThanZero: true,
+			wantTPOTGreaterThanZero: false, // No TPOT for single chunk
+			wantGeneratedTokenCount: 0,
+		},
+		{
+			name: "empty response",
+			chunks: [][]byte{
+				[]byte(""),
+			},
+			wantTTFTGreaterThanZero: false,
+			wantTPOTGreaterThanZero: false,
+			wantGeneratedTokenCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &StreamingServer{
+				parser:   openai.NewOpenAIParser(),
+				director: &mockDirector{},
+			}
+			reqCtx := &RequestContext{
+				RequestReceivedTimestamp:    time.Now().Add(-100 * time.Millisecond),
+				SchedulingCompleteTimestamp: time.Now().Add(-90 * time.Millisecond),
+				Response: &Response{
+					Headers: map[string]string{
+						"content-type": "text/event-stream",
+					},
+				},
+			}
+
+			for i, chunk := range tt.chunks {
+				endOfStream := i == len(tt.chunks)-1
+				// Add small delay between chunks to simulate real streaming
+				if i > 0 {
+					time.Sleep(1 * time.Millisecond)
+				}
+				server.HandleResponseBody(ctx, reqCtx, chunk, endOfStream)
+			}
+
+			if tt.wantTTFTGreaterThanZero {
+				assert.Greater(t, reqCtx.TTFT, 0.0, "TTFT should be greater than zero")
+				assert.Greater(t, reqCtx.TTFTEPP, 0.0, "TTFTEPP should be greater than zero")
+			} else {
+				assert.Equal(t, 0.0, reqCtx.TTFT, "TTFT should be zero")
+			}
+
+			if tt.wantTPOTGreaterThanZero {
+				assert.Greater(t, reqCtx.TPOT, 0.0, "TPOT should be greater than zero")
+				assert.Greater(t, reqCtx.TPOTEPP, 0.0, "TPOTEPP should be greater than zero")
+			} else {
+				assert.Equal(t, 0.0, reqCtx.TPOT, "TPOT should be zero")
+			}
+
+			assert.Equal(t, tt.wantGeneratedTokenCount, reqCtx.GeneratedTokenCount, "Generated token count should match")
 		})
 	}
 }

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -79,22 +79,22 @@ type StreamingServer struct {
 // Refactor this monolithic struct. Fields related to the Envoy ext-proc protocol should be decoupled from the internal
 // request lifecycle state.
 type RequestContext struct {
-	TargetPod                 *fwkdl.EndpointMetadata
-	TargetEndpoint            string
-	IncomingModelName         string
-	TargetModelName           string
-	FairnessID                string
-	ObjectiveKey              string
-	Priority                  int
-	RequestReceivedTimestamp  time.Time
-	ResponseCompleteTimestamp time.Time
-	RequestSize               int
-	Usage                     fwkrq.Usage
-	ResponseSize              int
-	ResponseComplete          bool
-	ResponseStatusCode        string
-	RequestRunning            bool
-	Request                   *Request
+	TargetPod                   *fwkdl.EndpointMetadata
+	TargetEndpoint              string
+	IncomingModelName           string
+	TargetModelName             string
+	FairnessID                  string
+	ObjectiveKey                string
+	RequestReceivedTimestamp    time.Time
+	SchedulingCompleteTimestamp time.Time
+	ResponseCompleteTimestamp   time.Time
+	RequestSize                 int
+	Usage                       fwkrq.Usage
+	ResponseSize                int
+	ResponseComplete            bool
+	ResponseStatusCode          string
+	RequestRunning              bool
+	Request                     *Request
 
 	SchedulingRequest *schedulingtypes.LLMRequest
 
@@ -102,6 +102,16 @@ type RequestContext struct {
 	modelServerStreaming bool
 
 	Response *Response
+
+	// Metrics - Client POV (from RequestReceivedTimestamp)
+	TTFT                float64
+	TPOT                float64
+	LastTokenTimestamp  time.Time
+	GeneratedTokenCount int
+
+	// Metrics - EPP POV (from SchedulingCompleteTimestamp)
+	TTFTEPP float64
+	TPOTEPP float64
 
 	reqHeaderResp  *extProcPb.ProcessingResponse
 	reqBodyResp    []*extProcPb.ProcessingResponse
@@ -155,7 +165,8 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 	// Create request context to share states during life time of an HTTP request.
 	// See https://github.com/envoyproxy/envoy/issues/17540.
 	reqCtx := &RequestContext{
-		RequestState: RequestReceived,
+		RequestState:             RequestReceived,
+		RequestReceivedTimestamp: time.Now(),
 		Request: &Request{
 			Headers:  make(map[string]string),
 			Metadata: make(map[string]any),
@@ -244,13 +255,16 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
+				// Set SchedulingCompleteTimestamp after scheduling is complete
+				reqCtx.SchedulingCompleteTimestamp = time.Now()
+
 				if reqCtx.SchedulingRequest != nil && reqCtx.SchedulingRequest.Body != nil {
 					reqCtx.modelServerStreaming = reqCtx.SchedulingRequest.Body.Stream
 				}
 
 				reqCtx.reqHeaderResp = s.generateRequestHeaderResponse(ctx, reqCtx)
 				reqCtx.reqBodyResp = envoy.GenerateRequestBodyResponses(reqCtx.Request.RawBody)
-				metrics.RecordRequestCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.Priority)
+				metrics.RecordRequestCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.SchedulingRequest.Objectives.Priority)
 				metrics.RecordRequestSizes(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.RequestSize)
 			}
 		case *extProcPb.ProcessingRequest_RequestTrailers:

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -143,7 +143,6 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 
 	infObjective := d.getInferenceObjective(ctx, reqCtx)
-	reqCtx.Priority = *infObjective.Spec.Priority
 	requestObjectives := fwksched.RequestObjectives{Priority: *infObjective.Spec.Priority}
 
 	span.SetAttributes(


### PR DESCRIPTION
-Implements critical inference metrics directly within the IGW framework, removing the dependency on the SLO predictor plugin for observability. 
-Framework now natively tracks 
>Time to First Token (TTFT)
Time to Predict Output Token (TPOT)
Inter-Token Latency (ITL) ( `request_itl_seconds` )
Decode Duration ( `request_decode_duration_seconds` ): Total Duration - TTFT
End-to-End (E2E) latency ( `request_e2e_latency_seconds` )

-Added tests to validate metrics tracking

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2163 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Metrics (TTFT, TPOT, ITL, Decode Duration, E2E latency) are directly exposed by IGW framework removing the dependency on SLO predictor plugin for basic metrics
```
