### PR TITLE
Moved DataSource and Extractor type validation to framework

### DIFF
--- a/pkg/epp/datalayer/datasource.go
+++ b/pkg/epp/datalayer/datasource.go
@@ -19,7 +19,6 @@ package datalayer
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
@@ -65,20 +64,4 @@ func RegisterSource(src fwkdl.DataSource) error {
 // GetSources returns the list of data sources registered in the default registry.
 func GetSources() []fwkdl.DataSource {
 	return defaultDataSources.GetSources()
-}
-
-// ValidateExtractorType checks if an extractor can handle
-// the DataSource's output. It should be called by a DataSource
-// when an extractor is added.
-func ValidateExtractorType(collectorOutput, extractorInput reflect.Type) error {
-	if collectorOutput == nil || extractorInput == nil {
-		return errors.New("extractor input type or data source output type can't be nil")
-	}
-	if collectorOutput == extractorInput ||
-		(extractorInput.Kind() == reflect.Interface && extractorInput.NumMethod() == 0) ||
-		(extractorInput.Kind() == reflect.Interface && collectorOutput.Implements(extractorInput)) {
-		return nil
-	}
-	return fmt.Errorf("extractor input type %v cannot handle data source output type %v",
-		extractorInput, collectorOutput)
 }

--- a/pkg/epp/datalayer/datasource_test.go
+++ b/pkg/epp/datalayer/datasource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package datalayer
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,44 +61,4 @@ func TestGetSourceWhenNoneAreRegistered(t *testing.T) {
 	reg := DataSourceRegistry{}
 	found := reg.GetSources()
 	assert.Empty(t, found, "expected no sources to be returned")
-}
-
-func TestValidateExtractorType(t *testing.T) {
-	type rawStruct struct{}
-	type iface interface{ Foo() }
-
-	tests := []struct {
-		name   string
-		output reflect.Type
-		input  reflect.Type
-		valid  bool
-	}{
-		{"exact match", typeOf(rawStruct{}), typeOf(rawStruct{}), true},
-		{"input is interface{}", typeOf(rawStruct{}), typeOf((*any)(nil)), true},
-		{"nil types are not allowed", typeOf(rawStruct{}), typeOf(nil), false},
-		{"output does not implement input", typeOf(rawStruct{}), typeOf((*iface)(nil)), false},
-	}
-
-	for _, tt := range tests {
-		err := ValidateExtractorType(tt.output, tt.input)
-		if tt.valid {
-			assert.NoError(t, err, "%s: expected valid extractor type", tt.name)
-		} else {
-			assert.Error(t, err, "%s: expected invalid extractor type", tt.name)
-		}
-	}
-}
-
-// typeOf returns the reflect.Type of a value.
-// If the value is a pointer (e.g., (*iface)(nil)), it returns the pointed-to type (via Elem()).
-// Otherwise, it returns the type as-is.
-func typeOf(v any) reflect.Type {
-	t := reflect.TypeOf(v)
-	if t == nil {
-		return nil
-	}
-	if t.Kind() == reflect.Ptr {
-		return t.Elem()
-	}
-	return t
 }

--- a/pkg/epp/framework/interface/datalayer/plugin_test.go
+++ b/pkg/epp/framework/interface/datalayer/plugin_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateExtractorType(t *testing.T) {
+	type rawStruct struct{}
+	type iface interface{ Foo() }
+
+	tests := []struct {
+		name   string
+		output reflect.Type
+		input  reflect.Type
+		valid  bool
+	}{
+		{"exact match", typeOfTest(rawStruct{}), typeOfTest(rawStruct{}), true},
+		{"input is interface{}", typeOfTest(rawStruct{}), typeOfTest((*any)(nil)), true},
+		{"nil types are not allowed", typeOfTest(rawStruct{}), typeOfTest(nil), false},
+		{"output does not implement input", typeOfTest(rawStruct{}), typeOfTest((*iface)(nil)), false},
+	}
+
+	for _, tt := range tests {
+		err := ValidateExtractorType(tt.output, tt.input)
+		if tt.valid {
+			assert.NoError(t, err, "%s: expected valid extractor type", tt.name)
+		} else {
+			assert.Error(t, err, "%s: expected invalid extractor type", tt.name)
+		}
+	}
+}
+
+func typeOfTest(v any) reflect.Type {
+	t := reflect.TypeOf(v)
+	if t == nil {
+		return nil
+	}
+	if t.Kind() == reflect.Ptr {
+		return t.Elem()
+	}
+	return t
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -26,7 +26,6 @@ import (
 	"reflect"
 	"sync"
 
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
@@ -92,7 +91,7 @@ func (dataSrc *HTTPDataSource) Extractors() []string {
 // AddExtractor adds an extractor to the data source, validating it can process
 // the data source output type.
 func (dataSrc *HTTPDataSource) AddExtractor(extractor fwkdl.Extractor) error {
-	if err := datalayer.ValidateExtractorType(dataSrc.outputType, extractor.ExpectedInputType()); err != nil {
+	if err := fwkdl.ValidateExtractorType(dataSrc.outputType, extractor.ExpectedInputType()); err != nil {
 		return err
 	}
 	if _, loaded := dataSrc.extractors.LoadOrStore(extractor.TypedName().Name, extractor); loaded {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Following up on comments in #2228 - moved `ValidateExtractorType` function and test under `epp/framework`.

**Which issue(s) this PR fixes**:
Fixes #2234 

Notes
- The metric names used in `Produces()` and other Plugin's `Consumes()` are already in the metrics Extractor under the framework.
- Morphing `Metrics` (or `MetadataState`) as generic `Attributes` is not done (low impact, large changeset).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
