### PR TITLE
add the option to register custom metrics

### DIFF
--- a/cmd/bbr/runner/runner.go
+++ b/cmd/bbr/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
@@ -51,6 +52,8 @@ var setupLog = ctrl.Log.WithName("setup")
 func NewRunner() *Runner {
 	return &Runner{
 		bbrExecutableName: "BBR",
+		requestPlugins:    []framework.PayloadProcessor{},
+		customCollectors:  []prometheus.Collector{},
 	}
 }
 
@@ -60,12 +63,19 @@ type Runner struct {
 	// The slice of BBR plugin instances executed by the request handler,
 	// in the same order the plugin flags are provided.
 	requestPlugins []framework.PayloadProcessor
+
+	customCollectors []prometheus.Collector
 }
 
 // WithExecutableName sets the name of the executable containing the runner.
 // The name is used in the version log upon startup and is otherwise opaque.
 func (r *Runner) WithExecutableName(exeName string) *Runner {
 	r.bbrExecutableName = exeName
+	return r
+}
+
+func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runner {
+	r.customCollectors = collectors
 	return r
 }
 
@@ -105,7 +115,9 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	ds := datastore.NewDatastore()
 
-	metrics.Register()
+	// --- Setup Metrics Server ---
+	metrics.Register(r.customCollectors...)
+	metrics.RecordBBRInfo(version.CommitSHA, version.BuildRef)
 	// Register metrics handler.
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/pkg/bbr/metrics/metrics.go
+++ b/pkg/bbr/metrics/metrics.go
@@ -30,6 +30,16 @@ import (
 const component = "bbr"
 
 var (
+	// --- Info Metrics ---
+	bbrInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: component,
+			Name:      "info",
+			Help:      metricsutil.HelpMsgWithStability("General information of the current build of BBR.", compbasemetrics.ALPHA),
+		},
+		[]string{"commit", "build_ref"},
+	)
+
 	successCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: component,
@@ -66,31 +76,26 @@ var (
 		},
 		[]string{"extension_point", "plugin_type", "plugin_name"},
 	)
-
-	// TODO: Uncomment and use this metrics once the core server implementation has handling to skip body parsing if header exists.
-	/*
-		modelAlreadyPresentInHeaderCounter = prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Subsystem:      component,
-				Name:           "model_already_present_in_header_total",
-				Help:           "Count of times the model was already present in request headers.",
-			},
-			[]string{},
-		)
-	*/
 )
 
 var registerMetrics sync.Once
 
 // Register all metrics.
-func Register() {
+func Register(customCollectors ...prometheus.Collector) {
 	registerMetrics.Do(func() {
+		metrics.Registry.MustRegister(bbrInfo)
 		metrics.Registry.MustRegister(successCounter)
 		metrics.Registry.MustRegister(modelNotInBodyCounter)
 		metrics.Registry.MustRegister(modelNotParsedCounter)
 		metrics.Registry.MustRegister(pluginProcessingLatencies)
-		// metrics.Registry.MustRegister(modelAlreadyPresentInHeaderCounter)
+		for _, collector := range customCollectors {
+			metrics.Registry.MustRegister(collector)
+		}
 	})
+}
+
+func RecordBBRInfo(commitSha, buildRef string) {
+	bbrInfo.WithLabelValues(commitSha, buildRef).Set(1)
 }
 
 // RecordSuccessCounter records the number of successful requests to inject the model name into request headers.
@@ -112,10 +117,3 @@ func RecordModelNotParsedCounter() {
 func RecordPluginProcessingLatency(extensionPoint, pluginType, pluginName string, duration time.Duration) {
 	pluginProcessingLatencies.WithLabelValues(extensionPoint, pluginType, pluginName).Observe(duration.Seconds())
 }
-
-/*
-// RecordModelAlreadyInHeaderCounter records the number of times the model was already found in the request headers.
-func RecordModelAlreadyInHeaderCounter() {
-	modelAlreadyPresentInHeaderCounter.WithLabelValues().Inc()
-}
-*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
adds the ability to register custom metrics when starting bbr.
record bbr commit sha and version on startup.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2444

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
users can now set custom collector when configuring bbr through code.
```
