### PR TITLE
fix: log correct error from Prepare Data Plugins

### DIFF
--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -166,7 +166,8 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	snapshotOfCandidatePods := d.toSchedulerPodMetrics(candidatePods)
 
 	// Prepare per request data by running PrepareData plugins.
-	if d.runPrepareDataPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods) != nil {
+	err = d.runPrepareDataPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
+	if err != nil {
 		// Don't fail the request if PrepareData plugins fail.
 		logger.V(logutil.DEFAULT).Error(err, "failed to prepare per request data")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
`HandleRequest()` ignored the error returned by `runPrepareDataPlugins` and logged a stale `err` variable, causing misleading logs. 
Capture and log the actual returned error to improve observability.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes  #2508

**Does this PR introduce a user-facing change?**:
NONE

