### PR TITLE
Have a default configuration for the EndpointPicker

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -439,10 +439,6 @@ func (r *Runner) registerInTreePlugins() {
 }
 
 func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver.Options) (*configapi.EndpointPickerConfig, error) {
-	if opts.ConfigText == "" && opts.ConfigFile == "" {
-		return nil, nil // configuring through code, not through file
-	}
-
 	logger := log.FromContext(ctx)
 
 	var configBytes []byte

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -55,11 +55,19 @@ func RegisterFeatureGate(gate string) {
 // LoadRawConfig parses the raw configuration bytes, applies initial defaults, and extracts feature gates.
 // It does not instantiate plugins.
 func LoadRawConfig(configBytes []byte, logger logr.Logger) (*configapi.EndpointPickerConfig, map[string]bool, error) {
-	rawConfig, err := decodeRawConfig(configBytes)
-	if err != nil {
-		return nil, nil, err
+	var rawConfig *configapi.EndpointPickerConfig
+	var err error
+	if len(configBytes) != 0 {
+		rawConfig, err = decodeRawConfig(configBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		logger.Info("Loaded raw configuration", "config", rawConfig.String())
+	} else {
+		logger.Info("A configuration wasn't specified. A default one is being used.")
+		rawConfig = loadDefaultConfig()
+		logger.Info("Default raw configuration used", "config", rawConfig.String())
 	}
-	logger.Info("Loaded raw configuration", "config", rawConfig)
 
 	applyStaticDefaults(rawConfig)
 

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -228,9 +228,6 @@ func (opts *Options) Validate() error {
 		}
 	}
 
-	if opts.ConfigText == "" && opts.ConfigFile == "" {
-		return fmt.Errorf("one of the %q and %q flags must be set", "configText", "configFile")
-	}
 	if opts.ConfigText != "" && opts.ConfigFile != "" {
 		return fmt.Errorf("both the %q and %q flags can not be set at the same time", "configText", "configFile")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Today if the EndpointPicker is started without a configuration an error is issued and it fails to start.

It would be better if instead, a default configuration was provided and the EndpointPicker would start. This may make it easier for people to begin working with the EndpointPicker.

This PR provides a default configuration if one wasn't provided to the EndpointPicker in its command line arguments, either in-line or in a "file". In addition a new unit test was added to test this new functionality.

The details of the configuration can be found in issue #2324.

**Which issue(s) this PR fixes**:
Fixes #2324

**Does this PR introduce a user-facing change?**:
```release-note
If neither the --config-file nor the --config-text command line arguments are provided, the EndpointPicker will start using a default configuration.
```
