### PR TITLE
feat(concurrencydetector): ledger support for disaggregated prefill/decode accounting

### DIFF
--- a/pkg/epp/framework/interface/requestcontrol/types.go
+++ b/pkg/epp/framework/interface/requestcontrol/types.go
@@ -28,6 +28,8 @@ type Response struct {
 	RequestId string
 	// Headers is a map of the response headers. Nil during body processing
 	Headers map[string]string
+	// StartOfStream when true indicates that this invocation contains the first chunk of the response
+	StartOfStream bool
 	// EndOfStream when true indicates that this invocation contains the last chunk of the response
 	EndOfStream bool
 	// ReqMetadata is a map of metadata that can be passed from Envoy.

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -56,6 +56,8 @@ type InferenceRequest struct {
 	// TokenizedPrompt contains the tokenization results if external tokenization is enabled.
 	// This is nil if tokenization was not performed or if the tokenizer is not configured.
 	TokenizedPrompt *TokenizedPrompt
+	// SchedulingResult captures the scheduling decisions made during the cycle.
+	SchedulingResult *SchedulingResult
 }
 
 // TokenizedPrompt contains the result of tokenizing the request prompt.

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
@@ -23,9 +23,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
@@ -37,6 +34,7 @@ import (
 
 const (
 	InFlightLoadProducerType = "inflight-load-producer"
+	profilePrefill           = "prefill"
 )
 
 func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -52,7 +50,7 @@ var (
 	_ requestcontrol.PreRequest            = &InFlightLoadProducer{}
 	_ requestcontrol.ResponseBodyProcessor = &InFlightLoadProducer{}
 	_ requestcontrol.DataProducer          = &InFlightLoadProducer{}
-	_ datalayer.NotificationExtractor      = &InFlightLoadProducer{}
+	_ datalayer.EndpointExtractor          = &InFlightLoadProducer{}
 )
 
 type InFlightLoadProducer struct {
@@ -66,14 +64,9 @@ func (p *InFlightLoadProducer) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-// GVK returns the GroupVersionKind this extractor handles.
-func (p *InFlightLoadProducer) GVK() schema.GroupVersionKind {
-	return corev1.SchemeGroupVersion.WithKind("Pod")
-}
-
 // ExpectedInputType defines the type expected by the extractor.
 func (p *InFlightLoadProducer) ExpectedInputType() reflect.Type {
-	return reflect.TypeFor[datalayer.NotificationEvent]()
+	return datalayer.EndpointEventReflectType
 }
 
 // Extract transforms the raw data into structured attributes (not used for notifications).
@@ -81,20 +74,16 @@ func (p *InFlightLoadProducer) Extract(context.Context, any, datalayer.Endpoint)
 	return nil
 }
 
-// ExtractNotification handles pod deletion events to prune stateful trackers.
-func (p *InFlightLoadProducer) ExtractNotification(ctx context.Context, event datalayer.NotificationEvent) error {
-	if event.Type != datalayer.EventDelete || event.Object == nil {
+// ExtractEndpoint handles endpoint deletion events to prune stateful trackers.
+func (p *InFlightLoadProducer) ExtractEndpoint(ctx context.Context, event datalayer.EndpointEvent) error {
+	if event.Type != datalayer.EventDelete || event.Endpoint == nil {
 		return nil
 	}
 
-	nsn := types.NamespacedName{
-		Namespace: event.Object.GetNamespace(),
-		Name:      event.Object.GetName(),
-	}
-	id := nsn.String()
+	id := event.Endpoint.GetMetadata().NamespacedName.String()
 
 	p.DeleteEndpoint(id)
-	log.FromContext(ctx).V(logutil.DEFAULT).Info("Cleaned up in-flight load for deleted pod", "pod", id)
+	log.FromContext(ctx).V(logutil.DEFAULT).Info("Cleaned up in-flight load for deleted endpoint", "endpoint", id)
 	return nil
 }
 
@@ -114,13 +103,12 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.
 		return
 	}
 
-	// For the foundational Scorer PR, we only track the primary target endpoint.
-	primaryResult := result.ProfileResults[result.PrimaryProfileName]
-	if primaryResult == nil || len(primaryResult.TargetEndpoints) == 0 {
-		return
-	}
-
-	for _, endpoint := range primaryResult.TargetEndpoints {
+	for _, profileResult := range result.ProfileResults {
+		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+			continue
+		}
+		// Only track the first endpoint (the primary target), as requested by reviewers.
+		endpoint := profileResult.TargetEndpoints[0]
 		if endpoint == nil || endpoint.GetMetadata() == nil {
 			continue
 		}
@@ -132,17 +120,49 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.
 }
 
 func (p *InFlightLoadProducer) ResponseBody(
-	_ context.Context,
+	ctx context.Context,
 	request *framework.InferenceRequest,
 	resp *requestcontrol.Response,
-	targetEndpoint *datalayer.EndpointMetadata,
+	_ *datalayer.EndpointMetadata,
 ) {
-	// For the foundational Scorer PR, we only perform cleanup on EndOfStream.
-	if targetEndpoint == nil || resp == nil || !resp.EndOfStream {
+	if request == nil || resp == nil {
 		return
 	}
 
-	eid := targetEndpoint.NamespacedName.String()
+	result := request.SchedulingResult
+	if result == nil {
+		return
+	}
+
+	// 1. Early Prefill Release (on first chunk)
+	// Uses the new StartOfStream signal provided by the framework.
+	if resp.StartOfStream {
+		if prefillResult, ok := result.ProfileResults[profilePrefill]; ok && len(prefillResult.TargetEndpoints) > 0 {
+			p.release(prefillResult.TargetEndpoints[0], request)
+		}
+	}
+
+	// 2. Full Cleanup (on completion)
+	if resp.EndOfStream {
+		for name, profileResult := range result.ProfileResults {
+			if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+				continue
+			}
+			// Skip "prefill" as it was already released in the StartOfStream block.
+			// This works perfectly even if StartOfStream and EndOfStream are both true (single chunk).
+			if name == profilePrefill {
+				continue
+			}
+			p.release(profileResult.TargetEndpoints[0], request)
+		}
+	}
+}
+
+func (p *InFlightLoadProducer) release(endpoint framework.Endpoint, request *framework.InferenceRequest) {
+	if endpoint == nil || endpoint.GetMetadata() == nil {
+		return
+	}
+	eid := endpoint.GetMetadata().NamespacedName.String()
 	p.requestTracker.dec(eid)
 	tokens := p.tokenEstimator.Estimate(request)
 	p.tokenTracker.add(eid, -tokens)

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
@@ -82,11 +81,51 @@ func TestInFlightLoadProducer_Lifecycle(t *testing.T) {
 	require.Equal(t, int64(10), producer.tokenTracker.get(endpointID))
 
 	// 2. ResponseBody EndOfStream (Dec)
-	targetEndpoint := &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: endpointName, Namespace: "default"}}
-	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, targetEndpoint)
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
 
 	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
+}
+
+func TestInFlightLoadProducer_MultiPodLifecycle(t *testing.T) {
+	t.Parallel()
+
+	producer := &InFlightLoadProducer{
+		requestTracker: newConcurrencyTracker(),
+		tokenTracker:   newConcurrencyTracker(),
+		tokenEstimator: NewSimpleTokenEstimator(),
+	}
+	ctx := context.Background()
+	podA := "pod-a"
+	podB := "pod-b"
+	idA := fullEndpointName(podA)
+	idB := fullEndpointName(podB)
+
+	// 1. Dispatch to PodA (Prefill) and PodB (Decode)
+	req := makeTokenRequest("multi-req", "1234567890123456") // 10 tokens
+	res := &schedulingtypes.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
+			"prefill": {TargetEndpoints: []schedulingtypes.Endpoint{newStubSchedulingEndpoint(podA)}},
+			"decode":  {TargetEndpoints: []schedulingtypes.Endpoint{newStubSchedulingEndpoint(podB)}},
+		},
+	}
+
+	producer.PreRequest(ctx, req, res)
+	require.Equal(t, int64(1), producer.requestTracker.get(idA))
+	require.Equal(t, int64(1), producer.requestTracker.get(idB))
+
+	// 2. First Chunk arrives (Early Prefill Release)
+	req.SchedulingResult = res
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: false, StartOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(idA), "PodA should be released after first chunk")
+	require.Equal(t, int64(1), producer.requestTracker.get(idB), "PodB should still be busy")
+
+	// 3. Final Chunk arrives (Full Cleanup)
+	producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.requestTracker.get(idA), "PodA should stay clean")
+	require.Equal(t, int64(0), producer.requestTracker.get(idB), "PodB should now be released")
 }
 
 func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
@@ -104,17 +143,13 @@ func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
 	producer.requestTracker.add(endpointID, 10)
 	producer.tokenTracker.add(endpointID, 1000)
 
-	// Simulate Delete Notification
-	pod := &unstructured.Unstructured{}
-	pod.SetNamespace("default")
-	pod.SetName(endpointName)
-
-	event := datalayer.NotificationEvent{
-		Type:   datalayer.EventDelete,
-		Object: pod,
+	// Simulate Delete Notification (Endpoint)
+	eventEndpoint := datalayer.EndpointEvent{
+		Type:     datalayer.EventDelete,
+		Endpoint: newStubSchedulingEndpoint(endpointName),
 	}
 
-	err := producer.ExtractNotification(ctx, event)
+	err := producer.ExtractEndpoint(ctx, eventEndpoint)
 	require.NoError(t, err)
 
 	// Verify Cleanup
@@ -157,9 +192,10 @@ func TestInFlightLoadProducer_ConcurrencyStress(t *testing.T) {
 	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			targetEndpoint := &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: endpointName, Namespace: "default"}}
+			res := makeSchedulingResult(endpointName)
+			req := &schedulingtypes.InferenceRequest{SchedulingResult: res}
 			for range opsPerRoutine {
-				producer.ResponseBody(ctx, nil, &requestcontrol.Response{EndOfStream: true}, targetEndpoint)
+				producer.ResponseBody(ctx, req, &requestcontrol.Response{EndOfStream: true}, nil)
 			}
 		}()
 	}
@@ -199,8 +235,13 @@ func newStubSchedulingEndpoint(name string) *stubSchedulingEndpoint {
 	}
 }
 
-func (f *stubSchedulingEndpoint) GetMetadata() *datalayer.EndpointMetadata { return f.metadata }
-func (f *stubSchedulingEndpoint) Put(key string, val datalayer.Cloneable)  { f.attr.Put(key, val) }
+func (f *stubSchedulingEndpoint) GetMetadata() *datalayer.EndpointMetadata   { return f.metadata }
+func (f *stubSchedulingEndpoint) UpdateMetadata(*datalayer.EndpointMetadata) {}
+func (f *stubSchedulingEndpoint) GetMetrics() *datalayer.Metrics             { return nil }
+func (f *stubSchedulingEndpoint) UpdateMetrics(*datalayer.Metrics)           {}
+func (f *stubSchedulingEndpoint) GetAttributes() datalayer.AttributeMap      { return f.attr }
+func (f *stubSchedulingEndpoint) String() string                             { return "" }
+func (f *stubSchedulingEndpoint) Put(key string, val datalayer.Cloneable)    { f.attr.Put(key, val) }
 func (f *stubSchedulingEndpoint) Get(key string) (datalayer.Cloneable, bool) {
 	return f.attr.Get(key)
 }

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -40,7 +40,8 @@ import (
 // Non-streaming case:
 //
 //	Invoked exactly once with endOfStream=true. It processes the entire response
-//	body as a single "stream" event.
+//
+// body as a single "stream" event.
 func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *RequestContext, responseBytes []byte, endOfStream bool) *RequestContext {
 	logger := log.FromContext(ctx)
 	logger.V(logutil.DEBUG).Info("HandleResponseBody is triggered", "len(responseBytes)", len(responseBytes), "endOfStream", endOfStream)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -106,6 +106,7 @@ type RequestContext struct {
 	RequestSize               int
 	Usage                     fwkrh.Usage
 	ResponseSize              int
+	ResponseBodyStarted       bool
 	ResponseComplete          bool
 	ResponseStatusCode        string
 	RequestRunning            bool

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -192,6 +192,8 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 		return reqCtx, errcommon.Error{Code: errcommon.ResourceExhausted, Msg: fmt.Errorf("failed to find target endpoint: %w", err).Error()}
 	}
 
+	reqCtx.SchedulingRequest.SchedulingResult = result
+
 	// Prepare Request (Populates RequestContext and call PreRequest plugins)
 	// Insert target endpoint to instruct Envoy to route requests to the specified target pod and attach the port number.
 	// Invoke PreRequest registered plugins.
@@ -350,11 +352,14 @@ func (d *Director) HandleResponseHeader(ctx context.Context, reqCtx *handlers.Re
 func (d *Director) HandleResponseBody(ctx context.Context, reqCtx *handlers.RequestContext, endOfStream bool) *handlers.RequestContext {
 	logger := log.FromContext(ctx).WithValues("stage", "bodyChunk")
 	logger.V(logutil.TRACE).Info("Entering HandleResponseBodyChunk")
+	startOfStream := !reqCtx.ResponseBodyStarted
+	reqCtx.ResponseBodyStarted = true
 	response := &fwk.Response{
-		RequestId:   reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
-		Headers:     reqCtx.Response.Headers,
-		EndOfStream: endOfStream,
-		Usage:       reqCtx.Usage,
+		RequestId:     reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
+		Headers:       reqCtx.Response.Headers,
+		StartOfStream: startOfStream,
+		EndOfStream:   endOfStream,
+		Usage:         reqCtx.Usage,
 	}
 	d.runResponseBodyPlugins(ctx, reqCtx.SchedulingRequest, response, reqCtx.TargetPod)
 	reqCtx.Response.DynamicMetadata = response.DynamicMetadata


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR fixes PR #2271 (https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2271)
      because the token-based concurrency detector introduced there was not fully compatible with
      disaggregated prefill/decode (P/D) flows, which is a valid configuration.

This PR provides precise load tracking for disaggregated flows with the following improvements:
* Multi-Pod Tracking: The detector now accounts for all endpoints involved in a multi-profile request,
      not just the primary one.
* Leak Prevention: By using a request-level ledger, the detector ensures that all pods assigned to a
      request are credited upon completion, resolving "zombie load" issues on early client disconnects.
* Early Prefill Release: Plumbed a ResponseStreaming signal that allows the detector to release prefill
      pod load as soon as the first token is received.
* Robustness: Added deep validation for SchedulingResult and Request objects to prevent panics in
      complex lifecycle edge cases.

**Which issue(s) this PR fixes**:
Fixes PR #2271 (https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2271)

**Does this PR introduce a user-facing change?**:
```release-note
None