### PR TITLE
Config options fix

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -142,6 +142,9 @@ func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runne
 }
 
 func (r *Runner) Run(ctx context.Context) error {
+	// Setup a very basic logger in case command line argument parsing fails
+	logutil.InitSetupLogging()
+
 	setupLog.Info(r.eppExecutableName+" build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
 
 	opts := runserver.NewOptions()

--- a/pkg/common/observability/logging/logger.go
+++ b/pkg/common/observability/logging/logger.go
@@ -27,6 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+func InitSetupLogging() {
+	logger := zap.New(zap.RawZapOpts(uberzap.AddCaller()))
+	ctrl.SetLogger(logger)
+}
+
 func InitLogging(opts *zap.Options) {
 	logger := zap.New(zap.UseFlagOptions(opts), zap.RawZapOpts(uberzap.AddCaller()))
 	ctrl.SetLogger(logger)

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -228,6 +228,9 @@ func (opts *Options) Validate() error {
 		}
 	}
 
+	if opts.ConfigText == "" && opts.ConfigFile == "" {
+		return fmt.Errorf("one of the %q and %q flags must be set", "configText", "configFile")
+	}
 	if opts.ConfigText != "" && opts.ConfigFile != "" {
 		return fmt.Errorf("both the %q and %q flags can not be set at the same time", "configText", "configFile")
 	}

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -87,7 +87,8 @@ func TestEndpointTargetPorts(t *testing.T) {
 			opts := NewOptions()
 			opts.AddFlags(tt.fs)
 
-			argv := []string{"--endpoint-selector", "app=vllm"}
+			argv := []string{"--endpoint-selector", "app=vllm",
+				"--config-file", "fake-config.yaml"} // Needed to avoid an options validation error
 			argv = append(argv, tt.args...)
 
 			if err := tt.fs.Parse(argv); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A textual configuration is required by the EPP to run.

If neither the config-text nor the config-file options are specified, the EPP crashes with a nil pointer error.

This PR adds to the options validation code a check that one of the config-text or config-file command line arguments has been specified.

In addition this PR adds a very simple log setup for the initial log messages issued before the command line arguments parse and validate correctly. Without this, no error messages show up in the EPP's stdout. See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log#hdr-The_Log_Handle for more details.

**Which issue(s) this PR fixes**:
Fixes #2297

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
