### PR TITLE
Add a new scorer for approx prefix cache plugin

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix_match.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix_match.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,40 +27,40 @@ import (
 )
 
 const (
-	ApproximatePrefixCacheScorerPluginType = "approx-prefix-cache-scorer"
+	PrefixMatchScorerPluginType = "prefix-match-scorer"
 )
 
-type ApproxPrefixCacheScorer struct {
+type PrefixMatchScorer struct {
 	typedName plugin.TypedName
 }
 
 // compile-time type assertion
 var (
-	_ framework.Scorer = &ApproxPrefixCacheScorer{}
+	_ framework.Scorer = &PrefixMatchScorer{}
 )
 
 // Category returns the preference the scorer applies when scoring candidate endpoints.
-func (p *ApproxPrefixCacheScorer) Category() framework.ScorerCategory {
+func (p *PrefixMatchScorer) Category() framework.ScorerCategory {
 	return framework.Affinity
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *ApproxPrefixCacheScorer) TypedName() plugin.TypedName {
+func (p *PrefixMatchScorer) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
 // Consumes returns the data consumed by the plugin.
-func (p *ApproxPrefixCacheScorer) Consumes() map[string]any {
+func (p *PrefixMatchScorer) Consumes() map[string]any {
 	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
 }
 
 // Produces returns the data produced by the plugin.
-func (p *ApproxPrefixCacheScorer) Produces() map[string]any {
+func (p *PrefixMatchScorer) Produces() map[string]any {
 	return map[string]any{}
 }
 
 // Score returns the scoring result for the given list of pods based on context.
-func (p *ApproxPrefixCacheScorer) Score(ctx context.Context, _ *framework.CycleState, request *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (p *PrefixMatchScorer) Score(ctx context.Context, _ *framework.CycleState, request *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	// calculate the scores of endpoints
 	scores := make(map[framework.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix_match_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix_match_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
-func TestApproxPrefixCacheScorer_Score(t *testing.T) {
+func TestPrefixMatchScorer_Score(t *testing.T) {
 	epWithMatch := framework.NewEndpoint(&datalayer.EndpointMetadata{}, &datalayer.Metrics{}, nil)
 	epWithMatch.Put(attrprefix.PrefixCacheMatchInfoKey, attrprefix.NewPrefixCacheMatchInfo(5, 10, 1))
 
@@ -62,7 +62,7 @@ func TestApproxPrefixCacheScorer_Score(t *testing.T) {
 			},
 		},
 	}
-	scorer := &ApproxPrefixCacheScorer{}
+	scorer := &PrefixMatchScorer{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			scores := scorer.Score(context.Background(), nil, &framework.LLMRequest{}, tc.endpoints)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

Add scorer for approx prefix cache plugin that uses the prepare data hook added in https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2453. 

The current implementation of [prefix cache plugin](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go) does data preparation as well. Ideally, we want to data preparation separate since it can be used without the scorer as well, for example by the latency predictor.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind feature

**What this PR does / why we need it**:

Adds a scorer for approx prefix cache plugin that uses the prepare data hook.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses #1970 partly

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
yes, adds a new scorer. To be used along with the corresponding PrepareData plugin
```
