### PR TITLE
feat: improve filter plugin logging

### DIFF
--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -139,10 +139,11 @@ func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksch
 		metrics.RecordPluginProcessingLatency(filterExtensionPoint, filter.TypedName().Type, filter.TypedName().Name, time.Since(before))
 		logger.V(logutil.DEBUG).Info("Completed running filter plugin successfully", "plugin", filter.TypedName(), "endpoints", filteredEndpoints)
 		if len(filteredEndpoints) == 0 {
+			logger.V(logutil.VERBOSE).Info("Filter eliminated all endpoints", "plugin", filter.TypedName(), "endpointsBefore", len(endpoints))
 			break
 		}
 	}
-	logger.V(logutil.VERBOSE).Info("Completed running filter plugins successfully")
+	logger.V(logutil.VERBOSE).Info("Completed running filter plugins", "remainingEndpoints", len(filteredEndpoints))
 
 	return filteredEndpoints
 }


### PR DESCRIPTION



The current code at lines 141-143: when all endpoints are filtered out, it just breaks. There's a DEBUG log at line 140 that shows the empty result, but no explicit warning-level log identifying the culprit filter. The "completed successfully" message at line 145 is also misleading since we hit an empty result.

This PR improves it by:
  - Add logging when a filter plugin eliminates all candidate endpoints,
  identifying the culprit plugin
  - Include remaining endpoint count in filter completion log for better
  observability