### PR TITLE
test(envoy): add missing unit tests for envoy util functions

### DIFF
--- a/pkg/common/envoy/headers_test.go
+++ b/pkg/common/envoy/headers_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package envoy
 
 import (
+	"sort"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestExtractHeaderValue(t *testing.T) {
@@ -77,6 +80,89 @@ func TestExtractHeaderValue(t *testing.T) {
 			result := ExtractHeaderValue(req, tt.key)
 			if result != tt.expected {
 				t.Errorf("ExtractHeaderValue() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateHeadersMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    []*corev3.HeaderValueOption
+	}{
+		{
+			name:    "empty map returns empty slice",
+			headers: map[string]string{},
+			want:    []*corev3.HeaderValueOption{},
+		},
+		{
+			name:    "single header",
+			headers: map[string]string{"x-api-key": "secret-123"},
+			want: []*corev3.HeaderValueOption{
+				{
+					Header: &corev3.HeaderValue{
+						Key:      "x-api-key",
+						RawValue: []byte("secret-123"),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple headers",
+			headers: map[string]string{
+				"x-api-key":     "key-val",
+				"x-request-id":  "req-456",
+				"authorization": "Bearer tok",
+			},
+			want: []*corev3.HeaderValueOption{
+				{
+					Header: &corev3.HeaderValue{
+						Key:      "authorization",
+						RawValue: []byte("Bearer tok"),
+					},
+				},
+				{
+					Header: &corev3.HeaderValue{
+						Key:      "x-api-key",
+						RawValue: []byte("key-val"),
+					},
+				},
+				{
+					Header: &corev3.HeaderValue{
+						Key:      "x-request-id",
+						RawValue: []byte("req-456"),
+					},
+				},
+			},
+		},
+		{
+			name:    "header with empty value",
+			headers: map[string]string{"x-empty": ""},
+			want: []*corev3.HeaderValueOption{
+				{
+					Header: &corev3.HeaderValue{
+						Key:      "x-empty",
+						RawValue: []byte(""),
+					},
+				},
+			},
+		},
+	}
+
+	sortByKey := func(opts []*corev3.HeaderValueOption) {
+		sort.Slice(opts, func(i, j int) bool {
+			return opts[i].GetHeader().GetKey() < opts[j].GetHeader().GetKey()
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateHeadersMutation(tt.headers)
+			sortByKey(got)
+			sortByKey(tt.want)
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateHeadersMutation() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/common/envoy/test/utils.go
+++ b/pkg/common/envoy/test/utils.go
@@ -39,6 +39,14 @@ func SortSetHeadersInResponses(responses []*extProcPb.ProcessingResponse) {
 			if rr.RequestBody != nil && rr.RequestBody.Response != nil {
 				common = rr.RequestBody.Response
 			}
+		case *extProcPb.ProcessingResponse_ResponseHeaders:
+			if rr.ResponseHeaders != nil && rr.ResponseHeaders.Response != nil {
+				common = rr.ResponseHeaders.Response
+			}
+		case *extProcPb.ProcessingResponse_ResponseBody:
+			if rr.ResponseBody != nil && rr.ResponseBody.Response != nil {
+				common = rr.ResponseBody.Response
+			}
 		default:
 			continue
 		}

--- a/pkg/common/envoy/test/utils_test.go
+++ b/pkg/common/envoy/test/utils_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func makeHeaderValueOption(key, value string) *corev3.HeaderValueOption {
+	return &corev3.HeaderValueOption{
+		Header: &corev3.HeaderValue{
+			Key:      key,
+			RawValue: []byte(value),
+		},
+	}
+}
+
+func TestSortSetHeadersInResponses(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []*extProcPb.ProcessingResponse
+		want      []*extProcPb.ProcessingResponse
+	}{
+		{
+			name:      "nil slice",
+			responses: nil,
+			want:      nil,
+		},
+		{
+			name:      "nil response element is skipped",
+			responses: []*extProcPb.ProcessingResponse{nil},
+			want:      []*extProcPb.ProcessingResponse{nil},
+		},
+		{
+			name: "response with nil Response field is skipped",
+			responses: []*extProcPb.ProcessingResponse{
+				{Response: nil},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{Response: nil},
+			},
+		},
+		{
+			name: "RequestHeaders response with unsorted headers gets sorted",
+			responses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("z-header", "z-val"),
+										makeHeaderValueOption("a-header", "a-val"),
+										makeHeaderValueOption("m-header", "m-val"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("a-header", "a-val"),
+										makeHeaderValueOption("m-header", "m-val"),
+										makeHeaderValueOption("z-header", "z-val"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ResponseHeaders with unsorted headers gets sorted",
+			responses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+						ResponseHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("z-header", "z-val"),
+										makeHeaderValueOption("a-header", "a-val"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+						ResponseHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("a-header", "a-val"),
+										makeHeaderValueOption("z-header", "z-val"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ResponseBody with unsorted headers gets sorted",
+			responses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseBody{
+						ResponseBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("c-header", "c-val"),
+										makeHeaderValueOption("a-header", "a-val"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseBody{
+						ResponseBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("a-header", "a-val"),
+										makeHeaderValueOption("c-header", "c-val"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unhandled response type is skipped",
+			responses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseTrailers{},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseTrailers{},
+				},
+			},
+		},
+		{
+			name: "nil HeaderMutation is skipped",
+			responses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: nil,
+							},
+						},
+					},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: nil,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nil and valid responses mixed",
+			responses: []*extProcPb.ProcessingResponse{
+				nil,
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("z-header", "z"),
+										makeHeaderValueOption("a-header", "a"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{Response: nil},
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("c-header", "c"),
+										makeHeaderValueOption("b-header", "b"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				nil,
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("a-header", "a"),
+										makeHeaderValueOption("z-header", "z"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{Response: nil},
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("b-header", "b"),
+										makeHeaderValueOption("c-header", "c"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple response objects are sorted independently",
+			responses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("c-header", "c"),
+										makeHeaderValueOption("a-header", "a"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("z-header", "z"),
+										makeHeaderValueOption("b-header", "b"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("a-header", "a"),
+										makeHeaderValueOption("c-header", "c"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										makeHeaderValueOption("b-header", "b"),
+										makeHeaderValueOption("z-header", "z"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SortSetHeadersInResponses(tt.responses)
+			if diff := cmp.Diff(tt.want, tt.responses, protocmp.Transform()); diff != "" {
+				t.Errorf("SortSetHeadersInResponses() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Add missing unit tests for `GenerateHeadersMutation` and `SortSetHeadersInResponses` — two envoy util functions that were recently added without test coverage.

- `TestGenerateHeadersMutation` — 4 cases covering empty map, single header, multiple headers (with sort for map non-determinism), and empty value.
- `TestSortSetHeadersInResponses` — 9 cases covering nil safety, `RequestHeaders`/`RequestBody` sorting, single header skip, unknown response type skip, nil `HeaderMutation`, and mixed response types.

**Which issue(s) this PR fixes**:

Fixes #2528

**Does this PR introduce a user-facing change?**:

```
NONE
```