### PR TITLE
Make latency prediction server multi threaded compatable

### DIFF
--- a/latencypredictor/Dockerfile-prediction
+++ b/latencypredictor/Dockerfile-prediction
@@ -21,6 +21,9 @@ COPY . .
 # Expose the port the app runs on
 EXPOSE 8001
 
+# Number of worker processes — configurable via env var
+ENV UVICORN_WORKERS=8
+
 # Command to run the application using uvicorn
 # We use 0.0.0.0 to bind to all network interfaces inside the container
-CMD ["uvicorn", "prediction_server:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["sh", "-c", "uvicorn prediction_server:app --host 0.0.0.0 --port 8001 --workers $UVICORN_WORKERS"]

--- a/latencypredictor/test_dual_server_client.py
+++ b/latencypredictor/test_dual_server_client.py
@@ -1212,7 +1212,7 @@ def test_bulk_prediction_stress_test():
     print("Running bulk prediction stress test...")
     
     # Test with different batch sizes
-    batch_sizes = [5, 10, 25]
+    batch_sizes = [25, 50, 100]
     for batch_size in batch_sizes:
         print(f"\nTesting with batch size {batch_size}...")
         results = asyncio.run(run_bulk_prediction_stress_test(


### PR DESCRIPTION
This pull request introduces improvements to the prediction server's deployment configuration and updates the stress test parameters for bulk predictions. The main changes are focused on making the server more configurable and increasing the robustness of performance testing.

**Deployment configuration:**

* Added the `UVICORN_WORKERS` environment variable to the `Dockerfile-prediction`, allowing the number of Uvicorn worker processes to be configured via an environment variable. The default is set to 8.
* Modified the container startup command to use a shell and pass the `--workers` flag to Uvicorn, enabling dynamic worker configuration based on the environment variable.

**Testing improvements:**

* Increased the batch sizes used in the bulk prediction stress test from `[5, 10, 25]` to `[25, 50, 100]` in `test_dual_server_client.py`, making the stress test more demanding and representative of higher load scenarios.