### PR TITLE
conformance: better polling times

### DIFF
--- a/conformance/utils/config/timing.go
+++ b/conformance/utils/config/timing.go
@@ -54,8 +54,8 @@ func DefaultInferenceExtensionTimeoutConfig() InferenceExtensionTimeoutConfig {
 	return InferenceExtensionTimeoutConfig{
 		TimeoutConfig:                          config, // Initialize embedded struct
 		GeneralMustHaveConditionTimeout:        300 * time.Second,
-		InferencePoolMustHaveConditionInterval: 10 * time.Second,
-		GatewayObjectPollInterval:              5 * time.Second,
+		InferencePoolMustHaveConditionInterval: 1 * time.Second,
+		GatewayObjectPollInterval:              1 * time.Second,
 		HTTPRouteDeletionReconciliationTimeout: 5 * time.Second,
 		ServiceUpdateTimeout:                   10 * time.Second,
 	}


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup
/area conformance-machinery

**What this PR does / why we need it**:
Waiting 10s to poll is a huge waste. We are ~always going to wait at least once, which means even if an imlpementation is done in 10ms, it waits 10s. The cost to poll is very low, no need to make it so high.

I could override this in my repo but:
1. We use the CLI which has no timeout config support
2. This will help everyone

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
