### PR TITLE
feat: generic metrics scorer and prometheus extractor

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -380,6 +380,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(scorer.QueueScorerType, scorer.QueueScorerFactory)
 	fwkplugin.Register(scorer.RunningRequestsSizeScorerType, scorer.RunningRequestsSizeScorerFactory)
 	fwkplugin.Register(scorer.LoraAffinityScorerType, scorer.LoraAffinityScorerFactory)
+	fwkplugin.Register(scorer.MetricScorerType, scorer.MetricScorerFactory)
 	// Flow Control plugins
 	fwkplugin.Register(fairness.GlobalStrictFairnessPolicyType, fairness.GlobalStrictFairnessPolicyFactory)
 	fwkplugin.Register(fairness.RoundRobinFairnessPolicyType, fairness.RoundRobinFairnessPolicyFactory)
@@ -394,6 +395,7 @@ func (r *Runner) registerInTreePlugins() {
 	// register datalayer metrics collection plugins
 	fwkplugin.Register(dlmetrics.MetricsDataSourceType, dlmetrics.MetricsDataSourceFactory)
 	fwkplugin.Register(dlmetrics.MetricsExtractorType, dlmetrics.ModelServerExtractorFactory)
+	fwkplugin.Register(dlmetrics.PrometheusMetricPluginType, dlmetrics.PrometheusMetricPluginFactory)
 }
 
 func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver.Options) (*configapi.EndpointPickerConfig, error) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Concepts:
         API Overview: concepts/api-overview.md
         Design Principles: concepts/design-principles.md
+        Data Layer Architecture: concepts/data-layer-architecture.md
         Conformance: concepts/conformance.md
         Roles and Personas: concepts/roles-and-personas.md
         Priority and Capacity: concepts/priority-and-capacity.md

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -175,6 +175,42 @@ flowControl:
   maxBytes: 1024
 `
 
+// successMetricScorerConfigText tests that MetricScorer is correctly wired.
+const successMetricScorerConfigText = `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- name: metricScorer
+  type: metric-scorer
+  parameters:
+    metricName: "request_latency"
+    min: 0
+    max: 100
+    optimizationMode: Minimize
+    normalizationAlgo: Softmax
+- name: maxScore
+  type: max-score-picker
+- name: testSource
+  type: test-source
+- name: testExtractor
+  type: prometheus-metric
+  parameters:
+    metricName: "test_metric"
+    labels:
+      env: "test"
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: maxScore
+  - pluginRef: metricScorer
+    weight: 100
+data:
+  sources:
+  - pluginRef: testSource
+    extractors:
+    - pluginRef: testExtractor
+`
+
 // successComplexFlowControlConfigText tests that Flow Control configuration with custom plugins is correctly loaded.
 const successComplexFlowControlConfigText = `
 apiVersion: inference.networking.x-k8s.io/v1alpha1

--- a/pkg/epp/datalayer/metrics/datasource_test.go
+++ b/pkg/epp/datalayer/metrics/datasource_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestDatasource(t *testing.T) {
 	source := http.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
-		"metrics-data-source", parseMetrics, PrometheusMetricType)
+		"metrics-data-source", parseMetrics, fwkdl.PrometheusMetricType)
 	extractor, err := NewModelServerExtractor(defaultTotalQueuedRequestsMetric, "", "", "", "")
 	assert.Nil(t, err, "failed to create extractor")
 

--- a/pkg/epp/datalayer/metrics/extractor.go
+++ b/pkg/epp/datalayer/metrics/extractor.go
@@ -91,13 +91,13 @@ func (ext *Extractor) TypedName() fwkplugin.TypedName {
 // ExpectedType defines the type expected by the metrics.Extractor - a
 // parsed output from a Prometheus metrics endpoint.
 func (ext *Extractor) ExpectedInputType() reflect.Type {
-	return PrometheusMetricType
+	return fwkdl.PrometheusMetricType
 }
 
 // Extract transforms the data source output into a concrete attribute that
 // is stored on the given endpoint.
 func (ext *Extractor) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
-	families, ok := data.(PrometheusMetricMap)
+	families, ok := data.(fwkdl.PrometheusMetricMap)
 	if !ok {
 		return fmt.Errorf("unexpected input in Extract: %T", data)
 	}

--- a/pkg/epp/datalayer/metrics/extractor_test.go
+++ b/pkg/epp/datalayer/metrics/extractor_test.go
@@ -58,7 +58,7 @@ func TestExtractorExtract(t *testing.T) {
 		t.Error("empty extractor name")
 	}
 
-	if inputType := extractor.ExpectedInputType(); inputType != PrometheusMetricType {
+	if inputType := extractor.ExpectedInputType(); inputType != fwkdl.PrometheusMetricType {
 		t.Errorf("incorrect expected input type: %v", inputType)
 	}
 
@@ -81,13 +81,13 @@ func TestExtractorExtract(t *testing.T) {
 		},
 		{
 			name:    "empty PrometheusMetricMap",
-			data:    PrometheusMetricMap{},
+			data:    fwkdl.PrometheusMetricMap{},
 			wantErr: true,  // errors when metrics are missing
 			updated: false, // and also not updated...
 		},
 		{
 			name: "single valid metric",
-			data: PrometheusMetricMap{
+			data: fwkdl.PrometheusMetricMap{
 				defaultTotalQueuedRequestsMetric: &dto.MetricFamily{
 					Type: dto.MetricType_GAUGE.Enum(),
 					Metric: []*dto.Metric{
@@ -102,7 +102,7 @@ func TestExtractorExtract(t *testing.T) {
 		},
 		{
 			name: "multiple valid metrics",
-			data: PrometheusMetricMap{
+			data: fwkdl.PrometheusMetricMap{
 				defaultTotalQueuedRequestsMetric: &dto.MetricFamily{
 					Type: dto.MetricType_GAUGE.Enum(),
 					Metric: []*dto.Metric{

--- a/pkg/epp/datalayer/metrics/loraspec.go
+++ b/pkg/epp/datalayer/metrics/loraspec.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	dto "github.com/prometheus/client_model/go"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 )
 
 // LoRASpec extends the standard Spec to allow special case
@@ -46,7 +47,7 @@ func parseStringToLoRASpec(spec string) (*LoRASpec, error) {
 // generates new series and only most recent should be used. The value of each
 // series is its creation timestamp so we can retrieve the latest by sorting on
 // that the value first.
-func (spec *LoRASpec) getLatestMetric(families PrometheusMetricMap) (*dto.Metric, error) {
+func (spec *LoRASpec) getLatestMetric(families fwkdl.PrometheusMetricMap) (*dto.Metric, error) {
 	family, err := extractFamily(spec.Spec, families)
 	if err != nil {
 		return nil, err

--- a/pkg/epp/datalayer/metrics/prometheus_extractor.go
+++ b/pkg/epp/datalayer/metrics/prometheus_extractor.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+)
+
+const PrometheusMetricPluginType = "prometheus-metric"
+
+// PrometheusMetricPlugin extracts a specific metric from Prometheus format data.
+type PrometheusMetricPlugin struct {
+	typedName fwkplugin.TypedName
+	spec      *Spec
+}
+
+var (
+	_ fwkplugin.ProducerPlugin = &PrometheusMetricPlugin{}
+	_ fwkdl.Extractor          = &PrometheusMetricPlugin{}
+)
+
+// NewPrometheusMetricPlugin returns a new PrometheusMetricPlugin.
+func NewPrometheusMetricPlugin(metricName string, labels map[string]string) *PrometheusMetricPlugin {
+	return &PrometheusMetricPlugin{
+		typedName: fwkplugin.TypedName{
+			Type: PrometheusMetricPluginType,
+			Name: PrometheusMetricPluginType,
+		},
+		spec: &Spec{
+			Name:   metricName,
+			Labels: labels,
+		},
+	}
+}
+
+// TypedName returns the type and name of the plugin.
+func (p *PrometheusMetricPlugin) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// ExpectedInputType defines the type expected by the extractor.
+func (p *PrometheusMetricPlugin) ExpectedInputType() reflect.Type {
+	return fwkdl.PrometheusMetricType
+}
+
+// Produces returns the dynamic metric key this plugin produces.
+func (p *PrometheusMetricPlugin) Produces() map[string]any {
+	return map[string]any{
+		p.spec.Name: float64(0),
+	}
+}
+
+// Extract transforms the data source output into a concrete attribute.
+func (p *PrometheusMetricPlugin) Extract(ctx context.Context, data any, ep fwkdl.Endpoint) error {
+	families, ok := data.(fwkdl.PrometheusMetricMap)
+	if !ok {
+		return fmt.Errorf("unexpected input in Extract: %T", data)
+	}
+
+	metric, err := p.spec.getLatestMetric(families)
+	if err != nil {
+		return err
+	}
+
+	val := extractValue(metric)
+	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().NamespacedName, "metric", p.spec.Name)
+	logger.V(logutil.TRACE).Info("Extracted custom metric", "value", val)
+
+	current := ep.GetMetrics()
+	clone := current.Clone()
+	clone.Custom[p.spec.Name] = val
+	clone.UpdateTime = time.Now()
+	ep.UpdateMetrics(clone)
+
+	return nil
+}

--- a/pkg/epp/datalayer/metrics/prometheus_extractor_test.go
+++ b/pkg/epp/datalayer/metrics/prometheus_extractor_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/utils/ptr"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+)
+
+func TestPrometheusMetricPluginExtract(t *testing.T) {
+	ctx := context.Background()
+	metricName := "custom_metric"
+	labels := map[string]string{"label1": "value1"}
+
+	plugin := NewPrometheusMetricPlugin(metricName, labels)
+
+	tests := []struct {
+		name       string
+		data       any
+		expectVal  float64
+		wantErr    bool
+		wantUpdate bool
+	}{
+		{
+			name:       "nil data",
+			data:       nil,
+			wantErr:    true,
+			wantUpdate: false,
+		},
+		{
+			name:       "missing metric",
+			data:       fwkdl.PrometheusMetricMap{},
+			wantErr:    true,
+			wantUpdate: false,
+		},
+		{
+			name: "valid metric with matching labels",
+			data: fwkdl.PrometheusMetricMap{
+				metricName: &dto.MetricFamily{
+					Type: dto.MetricType_GAUGE.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{Name: proto.String("label1"), Value: proto.String("value1")},
+							},
+							Gauge: &dto.Gauge{Value: ptr.To(123.45)},
+						},
+					},
+				},
+			},
+			expectVal:  123.45,
+			wantErr:    false,
+			wantUpdate: true,
+		},
+		{
+			name: "valid metric with extra labels (should match)",
+			data: fwkdl.PrometheusMetricMap{
+				metricName: &dto.MetricFamily{
+					Type: dto.MetricType_GAUGE.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{Name: proto.String("label1"), Value: proto.String("value1")},
+								{Name: proto.String("extra"), Value: proto.String("foo")},
+							},
+							Gauge: &dto.Gauge{Value: ptr.To(67.89)},
+						},
+					},
+				},
+			},
+			expectVal:  67.89,
+			wantErr:    false,
+			wantUpdate: true,
+		},
+		{
+			name: "metric with mismatched labels",
+			data: fwkdl.PrometheusMetricMap{
+				metricName: &dto.MetricFamily{
+					Type: dto.MetricType_GAUGE.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{Name: proto.String("label1"), Value: proto.String("other")},
+							},
+							Gauge: &dto.Gauge{Value: ptr.To(0.0)},
+						},
+					},
+				},
+			},
+			wantErr:    true,
+			wantUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := fwkdl.NewEndpoint(nil, nil)
+			err := plugin.Extract(ctx, tt.data, ep)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tt.wantUpdate {
+				val, ok := ep.GetMetrics().Custom[metricName]
+				if !ok {
+					t.Errorf("custom metric not found in endpoint")
+				} else if val != tt.expectVal {
+					t.Errorf("expected value %v, got %v", tt.expectVal, val)
+				}
+			} else {
+				val, ok := ep.GetMetrics().Custom[metricName]
+				if ok {
+					t.Errorf("expected no custom metric, but found %v", val)
+				}
+			}
+		})
+	}
+}

--- a/pkg/epp/datalayer/metrics/spec_test.go
+++ b/pkg/epp/datalayer/metrics/spec_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/utils/ptr"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 )
 
 // --- Test Helpers ---
@@ -207,7 +208,7 @@ func TestStringToMetricSpec(t *testing.T) {
 
 // TestGetMetric checks retrieving of standard metrics from a metric families.
 func TestGetMetric(t *testing.T) {
-	metricFamilies := PrometheusMetricMap{
+	metricFamilies := fwkdl.PrometheusMetricMap{
 		"metric1": makeMetricFamily("metric1",
 			makeMetric(map[string]string{"label1": "value1"}, 1.0, 1000),
 			makeMetric(map[string]string{"label1": "value2"}, 2.0, 2000),
@@ -333,7 +334,7 @@ func TestGetLoRAMetric(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		metricFamilies   PrometheusMetricMap
+		metricFamilies   fwkdl.PrometheusMetricMap
 		expectedAdapters map[string]int
 		expectedMax      int
 		expectedErr      error
@@ -341,7 +342,7 @@ func TestGetLoRAMetric(t *testing.T) {
 	}{
 		{
 			name: "no lora metrics",
-			metricFamilies: PrometheusMetricMap{
+			metricFamilies: fwkdl.PrometheusMetricMap{
 				"some_other_metric": makeMetricFamily("some_other_metric",
 					makeMetric(nil, 1.0, 1000),
 				),
@@ -353,7 +354,7 @@ func TestGetLoRAMetric(t *testing.T) {
 		},
 		{
 			name: "basic lora metrics",
-			metricFamilies: PrometheusMetricMap{
+			metricFamilies: fwkdl.PrometheusMetricMap{
 				"vllm:lora_requests_info": makeMetricFamily("vllm:lora_requests_info",
 					makeMetric(map[string]string{"running_lora_adapters": "lora1", "max_lora": "2"}, 3000.0, 1000),       // Newer
 					makeMetric(map[string]string{"running_lora_adapters": "lora2,lora3", "max_lora": "4"}, 1000.0, 1000), // Older
@@ -367,7 +368,7 @@ func TestGetLoRAMetric(t *testing.T) {
 		},
 		{
 			name: "no matching lora metrics",
-			metricFamilies: PrometheusMetricMap{
+			metricFamilies: fwkdl.PrometheusMetricMap{
 				"vllm:lora_requests_info": makeMetricFamily("vllm:lora_requests_info",
 					makeMetric(map[string]string{"other_label": "value"}, 5.0, 3000),
 				),
@@ -510,6 +511,13 @@ func TestExtractValue(t *testing.T) {
 				Counter: &dto.Counter{Value: ptr.To(99.9)},
 			},
 			want: 99.9,
+		},
+		{
+			name: "untyped metric",
+			metric: &dto.Metric{
+				Untyped: &dto.Untyped{Value: ptr.To(123.456)},
+			},
+			want: 123.456,
 		},
 	}
 

--- a/pkg/epp/framework/interface/datalayer/metrics.go
+++ b/pkg/epp/framework/interface/datalayer/metrics.go
@@ -36,6 +36,9 @@ type Metrics struct {
 	// Number of GPU blocks in the model server for KV Cache.
 	CacheNumGPUBlocks int
 
+	// Custom holds custom metrics scraped from the model server.
+	// The key is the metric name and the value is the metric value.
+	Custom map[string]float64
 	// UpdateTime records the last time when the metrics were updated.
 	UpdateTime time.Time
 }
@@ -45,6 +48,7 @@ func NewMetrics() *Metrics {
 	return &Metrics{
 		ActiveModels:  make(map[string]int),
 		WaitingModels: make(map[string]int),
+		Custom:        make(map[string]float64),
 	}
 }
 
@@ -70,6 +74,10 @@ func (m *Metrics) Clone() *Metrics {
 	for key, value := range m.WaitingModels {
 		waitingModels[key] = value
 	}
+	custom := make(map[string]float64, len(m.Custom))
+	for key, value := range m.Custom {
+		custom[key] = value
+	}
 	return &Metrics{
 		ActiveModels:            activeModels,
 		WaitingModels:           waitingModels,
@@ -80,6 +88,7 @@ func (m *Metrics) Clone() *Metrics {
 		KvCacheMaxTokenCapacity: m.KvCacheMaxTokenCapacity,
 		CacheBlockSize:          m.CacheBlockSize,
 		CacheNumGPUBlocks:       m.CacheNumGPUBlocks,
+		Custom:                  custom,
 		UpdateTime:              m.UpdateTime,
 	}
 }

--- a/pkg/epp/framework/interface/datalayer/types.go
+++ b/pkg/epp/framework/interface/datalayer/types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package datalayer
 
 import (
 	"reflect"

--- a/pkg/epp/framework/plugins/scheduling/scorer/metric_scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/metric_scorer.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scorer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	MetricScorerType = "metric-scorer"
+)
+
+type OptimizationMode string
+
+const (
+	OptimizationModeMinimize OptimizationMode = "Minimize"
+	OptimizationModeMaximize OptimizationMode = "Maximize"
+)
+
+type NormalizationAlgo string
+
+const (
+	NormalizationAlgoLinear  NormalizationAlgo = "Linear"
+	NormalizationAlgoSoftmax NormalizationAlgo = "Softmax"
+)
+
+// normalizer transforms raw metrics into scores.
+type normalizer interface {
+	Normalize(metrics map[framework.Endpoint]float64) map[framework.Endpoint]float64
+}
+
+type linearNormalizer struct {
+	min  float64
+	max  float64
+	mode OptimizationMode
+}
+
+func (n *linearNormalizer) Normalize(rawMetrics map[framework.Endpoint]float64) map[framework.Endpoint]float64 {
+	scores := make(map[framework.Endpoint]float64, len(rawMetrics))
+	rangeVal := n.max - n.min
+	if rangeVal == 0 {
+		// Avoid division by zero; treat all equal.
+		for ep := range rawMetrics {
+			scores[ep] = 0
+		}
+		return scores
+	}
+
+	for ep, val := range rawMetrics {
+		clampedVal := min(max(n.min, val), n.max)
+		score := (clampedVal - n.min) / rangeVal
+		if n.mode == OptimizationModeMinimize {
+			score = 1.0 - score
+		}
+		scores[ep] = score
+	}
+	return scores
+}
+
+type softmaxNormalizer struct {
+	mode OptimizationMode
+}
+
+func (n *softmaxNormalizer) Normalize(rawMetrics map[framework.Endpoint]float64) map[framework.Endpoint]float64 {
+	scores := make(map[framework.Endpoint]float64, len(rawMetrics))
+	if len(rawMetrics) == 0 {
+		return scores
+	}
+
+	// Create inputs for softmax.
+	// If minimizing, negate values so that lower values become higher in the exponent.
+	inputs := make(map[framework.Endpoint]float64, len(rawMetrics))
+	for ep, val := range rawMetrics {
+		if n.mode == OptimizationModeMinimize {
+			inputs[ep] = -val
+		} else {
+			inputs[ep] = val
+		}
+	}
+
+	// Find max for numerical stability (prevents overflow).
+	maxVal := -1e18
+	first := true
+	for _, val := range inputs {
+		if first || val > maxVal {
+			maxVal = val
+			first = false
+		}
+	}
+
+	// Compute exponentials and sum.
+	sumExp := 0.0
+	expValues := make(map[framework.Endpoint]float64, len(rawMetrics))
+	for ep, val := range inputs {
+		v := math.Exp(val - maxVal)
+		expValues[ep] = v
+		sumExp += v
+	}
+
+	// Normalize.
+	for ep, v := range expValues {
+		if sumExp == 0 {
+			scores[ep] = 1.0 / float64(len(rawMetrics))
+		} else {
+			scores[ep] = v / sumExp
+		}
+	}
+
+	return scores
+}
+
+// MetricScorerConfig defines the configuration for MetricScorer.
+type MetricScorerConfig struct {
+	// MetricName is the name of the metric to use for scoring.
+	MetricName string `json:"metricName"`
+	// Min is the minimum expected value for the metric (used for normalization).
+	Min float64 `json:"min"`
+	// Max is the maximum expected value for the metric (used for normalization).
+	Max float64 `json:"max"`
+	// OptimizationMode defines how the metric value correlates to the score.
+	// Defaults to Minimize if unspecified.
+	OptimizationMode OptimizationMode `json:"optimizationMode"`
+	// NormalizationAlgo defines the algorithm used for normalization.
+	// Defaults to Linear if unspecified.
+	NormalizationAlgo NormalizationAlgo `json:"normalizationAlgo"`
+}
+
+// SetDefaults sets the default values for the configuration.
+func (c *MetricScorerConfig) SetDefaults() {
+	if c.OptimizationMode == "" {
+		c.OptimizationMode = OptimizationModeMinimize
+	}
+	if c.NormalizationAlgo == "" {
+		c.NormalizationAlgo = NormalizationAlgoLinear
+	}
+}
+
+// Validate validates the configuration.
+func (c *MetricScorerConfig) Validate() error {
+	if c.MetricName == "" {
+		return errors.New("metricName is required")
+	}
+
+	switch c.OptimizationMode {
+	case OptimizationModeMinimize, OptimizationModeMaximize:
+	default:
+		return fmt.Errorf("invalid optimizationMode %q, allowed: %s, %s",
+			c.OptimizationMode, OptimizationModeMinimize, OptimizationModeMaximize)
+	}
+
+	switch c.NormalizationAlgo {
+	case NormalizationAlgoLinear:
+		if c.Max <= c.Min {
+			return fmt.Errorf("max must be strictly greater than min found min: %v max: %v", c.Min, c.Max)
+		}
+	case NormalizationAlgoSoftmax:
+	default:
+		return fmt.Errorf("invalid normalizationAlgo %q, allowed: %s, %s",
+			c.NormalizationAlgo, NormalizationAlgoLinear, NormalizationAlgoSoftmax)
+	}
+	return nil
+}
+
+// DefaultMetricScorerConfig holds the default configuration.
+var DefaultMetricScorerConfig = MetricScorerConfig{
+	OptimizationMode:  OptimizationModeMinimize,
+	NormalizationAlgo: NormalizationAlgoLinear,
+}
+
+var (
+	_ framework.Scorer         = &metricScorer{}
+	_ fwkplugin.ConsumerPlugin = &metricScorer{}
+)
+
+// MetricScorerFactory defines the factory function for MetricScorer.
+func MetricScorerFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	config := DefaultMetricScorerConfig
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse configuration for %s: %w", name, err)
+		}
+	}
+
+	config.SetDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration for %s: %w", name, err)
+	}
+
+	return newMetricScorer(config).withName(name), nil
+}
+
+// newMetricScorer initializes a new MetricScorer.
+func newMetricScorer(config MetricScorerConfig) *metricScorer {
+	var normalizer normalizer
+	switch config.NormalizationAlgo {
+	case NormalizationAlgoSoftmax:
+		normalizer = &softmaxNormalizer{
+			mode: config.OptimizationMode,
+		}
+	case NormalizationAlgoLinear:
+		fallthrough
+	default:
+		normalizer = &linearNormalizer{
+			min:  config.Min,
+			max:  config.Max,
+			mode: config.OptimizationMode,
+		}
+	}
+
+	return &metricScorer{
+		typedName:  fwkplugin.TypedName{Type: MetricScorerType, Name: MetricScorerType},
+		config:     config,
+		normalizer: normalizer,
+	}
+}
+
+// metricScorer scores endpoints based on a generic metric.
+type metricScorer struct {
+	typedName  fwkplugin.TypedName
+	config     MetricScorerConfig
+	normalizer normalizer
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (s *metricScorer) TypedName() fwkplugin.TypedName {
+	return s.typedName
+}
+
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *metricScorer) Category() framework.ScorerCategory {
+	return framework.Distribution
+}
+
+// Consumes returns the list of data that is consumed by the plugin.
+func (s *metricScorer) Consumes() map[string]any {
+	return map[string]any{
+		s.config.MetricName: float64(0),
+	}
+}
+
+// withName sets the name of the scorer.
+func (s *metricScorer) withName(name string) *metricScorer {
+	s.typedName.Name = name
+	return s
+}
+
+// Score returns the scoring result for the given list of pods based on context.
+func (s *metricScorer) Score(
+	ctx context.Context,
+	_ *framework.CycleState,
+	_ *framework.LLMRequest,
+	endpoints []framework.Endpoint,
+) map[framework.Endpoint]float64 {
+	rawMetrics := make(map[framework.Endpoint]float64, len(endpoints))
+	logger := log.FromContext(ctx).V(logutil.TRACE)
+
+	minVal := s.config.Min
+	maxVal := s.config.Max
+
+	for _, endpoint := range endpoints {
+		val := 0.0
+		if v, ok := endpoint.GetMetrics().Custom[s.config.MetricName]; ok {
+			val = v
+		} else {
+			logger.Info("Missing custom metric for endpoint", "endpoint", endpoint.GetMetadata().NamespacedName, "metric", s.config.MetricName)
+			// Apply worst-case value for missing metrics.
+			if s.config.OptimizationMode == OptimizationModeMinimize {
+				val = maxVal
+			} else {
+				val = minVal
+			}
+		}
+		rawMetrics[endpoint] = val
+	}
+
+	scores := s.normalizer.Normalize(rawMetrics)
+	return scores
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/metric_scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/metric_scorer_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scorer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+func TestLinearNormalizer(t *testing.T) {
+	tests := []struct {
+		name     string
+		min, max float64
+		inputs   []float64
+		expected []float64
+	}{
+		{
+			name:     "Standard range 0-100",
+			min:      0,
+			max:      100,
+			inputs:   []float64{0, 50, 100},
+			expected: []float64{0.0, 0.5, 1.0},
+		},
+		{
+			name:     "Clamping values outside range",
+			min:      0,
+			max:      100,
+			inputs:   []float64{-10, 110},
+			expected: []float64{0.0, 1.0},
+		},
+		{
+			name:     "Zero range (avoid divide by zero)",
+			min:      10,
+			max:      10,
+			inputs:   []float64{5, 10, 15},
+			expected: []float64{0.0, 0.0, 0.0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &linearNormalizer{min: tt.min, max: tt.max}
+			metrics := make(map[fwksched.Endpoint]float64)
+			eps := make([]fwksched.Endpoint, len(tt.inputs))
+			for i, v := range tt.inputs {
+				ep := newEndpointWithMetric(v, "metric")
+				metrics[ep] = v
+				eps[i] = ep
+			}
+
+			scores := n.Normalize(metrics)
+
+			for i, ep := range eps {
+				assert.InDelta(t, tt.expected[i], scores[ep], 1e-6)
+			}
+		})
+	}
+}
+
+func TestSoftmaxNormalizer(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   []float64
+		expected []float64
+	}{
+		{
+			name:     "Basic Softmax",
+			inputs:   []float64{1.0, 2.0, 3.0},
+			expected: []float64{0.09003057, 0.24472847, 0.66524096}, // exp(1)/sum, exp(2)/sum, exp(3)/sum
+		},
+		{
+			name:     "Shift Invariance (adding constant doesn't change prob)",
+			inputs:   []float64{101.0, 102.0, 103.0},
+			expected: []float64{0.09003057, 0.24472847, 0.66524096},
+		},
+		{
+			name:     "All Equal",
+			inputs:   []float64{5.0, 5.0},
+			expected: []float64{0.5, 0.5},
+		},
+		{
+			name:     "Empty",
+			inputs:   []float64{},
+			expected: []float64{},
+		},
+	}
+
+	n := &softmaxNormalizer{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := make(map[fwksched.Endpoint]float64)
+			eps := make([]fwksched.Endpoint, len(tt.inputs))
+			for i, v := range tt.inputs {
+				ep := newEndpointWithMetric(0, fmt.Sprintf("metric-%d", i))
+				metrics[ep] = v
+				eps[i] = ep
+			}
+
+			scores := n.Normalize(metrics)
+
+			sum := 0.0
+			for i, ep := range eps {
+				if len(tt.expected) > 0 {
+					assert.InDelta(t, tt.expected[i], scores[ep], 1e-6)
+					sum += scores[ep]
+				}
+			}
+			if len(tt.inputs) > 0 {
+				assert.InDelta(t, 1.0, sum, 1e-6, "Sum of softmax scores should be 1.0")
+			}
+		})
+	}
+}
+
+func TestMetricScorer(t *testing.T) {
+	metricName := "custom_metric"
+
+	tests := []struct {
+		name           string
+		config         MetricScorerConfig
+		inputs         []float64
+		expectedScores map[int]float64 // expected map from input index to score
+	}{
+		{
+			name: "Linear + Minimize (Default)",
+			config: MetricScorerConfig{
+				MetricName: metricName,
+				Min:        0,
+				Max:        100,
+				// Defaults: Minimize, Linear
+			},
+			inputs: []float64{0, 50, 100},
+			expectedScores: map[int]float64{
+				0: 1.0, // Best
+				1: 0.5,
+				2: 0.0, // Worst
+			},
+		},
+		{
+			name: "Linear + Maximize",
+			config: MetricScorerConfig{
+				MetricName:       metricName,
+				Min:              0,
+				Max:              100,
+				OptimizationMode: OptimizationModeMaximize,
+			},
+			inputs: []float64{0, 50, 100},
+			expectedScores: map[int]float64{
+				0: 0.0, // Worst
+				1: 0.5,
+				2: 1.0, // Best
+			},
+		},
+		{
+			name: "Softmax + Maximize",
+			config: MetricScorerConfig{
+				MetricName:        metricName,
+				NormalizationAlgo: NormalizationAlgoSoftmax,
+				OptimizationMode:  OptimizationModeMaximize,
+			},
+			inputs: []float64{1, 2, 3},
+			expectedScores: map[int]float64{
+				0: 0.09003057,
+				1: 0.24472847,
+				2: 0.66524096,
+			},
+		},
+		{
+			name: "Softmax + Minimize (Inverted)",
+			config: MetricScorerConfig{
+				MetricName:        metricName,
+				NormalizationAlgo: NormalizationAlgoSoftmax,
+				OptimizationMode:  OptimizationModeMinimize,
+			},
+			inputs: []float64{1, 2, 3},
+			expectedScores: map[int]float64{
+				0: 0.66524096, // exp(-1) / sum(exp(-1), exp(-2), exp(-3))
+				1: 0.24472847, // exp(-2) / sum
+				2: 0.09003057, // exp(-3) / sum
+			},
+		},
+		{
+			name: "Missing Metric Handling",
+			config: MetricScorerConfig{
+				MetricName: metricName,
+				Min:        0, Max: 100,
+				OptimizationMode: OptimizationModeMinimize, // Default
+			},
+			// Special case: input -1 means missing metric for helper
+			inputs: []float64{50, -1},
+			expectedScores: map[int]float64{
+				0: 0.5, // 50 -> 0.5 -> 1-0.5=0.5
+				1: 0.0, // Missing -> Assumes Max (100) -> 1.0 -> 1-1=0
+			},
+		},
+		{
+			name: "Missing Metric + Maximize Mode",
+			config: MetricScorerConfig{
+				MetricName:       metricName,
+				Min:              0,
+				Max:              100,
+				OptimizationMode: OptimizationModeMaximize,
+			},
+			inputs: []float64{50, -1}, // -1 means missing
+			expectedScores: map[int]float64{
+				0: 0.5, // 50 -> 0.5
+				1: 0.0, // Missing -> Assumes Min (0) -> 0.0
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Apply defaults to simulate factory behavior or explicit setup.
+			test.config.SetDefaults()
+			scorer := newMetricScorer(test.config)
+
+			endpoints := make([]fwksched.Endpoint, len(test.inputs))
+			for i, v := range test.inputs {
+				if v == -1 {
+					endpoints[i] = newEndpointWithoutMetric()
+				} else {
+					endpoints[i] = newEndpointWithMetric(v, metricName)
+				}
+			}
+
+			scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.LLMRequest{}, endpoints)
+
+			for i, endpoint := range endpoints {
+				expected := test.expectedScores[i]
+				assert.InDelta(t, expected, scores[endpoint], 1e-5, "Endpoint %d", i)
+			}
+		})
+	}
+}
+
+func TestMetricScorerFactory_Validation(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawJson   string
+		expectErr bool
+	}{
+		{
+			name:      "Valid Config",
+			rawJson:   `{"metricName": "foo", "min": 0, "max": 100}`,
+			expectErr: false,
+		},
+		{
+			name:      "Missing MetricName",
+			rawJson:   `{"min": 0, "max": 100}`,
+			expectErr: true,
+		},
+		{
+			name:      "Invalid OptimizationMode",
+			rawJson:   `{"metricName": "foo", "optimizationMode": "Random"}`,
+			expectErr: true,
+		},
+		{
+			name:      "Invalid NormalizationAlgo",
+			rawJson:   `{"metricName": "foo", "normalizationAlgo": "Magic"}`,
+			expectErr: true,
+		},
+		{
+			name:      "Linear: Max <= Min",
+			rawJson:   `{"metricName": "foo", "normalizationAlgo": "Linear", "min": 100, "max": 0}`,
+			expectErr: true,
+		},
+		{
+			name:      "Softmax: Min/Max Ignored (should be valid even if weird)",
+			rawJson:   `{"metricName": "foo", "normalizationAlgo": "Softmax"}`,
+			expectErr: false,
+		},
+	}
+
+	factory := MetricScorerFactory
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Plugin, err := factory("test", json.RawMessage(tt.rawJson), nil)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, Plugin)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, Plugin)
+			}
+		})
+	}
+}
+
+func newEndpointWithMetric(val float64, name string) fwksched.Endpoint {
+	m := fwkdl.NewMetrics()
+	m.Custom[name] = val
+	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, m, nil)
+}
+
+func newEndpointWithoutMetric() fwksched.Endpoint {
+	m := fwkdl.NewMetrics()
+	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, m, nil)
+}

--- a/site-src/concepts/data-layer-architecture.md
+++ b/site-src/concepts/data-layer-architecture.md
@@ -1,0 +1,58 @@
+# EPP Data Layer Architecture
+
+The EPP Data Layer is a pluggable subsystem responsible for hydrating `Endpoint` objects with real-time signals (metrics, metadata) from external sources. It follows a highly decoupled architecture defined in `pkg/epp/framework/interface/datalayer`.
+
+## Pattern: Driver-Based Extraction (DataSource Push)
+
+Unlike a traditional "pull" model where consumers request data, the Data Layer uses a **Driver-Based Extraction** pattern:
+
+1.  **The Driver (DataSource)**: An implementation of `fwkdl.DataSource` (e.g., `HTTPDataSource`) is the active component. Its `Collect` method is triggered by the framework on a schedule.
+2.  **The Payload**: The `DataSource` fetches raw data (e.g., a Prometheus `/metrics` payload or a local status file).
+3.  **The Push**: The `DataSource` then iterates through all registered `Extractor` plugins and "pushes" the raw data to them via their `Extract(ctx, data, ep)` method.
+4.  **Wiring via Configuration**: Unlike scheduling plugins that are grouped in profiles, Extractors are explicitly associated with a DataSource in the `data` section of the configuration using `PluginRef`s. The configuration loader (`pkg/epp/config/loader/configloader.go`) resolves these references from the global `plugins` registry.
+5.  **Type Validation**: During initialization, `AddExtractor` validates that the `DataSource` output type matches the `Extractor`'s `ExpectedInputType()`, ensuring runtime safety.
+
+## Pattern: Driver-Based Push (Collector Loop)
+
+The Data Layer follows a **Push Model** orchestrated by the `Collector` (`pkg/epp/datalayer/collector.go`):
+1. The `Collector` runs a periodic loop for each endpoint.
+2. On each tick, it calls `Collect()` on all registered `DataSource` instances.
+3. The `DataSource` fetches data and "pushes" it to its registered `Extractors`.
+
+This ensures that all extractors update their state (e.g., populating `Metrics.Custom`) in a synchronized fashion driven by the central collection cycle.
+
+This architecture allows a single expensive network fetch (e.g., scraping vLLM metrics) to be shared by dozens of independent extraction plugins (Queue Depth, KV Cache, Custom Metrics) without redundant IO.
+
+## The Metric Scoring Pipeline: Hose, Filter, Consumer
+
+To configure scoring based on an arbitrary metric, it is helpful to visualize the three distinct roles in the pipeline:
+
+1.  **The Hose (DataSource)**: Responsible for fetching the raw data blob (e.g., a Prometheus `/metrics` payload). In the configuration, this is a plugin like `prometheus-data-source` (or custom HTTP source). It doesn't know about specific metrics; it just knows how to connect to the model server and pull the full text.
+2.  **The Filter (Extractor)**: A plugin like `prometheus-metric` that lives under the DataSource in the `data:` section. It parses the raw blob for **one specific metric** (e.g., `vllm:lora_requests_info`). It then populates the internal `Endpoint` object's `Metrics.Custom` map with that value.
+3.  **The Consumer (Scorer)**: A scheduling plugin like `metric-scorer` (referenced in a `schedulingProfile`). It doesn't know about DataSources or Prometheus. It simply looks at the `Endpoint.Metrics.Custom` map for a key that matches its configured `metricName` and uses that value to produce a score (0.0 - 1.0).
+
+**Key Wiring Rule**: For the pipeline to work, both the DataSource and the Extractor must be explicitly defined in the top-level `plugins:` section of the config, even though they are primarily used within the `data:` section.
+
+## Pluggable Inventory
+
+The Data Layer itself is fully pluggable. While the framework provides a robust `HTTPDataSource`, the architecture supports:
+- **Custom DataSources**: Non-HTTP sources like local Unix sockets or shared memory.
+- **Custom Extractors**: Plugins that parse arbitrary formats (JSON, Protobuf, custom text).
+- **Metric Plugins**: Specialized Extractors that populate the `Custom` metric map. The **Prometheus Metric Plugin** is the primary implementation, allowing operators to extract any scalar gauge or counter from model servers without code changes.
+
+## Validation and Consistency
+
+To ensure reliable data flow, the Data Layer follows a strict initialization lifecycle:
+
+1.  **Validation (Construction Time)**: The `ConfigLoader` (`pkg/epp/config/loader`) parses and validates the configuration structure.
+    - **Plugin Existence**: Verifies that all referenced `pluginRef`s are defined in the global `plugins` section.
+    - **Interface Compliance**: Verifies that Plugins implementing `fwkdl.DataSource` and `fwkdl.Extractor` are correctly typed.
+    - **Runtime Safety**: During the subsequent initialization phase (in `Runner`), the framework enforces **Type Safety** by verifying that a generic `DataSource` producing type `T` is only connected to `Extractors` that accept type `T`.
+
+2.  **Hydration (Scrape Cycle)**: Data is updated by the `Collector` on an independent, per-endpoint periodic loop.
+    - **The Update**: When a scrape succeeds, the Extractor populates the `Metrics.Custom` map and sets a fresh `UpdateTime`.
+    - **The Stale State**: If a scrape fails or is delayed beyond the `metricsStalenessThreshold`, the data remains in the map but becomes stale (indicated by an old `UpdateTime`).
+
+3.  **Consumption (Scheduling Cycle)**: Data is "consumable" at any point, but is most critical during the **Scoring Phase** of a request.
+    - **Freshness Check**: specialized plugins (like `UtilizationDetector`) can check the `UpdateTime` to decide if the metric is reliable.
+    - **Fallback logic**: If a metric is missing (e.g., first-time initialization or persistent scrape failure), plugins like `MetricScorer` operate on a default/worst-case value to avoid scheduling blind.

--- a/site-src/guides/epp-configuration/config-text.md
+++ b/site-src/guides/epp-configuration/config-text.md
@@ -252,6 +252,19 @@ available to serve new request).
 - *Type*: queue-scorer
 - *Parameters*: none
 
+#### MetricScorer
+
+Scores candidate pods based on a custom numerical metric (e.g. from Prometheus).
+See [Custom Metric Scheduling](custom-metrics.md) for a detailed guide.
+
+- *Type*: metric-scorer
+- *Parameters*:
+  - `metricName`: The name of the metric to use for scoring.
+  - `min`: The minimum expected value (for normalizing).
+  - `max`: The maximum expected value (for normalizing).
+  - `optimizationMode`: `Minimize` or `Maximize`.
+  - `normalizationAlgo`: `Linear` or `Softmax`.
+
 #### MaxScorePicker
 
 Picks the pod with the maximum score from the list of candidates. This is the default picker plugin

--- a/site-src/guides/epp-configuration/custom-metrics.md
+++ b/site-src/guides/epp-configuration/custom-metrics.md
@@ -1,0 +1,164 @@
+# Custom Metric Scheduling
+
+The Custom Metric Scheduling feature enables the Endpoint Picker (EPP) to use arbitrary Prometheus metrics as scoring signals. This allows for scheduling policies based on hardware telemetry, application-specific counters, or other environmental data not natively tracked by the default plugins purely through configuration, without modifying or recompiling EPP source code.
+
+## Architecture
+
+Custom Metric Scheduling is built on a "Source -> Extractor -> Scorer" pipeline:
+
+1.  **Data Source** (`metrics-data-source`): Fetches raw Prometheus text from the model server's `/metrics` endpoint.
+2.  **Extractor** (`prometheus-metric`): Parses the raw text to find a specific metric value, optionally filtering by labels (e.g., `gpu="0"`).
+3.  **Scorer** (`metric-scorer`): Uses the extracted value to score the candidate pod.
+
+## Configuration
+
+To enable custom metric scheduling, you must configure all three components in your EPP configuration file.
+
+### 1. Configure the Data Source
+
+First, define a `metrics-data-source` plugin. This plugin manages the HTTP connection to your model server's metrics endpoint.
+
+```yaml
+plugins:
+- name: model-server-metrics
+  type: metrics-data-source
+  parameters:
+    path: /metrics
+    scheme: http
+```
+
+### 2. Configure the Extractor
+
+Next, define a `prometheus-metric` extractor. This plugin tells EPP *which* metric to look for.
+
+*   `metricName`: The exact name of the Prometheus metric.
+*   `labels`: (Optional) A map of labels to match. This enables **Series Selection**, allowing you to target specific metric series.
+
+```yaml
+plugins:
+- name: running-requests-extractor
+  type: prometheus-metric
+  parameters:
+    metricName: vllm:num_requests_running
+    labels:
+      model_name: "llama-3-8b"
+```
+
+### 3. Configure the Scorer
+
+Finally, define the `metric-scorer`. This plugin translates the metric value into a scheduling score (0.0 to 1.0).
+
+*   `metricName`: Must match the name used in the Extractor.
+*   `optimizationMode`: `Minimize` (lower is better, e.g., latency, temperature) or `Maximize` (higher is better, e.g., throughput, available buffer).
+*   `min` / `max`: Expected range for normalization. Values outside this range are clamped.
+*   `normalizationAlgo`: `Linear` (default) or `Softmax` (distribution-aware).
+
+```yaml
+plugins:
+- name: active-load-scorer
+  type: metric-scorer
+  parameters:
+    metricName: vllm:num_requests_running
+    optimizationMode: Minimize
+    normalizationAlgo: Softmax
+    min: 0
+    max: 100
+```
+
+## Wiring It All Together
+
+Once the plugins are defined, you must "wire" them together in the `data` and `schedulingProfiles` sections.
+
+### Data Section (Wiring Source to Extractor)
+
+You must tell EPP to extract the configured metric from the defined Data Source.
+
+```yaml
+data:
+  sources:
+  - pluginRef: model-server-metrics
+    extractors:
+    - pluginRef: running-requests-extractor
+```
+
+### Scheduling Profiles (Wiring Scorer)
+
+You must add the Scorer to your scheduling profile, assigning it a weight relative to other scorers.
+
+```yaml
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: active-load-scorer
+    weight: 40  # Secondary: Avoid overloaded nodes.
+  - pluginRef: prefix-cache-scorer
+    weight: 60  # Primary: Prefer hot cache (affinity).
+```
+
+## Complete Example: Balancing Affinity with Active Load
+
+This example demonstrates a sophisticated policy that balances **Prefix Affinity** (routing requests to where their KV-cache is hot) with **Active Load** (avoiding overloaded servers).
+
+
+We use `vllm:num_requests_running` with a label filter (`model_name`) to ensure we are only counting load for the specific model we care about. We also use **Softmax** normalization to "softly" penalize load, allowing the Prefix Scorer to win in most cases unless a server is significantly more overloaded than others.
+
+```yaml
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+featureGates:
+- dataLayer # Required for custom metrics.
+
+plugins:
+# 1. The Data Source
+- name: prometheus-source
+  type: metrics-data-source
+  parameters:
+    path: /metrics
+    scheme: http
+
+# 2. The Extractor
+# Extracts the number of running requests SPECIFICALLY for Llama-3-8b
+# This demonstrates Series Selection: only metrics matching this label will be
+# extracted.
+- name: running-requests-extractor
+  type: prometheus-metric
+  parameters:
+    metricName: vllm:num_requests_running
+    labels:
+      model_name: "llama-3-8b"
+
+# 3. The Scorer
+# Penalize nodes with a high number of running requests using Softmax.
+# Softmax (Minimize) acts as a "Softmin", aggressively penalizing outliers
+# without unfairly punishing servers with average load.
+- name: active-load-scorer
+  type: metric-scorer
+  parameters:
+    metricName: vllm:num_requests_running
+    optimizationMode: Minimize
+    normalizationAlgo: Softmax # Use Softmax for distribution-aware scoring.
+    min: 0
+    max: 50
+
+# 4. Standard Components (including Prefix Cache)
+- type: max-score-picker
+- type: single-profile-handler
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 64
+
+data:
+  sources:
+  - pluginRef: prometheus-source
+    extractors:
+    - pluginRef: running-requests-extractor
+
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: active-load-scorer
+    weight: 40  # Secondary: Avoid overloaded nodes.
+  - pluginRef: prefix-cache-scorer
+    weight: 60  # Primary: Prefer hot cache (affinity).
+  - pluginRef: max-score-picker
+```

--- a/test/integration/epp/util.go
+++ b/test/integration/epp/util.go
@@ -140,16 +140,25 @@ func ExpectStreamResp(chunks ...string) []*extProcPb.ProcessingResponse {
 // --- Data Structures & Metrics Helpers ---
 
 type podState struct {
-	index        int
-	queueSize    int
-	kvCacheUsage float64
-	activeModels []string
+	index         int
+	queueSize     int
+	kvCacheUsage  float64
+	activeModels  []string
+	customMetrics map[string]float64
 }
 
 // P constructs a Pod State: Index, Queue, KV%, Models...
 // Usage: P(0, 5, 0.2, "model-a")
 func P(idx int, q int, kv float64, models ...string) podState {
-	return podState{index: idx, queueSize: q, kvCacheUsage: kv, activeModels: models}
+	return podState{index: idx, queueSize: q, kvCacheUsage: kv, activeModels: models, customMetrics: make(map[string]float64)}
+}
+
+func (p podState) WithMetric(name string, value float64) podState {
+	if p.customMetrics == nil {
+		p.customMetrics = make(map[string]float64)
+	}
+	p.customMetrics[name] = value
+	return p
 }
 
 type label struct{ name, value string }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Introduces a generic metrics scorer feature, enabling the EPP to schedule pods based on arbitrary Prometheus metrics (e.g., `vllm:num_requests_running`) without code modifications.

This PR implements a "Source -> Extractor -> Consumer" architecture:

1.  **Source**: `metrics-data-source` (Existing plugin, fetches raw Prometheus text).
2.  **Extractor**: `prometheus-metric` (New plugin).
    *   Parses raw text from the data source.
    *   Implements series selection (label matching) to extract specific vector values from a metric family.
3.  **Consumer**: `metric-scorer` (New plugin).
    *   **Maximization**: Standard normalization ([(val - min) / (max - min)]
    *   **Minimization**: Implements _Softmin_ logic for soft constraints on identifying the "least loaded" node.
    *   **Normalization**: Supports `Linear` and `Softmax` (distribution-aware) algorithms.
3.  **Consumer**: `metric-scorer` (New plugin).
    *   **Normalization**: Decouples algorithm `Linear` vs `Softmax` from optimization mode (`Minimize` vs `Maximize`).
    *   **Linear**: Clamped range normalization (`[(val - min) / (max - min)]`).
    *   **Softmax**: Distribution-aware scoring. When paired with `Minimize`, effectively implements _Softmin_ (`exp(-x)`).

**Which issue(s) this PR fixes**:

Fixes #2201 

**Does this PR introduce a user-facing change?**:

```release-note
Added generic metrics scorer to support scheduling based on arbitrary Prometheus metrics purely through config.
```