### PR TITLE
Fix: Downgrade NTPOT metrics error to verbose info to reduce noise

### DIFF
--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -711,15 +711,13 @@ func RecordPromptCachedTokens(modelName, targetModelName string, size int) {
 
 // RecordNormalizedTimePerOutputToken (NTPOT) records the normalized time per output token.
 func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetModelName string, received time.Time, complete time.Time, outputTokenCount int) bool {
-	if !complete.After(received) {
-		log.FromContext(ctx).Error(nil, "Request latency values are invalid for NTPOT calculation",
-			"modelName", modelName, "targetModelName", targetModelName, "completeTime", complete, "receivedTime", received)
+	if outputTokenCount <= 0 {
 		return false
 	}
 
-	if outputTokenCount <= 0 {
-		log.FromContext(ctx).Error(nil, "Output token count must be positive for NTPOT calculation",
-			"modelName", modelName, "targetModelName", targetModelName, "outputTokenCount", outputTokenCount)
+	if !complete.After(received) {
+		log.FromContext(ctx).Error(nil, "Request latency values are invalid for NTPOT calculation",
+			"modelName", modelName, "targetModelName", targetModelName, "completeTime", complete, "receivedTime", received)
 		return false
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test


Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:
This PR downgrades the log level of the error "Output token count must be positive for NTPOT calculation" from `Error` to `V(logutil.VERBOSE).Info`.

Currently, when a client performs a streaming request without explicitly setting `stream_options: {"include_usage": true}`, the vLLM backend (and likely others) does not return usage statistics (token counts) in the final chunk.

The EPP relies on `Usage.CompletionTokens` to calculate the **Normalized Time Per Output Token (NTPOT)** metric. When this usage data is missing (0 tokens), EPP logs an error for every single request, causing significant log noise. For example, when I was using inference-perf to run some benchmark, which doesn't specify stream_options, the epp logs were completely overwhelmed by this error, making it hard to see any other useful output.
<img width="1830" height="207" alt="image" src="https://github.com/user-attachments/assets/5cdd7f74-5b1f-41f4-92b7-41cdab4806b5" />


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
