### PR TITLE
chore(conformance): bump gateway-api to v1.5.0

### DIFF
--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -7,9 +7,9 @@ replace sigs.k8s.io/gateway-api-inference-extension => ../
 replace cloud.google.com/go/storage => cloud.google.com/go/storage v1.59.2
 
 require (
-	sigs.k8s.io/gateway-api v0.0.0-20260204183637-83afaade28bd
+	sigs.k8s.io/gateway-api v1.5.0
 	sigs.k8s.io/gateway-api-inference-extension v0.0.0-00010101000000-000000000000
-	sigs.k8s.io/gateway-api/conformance v0.0.0-20260204183637-83afaade28bd
+	sigs.k8s.io/gateway-api/conformance v1.5.0
 )
 
 require (

--- a/conformance/go.sum
+++ b/conformance/go.sum
@@ -95,8 +95,8 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTUGI4=
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
-github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
-github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
+github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
+github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
@@ -180,10 +180,10 @@ k8s.io/utils v0.0.0-20260108192941-914a6e750570 h1:JT4W8lsdrGENg9W+YwwdLJxklIuKW
 k8s.io/utils v0.0.0-20260108192941-914a6e750570/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
 sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
-sigs.k8s.io/gateway-api v0.0.0-20260204183637-83afaade28bd h1:xJ+tvf2XNl15jKYCOiwOoNzO26yWtAZQm1Y/nv2QFZI=
-sigs.k8s.io/gateway-api v0.0.0-20260204183637-83afaade28bd/go.mod h1:Y5zI1i67c8iSB6AqTCJSvPgKC0xf1Qt0/akYEh4OwRI=
-sigs.k8s.io/gateway-api/conformance v0.0.0-20260204183637-83afaade28bd h1:Pxk5bKt8L+9rklsvNa0ufYck1J/dI/yMeGz6X7ND9mM=
-sigs.k8s.io/gateway-api/conformance v0.0.0-20260204183637-83afaade28bd/go.mod h1:3PSPeSwAMLUZobcQb8R1o0QrzlfUYleLpkzA8qHwzus=
+sigs.k8s.io/gateway-api v1.5.0 h1:duoo14Ky/fJXpjpmyMISE2RTBGnfCg8zICfTYLTnBJA=
+sigs.k8s.io/gateway-api v1.5.0/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
+sigs.k8s.io/gateway-api/conformance v1.5.0 h1:IT966Ph4aSLjdgv9PtAkyLPaSQWN84BTnZ/lqXg9wPo=
+sigs.k8s.io/gateway-api/conformance v1.5.0/go.mod h1:mcvYR0Zll1i5hmcKn+jNbWdZTBls6s5GU+FPUFIceXw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area conformance-machinery

**What this PR does / why we need it**:
Bump the `./conformance` module's Gateway API dependencies to `v1.5.0`.

This updates both:
- `sigs.k8s.io/gateway-api`
- `sigs.k8s.io/gateway-api/conformance`

and refreshes `conformance/go.sum` accordingly.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
