### PR TITLE
datalayer: introduce Runtime core structure

### DIFF
--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+)
+
+// Runtime manages data sources, extractors, their mapping, and endpoint lifecycle.
+type Runtime struct {
+	pollingInterval time.Duration // used for polling sources
+	state           atomic.Int64  // stores RuntimeState
+
+	pollers          sync.Map // Map of polling sources (key=source name, value=PollingDataSource)
+	notifiers        sync.Map // Map of k8s notification sources (key=source name, value=NotificationSource)
+	sourceExtractors sync.Map // Map sources to extractors (key=source name. value=[]Extractor)
+
+	collectors sync.Map // Per-endpoint poller (key=namespaced name, value=*Collector)
+}
+
+const (
+	defaultRefreshInterval = 50 * time.Millisecond
+)
+
+// NewRuntime creates a new Runtime with the given polling interval.
+// If duration is <= 0, uses the defaultRefreshInterval.
+func NewRuntime(pollingInterval time.Duration) *Runtime {
+	interval := defaultRefreshInterval
+	if pollingInterval > 0 {
+		interval = pollingInterval
+	}
+	return &Runtime{
+		pollingInterval: interval,
+		// state defaults to 0 (i.e., StateInitial via iota)
+	}
+}
+
+// Configure is called to transform the configuration information into the Runtime's
+// internal fields.
+func (r *Runtime) Configure(cfg *Config, enableNewMetrics bool, disallowedExtractorType string, logger logr.Logger) error {
+	var err error
+
+	defer func() { // set the state to error on any failure
+		if err != nil {
+			r.setError()
+		}
+	}()
+
+	if err = r.transition(StateInitial, StateConfiguring); err != nil {
+		return err
+	}
+
+	if cfg == nil || len(cfg.Sources) == 0 {
+		if enableNewMetrics {
+			err = errors.New("data layer enabled but no data sources configured")
+			return err
+		}
+		return r.transition(StateConfiguring, StateConfigured)
+	}
+
+	logger.Info("Configuring datalayer runtime", "numSources", len(cfg.Sources))
+
+	pollersCount := 0
+	notifiersCount := 0
+	gvkToSource := make(map[string]string, len(cfg.Sources)) // track GVK uniqueness
+
+	for _, srcCfg := range cfg.Sources {
+		src := srcCfg.Plugin
+		srcName := src.TypedName().Name
+
+		logger.V(1).Info("Processing source", "source", srcName, "numExtractors", len(srcCfg.Extractors))
+		if err = r.validateSourceExtractors(src, srcCfg.Extractors, disallowedExtractorType); err != nil {
+			return err
+		}
+
+		if poller, ok := src.(fwkdl.PollingDataSource); ok { // Register to appropriate map based on type
+			r.pollers.Store(srcName, poller)
+			pollersCount++
+		} else if notifier, ok := src.(fwkdl.NotificationSource); ok {
+			gvk := notifier.GVK().String()
+			if existingSource, exists := gvkToSource[gvk]; exists {
+				err = fmt.Errorf("duplicate notification source GVK %s: already used by source %s, cannot add %s",
+					gvk, existingSource, src.TypedName().String())
+				return err
+			}
+			r.notifiers.Store(srcName, notifier)
+			gvkToSource[gvk] = srcName
+			notifiersCount++
+		} else {
+			err = fmt.Errorf("skipping unknown datasource plugin type %s", src.TypedName().String())
+			return err
+		}
+
+		if len(srcCfg.Extractors) > 0 { // Store extractors mapped to source
+			r.sourceExtractors.Store(srcName, srcCfg.Extractors)
+		}
+
+		extractorNames := make([]string, len(srcCfg.Extractors))
+		for i, ext := range srcCfg.Extractors {
+			extractorNames[i] = ext.TypedName().String()
+		}
+		logger.V(1).Info("Source configured", "source", srcName, "extractors", extractorNames)
+	}
+
+	logger.Info("Datalayer runtime configured", "pollers", pollersCount, "notifiers", notifiersCount)
+	err = r.transition(StateConfiguring, StateConfigured)
+	return err
+}
+
+// Start is called to enable the Runtime to start processing data collection. It wires
+// Kubernetes notifications into the manager.
+func (r *Runtime) Start(ctx context.Context, mgr ctrl.Manager) error {
+	var err error
+
+	defer func() {
+		if err != nil {
+			r.setError()
+		}
+	}()
+
+	if err = r.transition(StateConfigured, StateStarting); err != nil {
+		return err
+	}
+
+	r.notifiers.Range(func(key, val any) bool { // bind notification sources to the manager
+		ns := val.(fwkdl.NotificationSource)
+		srcName := ns.TypedName().Name
+
+		var extractors []fwkdl.NotificationExtractor
+		if rawExts, ok := r.sourceExtractors.Load(srcName); ok {
+			raw := rawExts.([]fwkdl.Extractor)
+			extractors = make([]fwkdl.NotificationExtractor, len(raw))
+			for i, e := range raw {
+				extractors[i] = e.(fwkdl.NotificationExtractor)
+			}
+		}
+
+		if bindErr := BindNotificationSource(ns, extractors, mgr); bindErr != nil {
+			err = fmt.Errorf("failed to bind notification source %s: %w", ns.TypedName(), bindErr)
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+
+	err = r.transition(StateStarting, StateStarted)
+	return err
+}
+
+// Stop is called to terminate the Runtime's data collection. It terminates all
+// go routines used for polling data sources.
+func (r *Runtime) Stop() error {
+	var err error
+
+	defer func() {
+		if err != nil {
+			r.setError()
+		}
+	}()
+
+	if err = r.transition(StateStarted, StateStopping); err != nil {
+		return err
+	}
+
+	r.collectors.Range(func(_, val any) bool {
+		if c, ok := val.(*Collector); ok {
+			_ = c.Stop()
+		}
+		return true
+	})
+
+	err = r.transition(StateStopping, StateStopped)
+	return err
+}
+
+// transition attempts to atomically transition from expectedState to newState.
+// Returns nil on success, or an error if the transition fails.
+// If the transition fails, sets the state to StateError.
+func (r *Runtime) transition(expectedState, newState RuntimeState) error {
+	if r.state.CompareAndSwap(int64(expectedState), int64(newState)) {
+		return nil
+	}
+	r.setError()
+	current := RuntimeState(r.state.Load())
+	return fmt.Errorf("%w: cannot transition from %s to %s", errInvalidRuntimeState, current, newState)
+}
+
+// setError sets the state to StateError atomically.
+func (r *Runtime) setError() {
+	r.state.Store(int64(StateError))
+}
+
+// NewEndpoint sets up data polling on the provided endpoint.
+func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.EndpointMetadata, _ PoolInfo) fwkdl.Endpoint {
+	// TODO: should we cache the sources and map after Configure? Or just replace with maps and Mutex?
+	// The code could be simpler and also would benefit from using RLock mutex for concurrent access
+	// (no change expected) instead of using sync.Map (avoid use of Range just to count, more idiomatic code, etc.).
+	logger, _ := logr.FromContext(ctx)
+	logger = logger.WithValues("endpoint", endpointMetadata.GetNamespacedName())
+
+	var pollers []fwkdl.PollingDataSource
+	r.pollers.Range(func(_, val any) bool {
+		if poller, ok := val.(fwkdl.PollingDataSource); ok {
+			pollers = append(pollers, poller)
+		}
+		return true
+	})
+
+	if len(pollers) == 0 {
+		logger.Info("No polling sources configured, creating endpoint without collector")
+		return fwkdl.NewEndpoint(endpointMetadata, nil)
+	}
+
+	extractors := make(map[string][]fwkdl.Extractor, len(pollers))
+	r.sourceExtractors.Range(func(key, val any) bool {
+		srcName := key.(string)
+		exts := val.([]fwkdl.Extractor)
+		extractors[srcName] = exts
+		return true
+	})
+
+	endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
+	collector := NewCollector()
+
+	key := endpointMetadata.GetNamespacedName()
+	if _, loaded := r.collectors.LoadOrStore(key, collector); loaded {
+		logger.Info("collector already running for endpoint", "endpoint", key)
+		return nil
+	}
+
+	ticker := NewTimeTicker(r.pollingInterval)
+	if err := collector.Start(ctx, ticker, endpoint, pollers, extractors); err != nil {
+		logger.Error(err, "failed to start collector for endpoint", "endpoint", key)
+		r.collectors.Delete(key)
+		return nil
+	}
+
+	return endpoint
+}
+
+// ReleaseEndpoint terminates polling for data on the given endpoint.
+func (r *Runtime) ReleaseEndpoint(ep fwkdl.Endpoint) {
+	key := ep.GetMetadata().GetNamespacedName()
+
+	if value, ok := r.collectors.LoadAndDelete(key); ok {
+		collector := value.(*Collector)
+		_ = collector.Stop()
+	}
+}
+
+// validates the compatibility of data source and configured extractors. This includes
+// expected Extractor type, source output and extractor input type compatibility and
+// optionally source specific validation.
+func (r *Runtime) validateSourceExtractors(src fwkdl.DataSource, extractors []fwkdl.Extractor, disallowedExtractorType string) error {
+	for _, ext := range extractors {
+		// check if disallowed extractor type
+		if disallowedExtractorType != "" && ext.TypedName().Type == disallowedExtractorType {
+			return fmt.Errorf("disallowed Extractor %s is configured for source %s",
+				ext.TypedName().String(), src.TypedName().String())
+		}
+
+		// validate extractor type
+		extractorType := reflect.TypeOf(ext)
+		if err := validateExtractorCompatible(extractorType, src.ExtractorType()); err != nil {
+			return fmt.Errorf("extractor %s type incompatible with datasource %s: %w",
+				ext.TypedName(), src.TypedName(), err)
+		}
+
+		// validate input/output types match
+		if err := validateInputTypeCompatible(src.OutputType(), ext.ExpectedInputType()); err != nil {
+			return fmt.Errorf("extractor %s input type incompatible with datasource %s: %w",
+				ext.TypedName(), src.TypedName(), err)
+		}
+		if notifySrc, ok := src.(fwkdl.NotificationSource); ok {
+			if notifyExt, ok := ext.(fwkdl.NotificationExtractor); ok {
+				if notifySrc.GVK().String() != notifyExt.GVK().String() {
+					return fmt.Errorf("extractor %s GVK %s does not match source %s GVK %s",
+						ext.TypedName(), notifyExt.GVK().String(), src.TypedName(), notifySrc.GVK().String())
+				}
+			}
+		}
+
+		// allow datasource custom validation
+		if validator, ok := src.(fwkdl.ValidatingDataSource); ok {
+			if err := validator.ValidateExtractor(ext); err != nil {
+				return fmt.Errorf("extractor %s failed custom validation for datasource %s: %w",
+					ext.TypedName(), src.TypedName(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// validate input/output type compatibility.
+func validateInputTypeCompatible(dataSourceOutput, extractorInput reflect.Type) error {
+	if dataSourceOutput == nil || extractorInput == nil {
+		return errors.New("data source output type or extractor input type can't be nil")
+	}
+	if dataSourceOutput == extractorInput ||
+		(extractorInput.Kind() == reflect.Interface && extractorInput.NumMethod() == 0) ||
+		(extractorInput.Kind() == reflect.Interface && dataSourceOutput.Implements(extractorInput)) {
+		return nil
+	}
+	return fmt.Errorf("extractor input type %v is not compatible with data source output type %v",
+		extractorInput, dataSourceOutput)
+}
+
+// validate extractor compatibility.
+func validateExtractorCompatible(extractorType reflect.Type, expectedInterfaceType reflect.Type) error {
+	if extractorType == nil || expectedInterfaceType == nil {
+		return errors.New("extractor type or expected interface type can't be nil")
+	}
+	if expectedInterfaceType.Kind() != reflect.Interface {
+		return fmt.Errorf("expected type must be an interface, got %v", expectedInterfaceType.Kind())
+	}
+	if !extractorType.Implements(expectedInterfaceType) {
+		return fmt.Errorf("extractor type %v does not implement interface %v",
+			extractorType, expectedInterfaceType)
+	}
+	return nil
+}

--- a/pkg/epp/datalayer/runtime_state.go
+++ b/pkg/epp/datalayer/runtime_state.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"errors"
+)
+
+var (
+	errInvalidRuntimeState = errors.New("invalid datalayer runtime state")
+)
+
+// RuntimeState represents the lifecycle state of Runtime.
+type RuntimeState int64
+
+const (
+	// StateInitial is the initial state when Runtime is created.
+	StateInitial RuntimeState = iota
+	// StateConfiguring indicates Runtime is currently being configured.
+	StateConfiguring
+	// StateConfigured indicates Runtime has been configured with sources.
+	StateConfigured
+	// StateStarting indicates Runtime is currently starting.
+	StateStarting
+	// StateStarted indicates Runtime is actively managing collectors and reconcilers.
+	StateStarted
+	// StateStopping indicates Runtime is currently stopping.
+	StateStopping
+	// StateStopped indicates Runtime has been stopped.
+	StateStopped
+	// StateError indicates Runtime is in an error state.
+	StateError
+)
+
+// String returns the string representation of RuntimeState.
+func (s RuntimeState) String() string {
+	switch s {
+	case StateInitial:
+		return "initial"
+	case StateConfiguring:
+		return "configuring"
+	case StateConfigured:
+		return "configured"
+	case StateStarting:
+		return "starting"
+	case StateStarted:
+		return "started"
+	case StateStopping:
+		return "stopping"
+	case StateStopped:
+		return "stopped"
+	case StateError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
Add new Runtime struct with state machine for managing data layer lifecycle. This introduces the foundation for the new data layer architecture while keeping the existing datasource.go implementation intact.

Key additions:
- Runtime struct with lifecycle management (Configure, Start, Stop)
- RuntimeState enum with state machine (Initial -> Configuring -> Configured -> Starting -> Started -> Stopping -> Stopped)
- Atomic state transitions with error handling
- Support for both polling and notification-based data sources
- Endpoint factory interface for creating/releasing endpoints

The old datasource.go remains functional. Migration to Runtime will happen in subsequent PRs.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind feature

**What this PR does / why we need it:**
Clearly separate between datalayer plugins (e.g., sources, extractors) and the runtime that manages their interactions.
Plugins should focus solely on their business logic, leaving all validation and orchestration to the runtime.
The new runtime owns all sources and manages thier mapping with extractors.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partially Fixes #2524 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
