### PR TITLE
Moved metrics keys to the datalayer framework pkg

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/source/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/extractor.go
@@ -31,10 +31,19 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/util/logging"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 )
 
 const (
+
+	// --- Internal Keys (for Legacy/Gauge Usage) ---
+	KVCacheUsagePercentKey = "KVCacheUsagePercent"
+	WaitingQueueSizeKey    = "WaitingQueueSize"
+	RunningRequestsSizeKey = "RunningRequestsSize"
+	MaxActiveModelsKey     = "MaxActiveModels"
+	ActiveModelsKey        = "ActiveModels"
+	WaitingModelsKey       = "WaitingModels"
+	UpdateTimeKey          = "UpdateTime"
+
 	// LoRA metrics based on MSP
 	LoraInfoRunningAdaptersMetricName = "running_lora_adapters"
 	LoraInfoWaitingAdaptersMetricName = "waiting_lora_adapters"
@@ -56,13 +65,13 @@ type Extractor struct {
 // package.
 func Produces() map[string]any {
 	return map[string]any{
-		metrics.WaitingQueueSizeKey:    int(0),
-		metrics.RunningRequestsSizeKey: int(0),
-		metrics.KVCacheUsagePercentKey: float64(0),
-		metrics.ActiveModelsKey:        map[string]int{},
-		metrics.WaitingModelsKey:       map[string]int{},
-		metrics.MaxActiveModelsKey:     int(0),
-		metrics.UpdateTimeKey:          time.Time{},
+		WaitingQueueSizeKey:    int(0),
+		RunningRequestsSizeKey: int(0),
+		KVCacheUsagePercentKey: float64(0),
+		ActiveModelsKey:        map[string]int{},
+		WaitingModelsKey:       map[string]int{},
+		MaxActiveModelsKey:     int(0),
+		UpdateTimeKey:          time.Time{},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcache_utilization.go
@@ -22,7 +22,7 @@ import (
 
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
 const (

--- a/pkg/epp/framework/plugins/scheduling/scorer/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/lora_affinity.go
@@ -22,7 +22,7 @@ import (
 
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
 const (

--- a/pkg/epp/framework/plugins/scheduling/scorer/queue.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queue.go
@@ -23,7 +23,7 @@ import (
 
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
 const (

--- a/pkg/epp/framework/plugins/scheduling/scorer/running.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/running.go
@@ -23,7 +23,7 @@ import (
 
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
 const (

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -36,15 +36,6 @@ const (
 	InferencePoolComponent      = "inference_pool"
 	InferenceExtension          = "inference_extension"
 
-	// --- Internal Keys (for Legacy/Gauge Usage) ---
-	KVCacheUsagePercentKey = "KVCacheUsagePercent"
-	WaitingQueueSizeKey    = "WaitingQueueSize"
-	RunningRequestsSizeKey = "RunningRequestsSize"
-	MaxActiveModelsKey     = "MaxActiveModels"
-	ActiveModelsKey        = "ActiveModels"
-	WaitingModelsKey       = "WaitingModels"
-	UpdateTimeKey          = "UpdateTime"
-
 	// Metric Type Values
 	TypeTPOT                   = "tpot"
 	TypePredictedTPOT          = "predicted_tpot"


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2234
