### PR TITLE
fix: Fix toggle for cpu/gpu/sim model server deployment

### DIFF
--- a/site-src/guides/standalone.md
+++ b/site-src/guides/standalone.md
@@ -44,7 +44,7 @@ For the endpoint discovery, you have two options:
     kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/vllm/gpu-deployment.yaml
     ```
 
---8<-- "site-src/_includes/vllm-cpu.md"
+--8<-- "site-src/_includes/model-server-cpu.md"
 
     ```bash
     kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/vllm/cpu-deployment.yaml


### PR DESCRIPTION
Currently, the toggle to deploy the CPU model server is not showing up properly. This is due to the incorrect file path. 

<img width="792" height="451" alt="image" src="https://github.com/user-attachments/assets/b77d41ee-9a6d-49c8-b1e5-6d8b4c652607" />
