### PR TITLE
fix: Add ALPN h2 support to gRPC TLS configuration

### DIFF
--- a/pkg/bbr/server/runserver.go
+++ b/pkg/bbr/server/runserver.go
@@ -77,7 +77,10 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 			if err != nil {
 				return fmt.Errorf("failed to create self signed certificate - %w", err)
 			}
-			creds := credentials.NewTLS(&tls.Config{Certificates: []tls.Certificate{cert}})
+			creds := credentials.NewTLS(&tls.Config{
+				Certificates: []tls.Certificate{cert},
+				NextProtos:   []string{"h2"},
+			})
 			srv = grpc.NewServer(grpc.Creds(creds))
 		} else {
 			srv = grpc.NewServer()

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -168,10 +168,12 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 					GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 						return reloader.Get(), nil
 					},
+					NextProtos: []string{"h2"},
 				})
 			} else {
 				creds = credentials.NewTLS(&tls.Config{
 					Certificates: []tls.Certificate{cert},
+					NextProtos:   []string{"h2"},
 				})
 			}
 			// Init the server.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR adds ALPN (Application-Layer Protocol Negotiation) support for HTTP/2 to the gRPC TLS configurations in both the EPP and BBR ext_proc servers.

Without ALPN negotiation, Envoy's ext_proc integration fails when connecting to the gRPC server over TLS because Envoy expects the server to advertise HTTP/2 (`h2`) support during the TLS handshake. This causes connection errors in production deployments using TLS-enabled ext_proc.

This fix adds `NextProtos: []string{"h2"}` to all TLS configurations:
- EPP server: Both certificate reloading and static certificate paths
- BBR server: Self-signed certificate configuration

**Which issue(s) this PR fixes**:

No existing issue - this bug was discovered during production GKE deployment with Istio + KServe using TLS-enabled ext_proc.

**Does this PR introduce a user-facing change?**:
```release-note
Fix gRPC TLS configuration to include ALPN HTTP/2 support, enabling proper Envoy ext_proc integration over TLS.
```

**Testing**:

Tested successfully on GKE cluster with the following configuration:
- Istio service mesh (Red Hat OpenShift Service Mesh)
- KServe v0.15 with LLMInferenceService
- EPP scheduler with TLS-enabled ext_proc
- vLLM inference workloads on TPU v6e

**Verified:**
- ✅ gRPC connections establish successfully with ALPN negotiation
- ✅ Envoy ext_proc integration works correctly with TLS enabled
- ✅ Requests routed properly to inference backends
- ✅ No regressions in existing deployments

**Changes:**
- `pkg/epp/server/runserver.go`: Added ALPN to 2 TLS config locations (lines 179, 187)
- `pkg/bbr/server/runserver.go`: Added ALPN to TLS config (line 161)
