### PR TITLE
make kaushikmitr latencypredictor owner

### DIFF
--- a/latencypredictor/OWNERS
+++ b/latencypredictor/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kaushikmitr


### PR DESCRIPTION
This pull request adds an OWNERS file for the `latencypredictor` component, specifying the approver for this part of the codebase.

Ownership and code review:

* Added a new `OWNERS` file to the `latencypredictor` directory, assigning `kaushikmitr` as the approver.