### PR TITLE
clean up: remove model server type

### DIFF
--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -73,14 +73,7 @@ spec:
           image: {{ .Values.inferenceExtension.image.hub }}/{{ .Values.inferenceExtension.image.name }}:{{ .Values.inferenceExtension.image.tag }}
           imagePullPolicy: {{ .Values.inferenceExtension.image.pullPolicy | default "IfNotPresent" }}
           args:
-          {{- /* 1. Determine Model Server Type Logic */ -}}
-          {{- $modelServerType := "vllm" }}
-          {{- if and .Values.inferenceExtension.endpointsServer (not .Values.inferenceExtension.endpointsServer.createInferencePool) -}}
-            {{- $modelServerType = .Values.inferenceExtension.endpointsServer.modelServerType | default "vllm" }}
-          {{- else }}
-            {{- $modelServerType = .Values.inferencePool.modelServerType | default "vllm" }}
-          {{- end }}
-          {{- /* 2. Mode Specific Flags */ -}}
+          {{- /* . Mode Specific Flags */ -}}
           {{- if and .Values.inferenceExtension.endpointsServer (not .Values.inferenceExtension.endpointsServer.createInferencePool) }}
               - --endpoint-selector
               - {{ .Values.inferenceExtension.endpointsServer.endpointSelector | quote }}
@@ -96,19 +89,6 @@ spec:
               - --pool-group
               - "{{ (split "/" .Values.inferencePool.apiVersion)._0 }}"
           {{- end }}
-          {{- end }}
-          # SGLang specific metrics.
-          {{- if eq $modelServerType "sglang" }}
-              - --total-queued-requests-metric="sglang:num_queue_reqs"
-              - --kv-cache-usage-percentage-metric="sglang:token_usage"
-          {{- end }}
-          {{- if eq $modelServerType "triton-tensorrt-llm" }}
-              - --total-queued-requests-metric
-              - "nv_trt_llm_request_metrics{request_type=waiting}"
-              - --kv-cache-usage-percentage-metric
-              - "nv_trt_llm_kv_cache_block_metrics{kv_cache_block_type=fraction}"
-              - --lora-info-metric
-              - "" # Set an empty metric to disable LoRA metric scraping as they are not supported by Triton yet.
           {{- end }}
               - --zap-encoder
               - "json"

--- a/config/charts/inferencepool/README.md
+++ b/config/charts/inferencepool/README.md
@@ -109,18 +109,6 @@ Then apply it with:
 $ helm install vllm-llama3-8b-instruct ./config/charts/inferencepool -f values.yaml
 ```
 
-### Install for Triton TensorRT-LLM
-
-Use `--set inferencePool.modelServerType=triton-tensorrt-llm` to install for Triton TensorRT-LLM, e.g.,
-
-```txt
-$ helm install triton-llama3-8b-instruct \
-  --set inferencePool.modelServers.matchLabels.app=triton-llama3-8b-instruct \
-  --set inferencePool.modelServerType=triton-tensorrt-llm \
-  --set provider.name=[none|gke|istio] \
-  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v0
-```
-
 ### Install with Latency-Based Routing
 
 For full details see the dedicated [Latency-Based Routing Guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/latency-based-predictor.md)
@@ -223,7 +211,6 @@ The following table list the configurable parameters of the chart.
 |------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `inferencePool.apiVersion`                                 | The API version of the InferencePool resource. Defaults to `inference.networking.k8s.io/v1`. This can be changed to `inference.networking.x-k8s.io/v1alpha2` to support older API versions.                                                        |
 | `inferencePool.targetPortNumber`                           | Target port number for the vllm backends, will be used to scrape metrics by the inference extension. Defaults to 8000.                                                                                                                             |
-| `inferencePool.modelServerType`                            | Type of the model servers in the pool, valid options are [vllm, triton-tensorrt-llm], default is vllm.                                                                                                                                             |
 | `inferencePool.modelServers.matchLabels`                   | Label selector to match vllm backends managed by the inference pool.                                                                                                                                                                               |
 | `inferenceExtension.replicas`                              | Number of replicas for the endpoint picker extension service. If More than one replica is used, EPP will run in HA active-passive mode. Defaults to `1`.                                                                                           |
 | `inferenceExtension.image.name`                            | Name of the container image used for the endpoint picker.                                                                                                                                                                                          |

--- a/config/charts/inferencepool/values.yaml
+++ b/config/charts/inferencepool/values.yaml
@@ -83,7 +83,6 @@ inferenceExtension:
 inferencePool:
   targetPorts:
     - number: 8000
-  modelServerType: vllm # vllm, triton-tensorrt-llm
   apiVersion: inference.networking.k8s.io/v1
   # modelServers: # REQUIRED
   #   matchLabels:

--- a/config/charts/standalone/values.yaml
+++ b/config/charts/standalone/values.yaml
@@ -21,8 +21,6 @@ inferenceExtension:
 #    endpointSelector: app=vllm-llama3-8b-instruct
     # unused when createInferencePool is true
     targetPorts: 8000
-    # unused when createInferencePool is true
-    modelServerType: vllm # vllm, triton-tensorrt-llm
 
 
   sidecar:
@@ -315,7 +313,6 @@ provider:
 inferencePool:
   targetPorts:
     - number: 8000
-  modelServerType: vllm # vllm, triton-tensorrt-llm
   apiVersion: inference.networking.k8s.io/v1
   # modelServers: # REQUIRED
   #   matchLabels:

--- a/site-src/_includes/epp-latest.md
+++ b/site-src/_includes/epp-latest.md
@@ -6,7 +6,6 @@
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=${MODEl_SERVER}-llama3-8b-instruct \
       --set provider.name=$GATEWAY_PROVIDER \
-      --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
       oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
@@ -20,7 +19,6 @@
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=${MODEl_SERVER}-llama3-8b-instruct \
       --set provider.name=$GATEWAY_PROVIDER \
-      --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
       oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
@@ -34,7 +32,6 @@
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=${MODEl_SERVER}-llama3-8b-instruct \
       --set provider.name=$GATEWAY_PROVIDER \
-      --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
       oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
@@ -48,7 +45,6 @@
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=${MODEl_SERVER}-llama3-8b-instruct \
       --set provider.name=$GATEWAY_PROVIDER \
-      --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
       oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool

--- a/site-src/guides/standalone.md
+++ b/site-src/guides/standalone.md
@@ -126,7 +126,7 @@ EOF
 ```
 Send an inference request via
 ```bash
-kubectl exec curl -- curl -i http://vllm-llama3-8b-instruct-epp:8081/v1/completions \
+kubectl exec curl -- curl -i http://vllm-llama3-8b-instruct-standalone-epp:8081/v1/completions \
 -H 'Content-Type: application/json' \
 -d '{"model": "food-review-1","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
 ```

--- a/site-src/implementations/model-servers.md
+++ b/site-src/implementations/model-servers.md
@@ -17,9 +17,6 @@ vLLM is configured as the default in the [endpoint picker extension](https://git
 
 ## Triton with TensorRT-LLM Backend
 
-Triton specific metric names need to be specified when starting the EPP.
-
-Use `--set inferencePool.modelServerType=triton-tensorrt-llm` to install the `inferencepool` via helm. See the [`inferencepool` helm guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/charts/inferencepool/README.md) for more details.
 
  Add the following to the `flags` in the helm chart as [flags to EPP](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/29ea29028496a638b162ff287c62c0087211bbe5/config/charts/inferencepool/values.yaml#L36)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind cleanup

**What this PR does / why we need it**:
As https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2161 merged, we no longer need model server type in helm chart as such info is now exposed via model server deployment via label `inference.networking.k8s.io/engine-type`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
No more `inferencePool.modelServerType` in `inferencepool` helm chart  and `standalone` helm chart and no more `inferenceExtension.endpointsServer.modelServerType` in `standalone` helm chart
```
