### PR TITLE
WIP - Support Openapi /v1/audio/transcriptions 

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -67,6 +67,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
 	testresponsereceived "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/router"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/picker"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/profile"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/scheduling/scorer"
@@ -552,7 +553,7 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 
 	r.applyDeprecatedSaturationConfig(cfg)
 
-	r.parser = handlers.NewParser(cfg.ParserConfig)
+	r.parser = router.NewRouterParser(handlers.NewParser(cfg.ParserConfig))
 	logger.Info("loaded configuration from file/text successfully")
 
 	return cfg, nil

--- a/pkg/bbr/handlers/request.go
+++ b/pkg/bbr/handlers/request.go
@@ -17,9 +17,13 @@ limitations under the License.
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime"
+	"mime/multipart"
+	"strings"
 	"time"
 
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -30,12 +34,30 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 	reqenvoy "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/request"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
 // HandleRequestBody parses the raw body bytes into reqCtx.Request.Body and processes the request.
 func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, requestBodyBytes []byte) ([]*eppb.ProcessingResponse, error) {
 	logger := log.FromContext(ctx)
 	var ret []*eppb.ProcessingResponse
+
+	contentType := getHeader(reqCtx.Request.Headers, "content-type")
+	path := getHeader(reqCtx.Request.Headers, ":path")
+	if strings.Contains(strings.ToLower(contentType), "multipart/form-data") {
+		if !metadata.PathAllowedForMultipartModelExtraction(path) {
+			return bodyOnlyResponse(s.streaming, requestBodyBytes, ret)
+		}
+		model, parseErr := parseModelFromMultipart(requestBodyBytes, contentType)
+		if parseErr != nil || model == "" {
+			metrics.RecordBodyFieldNotFound("model")
+			return bodyOnlyResponse(s.streaming, requestBodyBytes, ret)
+		}
+		metrics.RecordSuccessCounter()
+		reqCtx.Request.SetHeader(ModelHeader, model)
+		reqCtx.Request.SetHeader(BaseModelHeader, s.ds.GetBaseModel(model))
+		return buildHeaderAndBodyResponse(s.streaming, reqCtx, requestBodyBytes, ret)
+	}
 
 	if err := json.Unmarshal(requestBodyBytes, &reqCtx.Request.Body); err != nil {
 		return nil, err
@@ -102,6 +124,78 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 			},
 		},
 	}, nil
+}
+
+func getHeader(headers map[string]string, key string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return ""
+}
+
+func bodyOnlyResponse(streaming bool, body []byte, ret []*eppb.ProcessingResponse) ([]*eppb.ProcessingResponse, error) {
+	if streaming {
+		ret = append(ret, &eppb.ProcessingResponse{
+			Response: &eppb.ProcessingResponse_RequestHeaders{RequestHeaders: &eppb.HeadersResponse{}},
+		})
+		return addStreamedBodyResponse(ret, body), nil
+	}
+	return []*eppb.ProcessingResponse{{Response: &eppb.ProcessingResponse_RequestBody{RequestBody: &eppb.BodyResponse{}}}}, nil
+}
+
+func buildHeaderAndBodyResponse(streaming bool, reqCtx *RequestContext, body []byte, ret []*eppb.ProcessingResponse) ([]*eppb.ProcessingResponse, error) {
+	removed := reqCtx.Request.RemovedHeaders()
+	headerMutation := &eppb.HeaderMutation{
+		SetHeaders: reqenvoy.GenerateHeadersMutation(reqCtx.Request.MutatedHeaders()),
+	}
+	if len(removed) > 0 {
+		headerMutation.RemoveHeaders = removed
+	}
+	if streaming {
+		ret = append(ret, &eppb.ProcessingResponse{
+			Response: &eppb.ProcessingResponse_RequestHeaders{
+				RequestHeaders: &eppb.HeadersResponse{
+					Response: &eppb.CommonResponse{ClearRouteCache: true, HeaderMutation: headerMutation},
+				},
+			},
+		})
+		return addStreamedBodyResponse(ret, body), nil
+	}
+	return []*eppb.ProcessingResponse{{
+		Response: &eppb.ProcessingResponse_RequestBody{
+			RequestBody: &eppb.BodyResponse{
+				Response: &eppb.CommonResponse{ClearRouteCache: true, HeaderMutation: headerMutation},
+			},
+		},
+	}}, nil
+}
+
+func parseModelFromMultipart(body []byte, contentType string) (string, error) {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", err
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return "", nil
+	}
+	r := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		p, err := r.NextPart()
+		if err != nil {
+			break
+		}
+		if p.FormName() == "model" {
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(p); err != nil {
+				return "", err
+			}
+			return strings.TrimSpace(buf.String()), nil
+		}
+	}
+	return "", nil
 }
 
 // runRequestPlugins executes request plugins in the order they were registered.

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"mime/multipart"
 	"strings"
 	"testing"
 
@@ -34,6 +36,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
 func TestHandleRequestHeaders(t *testing.T) {
@@ -508,4 +511,91 @@ func mapToBytes(t *testing.T, m map[string]any) []byte {
 		t.Fatalf("Marshal(): %v", err)
 	}
 	return bytes
+}
+
+func TestHandleRequestBody_Multipart(t *testing.T) {
+	metrics.Register()
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	boundary := "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+	body := buildMultipartBody(t, boundary, "whisper-1", "audio.mp3", []byte("test audio"))
+	contentType := "multipart/form-data; boundary=" + boundary
+
+	server := NewServer(false, &fakeDatastore{}, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+	reqCtx := &RequestContext{Request: framework.NewInferenceRequest()}
+	reqCtx.Request.Headers["content-type"] = contentType
+	reqCtx.Request.Headers[":path"] = metadata.AudioTranscriptionsPathPrefix
+
+	resp, err := server.HandleRequestBody(ctx, reqCtx, body)
+	if err != nil {
+		t.Fatalf("HandleRequestBody: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resp))
+	}
+	br := resp[0].GetRequestBody()
+	if br == nil || br.Response == nil || br.Response.HeaderMutation == nil {
+		t.Fatal("expected header mutation")
+	}
+	var modelHeaderVal string
+	for _, h := range br.Response.HeaderMutation.SetHeaders {
+		if strings.EqualFold(h.Header.Key, ModelHeader) {
+			modelHeaderVal = string(h.Header.RawValue)
+			break
+		}
+	}
+	if modelHeaderVal != "whisper-1" {
+		t.Errorf("X-Gateway-Model-Name = %q, want whisper-1", modelHeaderVal)
+	}
+}
+
+func TestHandleRequestBody_MultipartWrongPath(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	boundary := "----boundary"
+	body := buildMultipartBody(t, boundary, "whisper-1", "audio.mp3", []byte("test audio"))
+	contentType := "multipart/form-data; boundary=" + boundary
+
+	server := NewServer(false, &fakeDatastore{}, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+	reqCtx := &RequestContext{Request: framework.NewInferenceRequest()}
+	reqCtx.Request.Headers["content-type"] = contentType
+	reqCtx.Request.Headers[":path"] = "/v1/video/something"
+
+	resp, err := server.HandleRequestBody(ctx, reqCtx, body)
+	if err != nil {
+		t.Fatalf("HandleRequestBody: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resp))
+	}
+	br := resp[0].GetRequestBody()
+	if br != nil && br.Response != nil && br.Response.HeaderMutation != nil && len(br.Response.HeaderMutation.SetHeaders) > 0 {
+		t.Error("multipart on non-transcriptions path should not set model headers")
+	}
+}
+
+func buildMultipartBody(t *testing.T, boundary, model, filename string, fileContent []byte) []byte {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if boundary != "" {
+		if err := w.SetBoundary(boundary); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if model != "" {
+		if err := w.WriteField("model", model); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if filename != "" && fileContent != nil {
+		part, err := w.CreateFormFile("file", filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := part.Write(fileContent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
 }

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -104,9 +104,19 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		var err error
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
+			if v.RequestHeaders != nil && v.RequestHeaders.Headers != nil {
+				for _, header := range v.RequestHeaders.Headers.Headers {
+					reqCtx.Request.Headers[header.Key] = reqenvoy.GetHeaderValue(header)
+				}
+			}
+			// If streaming and the body is not empty, then headers are handled when processing request body.
 			if s.streaming && !v.RequestHeaders.GetEndOfStream() {
-				// If streaming and the body is not empty, then headers are handled when processing request body.
 				loggerVerbose.Info("Received headers, passing off header processing until body arrives...")
+				responses = []*extProcPb.ProcessingResponse{{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{},
+					},
+				}}
 			} else {
 				if requestId := reqenvoy.ExtractHeaderValue(v, reqcommon.RequestIdHeaderKey); len(requestId) > 0 {
 					logger = logger.WithValues(reqcommon.RequestIdHeaderKey, requestId)
@@ -167,7 +177,8 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 }
 
 type streamedBody struct {
-	body []byte
+	body        []byte
+	contentType string
 }
 
 func (s *Server) processResponseBody(ctx context.Context, reqCtx *RequestContext, body *extProcPb.HttpBody, streamedRespBody *streamedBody) ([]*extProcPb.ProcessingResponse, error) {

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -59,7 +59,7 @@ func (r *LLMRequest) String() string {
 
 // LLMRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
-// An LLMRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, or ConversationsRequest.
+// An LLMRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, or AudioTranscriptionsRequest.
 type LLMRequestBody struct {
 	// CompletionsRequest is the representation of the OpenAI /v1/completions request body.
 	Completions *CompletionsRequest `json:"completions,omitempty"`
@@ -69,6 +69,8 @@ type LLMRequestBody struct {
 	Responses *ResponsesRequest `json:"responses,omitempty"`
 	// ConversationsRequest is the representation of the OpenAI /v1/conversations request body.
 	Conversations *ConversationsRequest `json:"conversations,omitempty"`
+	// AudioTranscriptionsRequest is used for header-only flows. When set, the Director uses ModelName for IncomingModelName/TargetModelName and returns nil body.
+	AudioTranscriptions *AudioTranscriptionsRequest `json:"audio_transcriptions,omitempty"`
 
 	// ParsedBody contains the unmarshaled request payload.
 	// Note: Because this handles multiple protocols, this field is strictly expected
@@ -189,6 +191,11 @@ func (r *ResponsesRequest) String() string {
 		return nilString
 	}
 	return fmt.Sprintf("{InputType: %T, InstructionsType: %T}", r.Input, r.Instructions)
+}
+
+// AudioTranscriptionsRequest represents a header-only request. ModelName is set from the header; body is not parsed.
+type AudioTranscriptionsRequest struct {
+	ModelName string `json:"-"`
 }
 
 // ConversationsRequest represents the OpenAI /v1/conversations request body structure

--- a/pkg/epp/framework/plugins/requesthandling/parsers/router/router.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/router/router.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
+)
+
+const (
+	RouterParserType = "router-parser"
+)
+
+var _ fwkrh.Parser = (*RouterParser)(nil)
+
+// RouterParser wraps a delegate and returns AudioTranscriptionsRequest for allowed header-only paths; otherwise delegates.
+type RouterParser struct {
+	typedName fwkplugin.TypedName
+	delegate  fwkrh.Parser
+}
+
+// NewRouterParser returns a parser that handles allowed header-only paths via AudioTranscriptionsRequest and delegates the rest.
+func NewRouterParser(delegate fwkrh.Parser) *RouterParser {
+	return &RouterParser{
+		typedName: fwkplugin.TypedName{Type: RouterParserType, Name: RouterParserType},
+		delegate:  delegate,
+	}
+}
+
+// TypedName returns the type and name of this plugin.
+func (p *RouterParser) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// ParseRequest returns AudioTranscriptionsRequest for allowed header-only paths; otherwise delegates.
+func (p *RouterParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
+	ct := getHeader(headers, "content-type")
+	path := getHeader(headers, ":path")
+	if strings.Contains(strings.ToLower(ct), "multipart/form-data") && metadata.PathAllowedForMultipartModelExtraction(path) {
+		model := getHeader(headers, metadata.ModelNameKey)
+		if model == "" {
+			return nil, errors.New("multipart request missing x-gateway-model-name header")
+		}
+		return &scheduling.LLMRequestBody{AudioTranscriptions: &scheduling.AudioTranscriptionsRequest{ModelName: model}}, nil
+	}
+	return p.delegate.ParseRequest(ctx, body, headers)
+}
+
+// ParseResponse delegates to the underlying parser.
+func (p *RouterParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endOfStream bool) (*fwkrh.ParsedResponse, error) {
+	return p.delegate.ParseResponse(ctx, body, headers, endOfStream)
+}
+
+func getHeader(headers map[string]string, key string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/router/router_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/router/router_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"testing"
+
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
+)
+
+func TestRouterParser_ParseRequest_MultipartTranscriptions(t *testing.T) {
+	ctx := context.Background()
+	delegate := &mockParser{}
+	p := NewRouterParser(delegate)
+
+	headers := map[string]string{
+		"content-type":         "multipart/form-data; boundary=----boundary",
+		":path":                metadata.AudioTranscriptionsPathPrefix,
+		metadata.ModelNameKey:  "whisper-1",
+	}
+	body := []byte("raw multipart body")
+
+	got, err := p.ParseRequest(ctx, body, headers)
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil LLMRequestBody")
+	}
+	if got.AudioTranscriptions == nil || got.AudioTranscriptions.ModelName != "whisper-1" {
+		t.Errorf("AudioTranscriptions.ModelName = %v, want whisper-1", got.AudioTranscriptions)
+	}
+	if delegate.parseRequestCalled {
+		t.Error("delegate ParseRequest should not be called for multipart transcriptions")
+	}
+}
+
+func TestRouterParser_ParseRequest_MultipartMissingModel(t *testing.T) {
+	ctx := context.Background()
+	delegate := &mockParser{}
+	p := NewRouterParser(delegate)
+
+	headers := map[string]string{
+		"content-type": "multipart/form-data; boundary=----boundary",
+		":path":        metadata.AudioTranscriptionsPathPrefix,
+	}
+	body := []byte("raw multipart body")
+
+	got, err := p.ParseRequest(ctx, body, headers)
+	if err == nil {
+		t.Fatal("expected error when model header missing")
+	}
+	if got != nil {
+		t.Errorf("expected nil body, got %v", got)
+	}
+}
+
+func TestRouterParser_ParseRequest_DelegatesNonMultipart(t *testing.T) {
+	ctx := context.Background()
+	delegate := &mockParser{}
+	p := NewRouterParser(delegate)
+
+	headers := map[string]string{
+		"content-type": "application/json",
+		":path":        "/v1/chat/completions",
+	}
+	body := []byte(`{"model":"gpt-4","messages":[]}`)
+
+	_, _ = p.ParseRequest(ctx, body, headers)
+	if !delegate.parseRequestCalled {
+		t.Error("delegate ParseRequest should be called for non-multipart")
+	}
+}
+
+type mockParser struct {
+	parseRequestCalled bool
+}
+
+var _ fwkrh.Parser = (*mockParser)(nil)
+
+func (m *mockParser) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock", Name: "mock"}
+}
+
+func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
+	m.parseRequestCalled = true
+	return nil, nil
+}
+
+func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endOfStream bool) (*fwkrh.ParsedResponse, error) {
+	return nil, nil
+}

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package metadata
 
+import "strings"
+
 const (
 	// SubsetFilterNamespace is the key for the outer namespace struct in the metadata field of the extproc request that is used to wrap the subset filter.
 	SubsetFilterNamespace = "envoy.lb.subset_hint"
@@ -39,4 +41,23 @@ const (
 	// This ensures that requests without explicit fairness identifiers are still grouped and managed by the Flow Control
 	// system.
 	DefaultFairnessID = "default-flow"
+	// ModelNameKey is the header BBR sets for routing.
+	ModelNameKey = "x-gateway-model-name"
+	// AudioTranscriptionsPathPrefix is the path prefix for /v1/audio/transcriptions.
+	AudioTranscriptionsPathPrefix = "/v1/audio/transcriptions"
 )
+
+// MultipartModelExtractionPathPrefixes lists path prefixes that get multipart model extraction.
+var MultipartModelExtractionPathPrefixes = []string{
+	AudioTranscriptionsPathPrefix,
+}
+
+// PathAllowedForMultipartModelExtraction returns true if path has a prefix in MultipartModelExtractionPathPrefixes.
+func PathAllowedForMultipartModelExtraction(path string) bool {
+	for _, prefix := range MultipartModelExtractionPathPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/epp/metadata/path_test.go
+++ b/pkg/epp/metadata/path_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import "testing"
+
+func TestPathAllowedForMultipartModelExtraction(t *testing.T) {
+	tests := []struct {
+		path    string
+		allowed bool
+	}{
+		{"/v1/audio/transcriptions", true},
+		{"/v1/audio/transcriptions/", true},
+		{"/v1/audio/transcriptions?foo=1", true},
+		{"/v1/video/test", false},
+		{"/v1/completions", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := PathAllowedForMultipartModelExtraction(tt.path)
+		if got != tt.allowed {
+			t.Errorf("PathAllowedForMultipartModelExtraction(%q) = %v, want %v", tt.path, got, tt.allowed)
+		}
+	}
+}

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -199,6 +199,19 @@ func (d *Director) processRequestBody(ctx context.Context, reqCtx *handlers.Requ
 	if err != nil {
 		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: err.Error()}
 	}
+	if llmRequestBody == nil {
+		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "parser returned nil body"}
+	}
+
+	if llmRequestBody.AudioTranscriptions != nil {
+		model := llmRequestBody.AudioTranscriptions.ModelName
+		reqCtx.IncomingModelName = model
+		if reqCtx.TargetModelName == "" {
+			reqCtx.TargetModelName = reqCtx.IncomingModelName
+		}
+		d.applyWeightedModelRewrite(reqCtx)
+		return nil, nil
+	}
 
 	switch v := llmRequestBody.ParsedBody.(type) {
 	case proto.Message:

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -51,7 +51,9 @@ import (
 	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/mocks"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/openai"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/router"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 	poolutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/pool"
 	testutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
 )
@@ -725,6 +727,59 @@ func TestDirector_HandleRequest(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestDirector_HandleRequest_Multipart(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+	ds := &mockDatastore{
+		pods: []backendmetrics.PodMetrics{
+			&backendmetrics.FakePodMetrics{
+				Metadata:   &fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "8000", NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"}},
+				Attributes: &fwkdl.Attributes{},
+			},
+		},
+	}
+	locator := NewCachedPodLocator(ctx, NewDatastorePodLocator(ds), time.Minute)
+	mockSched := &mockScheduler{
+		scheduleResults: &fwksched.SchedulingResult{
+			ProfileResults: map[string]*fwksched.ProfileRunResult{
+				"default": {
+					TargetEndpoints: []fwksched.Endpoint{
+						&fwksched.ScoredEndpoint{
+							Endpoint: fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+								Address: "10.0.0.1", Port: "8000",
+								NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
+							}, nil, nil),
+						},
+					},
+				},
+			},
+			PrimaryProfileName: "default",
+		},
+	}
+	director := NewDirectorWithConfig(ds, mockSched, &mockAdmissionController{}, router.NewRouterParser(openai.NewOpenAIParser()), locator, NewConfig())
+
+	reqCtx := &handlers.RequestContext{
+		Request: &handlers.Request{
+			Headers: map[string]string{
+				reqcommon.RequestIdHeaderKey: "req-1",
+				"content-type":                "multipart/form-data; boundary=----boundary",
+				":path":                       metadata.AudioTranscriptionsPathPrefix,
+				metadata.ModelNameKey:         "whisper-1",
+			},
+			RawBody:  []byte("raw multipart body"),
+			Metadata: map[string]any{},
+		},
+	}
+	reqCtx.RequestSize = len(reqCtx.Request.RawBody)
+
+	got, err := director.HandleRequest(ctx, reqCtx)
+	assert.NoError(t, err)
+	assert.Equal(t, "whisper-1", got.IncomingModelName)
+	assert.Equal(t, "whisper-1", got.TargetModelName)
+	assert.NotEmpty(t, got.TargetEndpoint)
+	assert.NotNil(t, got.SchedulingRequest)
+	assert.Nil(t, got.SchedulingRequest.Body, "multipart request should have nil Body for plugins")
 }
 
 func TestGetRandomEndpoint(t *testing.T) {

--- a/test/integration/bbr/hermetic_test.go
+++ b/test/integration/bbr/hermetic_test.go
@@ -86,15 +86,17 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		reqs          []*extProcPb.ProcessingRequest
-		wantResponses []*extProcPb.ProcessingResponse
-		wantErr       bool
+		name             string
+		reqs             []*extProcPb.ProcessingRequest
+		wantResponses    []*extProcPb.ProcessingResponse
+		wantErr          bool
+		skipExactCompare bool
 	}{
 		{
 			name: "success: adds model header from simple body",
 			reqs: integration.ReqLLM(logger, "test", "foo", "bar"),
 			wantResponses: []*extProcPb.ProcessingResponse{
+				ExpectBBRNoOpHeader(),
 				ExpectBBRHeader("foo"),
 				ExpectBBRBodyPassThrough("test", "foo"),
 			},
@@ -107,6 +109,7 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 				`ra-sheddable","prompt":"test","temperature":0}`,
 			),
 			wantResponses: []*extProcPb.ProcessingResponse{
+				ExpectBBRNoOpHeader(),
 				ExpectBBRHeader("sql-lora-sheddable"),
 				ExpectBBRBodyPassThrough("test", "sql-lora-sheddable"),
 			},
@@ -116,8 +119,25 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			reqs: integration.ReqLLM(logger, "test", "", ""),
 			wantResponses: []*extProcPb.ProcessingResponse{
 				ExpectBBRNoOpHeader(),
+				ExpectBBRNoOpHeader(),
 				ExpectBBRBodyPassThrough("test", ""),
 			},
+		},
+		{
+			name: "audio transcriptions: multipart form sets model header and passes body through",
+			reqs: func() []*extProcPb.ProcessingRequest {
+				headers, body := integration.BuildMultipartTranscriptionsRequest("whisper-1", "audio.mp3", []byte("test audio"))
+				return integration.ReqRaw(headers, string(body))
+			}(),
+			wantResponses: func() []*extProcPb.ProcessingResponse {
+				_, body := integration.BuildMultipartTranscriptionsRequest("whisper-1", "audio.mp3", []byte("test audio"))
+				return []*extProcPb.ProcessingResponse{
+					ExpectBBRNoOpHeader(),
+					ExpectBBRHeader("whisper-1"),
+					ExpectBBRBodyPassThroughRaw(body),
+				}
+			}(),
+			skipExactCompare: true,
 		},
 	}
 
@@ -139,7 +159,29 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			// sort headers in responses for deterministic tests
 			envoytest.SortSetHeadersInResponses(tc.wantResponses)
 			envoytest.SortSetHeadersInResponses(responses)
-			if diff := cmp.Diff(tc.wantResponses, responses, protocmp.Transform()); diff != "" {
+			if tc.skipExactCompare {
+				require.Len(t, responses, len(tc.wantResponses), "response count")
+				var gotModelHeader string
+				var gotBody []byte
+				for _, r := range responses {
+					if rh := r.GetRequestHeaders(); rh != nil && rh.Response != nil && rh.Response.HeaderMutation != nil {
+						for _, h := range rh.Response.HeaderMutation.SetHeaders {
+							if h.GetHeader().GetKey() == "X-Gateway-Model-Name" {
+								gotModelHeader = string(h.GetHeader().GetRawValue())
+								break
+							}
+						}
+					}
+					if rb := r.GetRequestBody(); rb != nil && rb.Response != nil && rb.Response.BodyMutation != nil {
+						if sr := rb.Response.BodyMutation.GetStreamedResponse(); sr != nil {
+							gotBody = sr.Body
+						}
+					}
+				}
+				require.Equal(t, "whisper-1", gotModelHeader, "X-Gateway-Model-Name")
+				_, wantBody := integration.BuildMultipartTranscriptionsRequest("whisper-1", "audio.mp3", []byte("test audio"))
+				require.Equal(t, wantBody, gotBody, "body pass-through")
+			} else if diff := cmp.Diff(tc.wantResponses, responses, protocmp.Transform()); diff != "" {
 				t.Errorf("Response mismatch (-want +got): %v", diff)
 			}
 		})

--- a/test/integration/bbr/util.go
+++ b/test/integration/bbr/util.go
@@ -54,6 +54,26 @@ func ExpectBBRHeader(modelName string) *extProcPb.ProcessingResponse {
 	}
 }
 
+// ExpectBBRBodyPassThroughRaw expects BBR to pass body through unchanged.
+func ExpectBBRBodyPassThroughRaw(body []byte) *extProcPb.ProcessingResponse {
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_RequestBody{
+			RequestBody: &extProcPb.BodyResponse{
+				Response: &extProcPb.CommonResponse{
+					BodyMutation: &extProcPb.BodyMutation{
+						Mutation: &extProcPb.BodyMutation_StreamedResponse{
+							StreamedResponse: &extProcPb.StreamedBodyResponse{
+								Body:        body,
+								EndOfStream: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // ExpectBBRBodyPassThrough asserts that BBR reconstructs and passes the body through.
 // BBR buffers the body to inspect it, then sends it downstream as a single chunk (usually).
 func ExpectBBRBodyPassThrough(prompt, model string) *extProcPb.ProcessingResponse {

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -23,11 +23,13 @@ limitations under the License.
 package integration
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net"
 	"strconv"
 	"testing"
@@ -65,6 +67,26 @@ func ReqLLM(logger logr.Logger, prompt, model, targetModel string) []*extProcPb.
 // Use this for tests where `streaming: false` or when testing legacy buffered behavior.
 func ReqLLMUnary(logger logr.Logger, prompt, model string) *extProcPb.ProcessingRequest {
 	return GenerateRequest(logger, prompt, model, nil)
+}
+
+// BuildMultipartTranscriptionsRequest builds multipart/form-data with model and file parts.
+func BuildMultipartTranscriptionsRequest(model, filename string, fileContent []byte) (headers map[string]string, body []byte) {
+	boundary := "----boundary"
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	_ = w.SetBoundary(boundary)
+	if model != "" {
+		_ = w.WriteField("model", model)
+	}
+	if filename != "" && fileContent != nil {
+		part, _ := w.CreateFormFile("file", filename)
+		_, _ = part.Write(fileContent)
+	}
+	_ = w.Close()
+	return map[string]string{
+		"content-type": "multipart/form-data; boundary=" + boundary,
+		":path":        "/v1/audio/transcriptions",
+	}, buf.Bytes()
 }
 
 // ReqRaw creates a custom sequence of gRPC messages with specific headers and arbitrary body chunks.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
Adds OpenAI-style /v1/audio/transcriptions support

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2203 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
