### PR TITLE
fix(predicted-latency-scorer): prevent nil pointer panic for non-completions API types

### DIFF
--- a/pkg/epp/framework/interface/scheduling/types_test.go
+++ b/pkg/epp/framework/interface/scheduling/types_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLLMRequestBody_PromptText(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     *LLMRequestBody
+		expected string
+	}{
+		{
+			name: "completions request returns prompt directly",
+			body: &LLMRequestBody{
+				Completions: &CompletionsRequest{
+					Prompt: "What is the meaning of life?",
+				},
+			},
+			expected: "What is the meaning of life?",
+		},
+		{
+			name: "chat completions with single raw message",
+			body: &LLMRequestBody{
+				ChatCompletions: &ChatCompletionsRequest{
+					Messages: []Message{
+						{Role: "user", Content: Content{Raw: "Hello, how are you?"}},
+					},
+				},
+			},
+			expected: "Hello, how are you? ",
+		},
+		{
+			name: "chat completions with multiple messages",
+			body: &LLMRequestBody{
+				ChatCompletions: &ChatCompletionsRequest{
+					Messages: []Message{
+						{Role: "system", Content: Content{Raw: "You are a helpful assistant."}},
+						{Role: "user", Content: Content{Raw: "Tell me a joke."}},
+					},
+				},
+			},
+			expected: "You are a helpful assistant. Tell me a joke. ",
+		},
+		{
+			name: "chat completions with structured content blocks",
+			body: &LLMRequestBody{
+				ChatCompletions: &ChatCompletionsRequest{
+					Messages: []Message{
+						{
+							Role: "user",
+							Content: Content{
+								Structured: []ContentBlock{
+									{Type: "text", Text: "Describe this image:"},
+									{Type: "image_url", ImageURL: ImageBlock{Url: "http://example.com/img.png"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "Describe this image:  ",
+		},
+		{
+			name: "responses request with string input",
+			body: &LLMRequestBody{
+				Responses: &ResponsesRequest{
+					Input: "Some response input",
+				},
+			},
+			expected: "Some response input",
+		},
+		{
+			name: "responses request with non-string input",
+			body: &LLMRequestBody{
+				Responses: &ResponsesRequest{
+					Input: map[string]interface{}{"key": "value"},
+				},
+			},
+			expected: `{"key":"value"}`,
+		},
+		{
+			name: "conversations request",
+			body: &LLMRequestBody{
+				Conversations: &ConversationsRequest{
+					Items: []ConversationItem{
+						{Type: "message", Role: "user", Content: "Hello"},
+					},
+				},
+			},
+			expected: `[{"type":"message","role":"user","content":"Hello"}]`,
+		},
+		{
+			name:     "empty body returns empty string",
+			body:     &LLMRequestBody{},
+			expected: "",
+		},
+		{
+			name: "chat completions with no messages",
+			body: &LLMRequestBody{
+				ChatCompletions: &ChatCompletionsRequest{
+					Messages: []Message{},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.body.PromptText()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/latencypredictor_helper.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/latencypredictor_helper.go
@@ -224,7 +224,7 @@ func recordTTFTTrainingData(
 		endpointRoleLabel,
 		targetEndpointMetadata,
 		m,
-		predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt,
+		predictedLatencyCtx.promptText,
 		predictedLatencyCtx.ttft,
 		0, // TTFT training
 		now,
@@ -299,7 +299,7 @@ func processTokenForLatencyPrediction(
 		endpointRoleLabel,
 		targetEndpointMetadata,
 		m,
-		predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt,
+		predictedLatencyCtx.promptText,
 		0, // TTFT not recorded for TPOT
 		latencyMs,
 		now,
@@ -316,7 +316,7 @@ func processTokenForLatencyPrediction(
 			endpointRoleLabel,
 			targetEndpointMetadata,
 			m,
-			predictedLatencyCtx.schedulingRequest.Body.Completions.Prompt,
+			predictedLatencyCtx.promptText,
 			predictedLatencyCtx.generatedTokenCount,
 			0, // TPOT does not use prefix cache score
 		)

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/prediction.go
@@ -42,7 +42,7 @@ type endpointPredictionResult struct {
 }
 
 // generatePredictions creates prediction results for all candidate pods
-func (s *PredictedLatency) generatePredictions(ctx context.Context, request *schedulingtypes.LLMRequest, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []schedulingtypes.Endpoint) ([]endpointPredictionResult, error) {
+func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []schedulingtypes.Endpoint) ([]endpointPredictionResult, error) {
 	logger := log.FromContext(ctx)
 	predictions := make([]endpointPredictionResult, 0, len(candidateEndpoints))
 
@@ -63,7 +63,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, request *sch
 
 		metricsStates[i] = endpoint.GetMetrics()
 		targetEndpointsMetadatas[i] = endpoint.GetMetadata()
-		prompts[i] = request.Body.Completions.Prompt
+		prompts[i] = predictedLatencyCtx.promptText
 		generatedTokenCounts[i] = 1
 		prefixCacheScores[i] = prefixCacheScore
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/preparedata_hooks.go
@@ -51,7 +51,7 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 		}
 		predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name] = prefixCacheScore
 	}
-	predictions, err := s.generatePredictions(ctx, request, predictedLatencyCtx, endpoints)
+	predictions, err := s.generatePredictions(ctx, predictedLatencyCtx, endpoints)
 	if err == nil && len(predictions) == len(endpoints) {
 		s.updateRequestContextWithPredictions(predictedLatencyCtx, predictions)
 		s.updateHasValidPod(ctx, predictedLatencyCtx, endpoints)

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks.go
@@ -67,6 +67,9 @@ type predictedLatencyCtx struct {
 	tpotObservations          []float64
 	predictedTPOTObservations []float64
 
+	// promptText is the cached plain-text prompt, computed once per request.
+	promptText string
+
 	prefixCacheScoresForEndpoints map[string]float64
 
 	// ttftSLO is the target time to first token SLO for the request.
@@ -82,8 +85,13 @@ type predictedLatencyCtx struct {
 }
 
 func newPredictedLatencyContext(request *schedulingtypes.LLMRequest) *predictedLatencyCtx {
+	var prompt string
+	if request.Body != nil {
+		prompt = request.Body.PromptText()
+	}
 	return &predictedLatencyCtx{
 		schedulingRequest:             *request,
+		promptText:                    prompt,
 		lastSeenMetrics:               make(map[string]*fwkdl.Metrics),
 		prefixCacheScoresForEndpoints: make(map[string]float64),
 		predictionsForScheduling:      make(map[string]endpointPredictionResult),

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks_test.go
@@ -77,11 +77,31 @@ func TestNewPredictedLatencyContext(t *testing.T) {
 
 	assert.NotNil(t, ctx)
 	assert.Equal(t, *request, ctx.schedulingRequest)
+	assert.Equal(t, "test prompt", ctx.promptText)
 	assert.NotNil(t, ctx.lastSeenMetrics)
 	assert.NotNil(t, ctx.prefixCacheScoresForEndpoints)
 	assert.NotNil(t, ctx.predictionsForScheduling)
 	assert.Empty(t, ctx.lastSeenMetrics)
 	assert.Empty(t, ctx.prefixCacheScoresForEndpoints)
+}
+
+func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
+	request := &schedulingtypes.LLMRequest{
+		Headers: map[string]string{requtil.RequestIdHeaderKey: "test-nil-body"},
+		Body:    nil,
+	}
+	ctx := newPredictedLatencyContext(request)
+
+	assert.NotNil(t, ctx)
+	assert.Empty(t, ctx.promptText)
+}
+
+func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
+	request := createTestChatCompletionsLLMRequest("test-chat", 1.0, 0.05)
+	ctx := newPredictedLatencyContext(request)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "You are a helpful assistant. Tell me a joke. ", ctx.promptText)
 }
 
 func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
@@ -668,6 +688,7 @@ func TestPredictedLatencyContext_Fields(t *testing.T) {
 	assert.Nil(t, ctx.targetMetadata)
 	assert.Nil(t, ctx.schedulingResult)
 	assert.Nil(t, ctx.tokenSampler)
+	assert.Equal(t, "test prompt", ctx.promptText)
 }
 
 func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The `predicted-latency-scorer` plugin crashes with a nil pointer dereference (`SIGSEGV`) when processing `/v1/chat/completions` requests.
The root cause is that `generatePredictions`, `recordTTFTTrainingData`, and `processTokenForLatencyPrediction` all access `Body.Completions.Prompt`
directly — which is `nil` for any non-`/v1/completions` API type.

This PR:
- Adds `LLMRequestBody.PromptText()` — a safe helper that extracts prompt text from whichever API type is present (`Completions`, `ChatCompletions`, `Responses`, `Conversations`), following the same switch-based pattern as
  the existing `CacheSalt()` method.
- Replaces all 4 direct `Body.Completions.Prompt` accesses in the `predictedlatency` scorer with `Body.PromptText()` calls.
- Adds comprehensive unit tests:
  - `TestLLMRequestBody_PromptText` — 9 subtests covering all API types and edge cases.
  - `TestPredictedLatency_Score/Chat_completions_request_does_not_panic` — scorer-level regression test.
  - `TestBulkPredictWithMetrics_ChatCompletionsPrompt` — helper-level regression test.

**Which issue(s) this PR fixes**:
Fixes #2394

**Does this PR introduce a user-facing change?**:
Fix nil pointer panic in` predicted-latency-scorer` when processing /v1/chat/completions, /v1/responses, and /v1/conversations requests.