### PR TITLE
Guide fixes as a followup to the qwen move

### DIFF
--- a/config/manifests/vllm/gpu-deployment.yaml
+++ b/config/manifests/vllm/gpu-deployment.yaml
@@ -27,6 +27,8 @@ spec:
           - "8000"
           - "--max-num-seq"
           - "1024"
+          - "-max-model-len"
+          - "16000"
           - "--enable-lora"
           - "--max-loras"
           - "2"

--- a/site-src/_includes/test.md
+++ b/site-src/_includes/test.md
@@ -7,7 +7,7 @@
    PORT=80
 
    curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
-   "model": "food-review-1",
+   "model": "Qwen/Qwen3-32B",
    "prompt": "Write as if you were a critic: San Francisco",
    "max_tokens": 100,
    "temperature": 0


### PR DESCRIPTION
Ran through the guide after we converted to Qwen model. A couple of minor changes are needed to fix the guide. Reducing the max prompt length is needed to fit the model in an H100 gpu. The other is fixing a typo in how to test the model.