### PR TITLE
conformance: modify warmup from weighted two-pools test

### DIFF
--- a/conformance/tests/gateway_weighted_two_pools.go
+++ b/conformance/tests/gateway_weighted_two_pools.go
@@ -113,6 +113,28 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 		// should filter to endpoints that actually belong to its pool.
 		allIPs := append(append([]string{}, primaryPodIPs...), secondaryPodIPs...)
 		eppHeaderValue := strings.Join(allIPs, ",")
+		rt := &RoundTripper
+		gwhttp.MakeRequestAndExpectEventuallyConsistentResponse(
+			t,
+			rt,
+			rt.TimeoutConfig,
+			gwAddr,
+			gwhttp.ExpectedResponse{
+				Request: gwhttp.Request{
+					Host:   hostname,
+					Path:   path,
+					Method: http.MethodPost,
+					Body:   `{"model":"conformance-fake-model","prompt":"Warmup"}`,
+					Headers: map[string]string{
+						test.HeaderTestEppEndPointSelectionKey: eppHeaderValue,
+					},
+				},
+				Response: gwhttp.Response{
+					StatusCodes: []int{http.StatusOK},
+				},
+				Namespace: resources.AppBackendNamespace,
+			},
+		)
 
 		requestBody := `{
 			"model": "conformance-fake-model",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Modify the per-pod warmup loop in GatewayWeightedAcrossTwoInferencePools. The warmup used MakeRequestAndExpectEventuallyConsistentResponse (3 consecutive successes), which made requests targeting secondary endpoints probabilistic under 70/30 backendRef weighting and caused flakes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2315

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
