### PR TITLE
feat: Add PD routing logic in IGW

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -64,8 +64,10 @@ import (
 	extractormetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/metrics"
 	sourcenotifications "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/notifications"
+	rcplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
 	testresponsereceived "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/filter"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/picker"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/profile"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer"
@@ -446,6 +448,9 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(picker.RandomPickerType, picker.RandomPickerFactory)
 	fwkplugin.Register(picker.WeightedRandomPickerType, picker.WeightedRandomPickerFactory)
 	fwkplugin.Register(profile.SingleProfileHandlerType, profile.SingleProfileHandlerFactory)
+	fwkplugin.Register(profile.PdProfileHandlerType, profile.PdProfileHandlerFactory)
+	fwkplugin.Register(profile.PrefixBasedPDDeciderPluginType, profile.PrefixBasedPDDeciderPluginFactory)
+	fwkplugin.Register(profile.AlwaysDisaggDeciderPluginType, profile.AlwaysDisaggPDDeciderPluginFactory)
 	fwkplugin.Register(scorer.KvCacheUtilizationScorerType, scorer.KvCacheUtilizationScorerFactory)
 	fwkplugin.Register(scorer.QueueScorerType, scorer.QueueScorerFactory)
 	fwkplugin.Register(scorer.RunningRequestsSizeScorerType, scorer.RunningRequestsSizeScorerFactory)
@@ -455,6 +460,8 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(fairness.RoundRobinFairnessPolicyType, fairness.RoundRobinFairnessPolicyFactory)
 	fwkplugin.Register(ordering.FCFSOrderingPolicyType, ordering.FCFSOrderingPolicyFactory)
 	fwkplugin.Register(ordering.EDFOrderingPolicyType, ordering.EDFOrderingPolicyFactory)
+	// Filter plugins
+	fwkplugin.Register(filter.ByLabelType, filter.ByLabelFactory)
 	// Latency predictor plugins
 	fwkplugin.Register(predictedlatency.PredictedLatencyPluginType, predictedlatency.PredictedLatencyFactory)
 	// register filter for test purpose only (used in conformance tests)
@@ -468,6 +475,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(sourcenotifications.NotificationSourceType, sourcenotifications.NotificationSourceFactory)
 	// register request control pluigns
 	fwkplugin.Register(requestattributereporter.RequestAttributeReporterType, requestattributereporter.RequestAttributeReporterPluginFactory)
+	fwkplugin.Register(rcplugin.PrefillInjectionPluginType, rcplugin.PrefillInjectionPluginFactory)
 }
 
 func (r *Runner) parseConfigurationPhaseOne(ctx context.Context, opts *runserver.Options) (*configapi.EndpointPickerConfig, error) {

--- a/pkg/epp/framework/interface/scheduling/plugins.go
+++ b/pkg/epp/framework/interface/scheduling/plugins.go
@@ -45,14 +45,14 @@ type ProfileHandler interface {
 	// Pick selects the SchedulingProfiles to run from a list of candidate profiles, while taking into consideration the request properties
 	// and the previously executed SchedluderProfile cycles along with their results.
 	Pick(ctx context.Context, cycleState *CycleState, request *LLMRequest, profiles map[string]SchedulerProfile,
-		profileResults map[string]*ProfileRunResult) map[string]SchedulerProfile
+		profileResults ProfileResults) map[string]SchedulerProfile
 
 	// ProcessResults handles the outcome of the profile runs after all profiles ran.
 	// It may aggregate results, log test profile outputs, or apply custom logic. It specifies in the SchedulingResult the
 	// key of the primary profile that should be used to get the request selected destination.
 	// When a profile run fails, its result in the profileResults map is nil.
 	ProcessResults(ctx context.Context, cycleState *CycleState, request *LLMRequest,
-		profileResults map[string]*ProfileRunResult) (*SchedulingResult, error)
+		profileResults ProfileResults) (*SchedulingResult, error)
 }
 
 // Filter defines the interface for filtering a list of pods based on context.

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -323,9 +323,24 @@ type ProfileRunResult struct {
 	TargetEndpoints []Endpoint
 }
 
+// ProfileResults captures the profile run result map.
+type ProfileResults map[string]*ProfileRunResult
+
+// DecodeResult returns the result of the decode profile.
+func (p ProfileResults) DecodeResult(profileName string) (*ProfileRunResult, bool) {
+	res, ok := p[profileName]
+	return res, ok
+}
+
+// PrefillResult returns the result of the prefill profile.
+func (p ProfileResults) PrefillResult(profileName string) (*ProfileRunResult, bool) {
+	res, ok := p[profileName]
+	return res, ok
+}
+
 // SchedulingResult captures the result of the scheduling cycle.
 type SchedulingResult struct {
-	ProfileResults     map[string]*ProfileRunResult
+	ProfileResults     ProfileResults
 	PrimaryProfileName string
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/prefill_injection.go
+++ b/pkg/epp/framework/plugins/requestcontrol/prefill_injection.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package requestcontrol provides request control plugins for GIE.
+package requestcontrol
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
+)
+
+const (
+	// PrefillInjectionPluginType is the type of the PrefillInjectionPlugin
+	PrefillInjectionPluginType = "prefill-injection-plugin"
+
+	defaultPrefillProfile = "prefill"
+)
+
+type prefillInjectionPluginParameters struct {
+	PrefillProfile string `json:"prefillProfile"`
+	HeaderName     string `json:"headerNameOverride"` // Optional override
+}
+
+// compile-time type assertion
+var _ requestcontrol.PreRequest = &PrefillInjectionPlugin{}
+
+// PrefillInjectionPluginFactory defines the factory function for the PrefillInjectionPlugin
+func PrefillInjectionPluginFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	parameters := prefillInjectionPluginParameters{
+		PrefillProfile: defaultPrefillProfile,
+	}
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' pre-request plugin - %w", PrefillInjectionPluginType, err)
+		}
+	}
+	return NewPrefillInjectionPlugin(parameters.PrefillProfile, parameters.HeaderName).WithName(name), nil
+}
+
+// NewPrefillInjectionPlugin initializes a new PrefillInjectionPlugin and returns its pointer.
+func NewPrefillInjectionPlugin(prefillProfile, headerName string) *PrefillInjectionPlugin {
+	if headerName == "" {
+		headerName = metadata.PrefillEndpointsHeader
+	}
+	return &PrefillInjectionPlugin{
+		typedName:      plugin.TypedName{Type: PrefillInjectionPluginType},
+		prefillProfile: prefillProfile,
+		headerName:     headerName,
+	}
+}
+
+// PrefillInjectionPlugin PreRequest plugin
+type PrefillInjectionPlugin struct {
+	typedName      plugin.TypedName
+	prefillProfile string
+	headerName     string
+}
+
+// TypedName returns the typed name of the plugin.
+func (p *PrefillInjectionPlugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// WithName sets the name of the plugin.
+func (p *PrefillInjectionPlugin) WithName(name string) *PrefillInjectionPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+// PreRequest wires prefill SchedulerProfile result into a header to indicate prefill worker
+func (p *PrefillInjectionPlugin) PreRequest(_ context.Context, request *scheduling.LLMRequest, schedulingResult *scheduling.SchedulingResult) {
+	if _, found := request.Headers[p.headerName]; found {
+		request.Headers[p.headerName] = "" // clear header, if already set
+	}
+
+	prefillProfileRunResult, _ := schedulingResult.ProfileResults.PrefillResult(p.prefillProfile)
+	if prefillProfileRunResult == nil {
+		return // prefill profile failed to run or we chose not to run it, no-op in this case
+	}
+
+	if len(prefillProfileRunResult.TargetEndpoints) == 0 {
+		return
+	}
+
+	var endpoints []string
+	for _, target := range prefillProfileRunResult.TargetEndpoints {
+		targetPod := target.GetMetadata()
+		endpoints = append(endpoints, net.JoinHostPort(targetPod.Address, targetPod.Port))
+	}
+
+	// Join with comma (e.g. "10.1.2.3:8000,10.1.2.4:8000")
+	request.Headers[p.headerName] = strings.Join(endpoints, ",")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/prefill_injection_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/prefill_injection_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestcontrol
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+func TestPrefillInjectionPluginFactory(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginName string
+		params     string
+		expectErr  bool
+	}{
+		{
+			name:       "valid defaults",
+			pluginName: "default-plugin",
+			params:     `{}`,
+			expectErr:  false,
+		},
+		{
+			name:       "valid custom",
+			pluginName: "custom-plugin",
+			params:     `{"prefillProfile": "my-prefill", "headerNameOverride": "x-custom"}`,
+			expectErr:  false,
+		},
+		{
+			name:       "invalid json",
+			pluginName: "invalid-json",
+			params:     `{invalid}`,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := PrefillInjectionPluginFactory(tt.pluginName, json.RawMessage(tt.params), nil)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, p)
+
+				if tt.name == "valid custom" {
+					plugin := p.(*PrefillInjectionPlugin)
+					assert.Equal(t, "my-prefill", plugin.prefillProfile)
+					assert.Equal(t, "x-custom", plugin.headerName)
+				}
+			}
+		})
+	}
+}
+
+// createEndpoint creates a mock Endpoint with customizable IP and port.
+func createEndpoint(nsn k8stypes.NamespacedName, ipaddr, port string) scheduling.Endpoint {
+	return scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: nsn,
+			Address:        ipaddr,
+			Port:           port,
+		},
+		nil,
+		fwkdl.NewAttributes(),
+	)
+}
+
+func TestPrefillInjectionPlugin_PreRequest(t *testing.T) {
+	defaultProfile := "prefill"
+	defaultHeader := "x-gateway-prefill-endpoints"
+
+	tests := []struct {
+		name             string
+		prefillProfile   string
+		headerName       string
+		schedulingResult *scheduling.SchedulingResult
+		existingHeader   string
+		expectedHeader   string
+	}{
+		{
+			name:           "no prefill result -> no header",
+			prefillProfile: defaultProfile,
+			headerName:     defaultHeader,
+			schedulingResult: &scheduling.SchedulingResult{
+				ProfileResults: map[string]*scheduling.ProfileRunResult{},
+			},
+			existingHeader: "",
+			expectedHeader: "",
+		},
+		{
+			name:           "prefill result exists -> header set",
+			prefillProfile: defaultProfile,
+			headerName:     defaultHeader,
+			schedulingResult: &scheduling.SchedulingResult{
+				ProfileResults: map[string]*scheduling.ProfileRunResult{
+					defaultProfile: {
+						TargetEndpoints: []scheduling.Endpoint{
+							createEndpoint(k8stypes.NamespacedName{Name: "pod1"}, "10.0.0.1", "8000"),
+						},
+					},
+				},
+			},
+			existingHeader: "",
+			expectedHeader: "10.0.0.1:8000",
+		},
+		{
+			name:           "prefill result exists with custom header -> header set",
+			prefillProfile: defaultProfile,
+			headerName:     "x-custom-prefill",
+			schedulingResult: &scheduling.SchedulingResult{
+				ProfileResults: map[string]*scheduling.ProfileRunResult{
+					defaultProfile: {
+						TargetEndpoints: []scheduling.Endpoint{
+							createEndpoint(k8stypes.NamespacedName{Name: "pod1"}, "1.2.3.4", "9090"),
+						},
+					},
+				},
+			},
+			existingHeader: "",
+			expectedHeader: "1.2.3.4:9090",
+		},
+		{
+			name:           "existing header cleared if no prefill",
+			prefillProfile: defaultProfile,
+			headerName:     defaultHeader,
+			schedulingResult: &scheduling.SchedulingResult{
+				ProfileResults: map[string]*scheduling.ProfileRunResult{},
+			},
+			existingHeader: "old-value",
+			expectedHeader: "",
+		},
+		{
+			name:           "existing header overwritten",
+			prefillProfile: defaultProfile,
+			headerName:     defaultHeader,
+			schedulingResult: &scheduling.SchedulingResult{
+				ProfileResults: map[string]*scheduling.ProfileRunResult{
+					defaultProfile: {
+						TargetEndpoints: []scheduling.Endpoint{
+							createEndpoint(k8stypes.NamespacedName{Name: "pod1"}, "10.0.0.1", "8000"),
+						},
+					},
+				},
+			},
+			existingHeader: "old-value",
+			expectedHeader: "10.0.0.1:8000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPrefillInjectionPlugin(tt.prefillProfile, tt.headerName)
+			req := &scheduling.LLMRequest{
+				Headers: map[string]string{},
+			}
+			if tt.existingHeader != "" {
+				req.Headers[tt.headerName] = tt.existingHeader
+			}
+
+			p.PreRequest(context.Background(), req, tt.schedulingResult)
+
+			assert.Equal(t, tt.expectedHeader, req.Headers[tt.headerName])
+		})
+	}
+}
+
+// Check interfaces
+var _ plugin.Plugin = &PrefillInjectionPlugin{}

--- a/pkg/epp/framework/plugins/scheduling/filter/by_label.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/by_label.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	// ByLabelType is the type of the ByLabel filter
+	ByLabelType = "by-label"
+)
+
+type byLabelParameters struct {
+	Label         string   `json:"label"`
+	ValidValues   []string `json:"validValues"`
+	AllowsNoLabel bool     `json:"allowsNoLabel"`
+}
+
+var _ scheduling.Filter = &ByLabel{} // validate interface conformance
+
+// ByLabelFactory defines the factory function for the ByLabel filter.
+func ByLabelFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	parameters := byLabelParameters{}
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", ByLabelType, err)
+		}
+	}
+	if name == "" {
+		return nil, fmt.Errorf("invalid configuration for '%s' filter: name cannot be empty", ByLabelType)
+	}
+	if parameters.Label == "" {
+		return nil, fmt.Errorf("invalid configuration for '%s' filter: 'label' must be specified", ByLabelType)
+	}
+	if len(parameters.ValidValues) == 0 && !parameters.AllowsNoLabel {
+		return nil, fmt.Errorf("invalid configuration for '%s' "+
+			"filter: either 'validValues' must be non-empty or 'allowsNoLabel' must be true", ByLabelType)
+	}
+	return NewByLabel(name, parameters.Label, parameters.AllowsNoLabel, parameters.ValidValues...), nil
+}
+
+// NewByLabel creates and returns an instance of the RoleBasedFilter based on the input parameters
+// name - the filter name
+// labelName - the name of the label to use
+// allowsNoLabel - if true endpoints without given label will be considered as valid (not filtered out)
+// validValuesApp - list of valid values
+func NewByLabel(name string, labelName string, allowsNoLabel bool, validValues ...string) *ByLabel {
+	validValuesMap := map[string]struct{}{}
+
+	for _, v := range validValues {
+		validValuesMap[v] = struct{}{}
+	}
+
+	return &ByLabel{
+		typedName:     plugin.TypedName{Type: ByLabelType, Name: name},
+		labelName:     labelName,
+		allowsNoLabel: allowsNoLabel,
+		validValues:   validValuesMap,
+	}
+}
+
+// ByLabel - filters out endpoints based on the values defined by the given label
+type ByLabel struct {
+	// name defines the filter typed name
+	typedName plugin.TypedName
+	// labelName defines the name of the label to be checked
+	labelName string
+	// validValues defines list of valid label values
+	validValues map[string]struct{}
+	// allowsNoLabel - if true endpoints without given label will be considered as valid (not filtered out)
+	allowsNoLabel bool
+}
+
+// TypedName returns the typed name of the plugin
+func (f *ByLabel) TypedName() plugin.TypedName {
+	return f.typedName
+}
+
+// WithName sets the name of the plugin.
+func (f *ByLabel) WithName(name string) *ByLabel {
+	f.typedName.Name = name
+	return f
+}
+
+// Filter filters out all endpoints that are not marked with one of roles from the validRoles collection
+// or has no role label in case allowsNoRolesLabel is true
+func (f *ByLabel) Filter(_ context.Context, _ *scheduling.CycleState, _ *scheduling.LLMRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	filteredEndpoints := []scheduling.Endpoint{}
+
+	for _, endpoint := range endpoints {
+		val, labelDefined := endpoint.GetMetadata().Labels[f.labelName]
+		_, valueExists := f.validValues[val]
+
+		if (!labelDefined && f.allowsNoLabel) || valueExists {
+			filteredEndpoints = append(filteredEndpoints, endpoint)
+		}
+	}
+
+	return filteredEndpoints
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/by_label_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/by_label_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+func TestByLabelFactory(t *testing.T) {
+	// Define test constants locally since pd_role.go is removed
+	const (
+		RoleLabel   = "llm-d.ai/role"
+		RolePrefill = "prefill"
+		RoleDecode  = "decode"
+		RoleBoth    = "both"
+	)
+
+	tests := []struct {
+		name       string
+		pluginName string
+		jsonParams string
+		expectErr  bool
+	}{
+		{
+			name:       "valid configuration with non-empty validValues",
+			pluginName: "valid-filter",
+			jsonParams: fmt.Sprintf(`{
+				"label": %q,
+				"allowsNoLabel": false,
+				"validValues": [%q]
+			}`, RoleLabel, RolePrefill),
+			expectErr: false,
+		},
+		{
+			name:       "allowsNoLabel true with empty validValues",
+			pluginName: "allow-no-label",
+			jsonParams: fmt.Sprintf(`{
+				"label": %q,
+				"allowsNoLabel": true,
+				"validValues": []
+			}`, RoleLabel),
+			expectErr: false,
+		},
+		{
+			name:       "allowsNoLabel true with multiple valid roles",
+			pluginName: "mixed-mode",
+			jsonParams: fmt.Sprintf(`{
+				"label": %q,
+				"allowsNoLabel": true,
+				"validValues": [%q, %q]
+			}`, RoleLabel, RoleDecode, RoleBoth),
+			expectErr: false,
+		},
+		{
+			name:       "empty label name should error",
+			pluginName: "empty-label",
+			jsonParams: fmt.Sprintf(`{
+				"label": "",
+				"allowsNoLabel": false,
+				"validValues": [%q]
+			}`, RolePrefill),
+			expectErr: true,
+		},
+		{
+			name:       "missing label field should error",
+			pluginName: "missing-label",
+			jsonParams: fmt.Sprintf(`{
+				"allowsNoLabel": false,
+				"validValues": [%q]
+			}`, RolePrefill),
+			expectErr: true,
+		},
+		{
+			name:       "contradictory config: empty validValues and allowsNoLabel=false",
+			pluginName: "invalid-contradiction",
+			jsonParams: fmt.Sprintf(`{
+				"label": %q,
+				"allowsNoLabel": false,
+				"validValues": []
+			}`, RoleLabel),
+			expectErr: true,
+		},
+		{
+			name:       "contradictory config: no validValues field and allowsNoLabel=false",
+			pluginName: "no-valid-values",
+			jsonParams: fmt.Sprintf(`{
+				"label": %q,
+				"allowsNoLabel": false
+			}`, RoleLabel),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawParams := json.RawMessage(tt.jsonParams)
+			plugin, err := ByLabelFactory(tt.pluginName, rawParams, nil)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, plugin)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, plugin)
+			}
+		})
+	}
+}
+
+func TestByLabelFactoryInvalidJSON(t *testing.T) {
+	invalidTests := []struct {
+		name       string
+		jsonParams string
+	}{
+		{
+			name:       "malformed JSON",
+			jsonParams: `{"label": "app", "validValues": ["a"`, // missing closing ]
+		},
+		{
+			name:       "validValues as string instead of array",
+			jsonParams: `{"label": "app", "validValues": "true"}`,
+		},
+		{
+			name:       "allowsNoLabel as string",
+			jsonParams: `{"label": "app", "allowsNoLabel": "yes", "validValues": ["true"]}`,
+		},
+	}
+
+	for _, tt := range invalidTests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawParams := json.RawMessage(tt.jsonParams)
+			plugin, err := ByLabelFactory("test", rawParams, nil)
+
+			assert.Error(t, err)
+			assert.Nil(t, plugin)
+		})
+	}
+}
+
+// Helper functions
+func createEndpoint(nsn k8stypes.NamespacedName, ipaddr string, labels map[string]string) scheduling.Endpoint {
+	return scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: nsn,
+			Address:        ipaddr,
+			Labels:         labels,
+		},
+		&fwkdl.Metrics{},
+		nil,
+	)
+}
+
+func TestByLabelFiltering(t *testing.T) {
+	endpoints := []scheduling.Endpoint{
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "nginx-1"},
+			"10.0.0.1",
+			map[string]string{
+				"app":     "nginx",
+				"version": "v1.0",
+				"tier":    "frontend",
+			}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "nginx-2"},
+			"10.0.0.2",
+			map[string]string{
+				"app":     "nginx",
+				"version": "v1.1",
+				"tier":    "frontend",
+			}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "kube-system", Name: "coredns-1"},
+			"10.0.0.3",
+			map[string]string{
+				"app":  "coredns",
+				"tier": "system",
+			}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "redis-1"},
+			"10.0.0.4",
+			map[string]string{
+				"app":        "redis",
+				"tier":       "backend",
+				"deprecated": "true",
+			}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "web-1"},
+			"10.0.0.5",
+			map[string]string{
+				"app":         "web",
+				"tier":        "frontend",
+				"environment": "production",
+			}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "no-tier-pod"},
+			"10.0.0.6",
+			map[string]string{
+				"app": "unknown",
+			}),
+	}
+
+	tests := []struct {
+		testName      string
+		label         string
+		validValues   []string
+		allowsNoLabel bool
+		expectedPods  []string // pod names that should match
+	}{
+		{
+			testName:      "match app nginx",
+			label:         "app",
+			validValues:   []string{"nginx"},
+			expectedPods:  []string{"nginx-1", "nginx-2"},
+			allowsNoLabel: false,
+		},
+		{
+			testName:      "match exact version v1.0",
+			label:         "version",
+			validValues:   []string{"v1.0"},
+			expectedPods:  []string{"nginx-1"},
+			allowsNoLabel: false,
+		},
+		{
+			testName:      "allow pods without 'tier' label",
+			label:         "tier",
+			allowsNoLabel: true,
+			expectedPods:  []string{"no-tier-pod"}, // only "no-tier-pod" doesn't have a "tier" label
+		},
+		{
+			testName:      "allow all known tier values",
+			label:         "tier",
+			validValues:   []string{"frontend", "backend", "system"},
+			allowsNoLabel: false,
+			expectedPods:  []string{"nginx-1", "nginx-2", "coredns-1", "redis-1", "web-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			rawParams, err := json.Marshal(byLabelParameters{
+				Label:         tt.label,
+				ValidValues:   tt.validValues,
+				AllowsNoLabel: tt.allowsNoLabel,
+			})
+			require.NoError(t, err)
+
+			plugin, err := ByLabelFactory("test-label", rawParams, nil)
+			require.NoError(t, err)
+			require.NotNil(t, plugin)
+
+			blf, ok := plugin.(*ByLabel)
+			require.True(t, ok, "plugin should be of type *ByLabel")
+
+			// Use context.Background() as standard context
+			filteredEndpoints := blf.Filter(context.Background(), nil, nil, endpoints)
+
+			// We need to compare endpoints. Since the original test used namespaced names comparison
+			// which is simpler, let's keep it but also use cmp if we want more robust comparison.
+			// Reusing the original test's simple name comparison logic.
+			actualEndpointNames := make([]string, len(filteredEndpoints))
+			for idx, endpoint := range filteredEndpoints {
+				actualEndpointNames[idx] = endpoint.GetMetadata().NamespacedName.Name
+			}
+
+			assert.ElementsMatch(t, tt.expectedPods, actualEndpointNames,
+				"filtered endpoints should match expected endpoints")
+			assert.Len(t, filteredEndpoints, len(tt.expectedPods),
+				"filtered endpoints count should match expected count")
+
+			// Optional: use cmp to double check if we can
+			// Not strictly necessary if ElementsMatch works effectively
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/profile/always_disagg_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/always_disagg_decider.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"context"
+	"encoding/json"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	// AlwaysDisaggDeciderPluginType is the type-name of the alwaysDisaggPDDecider plugin.
+	AlwaysDisaggDeciderPluginType = "always-disagg-pd-decider"
+)
+
+// compile-time type assertion
+var _ pdDeciderPlugin = &AlwaysDisaggPDDecider{}
+
+// AlwaysDisaggPDDecider is a PD decider plugin which always decide to disaggregate PD
+type AlwaysDisaggPDDecider struct {
+	typedName plugin.TypedName
+}
+
+// AlwaysDisaggPDDeciderPluginFactory defines the factory function for creating
+// a new instance of the AlwaysDisaggPDDecider.
+func AlwaysDisaggPDDeciderPluginFactory(name string, _ json.RawMessage,
+	_ plugin.Handle) (plugin.Plugin, error) {
+	return NewAlwaysDisaggPDDecider().WithName(name), nil
+}
+
+func NewAlwaysDisaggPDDecider() *AlwaysDisaggPDDecider {
+	return &AlwaysDisaggPDDecider{
+		typedName: plugin.TypedName{Type: AlwaysDisaggDeciderPluginType},
+	}
+}
+
+// TypedName returns the typed name of the plugin.
+func (d *AlwaysDisaggPDDecider) TypedName() plugin.TypedName {
+	return d.typedName
+}
+
+// WithName sets the name of the plugin.
+func (d *AlwaysDisaggPDDecider) WithName(name string) *AlwaysDisaggPDDecider {
+	d.typedName.Name = name
+	return d
+}
+
+func (d *AlwaysDisaggPDDecider) disaggregate(ctx context.Context, inputTokens int, endpoint scheduling.Endpoint) bool {
+	return true
+}

--- a/pkg/epp/framework/plugins/scheduling/profile/prefill_decode.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/prefill_decode.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package profile provides profile handler plugin for the epp.
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+)
+
+const (
+	// PdProfileHandlerType is the type of the PdProfileHandler
+	PdProfileHandlerType = "pd-profile-handler"
+
+	defaultDecodeProfile     = "decode"
+	defaultPrefillProfile    = "prefill"
+	defaultDeciderPluginName = AlwaysDisaggDeciderPluginType
+
+	// AverageCharactersPerToken is an estimated average characters per token, used since the request we cached is not tokenized.
+	AverageCharactersPerToken = 4
+
+	// DataParallelPodHeader is the header name used to pass the data parallel pod address to the backend.
+	DataParallelPodHeader = "x-data-parallel-host-port"
+)
+
+// pdDeciderPlugin interface for pd decider plugins
+type pdDeciderPlugin interface {
+	plugin.Plugin
+	// disaggregate checks if disaggregated PD is required for the given request and endpoint.
+	disaggregate(ctx context.Context, inputTokens int, endpoint scheduling.Endpoint) bool
+}
+
+type pdProfileHandlerParameters struct {
+	DecodeProfile     string `json:"decodeProfile"`
+	PrefillProfile    string `json:"prefillProfile"`
+	PrimaryPort       int    `json:"primaryPort"`
+	DeciderPluginName string `json:"deciderPluginName"`
+}
+
+// compile-time type assertion
+var _ scheduling.ProfileHandler = &PdProfileHandler{}
+
+// PdProfileHandlerFactory defines the factory function for the PdProfileHandler
+func PdProfileHandlerFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+	parameters := pdProfileHandlerParameters{
+		DecodeProfile:     defaultDecodeProfile,
+		PrefillProfile:    defaultPrefillProfile,
+		PrimaryPort:       0,
+		DeciderPluginName: defaultDeciderPluginName,
+	}
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' profile handler - %w", PdProfileHandlerType, err)
+		}
+	}
+
+	if parameters.PrimaryPort != 0 {
+		if parameters.PrimaryPort < 1 || parameters.PrimaryPort > 65535 {
+			return nil, fmt.Errorf("invalid primaryPort: must be between 1 and 65535, got %d", parameters.PrimaryPort)
+		}
+	}
+
+	if parameters.DeciderPluginName == "" {
+		return nil, errors.New("decider plugin name is not defined")
+	}
+
+	pluginInstance := handle.Plugin(parameters.DeciderPluginName)
+	if pluginInstance == nil {
+		return nil, fmt.Errorf("invalid decider plugin type: %s", parameters.DeciderPluginName)
+	}
+
+	deciderPlugin, ok := pluginInstance.(pdDeciderPlugin)
+	if !ok {
+		return nil, fmt.Errorf("decider plugin of type: %s does not implement pdDeciderPlugin", parameters.DeciderPluginName)
+	}
+
+	handler, err := NewPdProfileHandler(parameters.PrefillProfile, parameters.DecodeProfile, parameters.PrimaryPort, deciderPlugin)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return handler.WithName(name), nil
+
+}
+
+// NewPdProfileHandler initializes a new PdProfileHandler and returns its pointer.
+func NewPdProfileHandler(prefillProfile, decodeProfile string, primaryPort int, deciderPlugin pdDeciderPlugin) (*PdProfileHandler, error) {
+	result := &PdProfileHandler{
+		typedName:      plugin.TypedName{Type: PdProfileHandlerType},
+		decodeProfile:  decodeProfile,
+		prefillProfile: prefillProfile,
+		decider:        deciderPlugin,
+	}
+	if primaryPort != 0 {
+		result.primaryPort = strconv.Itoa(primaryPort)
+	}
+
+	return result, nil
+}
+
+// PdProfileHandler handles scheduler profiles for PD.
+type PdProfileHandler struct {
+	typedName plugin.TypedName
+
+	decodeProfile  string
+	prefillProfile string
+	primaryPort    string
+	decider        pdDeciderPlugin
+}
+
+// TypedName returns the typed name of the plugin.
+func (h *PdProfileHandler) TypedName() plugin.TypedName {
+	return h.typedName
+}
+
+// WithName sets the name of the plugin.
+func (h *PdProfileHandler) WithName(name string) *PdProfileHandler {
+	h.typedName.Name = name
+	return h
+}
+
+// Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the
+// previously executed cycles along with their results.
+func (h *PdProfileHandler) Pick(ctx context.Context, _ *scheduling.CycleState, request *scheduling.LLMRequest, profiles map[string]scheduling.SchedulerProfile,
+	profileResults scheduling.ProfileResults) map[string]scheduling.SchedulerProfile {
+	if _, executed := profileResults.DecodeResult(h.decodeProfile); !executed {
+		// if decode profile was not executed yet, first let the scheduler run the decode profile
+		return map[string]scheduling.SchedulerProfile{
+			h.decodeProfile: profiles[h.decodeProfile],
+		}
+	}
+	// otherwise, decode was already executed.
+
+	// when a profile run fails its result value is nil. we need to check decode result before continuing to prefill
+	// check if all configured profiles have been executed, or if decode failed, no need to run more profiles.
+	decodeResult, _ := profileResults.DecodeResult(h.decodeProfile)
+	if len(profiles) == len(profileResults) || decodeResult == nil {
+		return map[string]scheduling.SchedulerProfile{}
+	}
+
+	inputTokens, err := getUserInputLenInTokens(request)
+	if err != nil {
+		log.FromContext(ctx).V(logutil.DEBUG).Error(err, "Failed to get user input")
+		return nil
+	}
+
+	// Ensure we have at least one target endpoint
+	if len(decodeResult.TargetEndpoints) == 0 {
+		return map[string]scheduling.SchedulerProfile{}
+	}
+
+	decodeResult, _ = profileResults.DecodeResult(h.decodeProfile)
+	if h.decider != nil && h.decider.disaggregate(ctx, inputTokens, decodeResult.TargetEndpoints[0]) {
+		metrics.RecordPDDecision(request.TargetModel, metrics.DecisionTypePrefillDecode)
+		// run the prefill profile
+		return map[string]scheduling.SchedulerProfile{
+			h.prefillProfile: profiles[h.prefillProfile],
+		}
+	}
+
+	metrics.RecordPDDecision(request.TargetModel, metrics.DecisionTypeDecodeOnly)
+	return map[string]scheduling.SchedulerProfile{} // do not run prefill
+}
+
+// ProcessResults handles the outcome of the profile runs after the selected profiles ran.
+// In case of an error in any of the profiles, the matching entry in the profileResults will contain nil, to indicate there was
+// an error while running the profile.
+func (h *PdProfileHandler) ProcessResults(_ context.Context, _ *scheduling.CycleState, request *scheduling.LLMRequest,
+	profileResults scheduling.ProfileResults) (*scheduling.SchedulingResult, error) {
+	decodeRunResults, _ := profileResults.DecodeResult(h.decodeProfile)
+	if decodeRunResults == nil { // if decode profile failed to run, we should fail
+		return nil, errors.New("failed to find available decode workers")
+	}
+	// otherwise, decode ran successfully
+
+	updatedResults := scheduling.ProfileResults{}
+
+	// Add decode profile to result
+	if h.primaryPort != "" {
+		// Data Parallel is active
+
+		if len(decodeRunResults.TargetEndpoints) > 0 {
+			targetEndpoint := decodeRunResults.TargetEndpoints[0].GetMetadata()
+			request.Headers[DataParallelPodHeader] = net.JoinHostPort(targetEndpoint.Address, targetEndpoint.Port)
+		}
+
+		updatedResult := scheduling.ProfileRunResult{
+			TargetEndpoints: []scheduling.Endpoint{},
+		}
+
+		for _, target := range decodeRunResults.TargetEndpoints {
+			updatedEndpointInfo := target.GetMetadata().Clone()
+			// Port is string, primaryPort is string (from int in factory)
+			updatedEndpointInfo.Port = h.primaryPort
+			targetEndpoint := scheduling.NewEndpoint(updatedEndpointInfo, target.GetMetrics().Clone(), nil)
+			updatedResult.TargetEndpoints = append(updatedResult.TargetEndpoints, targetEndpoint)
+		}
+		updatedResults[h.decodeProfile] = &updatedResult
+	} else {
+		updatedResults[h.decodeProfile] = decodeRunResults
+	}
+
+	// if both prefill and decode ran successfully
+	if prefillResult, _ := profileResults.PrefillResult(h.prefillProfile); prefillResult != nil {
+		// Add the prefill profile to the results
+		updatedResults[h.prefillProfile] = prefillResult
+	}
+
+	return &scheduling.SchedulingResult{
+		PrimaryProfileName: h.decodeProfile,
+		ProfileResults:     updatedResults,
+	}, nil
+}
+
+// returns length of user input in tokens
+func getUserInputLenInTokens(request *scheduling.LLMRequest) (int, error) {
+	if request.Body.Completions != nil { // assumed to be valid if not nil
+		return len([]byte(request.Body.Completions.Prompt)) / AverageCharactersPerToken, nil
+	}
+
+	// must be chat-completions request at this point, return bytes of entire messages
+	prompt, err := json.Marshal(request.Body.ChatCompletions.Messages)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return len(prompt) / AverageCharactersPerToken, nil
+}

--- a/pkg/epp/framework/plugins/scheduling/profile/prefill_decode_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/prefill_decode_test.go
@@ -1,0 +1,642 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+)
+
+// Mock decider for testing
+type mockDecider struct {
+	shouldDisagg bool
+}
+
+func (m *mockDecider) Name() string {
+	return "mock-decider"
+}
+
+func (m *mockDecider) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: "mock-decider", Name: "mock-decider"}
+}
+
+func (m *mockDecider) Produces() map[string]any { return nil }
+func (m *mockDecider) Consumes() map[string]any { return nil }
+
+func (m *mockDecider) disaggregate(ctx context.Context, inputTokens int, endpoint scheduling.Endpoint) bool {
+	return m.shouldDisagg
+}
+
+func TestPdProfileHandlerFactory(t *testing.T) {
+	ctx := context.Background()
+	// Register metrics to avoid panics if tests run in parallel or if metrics are accessed
+	// But in unit tests usually we don't need real metrics unless we test them.
+	// Reset metrics just in case.
+	metrics.Reset()
+
+	tests := []struct {
+		name       string
+		pluginName string
+		params     map[string]any
+		expectErr  bool
+	}{
+		{
+			name:       "valid configuration with all defaults",
+			pluginName: "default-handler",
+			params:     map[string]any{},
+			expectErr:  false,
+		},
+		{
+			name:       "valid configuration with custom values",
+			pluginName: "custom-handler",
+			params: map[string]any{
+				"decodeProfile":     "my-decode",
+				"prefillProfile":    "my-prefill",
+				"prefixPluginName":  "my-prefix-cache",
+				"primaryPort":       8080,
+				"deciderPluginName": PrefixBasedPDDeciderPluginType,
+			},
+			expectErr: false,
+		},
+		{
+			name:       "zero primaryPort is allowed",
+			pluginName: "zero-port",
+			params: map[string]any{
+				"primaryPort": 0,
+			},
+			expectErr: false,
+		},
+		{
+			name:       "nonCachedTokens = 0 is allowed",
+			pluginName: "zero-non-cached-tokens",
+			params: map[string]any{
+				"deciderPluginName": PrefixBasedPDDeciderPluginType,
+			},
+			expectErr: false,
+		},
+		{
+			name:       "primaryPort below range should error",
+			pluginName: "port-too-low",
+			params:     map[string]any{"primaryPort": 0}, // OK
+			expectErr:  false,
+		},
+		{
+			name:       "primaryPort = 1 is valid",
+			pluginName: "port-min",
+			params:     map[string]any{"primaryPort": 1},
+			expectErr:  false,
+		},
+		{
+			name:       "primaryPort = 65535 is valid",
+			pluginName: "port-max",
+			params:     map[string]any{"primaryPort": 65535},
+			expectErr:  false,
+		},
+		{
+			name:       "empty decodeProfile is valid",
+			pluginName: "empty-decode",
+			params:     map[string]any{"decodeProfile": ""},
+			expectErr:  false,
+		},
+		{
+			name:       "empty prefillProfile is valid",
+			pluginName: "empty-prefill",
+			params:     map[string]any{"prefillProfile": ""},
+			expectErr:  false,
+		},
+		{
+			name:       "empty prefixPluginName is valid",
+			pluginName: "empty-prefix-plugin",
+			params:     map[string]any{"prefixPluginName": ""},
+			expectErr:  false,
+		},
+		{
+			name:       "primaryPort = 65536 should error",
+			pluginName: "port-too-high",
+			params:     map[string]any{"primaryPort": 65536},
+			expectErr:  true,
+		},
+		{
+			name:       "primaryPort = -10 should error",
+			pluginName: "port-negative",
+			params:     map[string]any{"primaryPort": -10},
+			expectErr:  true,
+		},
+	}
+
+	handle, err := createHandleWithDeciderPlugins(ctx)
+	assert.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rawParams json.RawMessage
+			if tt.params != nil {
+				bytes, err := json.Marshal(tt.params)
+				assert.NoError(t, err)
+				rawParams = json.RawMessage(bytes)
+			}
+			plugin, err := PdProfileHandlerFactory(tt.pluginName, rawParams, handle)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, plugin)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, plugin)
+			}
+		})
+	}
+}
+
+func TestPdProfileHandlerFactoryInvalidJSON(t *testing.T) {
+	ctx := context.Background()
+
+	invalidTests := []struct {
+		name       string
+		jsonParams string
+	}{
+		{
+			name:       "malformed JSON",
+			jsonParams: `{"deciderPluginName": `, // incomplete
+		},
+		{
+			name:       "invalid decider plugin type",
+			jsonParams: `{"deciderPluginName": "INVALID"}`,
+		},
+		{
+			name:       "primaryPort as float",
+			jsonParams: `{"primaryPort": 8080.5}`,
+		},
+	}
+
+	handle, err := createHandleWithDeciderPlugins(ctx)
+	assert.NoError(t, err)
+
+	for _, tt := range invalidTests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawParams := json.RawMessage(tt.jsonParams)
+			plugin, err := PdProfileHandlerFactory("test", rawParams, handle)
+
+			assert.Error(t, err)
+			assert.Nil(t, plugin)
+		})
+	}
+}
+
+const DefaultTestPodPort = "8000"
+
+// createEndpoint creates a mock Endpoint with customizable IP and port.
+func createEndpoint(nsn k8stypes.NamespacedName, ipaddr, port string, labels map[string]string) scheduling.Endpoint {
+	return scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: nsn,
+			Address:        ipaddr,
+			Port:           port,
+			Labels:         labels,
+		},
+		nil,
+		fwkdl.NewAttributes(),
+	)
+}
+
+// newMockProfileRunResult creates a ProfileRunResult with Pods using the given port.
+func newMockProfileRunResult(port string, endpointNames ...string) *scheduling.ProfileRunResult {
+	endpoints := make([]scheduling.Endpoint, 0, len(endpointNames))
+	for i, name := range endpointNames {
+		ip := fmt.Sprintf("10.0.0.%d", i+1)
+		endpoints = append(endpoints, createEndpoint(
+			k8stypes.NamespacedName{Namespace: "default", Name: name},
+			ip,
+			port,
+			map[string]string{},
+		))
+	}
+	return &scheduling.ProfileRunResult{
+		TargetEndpoints: endpoints,
+	}
+}
+
+func newMockSchedulerProfile() scheduling.SchedulerProfile {
+	return &mockSchedulerProfile{}
+}
+
+type mockSchedulerProfile struct{}
+
+func (p *mockSchedulerProfile) Run(_ context.Context, _ *scheduling.LLMRequest, _ *scheduling.CycleState, _ []scheduling.Endpoint) (*scheduling.ProfileRunResult, error) {
+	return &scheduling.ProfileRunResult{}, nil
+}
+
+// creates and returns llm completion request forthe given prompt
+func createRequest(prompt string) *scheduling.LLMRequest {
+	return &scheduling.LLMRequest{
+		Body: &scheduling.LLMRequestBody{
+			Completions: &scheduling.CompletionsRequest{
+				Prompt: prompt,
+			},
+		},
+	}
+}
+
+// returns array of profile names in the given profile pick result
+func getProfilesFromResult(result map[string]scheduling.SchedulerProfile) []string {
+	profiles := make([]string, len(result))
+	index := 0
+
+	for name := range result {
+		profiles[index] = name
+		index++
+	}
+
+	return profiles
+}
+
+func TestPdProfileHandler_Pick(t *testing.T) {
+	ctx := context.Background()
+	metrics.Reset()
+	request := createRequest("hello world hello world hello world")
+
+	profiles := map[string]scheduling.SchedulerProfile{
+		"decode":  newMockSchedulerProfile(),
+		"prefill": newMockSchedulerProfile(),
+	}
+
+	tests := []struct {
+		name                 string
+		nonCachedTokensLimit int
+		cachedTokens         int
+		profileResults       map[string]*scheduling.ProfileRunResult
+		expectedProfiles     []string
+	}{
+		{
+			name:                 "decode not executed yet → run decode",
+			nonCachedTokensLimit: 10,
+			profileResults:       map[string]*scheduling.ProfileRunResult{},
+			expectedProfiles:     []string{defaultDecodeProfile},
+		},
+		{
+			name:                 "decode failed (nil result) → run nothing",
+			nonCachedTokensLimit: 10,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile: nil,
+			},
+			expectedProfiles: []string{},
+		},
+		{
+			name:                 "all profiles already executed → run nothing",
+			nonCachedTokensLimit: 10,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile:  newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+				defaultPrefillProfile: newMockProfileRunResult(DefaultTestPodPort, "pod2"),
+			},
+			expectedProfiles: []string{},
+		},
+		{
+			name: "has enough not-cached tokens → run prefill",
+			// Need at least 4 non-cached tokens (16+ chars) to trigger disaggregated prefill
+			// In this case: prompt length is 35 chars (8 tokens), cached length is 2 tokens -> disaggregated prefill should trigger
+			nonCachedTokensLimit: 4,
+			cachedTokens:         2,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+			},
+			expectedProfiles: []string{defaultPrefillProfile},
+		},
+		{
+			name: "short non-cached suffix → skip prefill",
+			// Need at least 4 non-cached tokens (16+ chars) to trigger disaggregated prefill
+			// In this case: prompt length is 35 chars (8 tokens), cached length is 5 tokens -> skip prefill
+			nonCachedTokensLimit: 4,
+			cachedTokens:         5,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+			},
+			expectedProfiles: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		deciderPlugin, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: tt.nonCachedTokensLimit})
+		assert.NoError(t, err)
+
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewPdProfileHandler(
+				defaultPrefillProfile,
+				defaultDecodeProfile,
+				0,
+				deciderPlugin,
+			)
+			assert.NoError(t, err)
+
+			// set prefix to the given cached tokens number for pod "pod1" in decode profile results
+			inputTokens := len(request.Body.Completions.Prompt) / AverageCharactersPerToken
+
+			for profileName, profileRes := range tt.profileResults {
+				if profileName == defaultDecodeProfile && profileRes != nil {
+					for _, pod := range profileRes.TargetEndpoints {
+						pod.Put(attrprefix.PrefixCacheMatchInfoKey,
+							attrprefix.NewPrefixCacheMatchInfo(tt.cachedTokens, inputTokens, 1))
+					}
+				}
+			}
+			result := handler.Pick(ctx, nil, request, profiles, tt.profileResults)
+			assert.ElementsMatch(t, tt.expectedProfiles, getProfilesFromResult(result))
+		})
+	}
+}
+
+func TestPdProfileHandler_PickSeries(t *testing.T) {
+	ctx := context.Background()
+	metrics.Reset()
+	prompt := "hello world, hello world, hello world, hello world, hello world, hello world, hello world!"
+	request := createRequest(prompt)
+	longerRequest := createRequest(prompt + "123")
+	longRequest := createRequest(prompt + prompt)
+
+	profiles := map[string]scheduling.SchedulerProfile{
+		defaultDecodeProfile:  newMockSchedulerProfile(),
+		defaultPrefillProfile: newMockSchedulerProfile(),
+	}
+	profileResults := map[string]*scheduling.ProfileRunResult{
+		defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+	}
+
+	type testData struct {
+		request          *scheduling.LLMRequest
+		cachedTokens     int
+		expectedProfiles []string
+	}
+	tests := []struct {
+		name                 string
+		nonCachedTokensLimit int
+		tests                []testData
+	}{
+		{
+			name:                 "same request twice",
+			nonCachedTokensLimit: 2,
+			tests: []testData{{
+				request:          request,
+				cachedTokens:     0,
+				expectedProfiles: []string{defaultPrefillProfile},
+			}, {
+				request:          request,
+				cachedTokens:     len(request.Body.Completions.Prompt) / AverageCharactersPerToken,
+				expectedProfiles: []string{},
+			}},
+		}, {
+			name: "short request and a little bit longer after it",
+			// Need at least 2 non-cached tokens (8+ chars) to trigger disaggregated prefill
+			// In this case: longer request is longer in 4 chars than the request -> no disaggregated prefill
+			nonCachedTokensLimit: 2,
+			tests: []testData{{
+				request:          request,
+				cachedTokens:     0,
+				expectedProfiles: []string{defaultPrefillProfile},
+			}, {
+				request:          longerRequest,
+				cachedTokens:     len(request.Body.Completions.Prompt) / AverageCharactersPerToken,
+				expectedProfiles: []string{},
+			}},
+		}, {
+			name: "short request and a long one after it",
+			// Need at least 2 non-cached tokens (8+ chars) to trigger disaggregated prefill
+			// In this case: long request is longer enough than the request -> should have disaggregated prefill
+			nonCachedTokensLimit: 2,
+			tests: []testData{{
+				request:          request,
+				cachedTokens:     0,
+				expectedProfiles: []string{defaultPrefillProfile},
+			}, {
+				request:          longRequest,
+				cachedTokens:     len(request.Body.Completions.Prompt) / AverageCharactersPerToken,
+				expectedProfiles: []string{defaultPrefillProfile},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deciderPlugin, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: tt.nonCachedTokensLimit})
+			assert.NoError(t, err)
+
+			handler, err := NewPdProfileHandler(
+				defaultPrefillProfile,
+				defaultDecodeProfile,
+				0,
+				deciderPlugin,
+			)
+			assert.NoError(t, err)
+
+			// run sequences of request
+			for _, innerTest := range tt.tests {
+				cs := &scheduling.CycleState{}
+
+				// set prefix to the given cached tokens number for pod "pod1" in decode profile results
+				inputTokens := len(innerTest.request.Body.Completions.Prompt) / AverageCharactersPerToken
+
+				for profileName, profileRes := range profileResults {
+					if profileName == defaultDecodeProfile && profileRes != nil {
+						for _, endpoint := range profileRes.TargetEndpoints {
+							endpoint.Put(attrprefix.PrefixCacheMatchInfoKey,
+								attrprefix.NewPrefixCacheMatchInfo(innerTest.cachedTokens, inputTokens, 1))
+						}
+					}
+				}
+
+				result := handler.Pick(ctx, cs, innerTest.request, profiles, profileResults)
+				assert.ElementsMatch(t, innerTest.expectedProfiles, getProfilesFromResult(result))
+			}
+		})
+	}
+}
+
+func TestPdProfileHandler_AlwaysDisagg(t *testing.T) {
+	ctx := context.Background()
+	prompt := "hello world"
+	request := createRequest(prompt)
+
+	profiles := map[string]scheduling.SchedulerProfile{
+		defaultDecodeProfile:  newMockSchedulerProfile(),
+		defaultPrefillProfile: newMockSchedulerProfile(),
+	}
+	profileResults := map[string]*scheduling.ProfileRunResult{
+		defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+	}
+
+	// AlwaysDisaggPDDecider should always return true, even if prefix match is perfect.
+	deciderPlugin := NewAlwaysDisaggPDDecider()
+
+	handler, err := NewPdProfileHandler(
+		defaultPrefillProfile,
+		defaultDecodeProfile,
+		0,
+		deciderPlugin,
+	)
+	assert.NoError(t, err)
+
+	// Case 1: Perfect prefix match (should skip prefill with PrefixBasedDecider, but run it with AlwaysDisagg)
+	cs := &scheduling.CycleState{}
+	inputTokens := len(request.Body.Completions.Prompt) / AverageCharactersPerToken
+
+	// Simulate perfect cache hit on decode node
+	for _, profileRes := range profileResults {
+		for _, endpoint := range profileRes.TargetEndpoints {
+			endpoint.Put(attrprefix.PrefixCacheMatchInfoKey,
+				attrprefix.NewPrefixCacheMatchInfo(inputTokens, inputTokens, 1))
+		}
+	}
+
+	result := handler.Pick(ctx, cs, request, profiles, profileResults)
+	// Expect prefill because decider says "Always"
+	assert.Contains(t, getProfilesFromResult(result), defaultPrefillProfile)
+
+	// Case 2: No cache hit (should run prefill anyway)
+	for _, profileRes := range profileResults {
+		for _, endpoint := range profileRes.TargetEndpoints {
+			endpoint.Put(attrprefix.PrefixCacheMatchInfoKey,
+				attrprefix.NewPrefixCacheMatchInfo(0, inputTokens, 1))
+		}
+	}
+	result = handler.Pick(ctx, cs, request, profiles, profileResults)
+	assert.Contains(t, getProfilesFromResult(result), defaultPrefillProfile)
+}
+
+func TestPdProfileHandler_ProcessResults(t *testing.T) {
+	tests := []struct {
+		name           string
+		primaryPort    int
+		profileResults map[string]*scheduling.ProfileRunResult
+		expectError    bool
+		checkResult    func(*testing.T, *scheduling.SchedulingResult, map[string]string)
+	}{
+		{
+			name: "decode failed → error",
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile: nil,
+			},
+			expectError: true,
+		},
+		{
+			name:        "decode success, no prefill, no primaryPort",
+			primaryPort: 0,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, res *scheduling.SchedulingResult, headers map[string]string) {
+				assert.Equal(t, defaultDecodeProfile, res.PrimaryProfileName)
+				assert.Contains(t, res.ProfileResults, defaultDecodeProfile)
+				assert.NotContains(t, res.ProfileResults, defaultPrefillProfile)
+				metadata := res.ProfileResults[defaultDecodeProfile].TargetEndpoints[0].GetMetadata()
+				assert.Equal(t, DefaultTestPodPort, metadata.Port)
+				// check header is empty or not set
+				val, ok := headers[DataParallelPodHeader]
+				assert.True(t, !ok || val == "")
+			},
+		},
+		{
+			name:        "decode success, with prefill",
+			primaryPort: 0,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile:  newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+				defaultPrefillProfile: newMockProfileRunResult(DefaultTestPodPort, "pod2"),
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, res *scheduling.SchedulingResult, _ map[string]string) {
+				assert.Equal(t, defaultDecodeProfile, res.PrimaryProfileName)
+				assert.Contains(t, res.ProfileResults, defaultDecodeProfile)
+				assert.Contains(t, res.ProfileResults, defaultPrefillProfile)
+			},
+		},
+		{
+			name:        "with primaryPort → port updated and header set",
+			primaryPort: 9000,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				defaultDecodeProfile: newMockProfileRunResult(DefaultTestPodPort, "pod1"),
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, res *scheduling.SchedulingResult, headers map[string]string) {
+				metadata := res.ProfileResults[defaultDecodeProfile].TargetEndpoints[0].GetMetadata()
+				assert.Equal(t, "9000", metadata.Port)
+
+				hostPort := headers[DataParallelPodHeader]
+				assert.Equal(t, "10.0.0.1:8000", hostPort)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		deciderPlugin, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: 0})
+		assert.NoError(t, err)
+
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewPdProfileHandler(
+				defaultPrefillProfile,
+				defaultDecodeProfile,
+				tt.primaryPort,
+				deciderPlugin,
+			)
+			assert.NoError(t, err)
+
+			headers := make(map[string]string)
+			req := &scheduling.LLMRequest{
+				Headers: headers,
+			}
+			result, err := handler.ProcessResults(context.Background(), &scheduling.CycleState{}, req, tt.profileResults)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			tt.checkResult(t, result, headers)
+		})
+	}
+}
+
+func createHandleWithDeciderPlugins(ctx context.Context) (plugin.Handle, error) {
+	handle := plugin.NewEppHandle(ctx, func() []k8stypes.NamespacedName { return nil })
+	plugin1, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{NonCachedTokens: 4})
+	if err != nil {
+		return nil, err
+	}
+	handle.AddPlugin(PrefixBasedPDDeciderPluginType, plugin1)
+
+	plugin3, err := NewAlwaysDisaggPDDecider(), nil
+	if err != nil {
+		return nil, err
+	}
+	handle.AddPlugin(AlwaysDisaggDeciderPluginType, plugin3)
+
+	// Add mock decider
+	plugin2 := &mockDecider{shouldDisagg: true}
+	handle.AddPlugin("mock-decider", plugin2)
+
+	return handle, nil
+}

--- a/pkg/epp/framework/plugins/scheduling/profile/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/prefix_based_pd_decider.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+)
+
+const (
+	// PrefixBasedPDDeciderPluginType is the type-name of the prefixBasedPDDecider plugin.
+	PrefixBasedPDDeciderPluginType = "prefix-based-pd-decider"
+)
+
+// PrefixBasedPDDeciderConfig holds the configuration for the prefixBasedPDDecider plugin.
+type PrefixBasedPDDeciderConfig struct {
+	// NonCachedTokens non cached minimum tokens that triggers disaggregated PD
+	NonCachedTokens int `json:"nonCachedTokens"`
+}
+
+func (p PrefixBasedPDDeciderConfig) validate() error {
+	if p.NonCachedTokens < 0 {
+		return errors.New("nonCachedTokens parameter of prefix disaggregation decider cannot be negative")
+	}
+
+	return nil
+}
+
+// compile-time type assertion
+var _ pdDeciderPlugin = &PrefixBasedPDDecider{}
+
+// PrefixBasedPDDecider is a PD decider plugin which decision is based prefix aware
+type PrefixBasedPDDecider struct {
+	typedName plugin.TypedName
+	config    PrefixBasedPDDeciderConfig
+}
+
+// PrefixBasedPDDeciderPluginFactory defines the factory function for creating
+// a new instance of the prefixBasedPDDecider.
+func PrefixBasedPDDeciderPluginFactory(name string, rawParameters json.RawMessage,
+	handle plugin.Handle) (plugin.Plugin, error) {
+	config := PrefixBasedPDDeciderConfig{
+		NonCachedTokens: 0,
+	}
+
+	if rawParameters != nil {
+		if err := json.Unmarshal(rawParameters, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse %s plugin config: %w", PrefixBasedPDDeciderPluginType, err)
+		}
+	}
+
+	decider, err := NewPrefixBasedPDDecider(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create %s plugin: %w", PrefixBasedPDDeciderPluginType, err)
+	}
+
+	return decider.WithName(name), nil
+}
+
+// NewPrefixBasedPDDecider initializes a NewPrefixBasedPDDecider prefix based PD decider Plugin and returns its pointer.
+// If the configuration is invalid an error is returned.
+func NewPrefixBasedPDDecider(config PrefixBasedPDDeciderConfig) (*PrefixBasedPDDecider, error) {
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+
+	return &PrefixBasedPDDecider{
+		config: config,
+	}, nil
+}
+
+// TypedName returns the typed name of the plugin.
+func (d *PrefixBasedPDDecider) TypedName() plugin.TypedName {
+	return d.typedName
+}
+
+// WithName sets the name of the plugin.
+func (d *PrefixBasedPDDecider) WithName(name string) *PrefixBasedPDDecider {
+	d.typedName.Name = name
+	return d
+}
+
+func (d *PrefixBasedPDDecider) disaggregate(ctx context.Context, inputTokens int, endpoint scheduling.Endpoint) bool {
+	logger := log.FromContext(ctx)
+	debugLogger := log.FromContext(ctx).V(logutil.DEBUG)
+
+	if d.config.NonCachedTokens <= 0 { // always use disaggregation in case of non cached tokens number is 0
+		return true
+	}
+	if endpoint == nil {
+		logger.Error(nil, "prefix decider: endpoint is nil")
+		return false
+	}
+	if inputTokens < d.config.NonCachedTokens {
+		debugLogger.Info("Input is shorter than the nonCachedToken, no disaggregated PD")
+		return false
+	}
+	// inspect the decode endpoint to decide if prefill should run or not.
+	// if the non-cached part is short enough - no disaggregation.
+	prefixInfoRaw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey)
+	if !ok || prefixInfoRaw == nil {
+		logger.Error(nil, "unable to read prefix cache state")
+		return false
+	}
+	prefixCacheMatchInfo, ok := prefixInfoRaw.(*attrprefix.PrefixCacheMatchInfo)
+	if !ok {
+		logger.Error(nil, "wrong type of prefix cache match info")
+		return false
+	}
+
+	// number of cached tokens
+	hitPrefixTokens := prefixCacheMatchInfo.MatchBlocks() * prefixCacheMatchInfo.BlockSizeTokens()
+	// length of non-cached suffix in tokens
+	nonCachedTokens := inputTokens - hitPrefixTokens
+
+	debugLogger.Info("Computed hit percentage for prefix cache",
+		"absolute hit prefix len (tokens)", hitPrefixTokens,
+		"prompt length (token)", inputTokens)
+
+	if nonCachedTokens < d.config.NonCachedTokens {
+		debugLogger.Info("Non-cached suffix is smaller than threshold, using decode profile only")
+		return false // do not run prefill
+	}
+
+	return true
+}
+
+// Consumes defines data types consumed by this plugin
+func (*PrefixBasedPDDecider) Consumes() map[string]any {
+	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
+}

--- a/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler.go
@@ -64,7 +64,7 @@ func (h *SingleProfileHandler) WithName(name string) *SingleProfileHandler {
 // Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the
 // previously executed cycles along with their results.
 func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, request *framework.LLMRequest, profiles map[string]framework.SchedulerProfile,
-	profileResults map[string]*framework.ProfileRunResult) map[string]framework.SchedulerProfile {
+	profileResults framework.ProfileResults) map[string]framework.SchedulerProfile {
 	if len(profiles) == len(profileResults) { // all profiles have been executed already in previous call
 		return map[string]framework.SchedulerProfile{}
 	}
@@ -77,7 +77,7 @@ func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, 
 // key of the primary profile that should be used to get the request selected destination.
 // When a profile run fails, its result in the profileResults map is nil.
 func (h *SingleProfileHandler) ProcessResults(_ context.Context, _ *framework.CycleState, _ *framework.LLMRequest,
-	profileResults map[string]*framework.ProfileRunResult) (*framework.SchedulingResult, error) {
+	profileResults framework.ProfileResults) (*framework.SchedulingResult, error) {
 	if len(profileResults) != 1 {
 		return nil, errors.New("single profile handler is intended to be used with a single profile, failed to process multiple profiles")
 	}

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -34,4 +34,6 @@ const (
 	ObjectiveKey = "x-gateway-inference-objective"
 	// ModelNameRewriteKey is the header key used to specify the model name to be used when the request is forwarded to the model server.
 	ModelNameRewriteKey = "x-gateway-model-name-rewrite"
+	// PrefillEndpointsHeader is the header name used to indicate Prefill worker <ip:port>
+	PrefillEndpointsHeader = "x-gateway-prefill-endpoints"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
This PR implements the PD Disaggregation logic in the EPP, as proposed in #2276 and discussed in #1650. Main logics were upstreamed from llm-d-inference-scheduler pd profile [logic](https://github.com/llm-d/llm-d-inference-scheduler/tree/main/pkg/plugins/profile):

*PdProfileHandler*: The core orchestrator plugin. It attempts to schedule the request for decoding first. If disaggregation is needed (decided by the Decider), it schedules a separate prefill step (Prefill Profile). 
*PrefixBasedPDDecider*: Makes the decision to split requests based on NonCachedTokens and prefix cache state.
*PrefillInjectionPlugin*: Handles header injection (x-gateway-prefill-endpoints) to route prefill information to the backend.
*ByLabelFilter*: Replaces the specific prefill-filter and decode-filter from [pd_role.go](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/plugins/filter/pd_role.go) with a generic label-based filter.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1650

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
* **New Plugin**: `pd-profile-handler` - Orchestrates P/D disaggregation.
* **New Plugin**: `prefix-based-pd-decider` - Decides when to disaggregate based on cache state.
* **New Plugin**: `prefill-injection-plugin` - Injects prefill endpoint headers.
* **New Plugin**: `always-disagg-decider` - Simple decider that always triggers disaggregation.
* **New Plugin**: `by-label` - Filters endpoints by label matching.
* **Metric**: Added `pd_decision_total` to track P/D scheduling decisions.
```

**Test**
1. Followed the [llm-d P/D Disaggregation Guide](https://github.com/llm-d/llm-d/tree/main/guides/pd-disaggregation) to set up a working PD environment.
2. Updated the EPP ConfigMap with the new plugins
```
pd-config.yaml: |
    apiVersion: inference.networking.x-k8s.io/v1alpha1
    kind: EndpointPickerConfig
    plugins:
    - type: prefill-injection-plugin
      name: prefill-header-injector
      parameters:
        headerNameOverride: "x-prefiller-host-port"
    - type: by-label
      name: prefill-filter
      parameters:
        label: llm-d.ai/role
        validValues: ["prefill"]
    - type: by-label
      name: decode-filter
      parameters:
        label: llm-d.ai/role
        validValues: ["decode"]
    - type: queue-scorer
    - type: prefix-based-pd-decider
      name: pd-decider
      parameters:
        nonCachedTokens: 0
    - type: pd-profile-handler
      parameters:
        deciderPluginName: pd-decider
    schedulingProfiles:
    - name: prefill
      plugins:
      - pluginRef: prefill-filter
      - pluginRef: queue-scorer
        weight: 1.0
    - name: decode
      plugins:
      - pluginRef: decode-filter
      - pluginRef: queue-scorer
        weight: 1.0
```

3. Built a custom EPP image with the changes in this pr and replaced the llm-d-inference-scheduler image in the epp deployment and redeploy.

4. Verification: Ran some benchmarks tests and verified P/D logic by observing the new metric inference_extension_pd_decision_total{decision_type="prefill-decode"} incrementing and vllm logs/metrics showing activities on both prefill pod and decode pod.
