### PR TITLE
[bbr] add integration tests for response plugin execution

### DIFF
--- a/test/integration/bbr/body_mutation_test.go
+++ b/test/integration/bbr/body_mutation_test.go
@@ -60,7 +60,7 @@ func TestBodyMutation_Unary(t *testing.T) {
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	h := NewBBRHarnessWithPlugins(t, ctx, false, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin})
+	h := NewBBRHarnessWithPlugins(t, ctx, false, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 
 	body := map[string]any{"prompt": "hello"}
 	bodyBytes, _ := json.Marshal(body)
@@ -127,7 +127,7 @@ func TestBodyMutation_Streaming(t *testing.T) {
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
-	h := NewBBRHarnessWithPlugins(t, ctx, true, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin})
+	h := NewBBRHarnessWithPlugins(t, ctx, true, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 
 	body := map[string]any{"prompt": "hello"}
 	bodyBytes, _ := json.Marshal(body)

--- a/test/integration/bbr/harness.go
+++ b/test/integration/bbr/harness.go
@@ -52,7 +52,7 @@ type BBRHarness struct {
 }
 
 // NewBBRHarness boots up an isolated BBR server on a random port with the default
-// BodyFieldToHeaderPlugin for model extraction.
+// BodyFieldToHeaderPlugin for model extraction and no response plugins.
 func NewBBRHarness(t *testing.T, ctx context.Context, streaming bool) *BBRHarness {
 	t.Helper()
 	modelToHeaderPlugin, err := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
@@ -94,11 +94,18 @@ func NewBBRHarness(t *testing.T, ctx context.Context, streaming bool) *BBRHarnes
 
 	baseModelToHeaderPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: store}
 
-	return NewBBRHarnessWithPlugins(t, ctx, streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin})
+	return NewBBRHarnessWithPlugins(t, ctx, streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 }
 
-// NewBBRHarnessWithPlugins boots up an isolated BBR server with custom request plugins.
-func NewBBRHarnessWithPlugins(t *testing.T, ctx context.Context, streaming bool, requestPlugins []framework.RequestProcessor) *BBRHarness {
+// NewBBRHarnessWithPlugins boots up an isolated BBR server on a random port
+// with the given request and response plugins.
+func NewBBRHarnessWithPlugins(
+	t *testing.T,
+	ctx context.Context,
+	streaming bool,
+	requestPlugins []framework.RequestProcessor,
+	responsePlugins []framework.ResponseProcessor,
+) *BBRHarness {
 	t.Helper()
 
 	// 1. Allocate Free Port
@@ -110,6 +117,7 @@ func NewBBRHarnessWithPlugins(t *testing.T, ctx context.Context, streaming bool,
 	runner.SecureServing = false
 	runner.Streaming = streaming
 	runner.RequestPlugins = requestPlugins
+	runner.ResponsePlugins = responsePlugins
 
 	// 3. Start Server in Background
 	serverCtx, serverCancel := context.WithCancel(ctx)

--- a/test/integration/bbr/hermetic_test.go
+++ b/test/integration/bbr/hermetic_test.go
@@ -19,20 +19,26 @@ package bbr
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
+	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/basemodelextractor"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/bodyfieldtoheader"
 	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
+	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
 
-// TestBodyBasedRouting validates the "Unary" (Non-Streaming) behavior of BBR.
+// TestBodyBasedRouting validates the "Unary" (Non-Streaming) request-phase behavior of BBR.
 // This simulates scenarios where Envoy buffers the body before sending it to ext_proc.
 func TestBodyBasedRouting(t *testing.T) {
 	t.Parallel()
@@ -41,7 +47,6 @@ func TestBodyBasedRouting(t *testing.T) {
 		name             string
 		req              *extProcPb.ProcessingRequest
 		wantResponse     *extProcPb.ProcessingResponse
-		wantErr          bool
 		wantStatusCode   envoyTypePb.StatusCode
 		wantBodyContains string
 	}{
@@ -66,11 +71,6 @@ func TestBodyBasedRouting(t *testing.T) {
 			h := NewBBRHarness(t, ctx, false)
 
 			res, err := integration.SendRequest(t, h.Client, tc.req)
-
-			if tc.wantErr {
-				require.Error(t, err, "expected error during request processing")
-				return
-			}
 			require.NoError(t, err, "unexpected error during request processing")
 
 			if tc.wantStatusCode != 0 {
@@ -84,10 +84,113 @@ func TestBodyBasedRouting(t *testing.T) {
 				return
 			}
 
-			// sort headers in responses for deterministic tests
 			envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{tc.wantResponse})
 			envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{res})
 			if diff := cmp.Diff(tc.wantResponse, res, protocmp.Transform()); diff != "" {
+				t.Errorf("Response mismatch (-want +got): %v", diff)
+			}
+		})
+	}
+}
+
+// TestResponsePlugins validates the full request→response lifecycle in unary mode,
+// testing that response plugins can mutate the response body and that responses
+// pass through unchanged when no response plugins are configured.
+func TestResponsePlugins(t *testing.T) {
+	t.Parallel()
+
+	responsePlugin := &testResponsePlugin{
+		name: "guardrail",
+		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+			response.SetBodyField("guardrail", "applied")
+			return nil
+		},
+	}
+
+	respHeaders := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HttpHeaders{
+				Headers: &envoyCorev3.HeaderMap{
+					Headers: []*envoyCorev3.HeaderValue{
+						{Key: "content-type", Value: "application/json"},
+					},
+				},
+			},
+		},
+	}
+	respBodyReq := func(body map[string]any) *extProcPb.ProcessingRequest {
+		b, _ := json.Marshal(body)
+		return &extProcPb.ProcessingRequest{
+			Request: &extProcPb.ProcessingRequest_ResponseBody{
+				ResponseBody: &extProcPb.HttpBody{Body: b, EndOfStream: true},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		createHarness func(t *testing.T, ctx context.Context) *BBRHarness
+		reqs          []*extProcPb.ProcessingRequest
+		wantResponses []*extProcPb.ProcessingResponse
+	}{
+		{
+			name: "no plugins: response passes through unchanged",
+			createHarness: func(t *testing.T, ctx context.Context) *BBRHarness {
+				return NewBBRHarness(t, ctx, false)
+			},
+			reqs: []*extProcPb.ProcessingRequest{
+				integration.ReqLLMUnary(logger, "test", "llama"),
+				respHeaders,
+				respBodyReq(map[string]any{"choices": []any{map[string]any{"text": "Hi there!"}}}),
+			},
+			wantResponses: []*extProcPb.ProcessingResponse{
+				ExpectBBRUnaryResponse("llama", "llama", "test"),
+				ExpectResponseHeadersPassThrough(),
+				ExpectResponseBodyPassThrough(),
+			},
+		},
+		{
+			name: "response plugin mutates response body",
+			createHarness: func(t *testing.T, ctx context.Context) *BBRHarness {
+				t.Helper()
+				modelToHeaderPlugin, err := bodyfieldtoheader.NewBodyFieldToHeaderPlugin(modelField, bodyfieldtoheader.ModelHeader)
+				require.NoError(t, err, "failed to create body-field-to-header plugin")
+				baseModelPlugin := &basemodelextractor.BaseModelToHeaderPlugin{AdaptersStore: basemodelextractor.NewAdaptersStore()}
+				return NewBBRHarnessWithPlugins(t, ctx, false,
+					[]framework.RequestProcessor{modelToHeaderPlugin, baseModelPlugin},
+					[]framework.ResponseProcessor{responsePlugin},
+				)
+			},
+			reqs: []*extProcPb.ProcessingRequest{
+				integration.ReqLLMUnary(logger, "hello", "test-model"),
+				respHeaders,
+				respBodyReq(map[string]any{"choices": []any{map[string]any{"text": "Hello!"}}}),
+			},
+			wantResponses: []*extProcPb.ProcessingResponse{
+				ExpectBBRUnaryResponse("test-model", "", "hello"),
+				ExpectResponseHeadersPassThrough(),
+				ExpectResponseBodyMutation(map[string]any{
+					"choices":   []any{map[string]any{"text": "Hello!"}},
+					"guardrail": "applied",
+				}),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			h := tc.createHarness(t, ctx)
+
+			responses, err := integration.StreamedRequest(t, h.Client, tc.reqs, len(tc.wantResponses))
+			require.NoError(t, err, "unexpected error during streamed request")
+			require.Len(t, responses, len(tc.wantResponses))
+
+			envoytest.SortSetHeadersInResponses(tc.wantResponses)
+			envoytest.SortSetHeadersInResponses(responses)
+			if diff := cmp.Diff(tc.wantResponses, responses, protocmp.Transform()); diff != "" {
 				t.Errorf("Response mismatch (-want +got): %v", diff)
 			}
 		})
@@ -176,3 +279,19 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 		})
 	}
 }
+
+// testResponsePlugin implements framework.ResponseProcessor for integration tests.
+type testResponsePlugin struct {
+	name     string
+	mutateFn func(ctx context.Context, response *framework.InferenceResponse) error
+}
+
+func (p *testResponsePlugin) TypedName() epp.TypedName {
+	return epp.TypedName{Type: "test", Name: p.name}
+}
+
+func (p *testResponsePlugin) ProcessResponse(ctx context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
+	return p.mutateFn(ctx, response)
+}
+
+var _ framework.ResponseProcessor = &testResponsePlugin{}

--- a/test/integration/bbr/util.go
+++ b/test/integration/bbr/util.go
@@ -18,6 +18,7 @@ package bbr
 
 import (
 	"encoding/json"
+	"strconv"
 
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -99,7 +100,58 @@ func ExpectBBRNoOpHeader() *extProcPb.ProcessingResponse {
 	}
 }
 
-// --- Response Expectations (Unary) ---
+// --- Response Phase Expectations ---
+
+// ExpectResponseHeadersPassThrough asserts that BBR passed response headers through with no mutations.
+func ExpectResponseHeadersPassThrough() *extProcPb.ProcessingResponse {
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+			ResponseHeaders: &extProcPb.HeadersResponse{},
+		},
+	}
+}
+
+// ExpectResponseBodyPassThrough asserts that BBR passed the response body through with no mutations
+// (i.e., no response plugins configured).
+func ExpectResponseBodyPassThrough() *extProcPb.ProcessingResponse {
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ResponseBody{
+			ResponseBody: &extProcPb.BodyResponse{},
+		},
+	}
+}
+
+// ExpectResponseBodyMutation asserts that a response plugin mutated the response body (unary mode).
+// Includes the Content-Length header mutation.
+func ExpectResponseBodyMutation(body map[string]any) *extProcPb.ProcessingResponse {
+	b, _ := json.Marshal(body)
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ResponseBody{
+			ResponseBody: &extProcPb.BodyResponse{
+				Response: &extProcPb.CommonResponse{
+					ClearRouteCache: true,
+					HeaderMutation: &extProcPb.HeaderMutation{
+						SetHeaders: []*envoyCorev3.HeaderValueOption{
+							{
+								Header: &envoyCorev3.HeaderValue{
+									Key:      "Content-Length",
+									RawValue: []byte(strconv.Itoa(len(b))),
+								},
+							},
+						},
+					},
+					BodyMutation: &extProcPb.BodyMutation{
+						Mutation: &extProcPb.BodyMutation_Body{
+							Body: b,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// --- Request Phase Expectations (Unary) ---
 
 // ExpectBBRUnaryResponse creates expected response for unary tests where the body is mutated directly.
 // baseModelName is the expected base model name (e.g., "llama" for both "llama" and "sql-lora-sheddable")


### PR DESCRIPTION


**What this PR does / why we need it**:

Follow-up to PR #2369 ([pluggable bbr] mirror request plugins execution to the response path).

This PR adds integration tests that validate response plugin execution over a real gRPC ext_proc stream, covering:
- **Unary mode with plugin**: a response plugin mutates the response body (e.g., guardrail adding a field)
- **Unary mode without plugins**: no response plugins configured results in passthrough behavior

These tests exercise the full `Process` loop (request body → response headers → response body) to ensure end-to-end correctness.

Also adds:
- `NewBBRHarnessWithPlugins` helper to support configuring request/response plugins in test harnesses
- Response phase expectation helpers (`ExpectResponseHeadersPassThrough`, `ExpectResponseBodyPassThrough`, `ExpectResponseBodyMutation`)

**Which issue(s) this PR fixes**:

Fixes #2449

**Does this PR introduce a user-facing change?**:
