### PR TITLE
Refactor: Centralize EndpointPool initialization for Standalone mode

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -357,20 +357,51 @@ func (r *Runner) Run(ctx context.Context) error {
 	return nil
 }
 
+// NewEndpointPoolFromOptions constructs an EndpointPool from standalone options.
+// This is shared between the production runner and standalone integration tests.
+func NewEndpointPoolFromOptions(
+	namespace string,
+	name string,
+	endpointSelector string,
+	endpointTargetPorts []int,
+) (*datalayer.EndpointPool, error) {
+
+	if namespace == "" {
+		return nil, errors.New("namespace must not be empty")
+	}
+	if name == "" {
+		return nil, errors.New("name must not be empty")
+	}
+	if endpointSelector == "" {
+		return nil, errors.New("endpoint selector must not be empty")
+	}
+	if len(endpointTargetPorts) == 0 {
+		return nil, errors.New("endpoint target ports must not be empty")
+	}
+
+	selectorMap, err := labels.ConvertSelectorToLabelsMap(endpointSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint selector %q: %w", endpointSelector, err)
+	}
+
+	pool := datalayer.NewEndpointPool(namespace, name)
+	pool.Selector = selectorMap
+	pool.TargetPorts = append(pool.TargetPorts, endpointTargetPorts...)
+
+	return pool, nil
+}
+
 func setupDatastore(ctx context.Context, epFactory datalayer.EndpointFactory, modelServerMetricsPort int32,
 	startCrdReconcilers bool, namespace, name, endpointSelector string, endpointTargetPorts []int) (datastore.Datastore, error) {
+
 	if startCrdReconcilers {
 		return datastore.NewDatastore(ctx, epFactory, modelServerMetricsPort), nil
 	} else {
-		endpointPool := datalayer.NewEndpointPool(namespace, name)
-		labelsMap, err := labels.ConvertSelectorToLabelsMap(endpointSelector)
+		endpointPool, err := NewEndpointPoolFromOptions(namespace, name, endpointSelector, endpointTargetPorts)
 		if err != nil {
-			setupLog.Error(err, "Failed to parse flag %q with error: %w", "endpoint-selector", err)
+			setupLog.Error(err, "Failed to construct endpoint pool from options")
 			return nil, err
 		}
-		endpointPool.Selector = labelsMap
-		endpointPool.TargetPorts = append(endpointPool.TargetPorts, endpointTargetPorts...)
-
 		endpointPoolOption := datastore.WithEndpointPool(endpointPool)
 		return datastore.NewDatastore(ctx, epFactory, modelServerMetricsPort, endpointPoolOption), nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind cleanup
/kind test

**What this PR does / why we need it**:
This PR refactors the construction of `datalayer.EndpointPool` for Standalone mode into a shared helper function. Previously, the EndpointPool initialization logic was duplicated across the production runner and Standalone integration tests.

**Which issue(s) this PR fixes**:
Fixes #2174 


**Does this PR introduce a user-facing change?**:
NONE

logs:
e2e logs: [e2e-logs.txt](https://github.com/user-attachments/files/24980559/e2e-logs.txt)
Integration test logs: [test-integration.txt](https://github.com/user-attachments/files/24980565/test-integration.txt)
