### PR TITLE
feat(bbr): integrate request body into RequestContext for plugins

### DIFF
--- a/pkg/bbr/handlers/request.go
+++ b/pkg/bbr/handlers/request.go
@@ -41,17 +41,16 @@ const (
 	executeExtensionPoint = "Request"
 )
 
-// HandleRequestBody handles request bodies.
-func (s *Server) HandleRequestBody(ctx context.Context, requestBodyBytes []byte) ([]*eppb.ProcessingResponse, error) {
+// HandleRequestBody parses the raw body bytes into reqCtx.Request.Body and processes the request.
+func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, requestBodyBytes []byte) ([]*eppb.ProcessingResponse, error) {
 	logger := log.FromContext(ctx)
 	var ret []*eppb.ProcessingResponse
 
-	var requestBody map[string]any
-	if err := json.Unmarshal(requestBodyBytes, &requestBody); err != nil {
+	if err := json.Unmarshal(requestBodyBytes, &reqCtx.Request.Body); err != nil {
 		return nil, err
 	}
 
-	targetModelAny, ok := requestBody["model"]
+	targetModelAny, ok := reqCtx.Request.Body["model"]
 	if !ok {
 		metrics.RecordModelNotParsedCounter()
 		targetModelAny = ""
@@ -86,9 +85,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, requestBodyBytes []byte)
 		return ret, nil
 	}
 
-	// TODO pass headers!
-	// TODO handle updated headers and body
-	if err := s.executePlugins(ctx, map[string]string{}, requestBody, s.requestPlugins); err != nil {
+	if err := s.executePlugins(ctx, reqCtx.Request.Headers, reqCtx.Request.Body, s.requestPlugins); err != nil {
 		return nil, fmt.Errorf("failed to execute request plugins - %w", err)
 	}
 

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -111,8 +111,7 @@ func TestHandleRequestHeaders(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := NewServer(false, &fakeDatastore{}, []framework.PayloadProcessor{}, []framework.PayloadProcessor{})
 			reqCtx := &RequestContext{
-				Request:  &Request{Headers: make(map[string]string)},
-				Response: &Response{Headers: make(map[string]string)},
+				Request: &Request{Headers: make(map[string]string)},
 			}
 
 			resp, err := server.HandleRequestHeaders(reqCtx, tc.headers)
@@ -370,8 +369,11 @@ func TestHandleRequestBody(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			server := NewServer(test.streaming, &fakeDatastore{}, []framework.PayloadProcessor{}, []framework.PayloadProcessor{})
+			reqCtx := &RequestContext{
+				Request: &Request{Headers: make(map[string]string)},
+			}
 			bodyBytes, _ := json.Marshal(test.body)
-			resp, err := server.HandleRequestBody(ctx, bodyBytes)
+			resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)
 			if err != nil {
 				if !test.wantErr {
 					t.Fatalf("HandleRequestBody returned unexpected error: %v, want %v", err, test.wantErr)
@@ -408,12 +410,15 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 
 	noopPlugin := plugins.NewDefaultPlugin()
 	server := NewServer(false, &fakeDatastore{}, []framework.PayloadProcessor{noopPlugin}, []framework.PayloadProcessor{})
+	reqCtx := &RequestContext{
+		Request: &Request{Headers: make(map[string]string)},
+	}
 
 	bodyBytes, _ := json.Marshal(map[string]any{
 		"model":  "bar",
 		"prompt": "test",
 	})
-	_, err := server.HandleRequestBody(ctx, bodyBytes)
+	_, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)
 	if err != nil {
 		t.Fatalf("HandleRequestBody returned unexpected error: %v", err)
 	}

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -82,10 +82,16 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	loggerVerbose.Info("Processing")
 
 	reqCtx := &RequestContext{
-		Request:  &Request{Headers: make(map[string]string)},
-		Response: &Response{Headers: make(map[string]string)},
+		Request: &Request{
+			Headers: make(map[string]string),
+			Body:    make(map[string]any),
+		},
+		Response: &Response{
+			Headers: make(map[string]string),
+			Body:    make(map[string]any),
+		},
 	}
-	reqStreamedBody := &streamedBody{}
+	var body []byte
 	respStreamedBody := &streamedBody{}
 
 	for {
@@ -124,7 +130,12 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			} else {
 				loggerVerbose.Info("Incoming body chunk", "EoS", v.RequestBody.EndOfStream)
 			}
-			responses, err = s.processRequestBody(ctx, req.GetRequestBody(), reqStreamedBody)
+			body = append(body, v.RequestBody.Body...)
+			if s.streaming && !v.RequestBody.EndOfStream {
+				continue
+			}
+			responses, err = s.HandleRequestBody(ctx, reqCtx, body)
+			loggerVerbose.Info("Processing complete body")
 		case *extProcPb.ProcessingRequest_RequestTrailers:
 			responses, err = s.HandleRequestTrailers(req.GetRequestTrailers())
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
@@ -168,33 +179,12 @@ type streamedBody struct {
 	body []byte
 }
 
-func (s *Server) processRequestBody(ctx context.Context, body *extProcPb.HttpBody, streamedBody *streamedBody) ([]*extProcPb.ProcessingResponse, error) {
-	loggerVerbose := log.FromContext(ctx).V(logutil.VERBOSE)
-
-	var requestBodyBytes []byte
-	if s.streaming {
-		streamedBody.body = append(streamedBody.body, body.Body...)
-		// In the stream case, we can receive multiple request bodies.
-		if body.EndOfStream {
-			loggerVerbose.Info("Flushing stream buffer")
-			requestBodyBytes = streamedBody.body
-		} else {
-			return nil, nil
-		}
-	} else {
-		requestBodyBytes = body.GetBody()
-	}
-
-	return s.HandleRequestBody(ctx, requestBodyBytes)
-}
-
 func (s *Server) processResponseBody(ctx context.Context, reqCtx *RequestContext, body *extProcPb.HttpBody, streamedRespBody *streamedBody) ([]*extProcPb.ProcessingResponse, error) {
 	loggerVerbose := log.FromContext(ctx).V(logutil.VERBOSE)
 
 	var responseBodyBytes []byte
 	if s.streaming {
 		streamedRespBody.body = append(streamedRespBody.body, body.Body...)
-		// In the stream case, we can receive multiple response bodies.
 		if body.EndOfStream {
 			loggerVerbose.Info("Flushing response stream buffer")
 			responseBodyBytes = streamedRespBody.body

--- a/pkg/bbr/handlers/server_test.go
+++ b/pkg/bbr/handlers/server_test.go
@@ -29,24 +29,20 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
-func TestProcessRequestBody(t *testing.T) {
+func TestHandleRequestBodyStreaming(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
 	cases := []struct {
 		desc      string
 		streaming bool
-		bodys     []*extProcPb.HttpBody
+		body      []byte
 		want      []*extProcPb.ProcessingResponse
 	}{
 		{
 			desc: "no-streaming",
-			bodys: []*extProcPb.HttpBody{
-				{
-					Body: mapToBytes(t, map[string]any{
-						"model": "foo",
-					}),
-				},
-			},
+			body: mapToBytes(t, map[string]any{
+				"model": "foo",
+			}),
 			want: []*extProcPb.ProcessingResponse{
 				{
 					Response: &extProcPb.ProcessingResponse_RequestBody{
@@ -79,16 +75,9 @@ func TestProcessRequestBody(t *testing.T) {
 		{
 			desc:      "streaming",
 			streaming: true,
-			bodys: []*extProcPb.HttpBody{
-				{
-					Body: mapToBytes(t, map[string]any{
-						"model": "foo",
-					}),
-				},
-				{
-					EndOfStream: true,
-				},
-			},
+			body: mapToBytes(t, map[string]any{
+				"model": "foo",
+			}),
 			want: []*extProcPb.ProcessingResponse{
 				{
 					Response: &extProcPb.ProcessingResponse_RequestHeaders{
@@ -140,18 +129,15 @@ func TestProcessRequestBody(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			srv := NewServer(tc.streaming, &fakeDatastore{}, []framework.PayloadProcessor{}, []framework.PayloadProcessor{})
-			streamedBody := &streamedBody{}
-			for i, body := range tc.bodys {
-				got, err := srv.processRequestBody(ctx, body, streamedBody)
-				if err != nil {
-					t.Fatalf("processRequestBody(): %v", err)
-				}
-
-				if i == len(tc.bodys)-1 {
-					if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
-						t.Errorf("processRequestBody returned unexpected response, diff(-want, +got): %v", diff)
-					}
-				}
+			reqCtx := &RequestContext{
+				Request: &Request{Headers: make(map[string]string)},
+			}
+			got, err := srv.HandleRequestBody(ctx, reqCtx, tc.body)
+			if err != nil {
+				t.Fatalf("HandleRequestBody(): %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("HandleRequestBody returned unexpected response, diff(-want, +got): %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

**Follow-up to #2368 (headers PR).** This PR completes the `RequestContext` integration by wiring the request body through `HandleRequestBody` and into plugins — so plugins can now operate on both headers and body.

- Remove `streamedBody` struct and `processRequestBody` helper; inline body accumulation in `Process()` following the EPP pattern (`var body []byte`)
- `HandleRequestBody` now accepts `reqCtx` and unmarshals directly into `reqCtx.Request.Body` (`map[string]any`)
- Pass `reqCtx.Request.Headers` (instead of an empty map) to `executePlugins`, so plugins receive the real request headers
- Rename `TestProcessRequestBody` to `TestHandleRequestBodyIntegration` and update all tests to use the new signatures

**Which issue(s) this PR fixes:**

Fixes #2352

**Does this PR introduce a user-facing change?:**

`NONE`