### PR TITLE
chore: remove deprecated top-level istio values

### DIFF
--- a/config/charts/inferencepool/templates/istio.yaml
+++ b/config/charts/inferencepool/templates/istio.yaml
@@ -1,8 +1,5 @@
 {{- if eq .Values.provider.name "istio" }}
-{{- /* Prefer .Values.provider.istio, fallback to legacy .Values.istio, then {} */ -}}
-{{- $provIstio := (index .Values "provider" "istio") -}}
-{{- $legacyIstio := .Values.istio -}}
-{{- $istio := coalesce $provIstio $legacyIstio (dict) -}}
+{{- $istio := (index .Values "provider" "istio") | default (dict) -}}
 {{- $dr := (index $istio "destinationRule") | default (dict) -}}
 
 apiVersion: networking.istio.io/v1beta1

--- a/config/charts/inferencepool/values.yaml
+++ b/config/charts/inferencepool/values.yaml
@@ -112,14 +112,3 @@ provider:
 experimentalHttpRoute:
   enabled: false # a flag to indicate whether to create the httproute as part of the chart or not.
   inferenceGatewayName: inference-gateway
-
-# DEPRECATED and will be removed in v1.3. Instead, use `provider.istio.*`.
-istio:
-  destinationRule:
-    # Provide a way to override the default calculated host
-    host: ""
-    # Optional: Enables customization of the traffic policy
-    trafficPolicy: {}
-      # connectionPool:
-      #   http:
-      #     maxRequestsPerConnection: 256000


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The backward compatibility window ended with v1.3. Istio configuration is now supported only via provider.istio.

**Which issue(s) this PR fixes**:

Fixes #1832

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Helm: Drops support for legacy top-level `istio` values. Users must configure Istio via `provider.istio`.
```
