### PR TITLE
test: fix flakes in controller and registry tests

### DIFF
--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -283,7 +283,7 @@ func TestFlowRegistry_Stats(t *testing.T) {
 func TestFlowRegistry_GarbageCollection(t *testing.T) {
 	t.Run("ShouldCollectIdleFlow", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{})
+		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 		key := flowcontrol.FlowKey{ID: "idle-flow", Priority: highPriority}
 
 		h.openConnectionOnFlow(key)                            // Create a flow, which is born Idle.


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Fixes two test flakes in the Flow Control layer (`TestFlowController_EnqueueAndWait` and `TestFlowRegistry_GarbageCollection`).

1. Controller Flake: Logic Race with RealClock

-  `OnReqCtxTimeoutAfterDistribution` used a frozen `FakeClock` for the request timestamp but `context.WithDeadline` (which uses the system wall clock) for the deadline. CI/CD latency or slow startup (simulated locally with a `35ms` sleep) caused the deadline to expire immediately relative to wall time, failing the test.
- This PR refactors`newUnitHarness` to accept options and injected `clock.RealClock{}` for this specific test case. This ensures the request timestamp and deadline check rely on the same time source.

2. Registry Flake: Background GC Race

- `TestFlowRegistry_GarbageCollection/ShouldCollectIdleFlow` failed intermittently because the background GC loop (enabled by default) raced with the test’s manual GC trigger. This sometimes caused the flow to be collected before the test asserted its state.
- This PR sets `manualGC: true` for this test case, preventing the background loop from interfering with deterministic test steps.

Reproduced flakes and verified fixes by injecting `time.Sleep(35 * time.Millisecond)` into `newUnitHarness` (for the controller test) and running:

```bash
go test -race -count=5000 -v -failfast -test.fullpath=true \
  -run ^TestFlowController_EnqueueAndWait$/^Lifecycle$/^OnReqCtxTimeoutAfterDistribution$ \
  sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/controller

go test -race -count=5000 -v -failfast -test.fullpath=true \
  -run ^TestFlowRegistry_GarbageCollection$/^ShouldCollectIdleFlow$ \
  sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/registry
```

**Which issue(s) this PR fixes**:

Fixes #2248 
Fixes #2249 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```