### PR TITLE
add PopulateControllerConfig in runner.go

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -200,6 +200,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	startCrdReconcilers := opts.EndpointSelector == "" // If endpointSelector is empty, it means it's not in the standalone mode. Then we should start the inferencePool and other CRD Reconciler.
 	controllerCfg := runserver.NewControllerConfig(startCrdReconcilers)
 
+	if err := controllerCfg.PopulateControllerConfig(cfg); err != nil {
+		setupLog.Error(err, "Failed to populate controller config")
+		return err
+	}
+
 	ds, err := setupDatastore(ctx, epf, int32(opts.ModelServerMetricsPort), startCrdReconcilers,
 		opts.PoolName, opts.PoolNamespace, opts.EndpointSelector, opts.EndpointTargetPorts)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces an important update to the `Runner`'s startup process in `runner.go`. The main change ensures that the controller configuration is properly populated and validated before proceeding, improving error handling and startup reliability. Currently CRDs like inferenceobjective and inferenceModelRewrite is not being read by EPP during startup. 

Key improvement to controller configuration:

* Added a call to `PopulateControllerConfig` on `controllerCfg`, which now validates and populates the controller configuration using the provided `cfg`. If this step fails, an error is logged and the startup process is halted to prevent misconfiguration.