### PR TITLE
[BBR] Add end-to-end tests with multi-pool routing verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ E2E_IMAGE ?= $(IMAGE_TAG)
 # it is possible though to run e2e tests against clusters other than kind. in such a case, it is the user's responsibility to load
 # the image into the cluster.
 E2E_USE_KIND ?= true
+# BBR E2E configuration
+BBR_E2E_MANIFEST_PATH ?= config/manifests/bbr/sim-deployment.yaml
+BBR_E2E_IMAGE ?= $(BBR_IMAGE_TAG)
 
 SYNCER_IMAGE_NAME := lora-syncer
 SYNCER_IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(SYNCER_IMAGE_NAME)
@@ -176,7 +179,11 @@ test-integration: envtest ## Run integration tests.
 
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests against an existing Kubernetes cluster.
-	MANIFEST_PATH=$(PROJECT_DIR)/$(E2E_MANIFEST_PATH) E2E_IMAGE=$(E2E_IMAGE) USE_KIND=$(E2E_USE_KIND) ./hack/test-e2e.sh
+	MANIFEST_PATH=$(PROJECT_DIR)/$(E2E_MANIFEST_PATH) E2E_IMAGE=$(E2E_IMAGE) USE_KIND=$(E2E_USE_KIND) COMPONENT=epp ./hack/test-e2e.sh
+
+.PHONY: test-e2e-bbr
+test-e2e-bbr: ## Run BBR end-to-end tests against an existing Kubernetes cluster.
+	MANIFEST_PATH=$(PROJECT_DIR)/$(BBR_E2E_MANIFEST_PATH) BBR_E2E_IMAGE=$(BBR_E2E_IMAGE) USE_KIND=$(E2E_USE_KIND) COMPONENT=bbr ./hack/test-e2e.sh
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -16,6 +16,27 @@
 
 set -euox pipefail
 
+COMPONENT=${COMPONENT:-epp}
+
+case "$COMPONENT" in
+  epp)
+    COMPONENT_IMAGE="${E2E_IMAGE}"
+    IMAGE_MAKE_VAR="IMAGE_TAG"
+    IMAGE_MAKE_TARGET="image-kind"
+    TEST_PATH="./test/e2e/epp/"
+    ;;
+  bbr)
+    COMPONENT_IMAGE="${BBR_E2E_IMAGE}"
+    IMAGE_MAKE_VAR="BBR_IMAGE_TAG"
+    IMAGE_MAKE_TARGET="bbr-image-kind"
+    TEST_PATH="./test/e2e/bbr/"
+    ;;
+  *)
+    echo "Unknown component: $COMPONENT. Supported: epp, bbr"
+    exit 1
+    ;;
+esac
+
 install_kind() {
   if ! command -v kind &>/dev/null; then
     echo "kind not found, installing..."
@@ -29,17 +50,22 @@ install_kind() {
   fi
 }
 
+load_image() {
+  local cluster=$1
+  env "KIND_CLUSTER=${cluster}" "${IMAGE_MAKE_VAR}=${COMPONENT_IMAGE}" make "${IMAGE_MAKE_TARGET}"
+}
+
 if [ "$USE_KIND" = "true" ]; then
   install_kind # make sure kind cli is installed
   if ! kubectl config current-context >/dev/null 2>&1; then # if no active kind cluster found
     echo "No active kubecontext found. creating a kind cluster for running the tests..."
     kind create cluster --name inference-e2e
-    KIND_CLUSTER=inference-e2e IMAGE_TAG=${E2E_IMAGE} make image-kind
+    load_image inference-e2e
   else 
     current_context=$(kubectl config current-context)
     current_kind_cluster="${current_context#kind-}"
     echo "Found an active kind cluster ${current_kind_cluster} for running the tests..."
-    KIND_CLUSTER=${current_kind_cluster} IMAGE_TAG=${E2E_IMAGE} make image-kind
+    load_image "${current_kind_cluster}"
   fi 
 else 
   # don't use kind. it's the caller responsibility to load the image into the cluster, we just run the tests.
@@ -50,5 +76,5 @@ else
   fi
 fi
 
-echo "Found an active cluster. Running Go e2e tests in ./epp..."
-go test ./test/e2e/epp/ -v -ginkgo.v
+echo "Found an active cluster. Running ${COMPONENT} e2e tests..."
+go test "${TEST_PATH}" -v -ginkgo.v

--- a/test/e2e/bbr/README.md
+++ b/test/e2e/bbr/README.md
@@ -1,0 +1,49 @@
+# BBR End-to-End Tests
+
+This document provides instructions on how to run the BBR (Body Based Router) end-to-end tests.
+
+## Overview
+
+The end-to-end tests validate BBR's core production behavior: request body parsing, model name extraction, base model lookup via ConfigMaps, header mutation (`X-Gateway-Base-Model-Name` with `ClearRouteCache`), and header-based routing to distinct backend clusters. These tests are executed against a Kubernetes cluster and use the Ginkgo testing framework.
+
+## Prerequisites
+
+- [Go](https://golang.org/doc/install) installed on your machine.
+- [Make](https://www.gnu.org/software/make/manual/make.html) installed to run the end-to-end test target.
+- [Docker](https://docs.docker.com/get-docker/) installed for building the BBR image.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) configured with access to a Kubernetes cluster.
+
+## Running the End-to-End Tests
+
+Follow these steps to run the end-to-end tests:
+
+1. **Clone the Repository**: Clone the `gateway-api-inference-extension` repository:
+
+   ```sh
+   git clone https://github.com/kubernetes-sigs/gateway-api-inference-extension.git && cd gateway-api-inference-extension
+   ```
+
+1. **Optional Settings**
+
+   - **Set the test namespace**: By default, the e2e test creates resources in the `bbr-e2e` namespace.
+     If you would like to change this namespace, set the following environment variable:
+
+     ```sh
+     export E2E_NS=<MY_NS>
+     ```
+
+   - **Pause before cleanup**: To pause the test run before cleaning up resources, set the `E2E_PAUSE_ON_EXIT` environment variable.
+     This is useful for debugging the state of the cluster after the test has run.
+
+     - To pause indefinitely, set it to `true`: `export E2E_PAUSE_ON_EXIT=true`
+     - To pause for a specific duration, provide a duration string: `export E2E_PAUSE_ON_EXIT=10m`
+
+1. **Run the Tests**: Run the `test-e2e-bbr` target:
+
+   ```sh
+   make test-e2e-bbr
+   ```
+
+   The test suite deploys two model server simulators (Llama + DeepSeek), a BBR instance, an Envoy proxy
+   with `ext_proc` routing, and a curl client pod. It then validates base model routing, LoRA adapter routing,
+   streaming request handling, and BBR metrics exposure.

--- a/test/e2e/bbr/e2e_suite_test.go
+++ b/test/e2e/bbr/e2e_suite_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bbr
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
+)
+
+const (
+	defaultNsName       = "bbr-e2e"
+	deepseekModelServer = "vllm-deepseek-r1"
+	llamaModelServer    = "vllm-llama3-8b-instruct"
+	bbrName             = "bbr"
+	envoyName           = "envoy"
+	envoyPort           = "8081"
+	clientManifest      = "../../testdata/client.yaml"
+	bbrManifest         = "../../testdata/bbr-deployment-e2e.yaml"
+	envoyManifest       = "../../testdata/envoy-bbr.yaml"
+	bbrImageEnvVar      = "BBR_E2E_IMAGE"
+	manifestPathEnvVar  = "MANIFEST_PATH"
+)
+
+var (
+	testConfig *testutils.TestConfig
+	bbrImage   string
+)
+
+func TestBBR(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t,
+		"BBR End To End Test Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	nsName := os.Getenv("E2E_NS")
+	if nsName == "" {
+		nsName = defaultNsName
+	}
+	testConfig = testutils.NewTestConfig(nsName, "")
+
+	bbrImage = os.Getenv(bbrImageEnvVar)
+	gomega.Expect(bbrImage).NotTo(gomega.BeEmpty(), bbrImageEnvVar+" environment variable is not set")
+
+	ginkgo.By("Setting up the test suite")
+	setupSuite()
+
+	ginkgo.By("Creating test infrastructure")
+	setupInfra()
+})
+
+func setupSuite() {
+	err := clientgoscheme.AddToScheme(testConfig.Scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	testConfig.CreateCli()
+}
+
+func setupInfra() {
+	modelServerManifestPath := readModelServerManifestPath()
+	createNamespace(testConfig)
+
+	ginkgo.By("Deploying DeepSeek model server from MANIFEST_PATH")
+	modelServerManifestArray := getYamlsFromModelServerManifest(modelServerManifestPath)
+	createModelServer(testConfig, modelServerManifestArray)
+
+	ginkgo.By("Deploying BBR, Llama model server, ConfigMaps, and Services")
+	createBBR(testConfig, bbrManifest)
+
+	ginkgo.By("Waiting for Llama model server to be available")
+	waitForDeployment(testConfig, llamaModelServer)
+
+	ginkgo.By("Waiting for DeepSeek model server to be available")
+	waitForDeployment(testConfig, deepseekModelServer)
+
+	createClient(testConfig, clientManifest)
+	createEnvoy(testConfig, envoyManifest)
+
+	ginkgo.By("Waiting for Envoy proxy to be available")
+	waitForDeployment(testConfig, envoyName)
+}
+
+var _ = ginkgo.AfterSuite(func() {
+	if pauseStr := os.Getenv("E2E_PAUSE_ON_EXIT"); pauseStr != "" {
+		ginkgo.By("Pausing before cleanup as requested by E2E_PAUSE_ON_EXIT=" + pauseStr)
+		pauseDuration, err := time.ParseDuration(pauseStr)
+		if err != nil {
+			ginkgo.By("Invalid duration, pausing indefinitely. Press Ctrl+C to stop.")
+			select {}
+		}
+		ginkgo.By(fmt.Sprintf("Pausing for %v...", pauseDuration))
+		time.Sleep(pauseDuration)
+	}
+
+	ginkgo.By("Performing global cleanup")
+	cleanupResources()
+})
+
+func cleanupResources() {
+	if testConfig.K8sClient == nil {
+		return
+	}
+
+	deleteBBRClusterResources()
+	deleteNamespace()
+}
+
+func deleteBBRClusterResources() {
+	ctx := testConfig.Context
+	c := testConfig.K8sClient
+
+	for _, obj := range []client.Object{
+		&rbacv1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: "bbr-auth-reviewer-binding"}},
+		&rbacv1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: "bbr-auth-reviewer"}},
+	} {
+		_ = c.Delete(ctx, obj)
+	}
+}
+
+func deleteNamespace() {
+	if testConfig.NsName == "default" {
+		return
+	}
+	ns := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: testConfig.NsName}}
+	_ = testConfig.K8sClient.Delete(testConfig.Context, ns)
+}
+
+func createNamespace(tc *testutils.TestConfig) {
+	ginkgo.By("Creating e2e namespace: " + tc.NsName)
+	obj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: tc.NsName,
+		},
+	}
+	err := tc.K8sClient.Create(tc.Context, obj)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create e2e test namespace")
+}
+
+func namespaceExists(tc *testutils.TestConfig) {
+	ginkgo.By("Ensuring namespace exists: " + tc.NsName)
+	testutils.EventuallyExists(tc, func() error {
+		return tc.K8sClient.Get(tc.Context,
+			types.NamespacedName{Name: tc.NsName}, &corev1.Namespace{})
+	})
+}
+
+func readModelServerManifestPath() string {
+	ginkgo.By(fmt.Sprintf("Ensuring %s environment variable is set", manifestPathEnvVar))
+	path := os.Getenv(manifestPathEnvVar)
+	gomega.Expect(path).NotTo(gomega.BeEmpty(), manifestPathEnvVar+" is not set")
+	return path
+}
+
+func getYamlsFromModelServerManifest(path string) []string {
+	ginkgo.By("Ensuring the model server manifest points to an existing file")
+	manifests := testutils.ReadYaml(path)
+	gomega.Expect(manifests).NotTo(gomega.BeEmpty())
+	return manifests
+}
+
+func createClient(tc *testutils.TestConfig, filePath string) {
+	ginkgo.By("Creating client resources from manifest: " + filePath)
+	testutils.ApplyYAMLFile(tc, filePath)
+}
+
+func createModelServer(tc *testutils.TestConfig, manifestArray []string) {
+	ginkgo.By("Creating model server resources")
+	testutils.CreateObjsFromYaml(tc, manifestArray)
+}
+
+func createBBR(tc *testutils.TestConfig, filePath string) {
+	inManifests := testutils.ReadYaml(filePath)
+	ginkgo.By("Replacing placeholders with environment variables")
+	outManifests := make([]string, 0, len(inManifests))
+	replacer := strings.NewReplacer(
+		"$E2E_NS", tc.NsName,
+		"$BBR_E2E_IMAGE", bbrImage,
+	)
+	for _, manifest := range inManifests {
+		outManifests = append(outManifests, replacer.Replace(manifest))
+	}
+
+	ginkgo.By("Creating BBR resources from manifest: " + filePath)
+	testutils.CreateObjsFromYaml(tc, outManifests)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      bbrName,
+			Namespace: tc.NsName,
+		},
+	}
+	testutils.DeploymentAvailable(tc, deploy)
+}
+
+func createEnvoy(tc *testutils.TestConfig, filePath string) {
+	inManifests := testutils.ReadYaml(filePath)
+	ginkgo.By("Replacing placeholder namespace with E2E_NS environment variable")
+	outManifests := make([]string, 0, len(inManifests))
+	for _, m := range inManifests {
+		outManifests = append(outManifests, strings.ReplaceAll(m, "$E2E_NS", tc.NsName))
+	}
+
+	ginkgo.By("Creating envoy proxy resources from manifest: " + filePath)
+	testutils.CreateObjsFromYaml(tc, outManifests)
+}
+
+func waitForDeployment(tc *testutils.TestConfig, name string) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: tc.NsName,
+		},
+	}
+	testutils.DeploymentAvailable(tc, deploy)
+}

--- a/test/e2e/bbr/e2e_test.go
+++ b/test/e2e/bbr/e2e_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bbr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "sigs.k8s.io/gateway-api-inference-extension/test/utils"
+)
+
+const (
+	defaultCurlTimeout  = 30 * time.Second
+	defaultCurlInterval = 5 * time.Second
+	maxRetries          = 5
+	backoff             = 5 * time.Second
+)
+
+var (
+	curlTimeout  = getEnvDuration("CURL_TIMEOUT", defaultCurlTimeout)
+	curlInterval = defaultCurlInterval
+)
+
+func getEnvDuration(key string, defaultVal time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return defaultVal
+}
+
+var _ = ginkgo.Describe("BBR", func() {
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Waiting for the namespace to exist.")
+		namespaceExists(testConfig)
+	})
+
+	ginkgo.When("The BBR extension is running with multi-pool routing", func() {
+		ginkgo.It("Should route base models to the correct pool", func() {
+			verifyBaseModelRouting()
+		})
+
+		ginkgo.It("Should route LoRA adapters to the correct pool via base model lookup", func() {
+			verifyLoRARouting()
+		})
+
+		ginkgo.It("Should handle streaming requests with correct pool routing", func() {
+			verifyStreamingRouting()
+		})
+
+		ginkgo.It("Should expose BBR metrics after processing traffic", func() {
+			verifyBBRMetrics()
+		})
+	})
+})
+
+func verifyBaseModelRouting() {
+	ginkgo.By("Verifying base model requests route to the correct pool")
+
+	for _, tc := range []struct {
+		api          string
+		model        string
+		expectedPool string
+		prompt       any
+	}{
+		{
+			api:          "/chat/completions",
+			model:        "meta-llama/Llama-3.1-8B-Instruct",
+			expectedPool: "llama",
+			prompt: []map[string]any{
+				{"role": "user", "content": "Hello from Llama"},
+			},
+		},
+		{
+			api:          "/completions",
+			model:        "deepseek/vllm-deepseek-r1",
+			expectedPool: "deepseek",
+			prompt:       "Hello from DeepSeek",
+		},
+	} {
+		ginkgo.By(fmt.Sprintf("Sending %s request with base model %q, expecting pool %q", tc.api, tc.model, tc.expectedPool))
+		resp := sendRequestWithRetry(tc.api, tc.model, tc.prompt, false)
+
+		gomega.Expect(resp).To(gomega.ContainSubstring("200 OK"),
+			fmt.Sprintf("Expected 200 OK for base model %s", tc.model))
+		gomega.Expect(resp).To(gomega.ContainSubstring("x-bbr-routed-pool: "+tc.expectedPool),
+			fmt.Sprintf("Expected routing to pool %q for base model %s, got response:\n%s", tc.expectedPool, tc.model, resp))
+	}
+}
+
+func verifyLoRARouting() {
+	ginkgo.By("Verifying LoRA adapter requests route via base model lookup")
+
+	for _, tc := range []struct {
+		api          string
+		model        string
+		expectedPool string
+		prompt       any
+	}{
+		{
+			api:          "/chat/completions",
+			model:        "food-review-1",
+			expectedPool: "llama",
+			prompt: []map[string]any{
+				{"role": "user", "content": "Review this pasta dish"},
+			},
+		},
+		{
+			api:          "/completions",
+			model:        "ski-resorts",
+			expectedPool: "deepseek",
+			prompt:       "Tell me about the best ski resorts",
+		},
+		{
+			api:          "/chat/completions",
+			model:        "movie-critique",
+			expectedPool: "deepseek",
+			prompt: []map[string]any{
+				{"role": "user", "content": "Review the latest sci-fi movie"},
+			},
+		},
+	} {
+		ginkgo.By(fmt.Sprintf("Sending %s request with LoRA %q, expecting pool %q", tc.api, tc.model, tc.expectedPool))
+		resp := sendRequestWithRetry(tc.api, tc.model, tc.prompt, false)
+
+		gomega.Expect(resp).To(gomega.ContainSubstring("200 OK"),
+			fmt.Sprintf("Expected 200 OK for LoRA %s", tc.model))
+		gomega.Expect(resp).To(gomega.ContainSubstring("x-bbr-routed-pool: "+tc.expectedPool),
+			fmt.Sprintf("Expected routing to pool %q for LoRA %s, got response:\n%s", tc.expectedPool, tc.model, resp))
+	}
+}
+
+func verifyStreamingRouting() {
+	ginkgo.By("Verifying streaming requests route correctly and produce SSE output")
+
+	for _, tc := range []struct {
+		model        string
+		expectedPool string
+	}{
+		{
+			model:        "food-review-1",
+			expectedPool: "llama",
+		},
+		{
+			model:        "ski-resorts",
+			expectedPool: "deepseek",
+		},
+	} {
+		ginkgo.By(fmt.Sprintf("Sending streaming request with model %q, expecting pool %q", tc.model, tc.expectedPool))
+		resp := sendRequestWithRetry("/chat/completions", tc.model, []map[string]any{
+			{"role": "user", "content": "Streaming test"},
+		}, true)
+
+		gomega.Expect(resp).To(gomega.ContainSubstring("200 OK"),
+			fmt.Sprintf("Expected 200 OK for streaming model %s", tc.model))
+		gomega.Expect(resp).To(gomega.ContainSubstring("x-bbr-routed-pool: "+tc.expectedPool),
+			fmt.Sprintf("Expected routing to pool %q for streaming model %s", tc.expectedPool, tc.model))
+		gomega.Expect(resp).To(gomega.ContainSubstring("data: "),
+			fmt.Sprintf("Expected SSE data chunks in streaming response for model %s", tc.model))
+	}
+}
+
+func verifyBBRMetrics() {
+	ginkgo.By("Generating traffic through BBR to populate metrics")
+	for _, model := range []string{"food-review-1", "ski-resorts", "movie-critique"} {
+		_ = sendRequestWithRetry("/completions", model, "Metrics test prompt", false)
+	}
+
+	ginkgo.By("Scraping metrics from the BBR endpoint")
+	bbrPodIP := findBBRPodIP()
+	metricScrapeCmd := []string{
+		"curl", "-i", "--max-time", strconv.Itoa(int(6 * curlTimeout.Seconds())),
+		fmt.Sprintf("http://%s:%d/metrics", bbrPodIP, 9090),
+	}
+
+	expectedMetrics := []string{
+		"bbr_success_total",
+		"bbr_info",
+	}
+
+	ginkgo.By("Verifying that all expected BBR metrics are present")
+	gomega.Eventually(func() error {
+		resp, err := testutils.ExecCommandInPod(testConfig, "curl", "curl", metricScrapeCmd)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(resp, "200 OK") {
+			return fmt.Errorf("did not get 200 OK from metrics endpoint: %s", resp)
+		}
+		for _, metric := range expectedMetrics {
+			if !strings.Contains(resp, metric) {
+				return fmt.Errorf("expected metric %s not found in metrics output", metric)
+			}
+		}
+		return nil
+	}, testConfig.ReadyTimeout, curlInterval).Should(gomega.Succeed())
+}
+
+func sendRequestWithRetry(api, model string, prompt any, streaming bool) string {
+	curlCmd := buildCurlCommand(envoyName, testConfig.NsName, envoyPort, model, curlTimeout, api, prompt, streaming)
+
+	var resp string
+	var err error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		resp, err = testutils.ExecCommandInPod(testConfig, "curl", "curl", curlCmd)
+		if err == nil && strings.Contains(resp, "200 OK") {
+			return resp
+		}
+		if attempt < maxRetries {
+			time.Sleep(backoff)
+		}
+	}
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Expected curl command to succeed")
+	gomega.Expect(resp).To(gomega.ContainSubstring("200 OK"),
+		fmt.Sprintf("Expected 200 OK for model %s via %s after %d retries, got:\n%s", model, api, maxRetries, resp))
+	return resp
+}
+
+func findBBRPodIP() string {
+	var podIP string
+	gomega.Eventually(func(g gomega.Gomega) {
+		podList := &corev1.PodList{}
+		err := testConfig.K8sClient.List(testConfig.Context, podList,
+			client.InNamespace(testConfig.NsName),
+			client.MatchingLabels{"app": bbrName})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		foundReady := false
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					g.Expect(pod.Status.PodIP).NotTo(gomega.BeEmpty(), "Ready BBR pod must have an IP")
+					podIP = pod.Status.PodIP
+					foundReady = true
+					break
+				}
+			}
+			if foundReady {
+				break
+			}
+		}
+		g.Expect(foundReady).To(gomega.BeTrue(), "No ready BBR pod found")
+	}, testConfig.ReadyTimeout, testConfig.Interval).Should(gomega.Succeed())
+	return podIP
+}
+
+func buildCurlCommand(name, ns, port, model string, timeout time.Duration, api string, promptOrMessages any, streaming ...bool) []string {
+	body := map[string]any{
+		"model":       model,
+		"max_tokens":  100,
+		"temperature": 0,
+	}
+	switch api {
+	case "/completions":
+		body["prompt"] = promptOrMessages
+	case "/chat/completions":
+		body["messages"] = promptOrMessages
+	}
+	if len(streaming) > 0 && streaming[0] {
+		body["stream"] = true
+		body["stream_options"] = map[string]any{
+			"include_usage": true,
+		}
+	}
+	b, err := json.Marshal(body)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return []string{
+		"curl",
+		"-i",
+		"--max-time",
+		strconv.Itoa(int(timeout.Seconds())),
+		fmt.Sprintf("%s.%s.svc:%s/v1%s", name, ns, port, api),
+		"-H",
+		"Content-Type: application/json",
+		"-H",
+		"Cache-Control: no-cache",
+		"-H",
+		"Connection: close",
+		"-d",
+		string(b),
+	}
+}

--- a/test/testdata/bbr-deployment-e2e.yaml
+++ b/test/testdata/bbr-deployment-e2e.yaml
@@ -1,0 +1,213 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: $E2E_NS
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct
+  template:
+    metadata:
+      labels:
+        app: vllm-llama3-8b-instruct
+    spec:
+      containers:
+      - name: vllm-sim
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
+        args:
+        - --model
+        - meta-llama/Llama-3.1-8B-Instruct
+        - --port
+        - "8000"
+        - --max-loras
+        - "2"
+        - --lora-modules
+        - '{"name": "food-review-1"}'
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: $E2E_NS
+spec:
+  selector:
+    app: vllm-llama3-8b-instruct
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-llama3-8b-instruct-adapters-allowlist
+  namespace: $E2E_NS
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+data:
+  baseModel: meta-llama/Llama-3.1-8B-Instruct
+  adapters: |
+    - food-review-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-deepseek-r1
+  namespace: $E2E_NS
+spec:
+  selector:
+    app: vllm-deepseek-r1
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bbr
+  namespace: $E2E_NS
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bbr-configmap-reader
+  namespace: $E2E_NS
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bbr-configmap-reader-binding
+  namespace: $E2E_NS
+subjects:
+- kind: ServiceAccount
+  name: bbr
+  namespace: $E2E_NS
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bbr-configmap-reader
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bbr-auth-reviewer
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bbr-auth-reviewer-binding
+subjects:
+- kind: ServiceAccount
+  name: bbr
+  namespace: $E2E_NS
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bbr-auth-reviewer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bbr
+  namespace: $E2E_NS
+  labels:
+    app: bbr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bbr
+  template:
+    metadata:
+      labels:
+        app: bbr
+    spec:
+      serviceAccountName: bbr
+      containers:
+      - name: bbr
+        image: $BBR_E2E_IMAGE
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--streaming"
+        - "--grpc-port"
+        - "9004"
+        - "--grpc-health-port"
+        - "9005"
+        - "--v"
+        - "4"
+        - "--zap-encoder"
+        - "json"
+        - "--metrics-endpoint-auth=false"
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 9004
+        - containerPort: 9005
+        - name: metrics
+          containerPort: 9090
+        livenessProbe:
+          grpc:
+            port: 9005
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          grpc:
+            port: 9005
+          initialDelaySeconds: 5
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bbr
+  namespace: $E2E_NS
+spec:
+  selector:
+    app: bbr
+  ports:
+  - protocol: TCP
+    port: 9004
+    targetPort: 9004
+    appProtocol: http2
+  type: ClusterIP

--- a/test/testdata/envoy-bbr.yaml
+++ b/test/testdata/envoy-bbr.yaml
@@ -1,0 +1,295 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy
+  labels:
+    app: envoy
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 19000
+      access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            path: /dev/null
+    static_resources:
+      listeners:
+        - name: envoy-proxy-ready-0.0.0.0-19001
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 19001
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: envoy-ready-http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                        - name: prometheus_stats
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: "/stats/prometheus"
+                              route:
+                                cluster: "prometheus_stats"
+                    http_filters:
+                      - name: envoy.filters.http.health_check
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                          pass_through_mode: false
+                          headers:
+                            - name: ":path"
+                              string_match:
+                                exact: "/ready"
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        - name: bbr-listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 8081
+          per_connection_buffer_limit_bytes: 32768
+          filter_chains:
+            - name: bbr
+              filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: http-8081
+                    route_config:
+                      name: bbr-multi-pool
+                      virtual_hosts:
+                        - name: bbr-routed
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: "/"
+                                headers:
+                                  - name: X-Gateway-Base-Model-Name
+                                    string_match:
+                                      exact: "meta-llama/Llama-3.1-8B-Instruct"
+                              route:
+                                cluster: llama_model_server
+                                timeout: 86400s
+                                idle_timeout: 86400s
+                              response_headers_to_add:
+                                - header:
+                                    key: x-bbr-routed-pool
+                                    value: llama
+                                  append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                            - match:
+                                prefix: "/"
+                                headers:
+                                  - name: X-Gateway-Base-Model-Name
+                                    string_match:
+                                      exact: "deepseek/vllm-deepseek-r1"
+                              route:
+                                cluster: deepseek_model_server
+                                timeout: 86400s
+                                idle_timeout: 86400s
+                              response_headers_to_add:
+                                - header:
+                                    key: x-bbr-routed-pool
+                                    value: deepseek
+                                  append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                            - match:
+                                prefix: "/"
+                              route:
+                                cluster: llama_model_server
+                                timeout: 86400s
+                                idle_timeout: 86400s
+                              response_headers_to_add:
+                                - header:
+                                    key: x-bbr-routed-pool
+                                    value: unrouted
+                                  append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                    http_filters:
+                      - name: envoy.filters.http.ext_proc
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                          grpc_service:
+                            envoy_grpc:
+                              cluster_name: bbr_ext_proc
+                              authority: bbr.$E2E_NS:9004
+                            timeout: 10s
+                          processing_mode:
+                            request_header_mode: SEND
+                            response_header_mode: SKIP
+                            request_body_mode: FULL_DUPLEX_STREAMED
+                            response_body_mode: NONE
+                            request_trailer_mode: SEND
+                            response_trailer_mode: SKIP
+                          message_timeout: 1000s
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                          suppress_envoy_headers: true
+                    http2_protocol_options:
+                      max_concurrent_streams: 100
+                      initial_stream_window_size: 65536
+                      initial_connection_window_size: 1048576
+                    use_remote_address: true
+                    normalize_path: true
+                    merge_slashes: true
+                    server_header_transformation: PASS_THROUGH
+                    common_http_protocol_options:
+                      headers_with_underscores_action: REJECT_REQUEST
+                    path_with_escaped_slashes_action: UNESCAPE_AND_REDIRECT
+                    access_log:
+                      - name: envoy.access_loggers.file
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                          path: /dev/stdout
+      clusters:
+        - name: prometheus_stats
+          type: STATIC
+          connect_timeout: 0.250s
+          load_assignment:
+            cluster_name: prometheus_stats
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 19000
+        - name: llama_model_server
+          type: STRICT_DNS
+          connect_timeout: 10s
+          load_assignment:
+            cluster_name: llama_model_server
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: vllm-llama3-8b-instruct.$E2E_NS
+                          port_value: 8000
+        - name: deepseek_model_server
+          type: STRICT_DNS
+          connect_timeout: 10s
+          load_assignment:
+            cluster_name: deepseek_model_server
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: vllm-deepseek-r1.$E2E_NS
+                          port_value: 8000
+        - name: bbr_ext_proc
+          type: STRICT_DNS
+          connect_timeout: 86400s
+          lb_policy: LEAST_REQUEST
+          circuit_breakers:
+            thresholds:
+              - max_connections: 40000
+                max_pending_requests: 40000
+                max_requests: 40000
+                max_retries: 1024
+          health_checks:
+            - timeout: 2s
+              interval: 10s
+              unhealthy_threshold: 3
+              healthy_threshold: 2
+              reuse_connection: true
+              grpc_health_check:
+                service_name: "envoy.service.ext_proc.v3.ExternalProcessor"
+              tls_options:
+                alpn_protocols: ["h2"]
+          transport_socket:
+            name: "envoy.transport_sockets.tls"
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                validation_context:
+                  trust_chain_verification: ACCEPT_UNTRUSTED
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options:
+                  connection_keepalive:
+                    interval: 30s
+                    timeout: 5s
+          load_assignment:
+            cluster_name: bbr_ext_proc
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: bbr.$E2E_NS
+                          port_value: 9004
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+  labels:
+    app: envoy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: envoy
+  template:
+    metadata:
+      labels:
+        app: envoy
+    spec:
+      containers:
+        - name: envoy
+          image: docker.io/envoyproxy/envoy:distroless-v1.33.2
+          ports:
+            - containerPort: 8081
+              protocol: TCP
+            - containerPort: 19001
+              protocol: TCP
+          command:
+            - "envoy"
+          args:
+            - "--config-path"
+            - "/etc/envoy/envoy.yaml"
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 19001
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 19001
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: envoy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy
+  labels:
+    app: envoy
+spec:
+  selector:
+    app: envoy
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8081
+      targetPort: 8081


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

Adds a comprehensive Ginkgo/Gomega E2E test suite for the Body Based Router (BBR) that validates its core production behavior: request body parsing, model name extraction, base model lookup via ConfigMaps, header mutation (`X-Gateway-Base-Model-Name` with `ClearRouteCache`), and header-based routing to distinct backend clusters.

The test infrastructure deploys two model server simulators (Llama + DeepSeek) with LoRA adapters, an Envoy proxy with `ext_proc` filter routing to BBR, and header-based routing with `x-bbr-routed-pool` response headers for explicit pool verification.

Test cases:
1. **Base model routing** — verifies base models route to the correct pool via `x-bbr-routed-pool` header, covering both `/completions` and `/chat/completions` APIs.
2. **LoRA adapter routing** — verifies BBR resolves LoRA adapter names to the correct base model via ConfigMap lookup, routing to the correct pool.
3. **Streaming routing** — verifies streaming requests route correctly and SSE `data:` chunks arrive at the client.
4. **BBR metrics** — scrapes BBR's Prometheus endpoint and verifies `bbr_success_total` and `bbr_info` metrics.

Run with `make test-e2e-bbr`. Follows the same pattern as the existing EPP E2E tests.

**Which issue(s) this PR fixes**:

Relates to #2493

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

---

> [!NOTE]
> **Reviewer note — `hack/test-e2e.sh` unification**
>
> This PR modifies the existing `hack/test-e2e.sh` rather than adding a separate `hack/test-e2e-bbr.sh` script. The two scripts would have been ~95% identical (Kind setup, cluster detection, image loading), differing only in the image variable, make target, and test path.
>
> The unified script uses a `COMPONENT` environment variable (`epp` by default, set by the Makefile targets), so `make test-e2e` continues to work identically with zero behavioral change for EPP.
>
> Note: the existing `test-e2e` Makefile target still addresses EPP (not renamed to `test-e2e-epp`), since renaming it would affect the EPP README, conformance docs, and developer workflows — out of scope for this PR.
>
> If reviewers prefer keeping separate scripts or renaming the targets, happy to adjust.