### PR TITLE
Build and distribute latencyprediction images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ latency-prediction-image-load: latency-prediction-image-build
 latency-prediction-image-kind: latency-prediction-image-build ## Build the latency prediction server image and load it to kind cluster $KIND_CLUSTER ("kind" by default).
 	kind load docker-image $(LATENCY_PREDICTION_IMAGE_TAG) --name $(KIND_CLUSTER)
 
-##@ Latency Prediction - Test
+##@ Latency Prediction - Test Job Image
 
 .PHONY: latency-prediction-test-image-local-build
 latency-prediction-test-image-local-build: ## Build the latency prediction test image using Docker Buildx for local development.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,21 +42,7 @@ steps:
     entrypoint: make
     args:
       - latency-training-image-push
-    env:
-    - GIT_TAG=$_GIT_TAG
-    - EXTRA_TAG=$_PULL_BASE_REF
-    - DOCKER_BUILDX_CMD=/buildx-entrypoint
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
-    entrypoint: make
-    args:
       - latency-prediction-image-push
-    env:
-    - GIT_TAG=$_GIT_TAG
-    - EXTRA_TAG=$_PULL_BASE_REF
-    - DOCKER_BUILDX_CMD=/buildx-entrypoint
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
-    entrypoint: make
-    args:
       - latency-prediction-test-image-push
     env:
     - GIT_TAG=$_GIT_TAG

--- a/latencypredictor/manifests/kustomization.yaml
+++ b/latencypredictor/manifests/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - dual-server-deployment.yaml
+  # Uncomment to include test job
+  # - test-dual-server-deployment.yaml
+
+images:
+  # Replace the placeholder training server image with the actual built image
+  - name: placeholder-for-training-server-image
+    newName: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/latency-training-server
+    newTag: latest
+
+  # Replace the placeholder prediction server image with the actual built image
+  - name: placeholder-for-prediction-server-image
+    newName: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/latency-prediction-server
+    newTag: latest
+
+  # Replace the placeholder test image with the actual built image (when test job is enabled)
+  - name: placeholder-for-test-image
+    newName: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/latency-prediction-test
+    newTag: latest
+
+# Optional: Add common labels to all resources
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: latency-predictor
+
+# Optional: Add namespace if deploying to a specific namespace
+# namespace: latency-prediction


### PR DESCRIPTION
cc @kaushikmitr 

Add one of the following kinds:
/kind build

**What this PR does / why we need it**:
Producing a public image stream for the 3 latency prediction images

**Which issue(s) this PR fixes**:
Fixes #2241

**Does this PR introduce a user-facing change?**:
None
