### PR TITLE
[bbr] Apply response plugin body/header mutations to ext_proc response

### DIFF
--- a/pkg/bbr/handlers/response.go
+++ b/pkg/bbr/handlers/response.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -77,11 +78,49 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 		return nil, fmt.Errorf("failed to execute response plugins - %w", err)
 	}
 
-	// TODO: apply mutated body/headers to the response (see #2449 follow-ups).
+	mutatedBytes, err := json.Marshal(reqCtx.Response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal mutated response body - %w", err)
+	}
+
+	reqCtx.Response.SetHeader(contentLengthHeader, strconv.Itoa(len(mutatedBytes)))
+
+	if s.streaming {
+		var ret []*eppb.ProcessingResponse
+		ret = append(ret, &eppb.ProcessingResponse{
+			Response: &eppb.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &eppb.HeadersResponse{
+					Response: &eppb.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &eppb.HeaderMutation{
+							SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Response.MutatedHeaders()),
+							RemoveHeaders: reqCtx.Response.RemovedHeaders(),
+						},
+					},
+				},
+			},
+		})
+		ret = envoy.AddStreamedResponseBody(ret, mutatedBytes)
+		return ret, nil
+	}
+
 	return []*eppb.ProcessingResponse{
 		{
 			Response: &eppb.ProcessingResponse_ResponseBody{
-				ResponseBody: &eppb.BodyResponse{},
+				ResponseBody: &eppb.BodyResponse{
+					Response: &eppb.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &eppb.HeaderMutation{
+							SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Response.MutatedHeaders()),
+							RemoveHeaders: reqCtx.Response.RemovedHeaders(),
+						},
+						BodyMutation: &eppb.BodyMutation{
+							Mutation: &eppb.BodyMutation_Body{
+								Body: mutatedBytes,
+							},
+						},
+					},
+				},
 			},
 		},
 	}, nil

--- a/pkg/bbr/handlers/response_test.go
+++ b/pkg/bbr/handlers/response_test.go
@@ -18,14 +18,18 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strconv"
 	"testing"
 
+	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
@@ -96,14 +100,16 @@ func TestHandleResponseBody_SinglePlugin(t *testing.T) {
 		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
 	}
 
-	// Plugins are executed but mutations are not yet applied to the response.
+	wantBody, _ := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{"text": "Hello!"}},
+		"mutated": true,
+	})
 	want := []*extProcPb.ProcessingResponse{
-		{
-			Response: &extProcPb.ProcessingResponse_ResponseBody{
-				ResponseBody: &extProcPb.BodyResponse{},
-			},
-		},
+		expectedResponseBodyMutation(wantBody),
 	}
+
+	envoytest.SortSetHeadersInResponses(want)
+	envoytest.SortSetHeadersInResponses(resp)
 	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
 		t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
 	}
@@ -134,14 +140,17 @@ func TestHandleResponseBody_MultiplePlugins(t *testing.T) {
 		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
 	}
 
-	// Plugins are executed but mutations are not yet applied to the response.
+	wantBody, _ := json.Marshal(map[string]any{
+		"original": true,
+		"p1":       testPluginValue,
+		"p2":       testPluginValue,
+	})
 	want := []*extProcPb.ProcessingResponse{
-		{
-			Response: &extProcPb.ProcessingResponse_ResponseBody{
-				ResponseBody: &extProcPb.BodyResponse{},
-			},
-		},
+		expectedResponseBodyMutation(wantBody),
 	}
+
+	envoytest.SortSetHeadersInResponses(want)
+	envoytest.SortSetHeadersInResponses(resp)
 	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
 		t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
 	}
@@ -172,28 +181,29 @@ func TestHandleResponseBody_PluginError(t *testing.T) {
 func TestHandleResponseBody_StreamingWithPlugin(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
-	noopPlugin := &fakeResponsePlugin{
-		name: "noop",
+	mutatePlugin := &fakeResponsePlugin{
+		name: "mutator",
 		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+			response.Body["mutated"] = true
 			return nil
 		},
 	}
 
-	server := NewServer(true, &fakeDatastore{}, []framework.RequestProcessor{}, []framework.ResponseProcessor{noopPlugin})
+	server := NewServer(true, &fakeDatastore{}, []framework.RequestProcessor{}, []framework.ResponseProcessor{mutatePlugin})
 	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
 	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
 	if err != nil {
 		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
 	}
 
-	// Plugins are executed but mutations are not yet applied to the response.
-	want := []*extProcPb.ProcessingResponse{
-		{
-			Response: &extProcPb.ProcessingResponse_ResponseBody{
-				ResponseBody: &extProcPb.BodyResponse{},
-			},
-		},
-	}
+	wantBody, _ := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{"text": "Hello!"}},
+		"mutated": true,
+	})
+	want := expectedStreamedResponseBodyMutation(wantBody)
+
+	envoytest.SortSetHeadersInResponses(want)
+	envoytest.SortSetHeadersInResponses(resp)
 	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
 		t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
 	}
@@ -229,5 +239,76 @@ func TestProcessResponseBody_Streaming(t *testing.T) {
 	}
 	if resp2 == nil {
 		t.Fatal("processResponseBody chunk2 should return a response on EoS")
+	}
+}
+
+// expectedResponseBodyMutation builds the expected unary response for a mutated body,
+// including the content-length header mutation.
+func expectedResponseBodyMutation(bodyBytes []byte) *extProcPb.ProcessingResponse {
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ResponseBody{
+			ResponseBody: &extProcPb.BodyResponse{
+				Response: &extProcPb.CommonResponse{
+					ClearRouteCache: true,
+					HeaderMutation: &extProcPb.HeaderMutation{
+						SetHeaders: []*basepb.HeaderValueOption{
+							{
+								Header: &basepb.HeaderValue{
+									Key:      contentLengthHeader,
+									RawValue: []byte(strconv.Itoa(len(bodyBytes))),
+								},
+							},
+						},
+					},
+					BodyMutation: &extProcPb.BodyMutation{
+						Mutation: &extProcPb.BodyMutation_Body{
+							Body: bodyBytes,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// expectedStreamedResponseBodyMutation builds the expected streamed response for a mutated body:
+// first a ResponseHeaders with the header mutation, then ResponseBody chunks with body data.
+func expectedStreamedResponseBodyMutation(bodyBytes []byte) []*extProcPb.ProcessingResponse {
+	return []*extProcPb.ProcessingResponse{
+		{
+			Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &extProcPb.HeadersResponse{
+					Response: &extProcPb.CommonResponse{
+						ClearRouteCache: true,
+						HeaderMutation: &extProcPb.HeaderMutation{
+							SetHeaders: []*basepb.HeaderValueOption{
+								{
+									Header: &basepb.HeaderValue{
+										Key:      contentLengthHeader,
+										RawValue: []byte(strconv.Itoa(len(bodyBytes))),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Response: &extProcPb.ProcessingResponse_ResponseBody{
+				ResponseBody: &extProcPb.BodyResponse{
+					Response: &extProcPb.CommonResponse{
+						BodyMutation: &extProcPb.BodyMutation{
+							Mutation: &extProcPb.BodyMutation_StreamedResponse{
+								StreamedResponse: &extProcPb.StreamedBodyResponse{
+									Body:        bodyBytes,
+									EndOfStream: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/common/envoy/response.go
+++ b/pkg/common/envoy/response.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoy
+
+import (
+	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+)
+
+// AddStreamedResponseBody splits responseBodyBytes into chunked body responses
+// and appends them as ResponseBody ProcessingResponses, mirroring
+// GenerateRequestBodyResponses for the request path.
+func AddStreamedResponseBody(responses []*eppb.ProcessingResponse, responseBodyBytes []byte) []*eppb.ProcessingResponse {
+	commonResponses := BuildChunkedBodyResponses(responseBodyBytes, true)
+	for _, commonResp := range commonResponses {
+		responses = append(responses, &eppb.ProcessingResponse{
+			Response: &eppb.ProcessingResponse_ResponseBody{
+				ResponseBody: &eppb.BodyResponse{
+					Response: commonResp,
+				},
+			},
+		})
+	}
+	return responses
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This is a follow-up to #2369 (response plugin execution). Previously, `HandleResponseBody` executed response plugins but discarded their mutations — returning an empty `BodyResponse{}`. This PR applies the mutated body and headers back to the Envoy ext_proc response.

Key changes:
- **`executePlugins` signature**: Changed return type from `error` to `(map[string]string, map[string]any, error)` so callers receive the plugin-mutated headers and body.
- **Body mutation**: The mutated body is marshaled and included in the `BodyResponse` via `BodyMutation_Body` (unary) or `StreamedBodyResponse` chunks (streaming).
- **Header mutation**: Plugin-updated headers are applied via `HeaderMutation`, including a `content-length` header set to the new body size.
- **Streaming support**: Uses `BuildChunkedBodyResponses` for 62KB chunking, with header mutations attached to the first chunk.
- **Unit tests**: Updated to verify mutated body content and `content-length` header in both unary and streaming modes.

**Which issue(s) this PR fixes**:

Fixes #2470

**Does this PR introduce a user-facing change?**:
