### PR TITLE
refactor(observability): extract common logging options to shared pac…

### DIFF
--- a/pkg/bbr/server/options.go
+++ b/pkg/bbr/server/options.go
@@ -17,13 +17,9 @@ limitations under the License.
 package server
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/spf13/pflag"
-	uberzap "go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/config"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
@@ -32,7 +28,6 @@ import (
 const (
 	DefaultGrpcPort       = 9004
 	DefaultGrpcHealthPort = 9005
-	ZapLogLevelFlagName   = "zap-log-level"
 )
 
 // Options contains the command-line configuration for the BBR server.
@@ -45,20 +40,19 @@ type Options struct {
 	//
 	// Diagnostics.
 	//
-	LogVerbosity        int         // Number for the log level verbosity.
-	ZapOptions          zap.Options // Zap logging options.
-	MetricsPort         int         // The metrics port exposed by BBR.
-	GRPCHealthPort      int         // The port for gRPC liveness and readiness probes.
-	EnablePprof         bool        // Enables pprof handlers.
-	SecureServing       bool        // Enables secure serving.
-	MetricsEndpointAuth bool        // Enables authentication and authorization of the metrics endpoint.
+	logging.LoggingOptions      // Logging configuration.
+	MetricsPort            int  // The metrics port exposed by BBR.
+	GRPCHealthPort         int  // The port for gRPC liveness and readiness probes.
+	EnablePprof            bool // Enables pprof handlers.
+	SecureServing          bool // Enables secure serving.
+	MetricsEndpointAuth    bool // Enables authentication and authorization of the metrics endpoint.
 	//
 	// Plugins.
 	//
 	PluginSpecs config.BBRPluginSpecs // Repeatable --plugin <type>:<name>[:<json>] flag values.
 
 	// internal
-	fs *pflag.FlagSet // FlagSet used in AddFlags() and consulted in Complete()
+	fs *pflag.FlagSet // FlagSet used in AddFlags()
 }
 
 // NewOptions returns a new Options struct initialized with default values.
@@ -66,8 +60,7 @@ func NewOptions() *Options {
 	return &Options{
 		GRPCPort:            DefaultGrpcPort,
 		GRPCHealthPort:      DefaultGrpcHealthPort,
-		LogVerbosity:        logging.DEFAULT,
-		ZapOptions:          zap.Options{Development: true},
+		LoggingOptions:      *logging.NewOptions(),
 		MetricsPort:         9090,
 		EnablePprof:         true,
 		SecureServing:       true,
@@ -80,6 +73,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	if fs == nil {
 		fs = pflag.CommandLine
 	}
+
 	opts.fs = fs
 
 	fs.IntVar(&opts.GRPCPort, "grpc-port", opts.GRPCPort,
@@ -94,30 +88,18 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 		"Enables streaming support for Envoy full-duplex streaming mode.")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing,
 		"Enables secure serving.")
-	fs.IntVarP(&opts.LogVerbosity, "v", "v", opts.LogVerbosity,
-		"Number for the log level verbosity.")
 	fs.BoolVar(&opts.EnablePprof, "enable-pprof", opts.EnablePprof,
 		"Enables pprof handlers. Defaults to true. Set to false to disable pprof handlers.")
 
 	fs.Var(&opts.PluginSpecs, "plugin", `Repeatable. --plugin <type>:<name>[:<json>]`)
 
-	// Bind zap flags (zap expects a standard Go FlagSet; pflag.FlagSet is not compatible).
-	gofs := flag.NewFlagSet("zap", flag.ExitOnError)
-	opts.ZapOptions.BindFlags(gofs)
-	fs.AddGoFlagSet(gofs)
+	opts.LoggingOptions.AddFlags(fs) // Add logging flags.
 }
 
 // Complete performs post-processing of parsed command-line arguments.
 func (opts *Options) Complete() error {
-	// Derive the zap log level from the -v flag when --zap-log-level is not set explicitly.
-	zapLogLevelFlag := opts.fs.Lookup(ZapLogLevelFlagName)
-	if zapLogLevelFlag != nil && !zapLogLevelFlag.Changed {
-		// See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.Level
-		lvl := -1 * (opts.LogVerbosity)
-		opts.ZapOptions.Level = uberzap.NewAtomicLevelAt(zapcore.Level(int8(lvl)))
-		zapLogLevelFlag.Changed = true
-	}
-	return nil
+	// Complete logging options.
+	return opts.LoggingOptions.Complete()
 }
 
 // Validate checks the Options for invalid or conflicting values.
@@ -147,9 +129,9 @@ func (opts *Options) Validate() error {
 			opts.GRPCPort, opts.GRPCHealthPort, opts.MetricsPort)
 	}
 
-	// Validate log verbosity is non-negative.
-	if opts.LogVerbosity < 0 {
-		return fmt.Errorf("invalid value %d for flag %q: must be >= 0", opts.LogVerbosity, "v")
+	// Validate logging options.
+	if err := opts.LoggingOptions.Validate(); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/bbr/server/options_test.go
+++ b/pkg/bbr/server/options_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
 func TestNewOptionsDefaults(t *testing.T) {
@@ -161,9 +163,9 @@ func TestValidate(t *testing.T) {
 		},
 		// Log verbosity validation.
 		{
-			name:        "negative log verbosity",
+			name:        "negative log verbosity corrected to default",
 			mutate:      func(o *Options) { o.LogVerbosity = -1 },
-			expectError: true,
+			expectError: false,
 		},
 		{
 			name:        "zero log verbosity is valid",
@@ -213,7 +215,7 @@ func TestCompleteDerivesZapLogLevel(t *testing.T) {
 
 	// After Complete(), the zap-log-level flag should be marked as changed
 	// and the zap level should be set to -5.
-	zapFlag := fs.Lookup(ZapLogLevelFlagName)
+	zapFlag := fs.Lookup(logging.ZapLogLevelFlagName)
 	if zapFlag == nil {
 		t.Fatal("Expected zap-log-level flag to exist after AddFlags")
 	}

--- a/pkg/common/observability/logging/options.go
+++ b/pkg/common/observability/logging/options.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"flag"
+
+	"github.com/spf13/pflag"
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	ZapLogLevelFlagName = "zap-log-level"
+)
+
+// LoggingOptions contains logging configuration for command-line flags.
+type LoggingOptions struct {
+	LogVerbosity int         // Number for the log level verbosity.
+	ZapOptions   zap.Options // Zap logging options.
+
+	// internal
+	loggingFS *pflag.FlagSet // FlagSet used in AddFlags() and consulted in Complete()
+}
+
+// NewOptions returns a new LoggingOptions struct initialized with default values.
+func NewOptions() *LoggingOptions {
+	return &LoggingOptions{
+		LogVerbosity: DEFAULT,
+		ZapOptions:   zap.Options{Development: true},
+	}
+}
+
+// AddFlags binds the LoggingOptions fields to command-line flags on the given FlagSet.
+func (opts *LoggingOptions) AddFlags(fs *pflag.FlagSet) {
+	if fs == nil {
+		fs = pflag.CommandLine
+	}
+	opts.loggingFS = fs
+
+	fs.IntVarP(&opts.LogVerbosity, "v", "v", opts.LogVerbosity,
+		"Number for the log level verbosity.")
+
+	// Bind zap flags (zap expects a standard Go FlagSet; pflag.FlagSet is not compatible).
+	gofs := flag.NewFlagSet("zap", flag.ExitOnError)
+	opts.ZapOptions.BindFlags(gofs)
+	fs.AddGoFlagSet(gofs)
+}
+
+// Complete performs post-processing of parsed command-line arguments.
+// Derives the zap log level from the -v flag when --zap-log-level is not set explicitly.
+func (opts *LoggingOptions) Complete() error {
+	zapLogLevelFlag := opts.loggingFS.Lookup(ZapLogLevelFlagName)
+	if zapLogLevelFlag != nil && !zapLogLevelFlag.Changed {
+		// See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.Level
+		lvl := -1 * (opts.LogVerbosity)
+		opts.ZapOptions.Level = uberzap.NewAtomicLevelAt(zapcore.Level(int8(lvl)))
+		zapLogLevelFlag.Changed = true
+	}
+	return nil
+}
+
+// Validate checks the LoggingOptions for invalid values.
+func (opts *LoggingOptions) Validate() error {
+	// Log verbosity must be non-negative; set to default if invalid.
+	if opts.LogVerbosity < 0 {
+		opts.LogVerbosity = DEFAULT
+	}
+	return nil
+}

--- a/pkg/common/observability/logging/options_test.go
+++ b/pkg/common/observability/logging/options_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/spf13/pflag"
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestNewOptions(t *testing.T) {
+	opts := NewOptions()
+	if opts.LogVerbosity != DEFAULT {
+		t.Errorf("Expected LogVerbosity to be %d, got %d", DEFAULT, opts.LogVerbosity)
+	}
+	if !opts.ZapOptions.Development {
+		t.Error("Expected ZapOptions.Development to be true")
+	}
+}
+
+func TestAddFlags(t *testing.T) {
+	opts := NewOptions()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.AddFlags(fs)
+
+	// Check that the -v flag was added
+	if fs.Lookup("v") == nil {
+		t.Error("Expected -v flag to be added")
+	}
+
+	// Check that zap flags were added
+	if fs.Lookup(ZapLogLevelFlagName) == nil {
+		t.Errorf("Expected %s flag to be added", ZapLogLevelFlagName)
+	}
+}
+
+func TestComplete(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		expectedVerbosity int
+		expectedZapLevel  zapcore.Level
+		zapShouldDerive   bool
+	}{
+		{
+			name:              "derive zap level from v flag",
+			args:              []string{"-v=3"},
+			expectedVerbosity: 3,
+			expectedZapLevel:  zapcore.Level(-3),
+			zapShouldDerive:   true,
+		},
+		{
+			name:              "explicit zap level takes precedence",
+			args:              []string{"-v=5", "--zap-log-level=info"},
+			expectedVerbosity: 5,
+			expectedZapLevel:  zapcore.InfoLevel,
+			zapShouldDerive:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions()
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			opts.AddFlags(fs)
+
+			err := fs.Parse(tt.args)
+			if err != nil {
+				t.Fatalf("Failed to parse flags: %v", err)
+			}
+
+			err = opts.Complete()
+			if err != nil {
+				t.Fatalf("Complete() failed: %v", err)
+			}
+
+			if opts.LogVerbosity != tt.expectedVerbosity {
+				t.Errorf("Expected LogVerbosity to be %d, got %d", tt.expectedVerbosity, opts.LogVerbosity)
+			}
+
+			atomicLevel, ok := opts.ZapOptions.Level.(uberzap.AtomicLevel)
+			if !ok {
+				t.Fatalf("Expected ZapOptions.Level to be zap.AtomicLevel, got %T", opts.ZapOptions.Level)
+			}
+			actualLevel := atomicLevel.Level()
+			if actualLevel != tt.expectedZapLevel {
+				t.Errorf("Expected zap level to be %v, got %v", tt.expectedZapLevel, actualLevel)
+			}
+
+			zapLogLevelFlag := fs.Lookup(ZapLogLevelFlagName)
+			if zapLogLevelFlag == nil {
+				t.Fatal("zap-log-level flag not found")
+			}
+			if !zapLogLevelFlag.Changed {
+				t.Error("Expected zap-log-level flag to be marked as changed after Complete()")
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		verbosity   int
+		expectError bool
+	}{
+		{"valid verbosity 0", 0, false},
+		{"valid verbosity 2", 2, false},
+		{"valid verbosity 5", 5, false},
+		{"negative verbosity corrected to default", -1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.LogVerbosity = tt.verbosity
+
+			err := opts.Validate()
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_SetsDefaultForNegativeVerbosity(t *testing.T) {
+	opts := NewOptions()
+	opts.LogVerbosity = -1
+
+	err := opts.Validate()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if opts.LogVerbosity != DEFAULT {
+		t.Errorf("Expected LogVerbosity to be set to DEFAULT (%d), got %d", DEFAULT, opts.LogVerbosity)
+	}
+}
+
+func init() {
+	// Clear any global flags from other tests
+	flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
+}

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -18,15 +18,11 @@ package server
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
-	uberzap "go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
@@ -34,7 +30,6 @@ import (
 const (
 	DefaultGrpcPort      = 9002
 	DefaultPoolNamespace = "default" // default when pool namespace is empty (CLI flag default is empty)
-	ZapLogLevelFlagName  = "zap-log-level"
 )
 
 // Options contains configuration values necessary to create and run the EPP.
@@ -74,17 +69,16 @@ type Options struct {
 	//
 	// Diagnostics.
 	//
-	LogVerbosity        int         // Number for the log level verbosity.
-	ZapOptions          zap.Options // Zap logging options
-	Tracing             bool        // Enables emitting traces.
-	HealthChecking      bool        // Enables health checking.
-	MetricsPort         int         // The metrics port exposed by EPP. (TODO: uint16)
-	GRPCHealthPort      int         // The port used for gRPC liveness and readiness probes. (TODO: uint16)
-	EnablePprof         bool        // Enables pprof handlers.
-	CertPath            string      // The path to the certificate for secure serving.
-	EnableCertReload    bool        // Enables certificate reloading of the certificates specified in --cert-path.
-	SecureServing       bool        // Enables secure serving.
-	MetricsEndpointAuth bool        // Enables authentication and authorization of the metrics endpoint.
+	logging.LoggingOptions        // Logging configuration.
+	Tracing                bool   // Enables emitting traces.
+	HealthChecking         bool   // Enables health checking.
+	MetricsPort            int    // The metrics port exposed by EPP. (TODO: uint16)
+	GRPCHealthPort         int    // The port used for gRPC liveness and readiness probes. (TODO: uint16)
+	EnablePprof            bool   // Enables pprof handlers.
+	CertPath               string // The path to the certificate for secure serving.
+	EnableCertReload       bool   // Enables certificate reloading of the certificates specified in --cert-path.
+	SecureServing          bool   // Enables secure serving.
+	MetricsEndpointAuth    bool   // Enables authentication and authorization of the metrics endpoint.
 	//
 	// Configuration.
 	//
@@ -92,7 +86,7 @@ type Options struct {
 	ConfigText string // The configuration specified as text, in lieu of a file.
 
 	// internal
-	fs *pflag.FlagSet // FlagSet used in AddFlags() and consulted in Complete()
+	fs *pflag.FlagSet // FlagSet used in AddFlags() and consulted in Validate()
 }
 
 // NewOptions returns a new Options struct initialized with the default values.
@@ -113,8 +107,7 @@ func NewOptions() *Options {
 		KVCacheUsagePercentageMetric:     "vllm:kv_cache_usage_perc",
 		LoRAInfoMetric:                   "vllm:lora_requests_info",
 		CacheInfoMetric:                  "vllm:cache_config_info",
-		LogVerbosity:                     logging.DEFAULT,
-		ZapOptions:                       zap.Options{Development: true},
+		LoggingOptions:                   *logging.NewOptions(),
 		Tracing:                          true,
 		MetricsPort:                      9090,
 		GRPCHealthPort:                   9003,
@@ -173,10 +166,9 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	_ = fs.MarkDeprecated("lora-info-metric", "use engineConfigs in EndpointPickerConfig instead")
 	fs.StringVar(&opts.CacheInfoMetric, "cache-info-metric", opts.CacheInfoMetric, "Prometheus metric for the cache info metrics.")
 	_ = fs.MarkDeprecated("cache-info-metric", "use engineConfigs in EndpointPickerConfig instead")
-	fs.IntVarP(&opts.LogVerbosity, "v", "v", opts.LogVerbosity, "Number for the log level verbosity.") // allow both --v and -v
-	gofs := flag.NewFlagSet("zap", flag.ExitOnError)
-	opts.ZapOptions.BindFlags(gofs) // zap expects a standard Go FlagSet and pflag.FlagSet is not compatible.
-	fs.AddGoFlagSet(gofs)
+
+	opts.LoggingOptions.AddFlags(fs) // Add logging flags.
+
 	fs.BoolVar(&opts.Tracing, "tracing", opts.Tracing, "Enables emitting traces.")
 	fs.BoolVar(&opts.HealthChecking, "health-checking", opts.HealthChecking, "Enables health checking.")
 	fs.IntVar(&opts.MetricsPort, "metrics-port", opts.MetricsPort, "The metrics port exposed by EPP.")
@@ -203,14 +195,8 @@ func (opts *Options) Complete() error {
 
 	opts.EndpointTargetPorts = removeDuplicatePorts(opts.EndpointTargetPorts)
 
-	// ensure zap log level is set - explicitly by user or from "-v"
-	zapLogLevelFlag := opts.fs.Lookup(ZapLogLevelFlagName)
-	if zapLogLevelFlag != nil && !zapLogLevelFlag.Changed { // not set explicitly
-		lvl := -1 * (opts.LogVerbosity) // See https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.Level
-		opts.ZapOptions.Level = uberzap.NewAtomicLevelAt(zapcore.Level(int8(lvl)))
-		zapLogLevelFlag.Changed = true
-	}
-	return nil
+	// Complete logging options.
+	return opts.LoggingOptions.Complete()
 }
 
 func (opts *Options) Validate() error {
@@ -248,6 +234,11 @@ func (opts *Options) Validate() error {
 		if f := opts.fs.Lookup(flagName); f != nil && f.Changed {
 			return fmt.Errorf("flag %q is deprecated and cannot be used; configure metrics via engineConfigs in EndpointPickerConfig instead", flagName)
 		}
+	}
+
+	// Validate logging options.
+	if err := opts.LoggingOptions.Validate(); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind refactor

**What this PR does / why we need it**:

Extracts duplicated logging configuration code from BBR and EPP into a shared package at `pkg/common/observability/logging/`, eliminating ~90 lines of code duplication.

Both components had identical implementations for managing logging options (verbosity, zap configuration, validation). The new shared `logging.Options` struct is embedded into BBR and EPP using Go's struct embedding, preserving backward compatibility while centralizing the logic.

Changes:
- **New**: `pkg/common/observability/logging/` with `options.go`, `errors.go`, and comprehensive tests (159 lines)
- **BBR**: Removed ~45 lines of duplicated code, now embeds `logging.Options`
- **EPP**: Removed ~43 lines of duplicated code, now embeds `logging.Options`

All existing functionality preserved (default verbosity, flag behavior, validation). All tests pass including BBR/EPP integration tests.

**Which issue(s) this PR fixes**:

Fixes #2378

**Does this PR introduce a user-facing change?**:
`None
`