### PR TITLE
Update Grafana setup directions

### DIFF
--- a/site-src/guides/metrics-and-observability.md
+++ b/site-src/guides/metrics-and-observability.md
@@ -178,11 +178,9 @@ We currently have 2 types of prometheus deployments documented:
         kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/observability/prometheus/rbac.yaml
      ```
 
-    Patch the metrics reader ClusterRoleBinding to reference the new ServiceAccount:
+    Create the metrics reader ClusterRoleBinding to reference the new ServiceAccount:
     ```bash
-       kubectl patch clusterrolebinding inference-gateway-sa-metrics-reader-role-binding \
-         --type='json' \
-         -p='[{"op": "replace", "path": "/subjects/0/namespace", "value": "monitoring"}]'
+    kubectl create clusterrolebinding inference-gateway-sa-metrics-reader-role-binding   --clusterrole=inference-gateway-metrics-reader   --serviceaccount=monitoring:default
     ```
 
     Add the prometheus-community helm repository:
@@ -199,7 +197,7 @@ We currently have 2 types of prometheus deployments documented:
      ```
 
     You can add the prometheus data source to grafana following [This Guide](https://grafana.com/docs/grafana/latest/administration/data-source-management/).
-    The prometheus server host is by default `http://prometheus-server`
+    Despite the URL reported from the previous step, the prometheus server host is by default `http://prometheus-server`.
 
     Notice that the given values file is very simple and will work directly after following the [Getting Started Guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/), you might need to modify it
 
@@ -211,7 +209,8 @@ We currently have 2 types of prometheus deployments documented:
 ## Load Inference Extension dashboard into Grafana
 
 Please follow [grafana instructions](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/) to load the dashboard json.
-The dashboard can be found here [Grafana Dashboard](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/inference_gateway.json)
+The dashboard can be found here [Grafana Dashboard](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/inference_gateway.json). Note that you may need to copy and paste the json
+file rather than using the import URL option.
 
 ## Prometheus Alerts
 


### PR DESCRIPTION


**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

It updates a command in the directions that fails do to a non-existent role. It seems that the role must be created. 

**Which issue(s) this PR fixes**:

Fixes #2334 

**Does this PR introduce a user-facing change?**:

```release-note
Updates user-facing documentation on Grafana setup for IGW.
```
