### PR TITLE
feat: switch saturation detection to gradient signal

### DIFF
--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -111,14 +111,14 @@ var _ contracts.RegistryShard = &MockRegistryShard{}
 
 // MockSaturationDetector is a simple "stub-style" mock for testing.
 type MockSaturationDetector struct {
-	IsSaturatedFunc func(ctx context.Context, candidatePods []metrics.PodMetrics) bool
+	SaturationFunc func(ctx context.Context, candidatePods []metrics.PodMetrics) float64
 }
 
-func (m *MockSaturationDetector) IsSaturated(ctx context.Context, candidatePods []metrics.PodMetrics) bool {
-	if m.IsSaturatedFunc != nil {
-		return m.IsSaturatedFunc(ctx, candidatePods)
+func (m *MockSaturationDetector) Saturation(ctx context.Context, candidatePods []metrics.PodMetrics) float64 {
+	if m.SaturationFunc != nil {
+		return m.SaturationFunc(ctx, candidatePods)
 	}
-	return false
+	return 0.0
 }
 
 // MockPodLocator provides a mock implementation of the contracts.PodLocator interface.

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -311,7 +311,7 @@ func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
 		// --- Viability Check (Saturation/HoL Blocking) ---
 		req := item.OriginalRequest()
 		candidates := sp.podLocator.Locate(ctx, req.GetMetadata())
-		if sp.saturationDetector.IsSaturated(ctx, candidates) {
+		if sp.saturationDetector.Saturation(ctx, candidates) >= 1.0 {
 			sp.logger.V(logutil.DEBUG).Info("Policy's chosen item is saturated; enforcing HoL blocking.",
 				"flowKey", req.FlowKey(), "reqID", req.ID(), "priorityName", originalBand.PriorityName())
 			// Stop the dispatch cycle entirely to respect strict policy decision and prevent priority inversion where

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -739,8 +739,8 @@ func TestShardProcessor(t *testing.T) {
 							qLow := h.addQueue(keyLow)
 							require.NoError(t, qLow.Add(h.newTestItem("item-low", keyLow, testTTL)))
 
-							h.saturationDetector.IsSaturatedFunc = func(_ context.Context, _ []metrics.PodMetrics) bool {
-								return true
+							h.saturationDetector.SaturationFunc = func(_ context.Context, _ []metrics.PodMetrics) float64 {
+								return 1.0 // Saturated
 							}
 						},
 						expectDidDispatch: false,

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
-	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
@@ -54,11 +53,6 @@ type AdmissionController interface {
 	) error
 }
 
-// saturationDetector defines the minimal interface required for checking if the backend pool is saturated.
-type saturationDetector interface {
-	IsSaturated(ctx context.Context, candidatePods []backendmetrics.PodMetrics) bool
-}
-
 // flowController defines the minimal interface required by FlowControlAdmissionController for enqueuing requests and
 // waiting for an admission outcome.
 type flowController interface {
@@ -68,14 +62,14 @@ type flowController interface {
 // rejectIfSheddableAndSaturated checks if a request should be immediately rejected.
 func rejectIfSheddableAndSaturated(
 	ctx context.Context,
-	sd saturationDetector,
+	sd contracts.SaturationDetector,
 	locator contracts.PodLocator,
 	reqCtx *handlers.RequestContext,
 	priority int,
 	logger logr.Logger,
 ) error {
 	if requtil.IsSheddable(priority) {
-		if sd.IsSaturated(ctx, locator.Locate(ctx, reqCtx.Request.Metadata)) {
+		if sd.Saturation(ctx, locator.Locate(ctx, reqCtx.Request.Metadata)) >= 1.0 {
 			logger.V(logutil.TRACE).Info("Request rejected: system saturated and request is sheddable",
 				"requestID", reqCtx.SchedulingRequest.RequestId)
 			return errutil.Error{
@@ -93,13 +87,13 @@ func rejectIfSheddableAndSaturated(
 // It rejects sheddable requests (priority < 0) if the saturationDetector indicates that the system is currently
 // saturated. Non-sheddable requests always bypass the saturation check.
 type LegacyAdmissionController struct {
-	saturationDetector saturationDetector
+	saturationDetector contracts.SaturationDetector
 	podLocator         contracts.PodLocator
 }
 
 // NewLegacyAdmissionController creates a new LegacyAdmissionController.
 func NewLegacyAdmissionController(
-	sd saturationDetector,
+	sd contracts.SaturationDetector,
 	pl contracts.PodLocator,
 ) *LegacyAdmissionController {
 	return &LegacyAdmissionController{

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -109,11 +109,16 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			saturationDetector := &mocks.MockSaturationDetector{
-				IsSaturatedFunc: func(context.Context, []backendmetrics.PodMetrics) bool { return tc.isSaturated },
+			mockDetector := &mocks.MockSaturationDetector{
+				SaturationFunc: func(context.Context, []backendmetrics.PodMetrics) float64 {
+					if tc.isSaturated {
+						return 1.0
+					}
+					return 0.0
+				},
 			}
 			locator := &mocks.MockPodLocator{Pods: tc.locatorPods}
-			ac := NewLegacyAdmissionController(saturationDetector, locator)
+			ac := NewLegacyAdmissionController(mockDetector, locator)
 
 			err := ac.Admit(ctx, reqCtx, tc.priority)
 

--- a/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector_test.go
+++ b/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector_test.go
@@ -22,217 +22,165 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 )
 
-func newMockPodMetrics(name string, metrics *backendmetrics.MetricsState) *backendmetrics.FakePodMetrics {
+func makePodMetric(name string, queueDepth int, kvUsage float64, updateTime time.Time) *backendmetrics.FakePodMetrics {
 	return &backendmetrics.FakePodMetrics{
 		Metadata: &fwkdl.EndpointMetadata{
 			NamespacedName: types.NamespacedName{Name: name, Namespace: "ns1"},
 		},
-		Metrics: metrics,
+		Metrics: &backendmetrics.MetricsState{
+			WaitingQueueSize:    queueDepth,
+			KVCacheUsagePercent: kvUsage,
+			UpdateTime:          updateTime,
+		},
 	}
 }
 
-// --- Tests ---
+func TestDetector_Saturation(t *testing.T) {
+	t.Parallel()
 
-func TestDetector_IsSaturated(t *testing.T) {
 	baseTime := time.Now()
-	defaultConfig := &Config{
+
+	// Config: Queue=5, KV=0.9
+	config := &Config{
 		QueueDepthThreshold:       5,
 		KVCacheUtilThreshold:      0.90,
 		MetricsStalenessThreshold: 100 * time.Millisecond,
 	}
 
 	tests := []struct {
-		name               string
-		config             *Config
-		pods               []backendmetrics.PodMetrics
-		expectedSaturation bool
+		name           string
+		pods           []backendmetrics.PodMetrics
+		wantSaturation float64
 	}{
 		{
-			name:               "No candidate pods",
-			config:             defaultConfig,
-			pods:               []backendmetrics.PodMetrics{},
-			expectedSaturation: true, // No capacity = saturated
+			name:           "No candidate pods",
+			pods:           []backendmetrics.PodMetrics{},
+			wantSaturation: 1.0, // Fail closed
 		},
 		{
-			name:   "Single pod with good capacity",
-			config: defaultConfig,
+			name: "Single pod with good capacity",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    2,
-					KVCacheUsagePercent: 0.5,
-				}),
+				// Q=2/5 (0.4). KV=0.5/0.9 (0.555...).
+				// Max(0.4, 0.555...) = 0.555...
+				makePodMetric("pod1", 2, 0.5, baseTime),
 			},
-			expectedSaturation: false,
+			wantSaturation: 0.5 / 0.9,
 		},
 		{
-			name:   "Single pod with stale metrics",
-			config: defaultConfig,
+			name: "Single pod with stale metrics",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime.Add(-200 * time.Millisecond), // Stale
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.1,
-				}),
+				// Stale = 1.0
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
 			},
-			expectedSaturation: true,
+			wantSaturation: 1.0,
 		},
 		{
-			name:   "Single pod with high queue depth",
-			config: defaultConfig,
+			name: "Single pod with high queue depth",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    10, // Exceeds threshold 5
-					KVCacheUsagePercent: 0.1,
-				}),
+				// Q=10/5 (2.0). KV=0.1/0.9 (0.11).
+				// Max(2.0, 0.11) = 2.0
+				makePodMetric("pod1", 10, 0.1, baseTime),
 			},
-			expectedSaturation: true,
+			wantSaturation: 2.0,
 		},
 		{
-			name:   "Single pod with high KV cache utilization",
-			config: defaultConfig,
+			name: "Single pod with high KV cache utilization",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.95, // Exceeds threshold 0.90
-				}),
+				// Q=1/5 (0.2). KV=0.95/0.90 (1.055...).
+				// Max(0.2, 1.055...) = 1.055...
+				makePodMetric("pod1", 1, 0.95, baseTime),
 			},
-			expectedSaturation: true,
+			wantSaturation: 0.95 / 0.90,
 		},
 		{
-			name:   "Single pod with nil metrics",
-			config: defaultConfig,
+			name: "Single pod with nil metrics",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", nil),
+				&backendmetrics.FakePodMetrics{
+					Metadata: &fwkdl.EndpointMetadata{
+						NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "ns1"},
+					},
+					Metrics: nil,
+				},
 			},
-			expectedSaturation: true,
+			wantSaturation: 1.0,
 		},
 		{
-			name:   "Multiple pods, all good capacity",
-			config: defaultConfig,
+			name: "Multiple pods, all good capacity",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.1,
-				}),
-				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime.Add(-10 * time.Millisecond),
-					WaitingQueueSize:    0,
-					KVCacheUsagePercent: 0.2,
-				}),
+				// Pod1: Q=1/5(0.2), KV=0.1/0.9(0.11). Max=0.2.
+				makePodMetric("pod1", 1, 0.1, baseTime),
+				// Pod2: Q=0/5(0.0), KV=0.2/0.9(0.22). Max=0.22...
+				makePodMetric("pod2", 0, 0.2, baseTime),
 			},
-			expectedSaturation: false,
+			// Avg(0.2, 0.222...) = 0.2111...
+			wantSaturation: (0.2 + (0.2 / 0.9)) / 2.0,
 		},
 		{
-			name:   "Multiple pods, one good, one bad (stale)",
-			config: defaultConfig,
+			name: "Multiple pods, one good, one stale",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime, // Good
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.1,
-				}),
-				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime.Add(-300 * time.Millisecond), // Stale
-					WaitingQueueSize:    0,
-					KVCacheUsagePercent: 0.2,
-				}),
+				// Pod1 (Good): Q=1/5(0.2), KV=0.1/0.9(0.11). Max=0.2.
+				makePodMetric("pod1", 1, 0.1, baseTime),
+				// Pod2 (Stale): 1.0.
+				makePodMetric("pod2", 0, 0.2, baseTime.Add(-300*time.Millisecond)),
 			},
-			expectedSaturation: false, // One good pod is enough
+			// Avg(0.2, 1.0) = 0.6
+			wantSaturation: 0.6,
 		},
 		{
-			name:   "Multiple pods, one good, one bad (high queue)",
-			config: defaultConfig,
+			name: "Multiple pods, one good, one bad (high queue)",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.1,
-				}),
-				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    15, // Bad queue
-					KVCacheUsagePercent: 0.2,
-				}),
+				// Pod1 (Good): Max=0.2.
+				makePodMetric("pod1", 1, 0.1, baseTime),
+				// Pod2 (Bad): Q=15/5(3.0). Max=3.0.
+				makePodMetric("pod2", 15, 0.2, baseTime),
 			},
-			expectedSaturation: false,
+			// Avg(0.2, 3.0) = 1.6
+			wantSaturation: 1.6,
 		},
 		{
-			name:   "Multiple pods, all bad capacity",
-			config: defaultConfig,
+			name: "Multiple pods, all bad capacity",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime.Add(-200 * time.Millisecond), // Stale
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.1,
-				}),
-				newMockPodMetrics("pod2", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    20, // High queue
-					KVCacheUsagePercent: 0.2,
-				}),
-				newMockPodMetrics("pod3", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.99, // High KV
-				}),
+				// Pod1 (Stale): 1.0
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
+				// Pod2 (High Q): 20/5 = 4.0
+				makePodMetric("pod2", 20, 0.2, baseTime),
+				// Pod3 (High KV): 0.99/0.90 = 1.1
+				makePodMetric("pod3", 1, 0.99, baseTime),
 			},
-			expectedSaturation: true,
+			// Avg(1.0, 4.0, 1.1) = 6.1 / 3 = 2.033...
+			wantSaturation: (1.0 + 4.0 + 1.1) / 3.0,
 		},
 		{
-			name:   "Queue depth exactly at threshold",
-			config: defaultConfig,
+			name: "Queue depth exactly at threshold",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    defaultConfig.QueueDepthThreshold, // Exactly at threshold (good)
-					KVCacheUsagePercent: 0.1,
-				}),
+				// Q=5/5(1.0). KV=Low.
+				// Max=1.0
+				makePodMetric("pod1", 5, 0.1, baseTime),
 			},
-			expectedSaturation: false,
+			wantSaturation: 1.0,
 		},
 		{
-			name:   "KV cache exactly at threshold",
-			config: defaultConfig,
+			name: "Metrics age just over staleness threshold",
 			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime,
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: defaultConfig.KVCacheUtilThreshold, // Exactly at threshold (good)
-				}),
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-101*time.Millisecond)),
 			},
-			expectedSaturation: false,
-		},
-		{
-			name:   "Metrics age just over staleness threshold",
-			config: defaultConfig,
-			pods: []backendmetrics.PodMetrics{
-				newMockPodMetrics("pod1", &backendmetrics.MetricsState{
-					UpdateTime:          baseTime.Add(-defaultConfig.MetricsStalenessThreshold - time.Nanosecond), // Just over (stale)
-					WaitingQueueSize:    1,
-					KVCacheUsagePercent: 0.1,
-				}),
-			},
-			expectedSaturation: true,
+			wantSaturation: 1.0,
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			detector := NewDetector(test.config, logr.Discard())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			detector := NewDetector(config, logr.Discard())
 
-			if got := detector.IsSaturated(context.Background(), test.pods); got != test.expectedSaturation {
-				t.Errorf("IsSaturated() = %v, want %v", got, test.expectedSaturation)
-			}
+			got := detector.Saturation(context.Background(), tc.pods)
+			require.InDelta(t, tc.wantSaturation, got, 1e-4, "Saturation mismatch")
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind cleanup

**What this PR does / why we need it**:

This lays the groundwork for the `Priority-based Holdback` mechanism in the [[PUBLIC] Improved Flow Control Request Management](https://docs.google.com/document/d/1JxzJc8gNv2wKK5-a8ohb0btn78ymVKw9XMIb4-S-ncA/edit?usp=sharing) proposal by refactoring the `SaturationDetector` interface to return a continuous utilization gradient (`float64`) rather than a binary signal (`bool`). This change allows the Flow Controller to detect "super-saturation" states and lays the foundation for future proportional backpressure mechanisms.

While consumers (Flow Controller, Admission) still enforce Head-of-Line (HoL) blocking at a threshold of `>= 1.0`, the underlying logic for calculating saturation has changed significantly to be more robust:

**Behavioral Changes:**

1.  **Concurrency Detector (Aggregate Capacity)**
    *   _Old Behavior:_ Checked if *any* endpoint had capacity. Fails open if one endpoint is empty while others are overloaded.
    *   _New Behavior:_ Calculates `Total Inflight / Total Capacity`.
    *   _Impact:_ Overloaded endpoints now "consume" the available capacity of underloaded endpoints in the saturation calculation. This makes the system sensitive to total pool health rather than single-pod availability.

2.  **Utilization Detector (Average Roofline)**
    *   _Old Behavior:_ Checked if *at least one* pod was healthy (Availability Check).
    *   _New Behavior:_ Calculates the average saturation of the pool using a **Roofline Model**:
        *   `PodSaturationScore = Max(Queue/Threshold, KV/Threshold)` (Saturated if *either* compute or memory is full).
        *   `PoolSaturation = Average(PodSaturationScores)`
    *   _Impact:_ This fixes a "Fail-Open" issue in high-affinity workloads where the scheduler would hammer a subset of pods (hot spots) while the detector remained green because one pod was idle. The new logic is fail-safe, triggering throttling when the aggregate pool health degrades.

**Which issue(s) this PR fixes**:

Part of #1793

**Does this PR introduce a user-facing change?**:
```release-note
Flow Control now uses a gradient-based saturation signal internally. The Utilization saturation detector now uses a strict roofline model (Max(Compute, Memory)) averaged across the backend pool, rather than a binary availability check. This may result in more strictly enforced throttling for high-affinity or unbalanced workloads to prevent backend overload.