### PR TITLE
release: include missing staging digests in release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -140,6 +140,8 @@ This document defines the process for releasing Gateway API Inference Extension.
        - `charts/standalone`
        - `epp`
        - `bbr`
+       - `latency-prediction-server`
+       - `latency-training-server`
     3. If an artifact does not yet have a section in `images.yaml` (for example a newly added chart), add a new section before adding the digest mapping.
     **Note:** Add a link to this issue when the PR is merged.
 11. Test the steps in the tagged quickstart guide after the PR merges, for example: `https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v0.1.0-rc.1/pkg/README.md`.

--- a/hack/release-staging-digests.sh
+++ b/hack/release-staging-digests.sh
@@ -41,6 +41,8 @@ images=(
   "charts/standalone"
   "epp"
   "bbr"
+  "latency-prediction-server"
+  "latency-training-server"
 )
 
 find_digest() {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Updates `hack/release-staging-digests.sh` to include missing release artifacts used in k8s.io promotion:
  - `charts/standalone` (already present, retained)
  - `latency-prediction-server`
  - `latency-training-server`
- Updates `.github/ISSUE_TEMPLATE/new-release.md` so the release checklist explicitly requires all of the above artifacts in `k8s.io` `images.yaml` promotion PRs.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
