### PR TITLE
Emit metrics on execution time of BBR plugins

### DIFF
--- a/pkg/bbr/metrics/metrics_test.go
+++ b/pkg/bbr/metrics/metrics_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/component-base/metrics/testutil"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestPluginProcessingLatency(t *testing.T) {
+	Register()
+
+	type pluginLatency struct {
+		extensionPoint string
+		pluginType     string
+		pluginName     string
+		duration       time.Duration
+	}
+
+	scenarios := []struct {
+		name      string
+		latencies []pluginLatency
+	}{
+		{
+			name: "multiple plugins",
+			latencies: []pluginLatency{
+				{
+					extensionPoint: "Request",
+					pluginType:     "TestPluginA",
+					pluginName:     "PluginA",
+					duration:       5 * time.Millisecond,
+				},
+				{
+					extensionPoint: "Request",
+					pluginType:     "TestPluginB",
+					pluginName:     "PluginB",
+					duration:       10 * time.Microsecond,
+				},
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			for _, latency := range scenario.latencies {
+				RecordPluginProcessingLatency(latency.extensionPoint, latency.pluginType, latency.pluginName, latency.duration)
+			}
+
+			wantPluginLatencies, err := os.Open("testdata/plugin_processing_latencies_metric")
+			defer func() {
+				if err := wantPluginLatencies.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := testutil.GatherAndCompare(crmetrics.Registry, wantPluginLatencies, "bbr_plugin_duration_seconds"); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/bbr/metrics/testdata/plugin_processing_latencies_metric
+++ b/pkg/bbr/metrics/testdata/plugin_processing_latencies_metric
@@ -1,0 +1,28 @@
+# HELP bbr_plugin_duration_seconds [ALPHA] Plugin processing latency distribution in seconds for each extension point, plugin type and plugin name.
+# TYPE bbr_plugin_duration_seconds histogram
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0001"} 0
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0002"} 0
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.0005"} 0
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.001"} 0
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.002"} 0
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.005"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.01"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.02"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.05"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="0.1"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA",le="+Inf"} 1
+bbr_plugin_duration_seconds_sum{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA"} 0.005
+bbr_plugin_duration_seconds_count{extension_point="Request",plugin_name="PluginA",plugin_type="TestPluginA"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0001"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0002"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.0005"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.001"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.002"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.005"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.01"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.02"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.05"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="0.1"} 1
+bbr_plugin_duration_seconds_bucket{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB",le="+Inf"} 1
+bbr_plugin_duration_seconds_sum{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB"} 1e-05
+bbr_plugin_duration_seconds_count{extension_point="Request",plugin_name="PluginB",plugin_type="TestPluginB"} 1


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds observability for BBR plugin execution latencies by introducing a
`bbr_plugin_duration_seconds` histogram metric. This mirrors the existing
EPP `inference_extension_plugin_duration_seconds` metric and enables
identification of performance bottlenecks caused by specific BBR plugins.

Each plugin execution in the request path is timed and recorded with
`extension_point`, `plugin_type`, and `plugin_name` labels, using the
same bucket boundaries as the EPP equivalent.

**Which issue(s) this PR fixes**:

Fixes #2355

**Does this PR introduce a user-facing change?**:

NONE

