### PR TITLE
Add logs (at log level 1) for better observability

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -213,7 +213,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				reqCtx.Request.Headers[requtil.RequestIdHeaderKey] = requestID // update in headers so director can consume it
 			}
 			logger = logger.WithValues(requtil.RequestIdHeaderKey, requestID)
-			logger.Info("EPP received request") // Request ID will be logged too as part of logger context values.
+			logger.V(1).Info("EPP received request") // Request ID will be logged too as part of logger context values.
 			loggerTrace = logger.V(logutil.TRACE)
 			ctx = log.IntoContext(ctx, logger)
 
@@ -243,7 +243,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 				reqCtx, err = s.director.HandleRequest(ctx, reqCtx)
 				if err != nil {
-					logger.Error(err, "Error handling request")
+					logger.V(1).Error(err, "Error handling request")
 					break
 				}
 
@@ -251,7 +251,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				var requestBodyBytes []byte
 				requestBodyBytes, err = json.Marshal(reqCtx.Request.Body)
 				if err != nil {
-					logger.Error(err, "Error marshalling request body")
+					logger.V(1).Error(err, "Error marshalling request body")
 					break
 				}
 				// Update RequestSize to match marshalled body for Content-Length header.
@@ -283,7 +283,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				if logger.V(logutil.DEBUG).Enabled() {
 					logger.V(logutil.DEBUG).Error(responseErr, "Failed to process response headers", "request", req)
 				} else {
-					logger.Error(responseErr, "Failed to process response headers")
+					logger.V(1).Error(responseErr, "Failed to process response headers")
 				}
 			}
 			reqCtx.respHeaderResp = s.generateResponseHeaderResponse(reqCtx)
@@ -323,7 +323,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 						if logger.V(logutil.DEBUG).Enabled() {
 							logger.V(logutil.DEBUG).Error(responseErr, "Error unmarshalling request body", "body", string(body))
 						} else {
-							logger.Error(responseErr, "Error unmarshalling request body", "body", string(body))
+							logger.V(logutil.DEFAULT).Error(responseErr, "Error unmarshalling request body", "body", string(body))
 						}
 						reqCtx.respBodyResp = generateResponseBodyResponses(body, true)
 						break
@@ -334,7 +334,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 						if logger.V(logutil.DEBUG).Enabled() {
 							logger.V(logutil.DEBUG).Error(responseErr, "Failed to process response body", "request", req)
 						} else {
-							logger.Error(responseErr, "Failed to process response body")
+							logger.V(1).Error(responseErr, "Failed to process response body")
 						}
 					} else if reqCtx.ResponseComplete {
 						reqCtx.ResponseCompleteTimestamp = time.Now()
@@ -359,14 +359,14 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			if logger.V(logutil.DEBUG).Enabled() {
 				logger.V(logutil.DEBUG).Error(err, "Failed to process request", "request", req)
 			} else {
-				logger.Error(err, "Failed to process request")
+				logger.V(1).Error(err, "Failed to process request")
 			}
 			resp, err := buildErrResponse(err)
 			if err != nil {
 				return err
 			}
 			if err := srv.Send(resp); err != nil {
-				logger.Error(err, "Send failed")
+				logger.V(1).Error(err, "Send failed")
 				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
 			}
 			return nil
@@ -386,7 +386,7 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 	if r.RequestState == RequestReceived && r.reqHeaderResp != nil {
 		loggerTrace.Info("Sending request header response", "obj", r.reqHeaderResp)
 		if err := srv.Send(r.reqHeaderResp); err != nil {
-			logger.Error(err, "error sending response")
+			logger.V(1).Error(err, "error sending response")
 			return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
 		}
 		r.RequestState = HeaderRequestResponseComplete
@@ -399,7 +399,7 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
 			}
 		}
-		logger.Info("EPP sent request body response(s) to proxy", "modelName", r.IncomingModelName, "targetModelName", r.TargetModelName)
+		logger.V(1).Info("EPP sent request body response(s) to proxy", "modelName", r.IncomingModelName, "targetModelName", r.TargetModelName)
 		r.RequestState = BodyRequestResponsesComplete
 		metrics.IncRunningRequests(r.IncomingModelName)
 		r.RequestRunning = true
@@ -427,7 +427,7 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 
 			body := response.Response.(*extProcPb.ProcessingResponse_ResponseBody)
 			if body.ResponseBody.Response.GetBodyMutation().GetStreamedResponse().GetEndOfStream() {
-				logger.Info("EPP sent response body back to proxy")
+				logger.V(1).Info("EPP sent response body back to proxy")
 				r.RequestState = BodyResponseResponsesComplete
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->
Add debug logs to log request/response is sent to the proxy at the default log level 1 (info logs) for better observability

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:
Ensure that EPP has logs at info level for request/response lifecycle. Sample logs for a request processed by EPP with based on current PR:

```
{"level":"info","ts":"2026-02-20T22:24:39Z","caller":"handlers/server.go:217","msg":"EPP received request","x-request-id":"bench-1f452021-72"}
{"level":"info","ts":"2026-02-20T22:24:39Z","caller":"handlers/server.go:406","msg":"EPP sent request body response(s) to proxy","x-request-id":"bench-1f452021-72","modelName":"meta-llama/Llama-3.1-8B-Instruct","targetModelName":"meta-llama/Llama-3.1-8B-Instruct"}
{"level":"info","ts":"2026-02-20T22:25:00Z","caller":"handlers/server.go:434","msg":"EPP sent response body back to proxy","x-request-id":"bench-1f452021-72"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
More per LLM request logging at default log level for better observability
```
