### PR TITLE
Add more tracing spans from orchestrator layer

### DIFF
--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -148,7 +148,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	span.SetAttributes(
 		attribute.String("target_model", reqCtx.TargetModelName),
-		attribute.Int("request_criticality", *infObjective.Spec.Priority),
+		attribute.Int("request_prio", *infObjective.Spec.Priority),
 	)
 
 	// Prepare LLMRequest (needed for both saturation detection and Scheduler)

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -27,6 +27,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
@@ -103,6 +107,9 @@ type HarnessConfig struct {
 
 	// configText overrides the default testConfig if provided. A nil value means use default.
 	configText *string
+
+	// Tracing indicates if tracing should be enabled for this test.
+	Tracing bool
 }
 
 // HarnessOption is a functional option for configuring the TestHarness.
@@ -130,6 +137,13 @@ func WithConfigText(text string) HarnessOption {
 	}
 }
 
+// WithTracing enables tracing for the test harness.
+func WithTracing() HarnessOption {
+	return func(c *HarnessConfig) {
+		c.Tracing = true
+	}
+}
+
 // TestHarness encapsulates the environment for a single isolated EPP test run.
 // It manages the lifecycle of the controller manager, the EPP server, and the K8s namespace.
 type TestHarness struct {
@@ -140,9 +154,14 @@ type TestHarness struct {
 	// --- Config State ---
 	runMode            runMode
 	standaloneStrategy standaloneStrategy
+	Tracing            bool
 
 	Client    extProcPb.ExternalProcessor_ProcessClient
 	Datastore datastore.Datastore
+
+	// --- Tracing State ---
+	Exporter *tracetest.InMemoryExporter
+	tp       *sdktrace.TracerProvider
 
 	// Internal handles for cleanup
 	grpcConn *grpc.ClientConn
@@ -179,6 +198,20 @@ func NewTestHarness(t *testing.T, ctx context.Context, opts ...HarnessOption) *T
 	fakePmc := &backendmetrics.FakePodMetricsClient{}
 	mgr, dataStore, err := eppRunner.NewTestRunnerSetup(ctx, testEnv.Config, eppOptions, fakePmc)
 	require.NoError(t, err, "failed to create manager")
+
+	// 6. Tracing Setup (InMemory)
+	var exporter *tracetest.InMemoryExporter
+	var tp *sdktrace.TracerProvider
+	if config.Tracing {
+		exporter = tracetest.NewInMemoryExporter()
+		tp = sdktrace.NewTracerProvider(
+			sdktrace.WithSyncer(exporter),
+		)
+		otel.SetTracerProvider(tp)
+	}
+
+	// 7. Start Background Processes
+
 	mgrCtx, mgrCancel := context.WithCancel(ctx)
 
 	// Start Manager.
@@ -204,14 +237,24 @@ func NewTestHarness(t *testing.T, ctx context.Context, opts ...HarnessOption) *T
 		Namespace:          eppOptions.PoolNamespace,
 		runMode:            config.runMode,
 		standaloneStrategy: config.standaloneStrategy,
+		Tracing:            config.Tracing,
 		Client:             client,
 		Datastore:          dataStore,
+		Exporter:           exporter,
+		tp:                 tp,
 		grpcConn:           conn,
 		fakePmc:            fakePmc,
 	}
 
+	// 8. Register Cleanup
+
 	t.Cleanup(func() {
 		mgrCancel()
+		if config.Tracing {
+			_ = tp.Shutdown(ctx)
+			// Reset to no-op to avoid pollution between tests.
+			otel.SetTracerProvider(noop.NewTracerProvider())
+		}
 		_ = h.grpcConn.Close()
 		// Deleting the Namespace cascades to all contained resources.
 		_ = k8sClient.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: eppOptions.PoolNamespace}})
@@ -244,6 +287,11 @@ func defaultEppServerOptions(t *testing.T, namespace string) *eppServer.Options 
 	eppOptions.EndpointTargetPorts = []int{8000}
 	eppOptions.SecureServing = false
 	return eppOptions
+}
+
+// GetSpans returns the currently recorded spans from the in-memory exporter.
+func (h *TestHarness) GetSpans() tracetest.SpanStubs {
+	return h.Exporter.GetSpans()
 }
 
 // --- Fluent Builder API ---

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -24,11 +24,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -117,6 +119,8 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 		// requiresCRDs indicates that this test case relies on specific Gateway API CRD features (like
 		// InferenceModelRewrite) which are not available in Standalone runMode without CRD.
 		requiresCRDs bool
+		// wantSpans lists the span names expected to be recorded.
+		wantSpans []string
 	}{
 		// --- Standard Routing Logic ---
 		{
@@ -132,6 +136,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 				"inference_objective_request_total": cleanMetric(metricReqTotal(modelMyModel, modelMyModelTarget)),
 				"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
 			},
+			wantSpans: []string{"gateway.request", "gateway.request_orchestration"},
 		},
 		{
 			name:     "select active lora, low queue",
@@ -398,11 +403,20 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 					defer cancel()
 
 					var h *TestHarness
-					if executionMode.mode == modeStandalone {
-						h = NewTestHarness(t, ctx, WithStandaloneMode(executionMode.standaloneStrategy))
-					} else {
-						h = NewTestHarness(t, ctx, WithStandardMode())
+					var harnessOpts []HarnessOption
+
+					if len(tc.wantSpans) > 0 {
+						harnessOpts = append(harnessOpts, WithTracing())
 					}
+
+					if executionMode.mode == modeStandalone {
+						harnessOpts = append(harnessOpts, WithStandaloneMode(executionMode.standaloneStrategy))
+					} else {
+						harnessOpts = append(harnessOpts, WithStandardMode())
+					}
+
+					h = NewTestHarness(t, ctx, harnessOpts...)
+
 					if executionMode.mode == modeStandard || executionMode.standaloneStrategy == strategyWithCRD {
 						h = h.WithBaseResources()
 					}
@@ -433,6 +447,26 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 
 					if len(tc.wantMetrics) > 0 {
 						h.ExpectMetrics(tc.wantMetrics)
+					}
+
+					if len(tc.wantSpans) > 0 {
+						// Close the stream so the server finishes processing and ends the root span
+						_ = h.Client.CloseSend()
+
+						assert.Eventually(t, func() bool {
+							spans := h.GetSpans()
+							recordedSpans := make(map[string]bool)
+							for _, s := range spans {
+								recordedSpans[s.Name] = true
+							}
+
+							for _, want := range tc.wantSpans {
+								if !recordedSpans[want] {
+									return false
+								}
+							}
+							return true
+						}, 5*time.Second, 50*time.Millisecond, "Expected spans %v not found", tc.wantSpans)
 					}
 				})
 			}


### PR DESCRIPTION
# What type of PR is this?

/kind feature

# What this PR does / why we need it:
Director orchestrates the request lifecycle
See https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1520 step2
And the PR also adds some tests. 

# Which issue(s) this PR fixes:
See https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1520

Does this PR introduce a user-facing change?:
Director request handler now includes one level of span. When enabled via the existing --tracing flag, one more trace span is created.