### PR TITLE
Update release promotion checklist for standalone chart

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -130,6 +130,17 @@ This document defines the process for releasing Gateway API Inference Extension.
 9. Pushing the tag triggers Prow to build and publish the container image to the [staging registry][].
 10. Submit a PR against [k8s.io][] to add the staging image tag and SHA to [`k8s-staging-gateway-api-inference-extension/images.yaml`][yaml]. This will
     promote the image to the production registry, e.g. `registry.k8s.io/gateway-api-inference-extension/epp:v${MAJOR}.${MINOR}.${PATCH}`.
+    1. Collect release digests from Artifact Registry:
+       ```shell
+       ./hack/release-staging-digests.sh
+       ```
+    2. Ensure the PR updates all release artifacts:
+       - `charts/inferencepool`
+       - `charts/body-based-routing`
+       - `charts/standalone`
+       - `epp`
+       - `bbr`
+    3. If an artifact does not yet have a section in `images.yaml` (for example a newly added chart), add a new section before adding the digest mapping.
     **Note:** Add a link to this issue when the PR is merged.
 11. Test the steps in the tagged quickstart guide after the PR merges, for example: `https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v0.1.0-rc.1/pkg/README.md`.
 12. Create a [new release][]:

--- a/hack/release-staging-digests.sh
+++ b/hack/release-staging-digests.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "error: gcloud is required" >&2
+  exit 1
+fi
+
+: "${MAJOR:?MAJOR must be set}"
+: "${MINOR:?MINOR must be set}"
+: "${PATCH:?PATCH must be set}"
+
+if [[ -n "${RC-}" ]]; then
+  RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}"
+else
+  RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+fi
+
+PROJECT="${PROJECT:-k8s-staging-images}"
+LOCATION="${LOCATION:-us-central1}"
+REPOSITORY="${REPOSITORY:-gateway-api-inference-extension}"
+LIMIT="${LIMIT:-5000}"
+
+images=(
+  "charts/inferencepool"
+  "charts/body-based-routing"
+  "charts/standalone"
+  "epp"
+  "bbr"
+)
+
+find_digest() {
+  local image="$1"
+  local resource="${LOCATION}-docker.pkg.dev/${PROJECT}/${REPOSITORY}/${image}"
+  local rows
+  rows="$(
+    gcloud artifacts docker images list "${resource}" \
+      --include-tags \
+      --limit="${LIMIT}" \
+      --format='value(version,tags)' 2>/dev/null | grep '^sha256:' || true
+  )"
+
+  local digest tags tag
+  while IFS=$'\t' read -r digest tags; do
+    [[ -z "${digest}" || -z "${tags}" ]] && continue
+    IFS=',' read -r -a tag_list <<< "${tags}"
+    for tag in "${tag_list[@]}"; do
+      if [[ "${tag}" == "${RELEASE_TAG}" ]]; then
+        echo "${digest}"
+        return 0
+      fi
+    done
+  done <<< "${rows}"
+
+  return 1
+}
+
+echo "Release tag: ${RELEASE_TAG}"
+echo "Registry: ${LOCATION}-docker.pkg.dev/${PROJECT}/${REPOSITORY}"
+echo
+
+digests=()
+missing=()
+
+for image in "${images[@]}"; do
+  digest="$(find_digest "${image}" || true)"
+  if [[ -n "${digest}" ]]; then
+    printf "  %-28s %s\n" "${image}" "${digest}"
+    digests+=("${digest}")
+  else
+    printf "  %-28s %s\n" "${image}" "MISSING"
+    digests+=("")
+    missing+=("${image}")
+  fi
+done
+
+echo
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  echo "Missing digest(s) for ${RELEASE_TAG}: ${missing[*]}" >&2
+  echo "Wait for Artifact Registry publication to complete and rerun." >&2
+  exit 1
+fi
+
+echo "k8s.io images.yaml entries for ${RELEASE_TAG}:"
+for i in "${!images[@]}"; do
+  printf "  - %s => \"%s\": [\"%s\"]\n" "${images[$i]}" "${digests[$i]}" "${RELEASE_TAG}"
+done


### PR DESCRIPTION
## Summary
- add `hack/release-staging-digests.sh` to collect release digests for promotion
- include all promoted artifacts in one place: `charts/inferencepool`, `charts/body-based-routing`, `charts/standalone`, `epp`, and `bbr`
- update the release checklist step for `k8s.io` promotion to call out `charts/standalone` explicitly and require adding a new section when needed

## Why
`charts/standalone` is now part of release artifacts and was easy to miss during manual `k8s.io` image promotion updates.

## Validation
- Ran: `MAJOR=1 MINOR=4 PATCH=0 RC=1 ./hack/release-staging-digests.sh`
- Verified script outputs digest mappings for all five artifacts.