### PR TITLE
feat: wire flow control policies and smart queue defaults

### DIFF
--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -302,8 +302,19 @@ type PriorityBandConfig struct {
 	// If 0 or omitted, the system default is used.
 	// Default: 1 GB.
 	MaxBytes *int64 `json:"maxBytes,omitempty"`
+
+	// +optional
+	// FairnessPolicyRef specifies the name of the policy that governs flow selection.
+	// If omitted, the system default ("global-strict-fairness-policy") is used.
+	FairnessPolicyRef string `json:"fairnessPolicyRef,omitempty"`
+
+	// +optional
+	// OrderingPolicyRef specifies the name of the policy that governs request selection within a flow.
+	// If omitted, the system default ("fcfs-ordering-policy") is used.
+	OrderingPolicyRef string `json:"orderingPolicyRef,omitempty"`
 }
 
 func (pbc PriorityBandConfig) String() string {
-	return fmt.Sprintf("{Priority: %d, MaxBytes: %v}", pbc.Priority, pbc.MaxBytes)
+	return fmt.Sprintf("{Priority: %d, MaxBytes: %v, FairnessPolicyRef: %s, OrderingPolicyRef: %s}",
+		pbc.Priority, pbc.MaxBytes, pbc.FairnessPolicyRef, pbc.OrderingPolicyRef)
 }

--- a/apix/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apix/config/v1alpha1/zz_generated.deepcopy.go
@@ -22,8 +22,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -59,6 +59,8 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	fccontroller "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/controller"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/fairness"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/framework/plugins/ordering"
 	fcregistry "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/registry"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/picker"
@@ -378,6 +380,11 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(scorer.QueueScorerType, scorer.QueueScorerFactory)
 	fwkplugin.Register(scorer.RunningRequestsSizeScorerType, scorer.RunningRequestsSizeScorerFactory)
 	fwkplugin.Register(scorer.LoraAffinityScorerType, scorer.LoraAffinityScorerFactory)
+	// Flow Control plugins
+	fwkplugin.Register(fairness.GlobalStrictFairnessPolicyType, fairness.GlobalStrictFairnessPolicyFactory)
+	fwkplugin.Register(fairness.RoundRobinFairnessPolicyType, fairness.RoundRobinFairnessPolicyFactory)
+	fwkplugin.Register(ordering.FCFSOrderingPolicyType, ordering.FCFSOrderingPolicyFactory)
+	fwkplugin.Register(ordering.EDFOrderingPolicyType, ordering.EDFOrderingPolicyFactory)
 	// Latency predictor plugins
 	fwkplugin.Register(predictedlatency.PredictedLatencyPluginType, predictedlatency.PredictedLatencyFactory)
 	// register filter for test purpose only (used in conformance tests)

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -175,6 +175,30 @@ flowControl:
   maxBytes: 1024
 `
 
+// successComplexFlowControlConfigText tests that Flow Control configuration with custom plugins is correctly loaded.
+const successComplexFlowControlConfigText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+- name: customFCFS
+  type: fcfs-ordering-policy
+- name: customFairness
+  type: global-strict-fairness-policy
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+featureGates:
+- flowControl
+flowControl:
+  priorityBands:
+  - priority: 100
+    orderingPolicyRef: customFCFS
+    fairnessPolicyRef: customFairness
+`
+
 // --- Invalid Configurations (Syntax/Structure) ---
 
 // errorBadYamlText contains invalid YAML syntax.
@@ -454,4 +478,46 @@ data:
 featureGates:
 - dataLayer
 - flowControl
+`
+
+// errorFlowControlMissingPluginText references a policy that does not exist.
+const errorFlowControlMissingPluginText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+featureGates:
+- flowControl
+flowControl:
+  priorityBands:
+  - priority: 100
+    orderingPolicyRef: non-existent-policy
+`
+
+// errorFlowControlWrongPluginTypeText references a plugin of the wrong type (Scorer instead of Policy).
+const errorFlowControlWrongPluginTypeText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: maxScore
+  type: max-score-picker
+- name: testScorer
+  type: test-scorer
+  parameters:
+    blockSize: 32
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+featureGates:
+- flowControl
+flowControl:
+  priorityBands:
+  - priority: 100
+    orderingPolicyRef: testScorer # Wrong type
 `

--- a/pkg/epp/flowcontrol/framework/plugins/fairness/besthead.go
+++ b/pkg/epp/flowcontrol/framework/plugins/fairness/besthead.go
@@ -31,10 +31,6 @@ import (
 // TODO: rename files to `global_strict.go` and `global_strict_test.go`.
 const GlobalStrictFairnessPolicyType = "global-strict-fairness-policy"
 
-func init() {
-	fwkplugin.Register(GlobalStrictFairnessPolicyType, GlobalStrictFairnessPolicyFactory)
-}
-
 func GlobalStrictFairnessPolicyFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
 	return newGlobalStrict(name), nil
 }

--- a/pkg/epp/flowcontrol/framework/plugins/fairness/roundrobin.go
+++ b/pkg/epp/flowcontrol/framework/plugins/fairness/roundrobin.go
@@ -31,13 +31,8 @@ import (
 // round-robin strategy.
 const RoundRobinFairnessPolicyType = "round-robin-fairness-policy"
 
-func init() {
-	fwkplugin.Register(
-		RoundRobinFairnessPolicyType,
-		func(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-			return newRoundRobin(name), nil
-		},
-	)
+func RoundRobinFairnessPolicyFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	return newRoundRobin(name), nil
 }
 
 // roundRobin implements FairnessPolicy.

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs.go
@@ -51,27 +51,31 @@ import (
 // `CapabilityPriorityConfigurable` queue is recommended.
 const FCFSOrderingPolicyType = "fcfs-ordering-policy"
 
-func init() {
-	plugin.Register(FCFSOrderingPolicyType, func(string, json.RawMessage, plugin.Handle) (plugin.Plugin, error) {
-		return newFCFS(), nil
-	})
+func FCFSOrderingPolicyFactory(name string, _ json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	return newFCFS().withName(name), nil
 }
 
 // fcfs is the internal implementation of the FCFS policy.
 // See the documentation for the exported `FCFSPolicyName` constant for detailed user-facing information about its
 // behavior.
-type fcfs struct{}
+type fcfs struct {
+	name string
+}
 
 var _ flowcontrol.OrderingPolicy = &fcfs{}
 
 // newFCFS creates a new `fcfs` policy instance.
 func newFCFS() *fcfs {
-	return &fcfs{}
+	return &fcfs{
+		name: FCFSOrderingPolicyType,
+	}
 }
 
-// Name returns the name of the policy.
-func (p *fcfs) Name() string {
-	return FCFSOrderingPolicyType
+func (p *fcfs) withName(name string) *fcfs {
+	if name != "" {
+		p.name = name
+	}
+	return p
 }
 
 // RequiredQueueCapabilities returns an empty slice, indicating that this policy can operate with any queue.
@@ -84,7 +88,7 @@ func (p *fcfs) RequiredQueueCapabilities() []flowcontrol.QueueCapability {
 func (p *fcfs) TypedName() plugin.TypedName {
 	return plugin.TypedName{
 		Type: FCFSOrderingPolicyType,
-		Name: FCFSOrderingPolicyType,
+		Name: p.name,
 	}
 }
 

--- a/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/ordering/fcfs_test.go
@@ -29,12 +29,6 @@ import (
 
 var testFlowKey = flowcontrol.FlowKey{ID: "test-flow", Priority: 0}
 
-func TestFCFS_Name(t *testing.T) {
-	t.Parallel()
-	policy := newFCFS()
-	assert.Equal(t, FCFSOrderingPolicyType, policy.Name())
-}
-
 func TestFCFS_RequiredQueueCapabilities(t *testing.T) {
 	t.Parallel()
 	policy := newFCFS()

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -129,7 +129,7 @@ func TestShard_New(t *testing.T) {
 		require.True(t, ok, "Priority band %d (High) must be initialized", highPriority)
 		assert.Equal(t, "High", bandHigh.config.PriorityName, "Priority band name must match the configuration")
 		require.NotNil(t, bandHigh.fairnessPolicy, "Fairness policy must be instantiated during construction")
-		assert.Equal(t, defaultFairnessPolicyRef, bandHigh.fairnessPolicy.TypedName().Name,
+		assert.Equal(t, DefaultFairnessPolicyRef, bandHigh.fairnessPolicy.TypedName().Name,
 			"Must match the configured fairness policy implementation")
 	})
 }
@@ -175,7 +175,7 @@ func TestShard_Accessors(t *testing.T) {
 			policy, err := h.shard.FairnessPolicy(highPriority)
 			require.NoError(t, err, "InterFlowDispatchPolicy accessor must succeed for a configured priority band")
 			require.NotNil(t, policy, "Returned policy must not be nil (guaranteed by contract)")
-			assert.Equal(t, defaultFairnessPolicyRef, policy.TypedName().Name,
+			assert.Equal(t, DefaultFairnessPolicyRef, policy.TypedName().Name,
 				"Must return the configured fairness policy implementation")
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind documentation
/kind cleanup

**What this PR does / why we need it**:

This PR builds upon #2217 by wiring up the policy plugins. It allows users to configure specific Fairness and Ordering policies (e.g., EDF, Round Robin) per Priority Band and ensures the underlying queue implementation supports the chosen policy's requirements.

**Key Changes:**

1.  API Extension:
    *   Added `FairnessPolicyRef` and `OrderingPolicyRef` to `PriorityBandConfig`.
    *   This enables users to reference specific named plugin instances for flow control logic.

2. Queue Defaulting:
    *   Implemented logic in the `registry` to inspect the selected Ordering Policy's capabilities.
    *   Defaults to `ListQueue` (O(1)) for standard policies like FCFS.
    *   Automatically upgrades to `MaxMinHeap` (O(log n)) if the policy requires heap capabilities (e.g., EDF).

3.  Plugin Architecture:
    *   Refactored Flow Control plugins (`ordering`, `fairness`) to remove `init()` side-effects in favor of explicit in-tree factory registration in `runner.go`.
    *   Updated `config/loader` to ensure system-default policy plugins (`fcfs-ordering-policy`, `global-strict-fairness-policy`) are automatically registered if not explicitly configured by the user.

4.  Documentation Overhaul:
    *   Restructured the plugin configuration guide. Plugins are now grouped by category (**Infrastructure**, **Scheduling**, **Flow Control**) rather than a flat list, improving readability.
    *   Added detailed documentation for the new Flow Control policy configuration fields.

**Which issue(s) this PR fixes**:

- Fixes #1715
- Fixes #1794

**Does this PR introduce a user-facing change?**:

```release-note
Added `fairnessPolicyRef` and `orderingPolicyRef` to Flow Control `PriorityBandConfig`, allowing configuration composable policies (e.g., Earliest Deadline First, Round Robin).
```