### PR TITLE
Second part of refactoring of the Ext Proc code between the EPP and the BBR

### DIFF
--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -27,18 +27,18 @@ type Error struct {
 }
 
 const (
-	Unknown                        = "Unknown"
-	BadRequest                     = "BadRequest"
-	Internal                       = "Internal"
-	ServiceUnavailable             = "ServiceUnavailable"
-	ModelServerError               = "ModelServerError"
-	BadConfiguration               = "BadConfiguration"
-	InferencePoolResourceExhausted = "InferencePoolResourceExhausted"
+	Unknown            = "Unknown"
+	BadRequest         = "BadRequest"
+	Internal           = "Internal"
+	ServiceUnavailable = "ServiceUnavailable"
+	ModelServerError   = "ModelServerError"
+	BadConfiguration   = "BadConfiguration"
+	ResourceExhausted  = "ResourceExhausted"
 )
 
 // Error returns a string version of the error.
 func (e Error) Error() string {
-	return fmt.Sprintf("inference gateway: %s - %s", e.Code, e.Msg)
+	return fmt.Sprintf("inference error: %s - %s", e.Code, e.Msg)
 }
 
 // CanonicalCode returns the error's ErrorCode.

--- a/pkg/common/error/error_test.go
+++ b/pkg/common/error/error_test.go
@@ -33,7 +33,7 @@ func TestError_Error(t *testing.T) {
 				Code: BadRequest,
 				Msg:  "invalid model name",
 			},
-			want: "inference gateway: BadRequest - invalid model name",
+			want: "inference error: BadRequest - invalid model name",
 		},
 		{
 			name: "Internal error",
@@ -41,7 +41,7 @@ func TestError_Error(t *testing.T) {
 				Code: Internal,
 				Msg:  "unexpected condition",
 			},
-			want: "inference gateway: Internal - unexpected condition",
+			want: "inference error: Internal - unexpected condition",
 		},
 		{
 			name: "ServiceUnavailable error",
@@ -49,7 +49,7 @@ func TestError_Error(t *testing.T) {
 				Code: ServiceUnavailable,
 				Msg:  "service unavailable",
 			},
-			want: "inference gateway: ServiceUnavailable - service unavailable",
+			want: "inference error: ServiceUnavailable - service unavailable",
 		},
 		{
 			name: "ModelServerError",
@@ -57,7 +57,7 @@ func TestError_Error(t *testing.T) {
 				Code: ModelServerError,
 				Msg:  "connection timeout",
 			},
-			want: "inference gateway: ModelServerError - connection timeout",
+			want: "inference error: ModelServerError - connection timeout",
 		},
 		{
 			name: "BadConfiguration error",
@@ -65,15 +65,15 @@ func TestError_Error(t *testing.T) {
 				Code: BadConfiguration,
 				Msg:  "missing required field",
 			},
-			want: "inference gateway: BadConfiguration - missing required field",
+			want: "inference error: BadConfiguration - missing required field",
 		},
 		{
-			name: "InferencePoolResourceExhausted error",
+			name: "ResourceExhausted error",
 			err: Error{
-				Code: InferencePoolResourceExhausted,
+				Code: ResourceExhausted,
 				Msg:  "no available pods",
 			},
-			want: "inference gateway: InferencePoolResourceExhausted - no available pods",
+			want: "inference error: ResourceExhausted - no available pods",
 		},
 		{
 			name: "Unknown error",
@@ -81,7 +81,7 @@ func TestError_Error(t *testing.T) {
 				Code: Unknown,
 				Msg:  "something went wrong",
 			},
-			want: "inference gateway: Unknown - something went wrong",
+			want: "inference error: Unknown - something went wrong",
 		},
 		{
 			name: "Empty message",
@@ -89,7 +89,7 @@ func TestError_Error(t *testing.T) {
 				Code: BadRequest,
 				Msg:  "",
 			},
-			want: "inference gateway: BadRequest - ",
+			want: "inference error: BadRequest - ",
 		},
 		{
 			name: "Empty code",
@@ -97,7 +97,7 @@ func TestError_Error(t *testing.T) {
 				Code: "",
 				Msg:  "error occurred",
 			},
-			want: "inference gateway:  - error occurred",
+			want: "inference error:  - error occurred",
 		},
 	}
 
@@ -157,12 +157,12 @@ func TestCanonicalCode(t *testing.T) {
 			want: BadConfiguration,
 		},
 		{
-			name: "Error type with InferencePoolResourceExhausted code",
+			name: "Error type with ResourceExhausted code",
 			err: Error{
-				Code: InferencePoolResourceExhausted,
+				Code: ResourceExhausted,
 				Msg:  "no resources",
 			},
-			want: InferencePoolResourceExhausted,
+			want: ResourceExhausted,
 		},
 		{
 			name: "Error type with Unknown code",
@@ -218,13 +218,13 @@ func (e customError) Error() string {
 func TestErrorConstants(t *testing.T) {
 	// Verify that error constants match their expected string values
 	tests := map[string]string{
-		Unknown:                        "Unknown",
-		BadRequest:                     "BadRequest",
-		Internal:                       "Internal",
-		ServiceUnavailable:             "ServiceUnavailable",
-		ModelServerError:               "ModelServerError",
-		BadConfiguration:               "BadConfiguration",
-		InferencePoolResourceExhausted: "InferencePoolResourceExhausted",
+		Unknown:            "Unknown",
+		BadRequest:         "BadRequest",
+		Internal:           "Internal",
+		ServiceUnavailable: "ServiceUnavailable",
+		ModelServerError:   "ModelServerError",
+		BadConfiguration:   "BadConfiguration",
+		ResourceExhausted:  "ResourceExhausted",
 	}
 
 	for constant, expected := range tests {

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/headers.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/headers.go
@@ -20,8 +20,8 @@ package predictedlatency
 import (
 	"strconv"
 
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 // parseFloatHeader retrieves a header by name, parses it as a float64,
@@ -36,8 +36,8 @@ func parseFloatHeader(request schedulingtypes.LLMRequest, headerName string) (fl
 	// 2. Parse the header value to a float64
 	parsedFloat, err := strconv.ParseFloat(headerValue, 64)
 	if err != nil {
-		return 0, errutil.Error{
-			Code: errutil.BadRequest,
+		return 0, errcommon.Error{
+			Code: errcommon.BadRequest,
 			Msg:  headerName + " must be a float",
 		}
 	}

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_helpers.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_helpers.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *schedulingtypes.LLMRequest, predictedLatencyCtx *predictedLatencyCtx) {
@@ -36,12 +36,12 @@ func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *schedul
 	// Get Request SLOs from request header
 	predictedLatencyCtx.ttftSLO, err = parseFloatHeader(*request, ttftSLOHeaderKey)
 	if err != nil {
-		logger.V(logutil.DEBUG).Error(errutil.Error{Code: errutil.BadRequest, Msg: fmt.Sprintf("%v must be a float: %v", ttftSLOHeaderKey, err)}, "PredictedLatency: Error parsing TTFT SLO from header")
+		logger.V(logutil.DEBUG).Error(errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("%v must be a float: %v", ttftSLOHeaderKey, err)}, "PredictedLatency: Error parsing TTFT SLO from header")
 	}
 
 	predictedLatencyCtx.avgTPOTSLO, err = parseFloatHeader(*request, tpotSLOHeaderKey)
 	if err != nil {
-		logger.V(logutil.DEBUG).Error(errutil.Error{Code: errutil.BadRequest, Msg: fmt.Sprintf("%v must be a float: %v", tpotSLOHeaderKey, err)}, "PredictedLatency: Error parsing TPOT SLO from header")
+		logger.V(logutil.DEBUG).Error(errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("%v must be a float: %v", tpotSLOHeaderKey, err)}, "PredictedLatency: Error parsing TPOT SLO from header")
 	}
 }
 

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -30,8 +30,8 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 	reqenvoy "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/request"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
 
@@ -46,7 +46,7 @@ func (s *StreamingServer) HandleRequestHeaders(ctx context.Context, reqCtx *Requ
 		// routed to a random upstream endpoint.
 		endpoint := s.director.GetRandomEndpoint()
 		if endpoint == nil {
-			return errutil.Error{Code: errutil.Internal, Msg: "no pods available in datastore"}
+			return errcommon.Error{Code: errcommon.Internal, Msg: "no pods available in datastore"}
 		}
 		reqCtx.TargetEndpoint = endpoint.GetIPAddress() + ":" + endpoint.GetPort()
 		reqCtx.RequestSize = 0

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	reqenvoy "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/request"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
@@ -42,7 +43,6 @@ import (
 	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 func NewStreamingServer(datastore Datastore, director Director, parser fwkrh.Parser) *StreamingServer {
@@ -168,7 +168,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		if reqCtx.ResponseStatusCode != "" {
 			metrics.RecordRequestErrCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, reqCtx.ResponseStatusCode)
 		} else if err != nil {
-			metrics.RecordRequestErrCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, errutil.CanonicalCode(err))
+			metrics.RecordRequestErrCounter(reqCtx.IncomingModelName, reqCtx.TargetModelName, errcommon.CanonicalCode(err))
 		}
 		if reqCtx.RequestRunning {
 			metrics.DecRunningRequests(reqCtx.IncomingModelName)
@@ -252,7 +252,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				value := string(header.RawValue)
 				loggerTrace.Info("header", "key", header.Key, "value", value)
 				if header.Key == "status" && value != "200" {
-					reqCtx.ResponseStatusCode = errutil.ModelServerError
+					reqCtx.ResponseStatusCode = errcommon.ModelServerError
 				} else if header.Key == "content-type" && strings.Contains(value, "text/event-stream") {
 					reqCtx.modelServerStreaming = true
 					loggerTrace.Info("model server is streaming response")
@@ -406,10 +406,10 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 func buildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
 	var resp *extProcPb.ProcessingResponse
 
-	switch errutil.CanonicalCode(err) {
+	switch errcommon.CanonicalCode(err) {
 	// This code can be returned by scheduler when there is no capacity for sheddable
 	// requests.
-	case errutil.InferencePoolResourceExhausted:
+	case errcommon.ResourceExhausted:
 		resp = &extProcPb.ProcessingResponse{
 			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
 				ImmediateResponse: &extProcPb.ImmediateResponse{
@@ -420,7 +420,7 @@ func buildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
 			},
 		}
 	// This code can be returned by when EPP processes the request and run into server-side errors.
-	case errutil.Internal:
+	case errcommon.Internal:
 		resp = &extProcPb.ProcessingResponse{
 			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
 				ImmediateResponse: &extProcPb.ImmediateResponse{
@@ -431,7 +431,7 @@ func buildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
 			},
 		}
 	// This code can be returned by the director when there are no candidate pods for the request scheduling.
-	case errutil.ServiceUnavailable:
+	case errcommon.ServiceUnavailable:
 		resp = &extProcPb.ProcessingResponse{
 			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
 				ImmediateResponse: &extProcPb.ImmediateResponse{
@@ -442,7 +442,7 @@ func buildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
 			},
 		}
 	// This code can be returned when users provide invalid json request.
-	case errutil.BadRequest:
+	case errcommon.BadRequest:
 		resp = &extProcPb.ProcessingResponse{
 			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
 				ImmediateResponse: &extProcPb.ImmediateResponse{
@@ -452,7 +452,7 @@ func buildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
 				},
 			},
 		}
-	case errutil.BadConfiguration:
+	case errcommon.BadConfiguration:
 		resp = &extProcPb.ProcessingResponse{
 			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
 				ImmediateResponse: &extProcPb.ImmediateResponse{

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 const (
@@ -140,22 +140,22 @@ func TestRecordRequestErrorCounter(t *testing.T) {
 				{
 					modelName:       "m10",
 					targetModelName: "t10",
-					error:           errutil.Internal,
+					error:           errcommon.Internal,
 				},
 				{
 					modelName:       "m10",
 					targetModelName: "t10",
-					error:           errutil.Internal,
+					error:           errcommon.Internal,
 				},
 				{
 					modelName:       "m10",
 					targetModelName: "t11",
-					error:           errutil.ModelServerError,
+					error:           errcommon.ModelServerError,
 				},
 				{
 					modelName:       "m20",
 					targetModelName: "t20",
-					error:           errutil.InferencePoolResourceExhausted,
+					error:           errcommon.ResourceExhausted,
 				},
 			},
 		},

--- a/pkg/epp/metrics/testdata/request_error_total_metric
+++ b/pkg/epp/metrics/testdata/request_error_total_metric
@@ -2,4 +2,4 @@
 # TYPE inference_objective_request_error_total counter
 inference_objective_request_error_total{error_code="Internal", model_name="m10",target_model_name="t10"} 2
 inference_objective_request_error_total{error_code="ModelServerError", model_name="m10",target_model_name="t11"} 1
-inference_objective_request_error_total{error_code="InferencePoolResourceExhausted", model_name="m20",target_model_name="t20"} 1
+inference_objective_request_error_total{error_code="ResourceExhausted", model_name="m20",target_model_name="t20"} 1

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -23,12 +23,12 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	requtil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/request"
 )
 
@@ -46,7 +46,7 @@ type AdmissionController interface {
 	//
 	// Returns:
 	//   - nil: If the request is admitted and should proceed to scheduling.
-	//   - errutil.Error: If the request is rejected.
+	//   - errcommon.Error: If the request is rejected.
 	Admit(
 		ctx context.Context,
 		reqCtx *handlers.RequestContext,
@@ -73,8 +73,8 @@ func rejectIfSheddableAndSaturated(
 		if sd.Saturation(ctx, locator.Locate(ctx, reqCtx.Request.Metadata)) >= 1.0 {
 			logger.V(logutil.TRACE).Info("Request rejected: system saturated and request is sheddable",
 				"requestID", reqCtx.SchedulingRequest.RequestId)
-			return errutil.Error{
-				Code: errutil.InferencePoolResourceExhausted,
+			return errcommon.Error{
+				Code: errcommon.ResourceExhausted,
 				Msg:  "system saturated, sheddable request dropped",
 			}
 		}
@@ -196,7 +196,7 @@ func (r *flowControlRequest) FlowKey() flowcontrol.FlowKey {
 	return flowcontrol.FlowKey{ID: r.fairnessID, Priority: r.priority}
 }
 
-// translateFlowControlOutcome maps the context-rich outcome of the Flow Control layer to the public errutil.Error
+// translateFlowControlOutcome maps the context-rich outcome of the Flow Control layer to the public errcommon.Error
 // contract used by the Director.
 func translateFlowControlOutcome(outcome types.QueueOutcome, err error) error {
 	msg := "request rejected by flow control"
@@ -208,14 +208,14 @@ func translateFlowControlOutcome(outcome types.QueueOutcome, err error) error {
 	case types.QueueOutcomeDispatched:
 		return nil
 	case types.QueueOutcomeRejectedCapacity:
-		return errutil.Error{Code: errutil.InferencePoolResourceExhausted, Msg: msg}
+		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: msg}
 	case types.QueueOutcomeEvictedTTL:
-		return errutil.Error{Code: errutil.ServiceUnavailable, Msg: "request timed out in queue: " + msg}
+		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "request timed out in queue: " + msg}
 	case types.QueueOutcomeEvictedContextCancelled:
-		return errutil.Error{Code: errutil.ServiceUnavailable, Msg: "client disconnected: " + msg}
+		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "client disconnected: " + msg}
 	case types.QueueOutcomeRejectedOther, types.QueueOutcomeEvictedOther:
-		return errutil.Error{Code: errutil.Internal, Msg: "internal flow control error: " + msg}
+		return errcommon.Error{Code: errcommon.Internal, Msg: "internal flow control error: " + msg}
 	default:
-		return errutil.Error{Code: errutil.Internal, Msg: "unhandled flow control outcome: " + msg}
+		return errcommon.Error{Code: errcommon.Internal, Msg: "unhandled flow control outcome: " + msg}
 	}
 }

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts/mocks"
@@ -31,7 +32,6 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 // --- Mocks ---
@@ -93,7 +93,7 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 			isSaturated:     true,
 			locatorPods:     mockPods,
 			expectErr:       true,
-			expectErrCode:   errutil.InferencePoolResourceExhausted,
+			expectErrCode:   errcommon.ResourceExhausted,
 			expectErrSubstr: "system saturated, sheddable request dropped",
 		},
 		{
@@ -102,7 +102,7 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 			isSaturated:     true,
 			locatorPods:     []backendmetrics.PodMetrics{},
 			expectErr:       true,
-			expectErrCode:   errutil.InferencePoolResourceExhausted,
+			expectErrCode:   errcommon.ResourceExhausted,
 			expectErrSubstr: "system saturated, sheddable request dropped",
 		},
 	}
@@ -127,8 +127,8 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 				assert.NoError(t, err, "Admit() should not have returned an error for scenario: %s", tc.name)
 			} else {
 				require.Error(t, err, "Admit() should have returned an error for scenario: %s", tc.name)
-				var e errutil.Error
-				if assert.ErrorAs(t, err, &e, "error should be of type errutil.Error") {
+				var e errcommon.Error
+				if assert.ErrorAs(t, err, &e, "error should be of type errcommon.Error") {
 					assert.Equal(t, tc.expectErrCode, e.Code, "incorrect error code for scenario: %s", tc.name)
 					assert.Contains(t, e.Msg, tc.expectErrSubstr, "incorrect error message substring for scenario: %s", tc.name)
 				}
@@ -214,7 +214,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeRejectedCapacity,
 			expectErr:       true,
-			expectErrCode:   errutil.InferencePoolResourceExhausted,
+			expectErrCode:   errcommon.ResourceExhausted,
 			expectErrSubstr: "request rejected by flow control",
 		},
 		{
@@ -223,7 +223,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			fcOutcome:       fctypes.QueueOutcomeEvictedTTL,
 			fcErr:           errors.New("timeout"),
 			expectErr:       true,
-			expectErrCode:   errutil.ServiceUnavailable,
+			expectErrCode:   errcommon.ServiceUnavailable,
 			expectErrSubstr: "request timed out in queue: timeout",
 		},
 		{
@@ -231,7 +231,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeEvictedContextCancelled,
 			expectErr:       true,
-			expectErrCode:   errutil.ServiceUnavailable,
+			expectErrCode:   errcommon.ServiceUnavailable,
 			expectErrSubstr: "client disconnected",
 		},
 		{
@@ -239,7 +239,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeRejectedOther,
 			expectErr:       true,
-			expectErrCode:   errutil.Internal,
+			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "internal flow control error",
 		},
 		{
@@ -248,7 +248,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			fcOutcome:       fctypes.QueueOutcomeEvictedOther,
 			fcErr:           errors.New("internal error"),
 			expectErr:       true,
-			expectErrCode:   errutil.Internal,
+			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "internal flow control error: internal error",
 		},
 		{
@@ -256,7 +256,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeNotYetFinalized,
 			expectErr:       true,
-			expectErrCode:   errutil.Internal,
+			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "unhandled flow control outcome",
 		},
 	}
@@ -275,8 +275,8 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 				assert.NoError(t, err, "Admit() returned an unexpected error for scenario: %s", tc.name)
 			} else {
 				require.Error(t, err, "Admit() should have returned an error for scenario: %s", tc.name)
-				var e errutil.Error
-				if assert.ErrorAs(t, err, &e, "error should be of type errutil.Error") {
+				var e errcommon.Error
+				if assert.ErrorAs(t, err, &e, "error should be of type errcommon.Error") {
 					assert.Equal(t, tc.expectErrCode, e.Code, "incorrect error code for scenario: %s", tc.name)
 					assert.Contains(t, e.Msg, tc.expectErrSubstr, "incorrect error message substring for scenario: %s", tc.name)
 				}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
@@ -43,7 +44,6 @@ import (
 	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 const (
@@ -158,8 +158,8 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	}
 	candidatePods := d.podLocator.Locate(ctx, reqCtx.Request.Metadata)
 	if len(candidatePods) == 0 {
-		return reqCtx, errutil.Error{
-			Code: errutil.ServiceUnavailable,
+		return reqCtx, errcommon.Error{
+			Code: errcommon.ServiceUnavailable,
 			Msg:  "failed to find candidate pods for serving the request",
 		}
 	}
@@ -174,12 +174,12 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	// Run admit request plugins
 	if !d.runAdmissionPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods) {
 		logger.V(logutil.DEFAULT).Info("Request cannot be admitted")
-		return reqCtx, errutil.Error{Code: errutil.Internal, Msg: "request cannot be admitted"}
+		return reqCtx, errcommon.Error{Code: errcommon.Internal, Msg: "request cannot be admitted"}
 	}
 
 	result, err := d.scheduler.Schedule(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if err != nil {
-		return reqCtx, errutil.Error{Code: errutil.InferencePoolResourceExhausted, Msg: fmt.Errorf("failed to find target pod: %w", err).Error()}
+		return reqCtx, errcommon.Error{Code: errcommon.ResourceExhausted, Msg: fmt.Errorf("failed to find target pod: %w", err).Error()}
 	}
 
 	// Prepare Request (Populates RequestContext and call PreRequest plugins)
@@ -196,7 +196,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 func (d *Director) processRequestBody(ctx context.Context, reqCtx *handlers.RequestContext, parser fwkrh.Parser) (*fwksched.LLMRequestBody, error) {
 	llmRequestBody, err := parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 	if err != nil {
-		return nil, errutil.Error{Code: errutil.BadRequest, Msg: err.Error()}
+		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: err.Error()}
 	}
 
 	switch v := llmRequestBody.ParsedBody.(type) {
@@ -208,7 +208,7 @@ func (d *Director) processRequestBody(ctx context.Context, reqCtx *handlers.Requ
 			return nil, err
 		}
 	default:
-		return nil, errutil.Error{Code: errutil.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
+		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
 	}
 	return llmRequestBody, nil
 }
@@ -226,7 +226,7 @@ func (d *Director) mutateAndRepackage(ctx context.Context, reqCtx *handlers.Requ
 	requestBodyBytes, err := json.Marshal(bodyMap)
 	if err != nil {
 		logger.V(logutil.DEFAULT).Error(err, "Error marshalling request body")
-		return errutil.Error{Code: errutil.Internal, Msg: "Error marshalling request body"}
+		return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
 	}
 
 	reqCtx.Request.RawBody = requestBodyBytes
@@ -239,7 +239,7 @@ func (d *Director) mutateModel(reqCtx *handlers.RequestContext, bodyMap map[stri
 	var ok bool
 	reqCtx.IncomingModelName, ok = bodyMap["model"].(string)
 	if !ok {
-		return reqCtx, errutil.Error{Code: errutil.BadRequest, Msg: "model not found in request body"}
+		return reqCtx, errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
 	}
 	if reqCtx.TargetModelName == "" {
 		// Default to incoming model name
@@ -292,7 +292,7 @@ func (d *Director) selectWeightedModel(models []v1alpha2.TargetModel) string {
 func (d *Director) prepareRequest(ctx context.Context, reqCtx *handlers.RequestContext, result *fwksched.SchedulingResult) (*handlers.RequestContext, error) {
 	logger := log.FromContext(ctx)
 	if result == nil || len(result.ProfileResults) == 0 {
-		return reqCtx, errutil.Error{Code: errutil.Internal, Msg: "results must be greater than zero"}
+		return reqCtx, errcommon.Error{Code: errcommon.Internal, Msg: "results must be greater than zero"}
 	}
 	// primary profile is used to set destination
 	targetMetadatas := []*fwkdl.EndpointMetadata{}

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
@@ -50,7 +51,6 @@ import (
 	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 	poolutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/pool"
 	testutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
 )
@@ -302,7 +302,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		schedulerMockSetup      func(m *mockScheduler)
 		initialTargetModelName  string // Initial target model in the reqCtx.
 		parser                  fwkrh.Parser
-		wantErrCode             string                   // Expected errutil code string
+		wantErrCode             string                   // Expected errcommon code string
 		wantReqCtx              *handlers.RequestContext // Fields to check in the returned RequestContext
 		wantMutatedBodyModel    string                   // Expected model in reqCtx.Request.Body after PostDispatch
 		targetModelName         string                   // Expected model name after target model resolution
@@ -463,7 +463,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 			wantMutatedBodyModel:    model,
 			targetModelName:         model,
 			admitRequestDenialError: errors.New("denied by admit plugin"),
-			wantErrCode:             errutil.Internal,
+			wantErrCode:             errcommon.Internal,
 		},
 		{
 			name: "successful chat completions request with multiple messages",
@@ -554,19 +554,19 @@ func TestDirector_HandleRequest(t *testing.T) {
 				"prompt": "sheddable prompt",
 			},
 			inferenceObjectiveName:  objectiveNameSheddable,
-			mockAdmissionController: &mockAdmissionController{admitErr: errutil.Error{Code: errutil.InferencePoolResourceExhausted, Msg: "simulated admission rejection"}},
-			wantErrCode:             errutil.InferencePoolResourceExhausted,
+			mockAdmissionController: &mockAdmissionController{admitErr: errcommon.Error{Code: errcommon.ResourceExhausted, Msg: "simulated admission rejection"}},
+			wantErrCode:             errcommon.ResourceExhausted,
 		},
 		{
 			name:                    "model not found, expect err",
 			reqBodyMap:              map[string]any{"prompt": "p"},
 			mockAdmissionController: &mockAdmissionController{admitErr: nil},
-			wantErrCode:             errutil.BadRequest,
+			wantErrCode:             errcommon.BadRequest,
 		},
 		{
 			name:        "prompt or messages not found, expect err",
 			reqBodyMap:  map[string]any{"model": model},
-			wantErrCode: errutil.BadRequest,
+			wantErrCode: errcommon.BadRequest,
 		},
 		{
 			name: "empty messages, expect err",
@@ -574,7 +574,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				"model":    model,
 				"messages": []any{},
 			},
-			wantErrCode: errutil.BadRequest,
+			wantErrCode: errcommon.BadRequest,
 		},
 		{
 			name: "scheduler returns error",
@@ -586,7 +586,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 			schedulerMockSetup: func(m *mockScheduler) {
 				m.scheduleErr = errors.New("simulated scheduler failure")
 			},
-			wantErrCode:            errutil.InferencePoolResourceExhausted,
+			wantErrCode:            errcommon.ResourceExhausted,
 			inferenceObjectiveName: objectiveName,
 		},
 		{
@@ -600,7 +600,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				m.scheduleResults = nil
 				m.scheduleErr = nil
 			},
-			wantErrCode:            errutil.Internal,
+			wantErrCode:            errcommon.Internal,
 			inferenceObjectiveName: objectiveName,
 		},
 	}
@@ -692,8 +692,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 
 				if test.wantErrCode != "" {
 					assert.Error(t, err, "HandleRequest() should have returned an error")
-					var e errutil.Error
-					if assert.ErrorAs(t, err, &e, "Error should be of type errutil.Error") {
+					var e errcommon.Error
+					if assert.ErrorAs(t, err, &e, "Error should be of type errcommon.Error") {
 						assert.Equal(t, test.wantErrCode, e.Code, "Error code mismatch")
 					}
 					return

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -24,11 +24,11 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	errcommmon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
-	errutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/error"
 )
 
 // NewSchedulerProfile creates a new SchedulerProfile object and returns its pointer.
@@ -117,7 +117,7 @@ func (p *SchedulerProfile) String() string {
 func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.LLMRequest, cycleState *fwksched.CycleState, candidateEndpoints []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
 	endpoints := p.runFilterPlugins(ctx, request, cycleState, candidateEndpoints)
 	if len(endpoints) == 0 {
-		return nil, errutil.Error{Code: errutil.Internal, Msg: "no endpoints available for the given request"}
+		return nil, errcommmon.Error{Code: errcommmon.Internal, Msg: "no endpoints available for the given request"}
 	}
 	// if we got here, there is at least one endpoint to score
 	weightedScorePerEndpoint := p.runScorerPlugins(ctx, request, cycleState, endpoints)

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -185,7 +185,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectReject(
 				envoyTypePb.StatusCode_BadRequest,
-				"inference gateway: BadRequest - error unmarshaling request bodyMap",
+				"inference error: BadRequest - Error unmarshaling request bodyMap",
 			),
 		},
 		{
@@ -214,7 +214,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 			requests: integration.ReqHeaderOnly(map[string]string{"content-type": "application/json"}),
 			pods:     nil,
 			wantResponses: ExpectReject(envoyTypePb.StatusCode_InternalServerError,
-				"inference gateway: Internal - no pods available in datastore"),
+				"inference error: Internal - no pods available in datastore"),
 		},
 		{
 			name: "request missing model field",
@@ -223,7 +223,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 				`{"prompt":"hello world"}`,
 			),
 			wantResponses: ExpectReject(envoyTypePb.StatusCode_BadRequest,
-				"inference gateway: BadRequest - model not found in request body"),
+				"inference error: BadRequest - model not found in request body"),
 		},
 
 		// --- Subsetting & Metadata ---
@@ -257,7 +257,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 				P(1, 0, 0.1, "foo", modelSQLLoraTarget),
 			},
 			wantResponses: ExpectReject(envoyTypePb.StatusCode_ServiceUnavailable,
-				"inference gateway: ServiceUnavailable - failed to find candidate pods for serving the request"),
+				"inference error: ServiceUnavailable - failed to find candidate pods for serving the request"),
 		},
 
 		// --- Request Modification (Passthrough & Rewrite) ---

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -185,7 +185,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectReject(
 				envoyTypePb.StatusCode_BadRequest,
-				"inference error: BadRequest - Error unmarshaling request bodyMap",
+				"inference error: BadRequest - error unmarshaling request bodyMap",
 			),
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Both the Endpoint Picker (EPP) and the Body Based Router (BBR) are Envoy ExtProc filters. There is much code that has been copy and pasted from one to the other.

This PR is the second in a series of PRs that will refactor out the common Ext Proc processing code into a set of reusable packages. This is being done to try and keep the PRs somewhat smaller.

In particular this PR:
    1. Moves the error utility code to a common package
    2. Changed the InferencePoolResourceExausted error code to ResourceExausted, to be more generic.
    3. Updates other parts of the code base due to the above changes

**Which issue(s) this PR fixes**:
Ref: #2427

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
