### PR TITLE
Moved data layer metrics compatibility test to keep framework imports self contained

### DIFF
--- a/hack/verify-framework-imports.go
+++ b/hack/verify-framework-imports.go
@@ -52,13 +52,6 @@ var globalExceptions = []string{
 // currentCodeExceptionMap maps existing violation in files to their allowed import exceptions.
 // This should cleaned-up alongside the relevant files and their imports.
 var currentCodeExceptionMap = map[string][]string{
-	"pkg/epp/framework/plugins/datalayer/extractor/metrics/podmetrics_parity_test.go": {
-		"pkg/epp/backend/metrics",
-		"pkg/epp/server",
-	},
-	"pkg/epp/framework/plugins/datalayer/source/http/datasource.go": {
-		"pkg/epp/datalayer",
-	},
 	"pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go": {
 		"pkg/epp/metadata",
 	},


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove current code framework import exceptions for datalayer.

- move compatibility test from framework metrics.extractor to the backend.metrics package (still comparing the same)
- removed the allowed exceptions from the verification

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
