### PR TITLE
Add TokenizedPrompt to LLMRequest for external tokenization support

### DIFF
--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -46,6 +46,18 @@ type LLMRequest struct {
 	Headers map[string]string
 	// Request Objective
 	Objectives RequestObjectives
+	// TokenizedPrompt contains the tokenization results if external tokenization is enabled.
+	// This is nil if tokenization was not performed or if the tokenizer is not configured.
+	TokenizedPrompt *TokenizedPrompt
+}
+
+// TokenizedPrompt contains the result of tokenizing the request prompt.
+// It is populated by external tokenization plugins (e.g., via a PrepareData plugin)
+// and consumed by scheduling plugins that benefit from actual token data
+// (e.g., prefix cache scoring, latency prediction).
+type TokenizedPrompt struct {
+	// TokenIDs are the token IDs for the prompt.
+	TokenIDs []uint32
 }
 
 func (r *LLMRequest) String() string {


### PR DESCRIPTION
## Summary

Add a `TokenizedPrompt` struct and field to `LLMRequest` to carry token IDs produced by external tokenization through the request flow. This is the only GIE-side change needed to enable downstream implementations (e.g., llm-d) to populate token data via `PrepareDataPlugin` for consumption by scheduling plugins such as prefix cache scoring and latency prediction.

## Motivation

The EPP currently operates entirely on text, leading to:

- **Inaccurate prefix cache scoring** — character-block boundaries don't align with vLLM's KV-cache token block boundaries
- **Chat template inconsistency** — `json.Marshal(messages)` bytes don't correspond to what vLLM tokenizes
- **Redundant tokenization** — without pre-tokenized input, every model server stage re-tokenizes the same request

Adding `TokenizedPrompt` to `LLMRequest` enables downstream tokenizer plugins to populate actual token IDs before scheduling runs, fixing all three issues.

**Design doc:** https://docs.google.com/document/d/1nXeWJZQlzMY43t_Yn5FJran_EhSE_z1n--KCk9cxxjk/edit?usp=sharing

Ref: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2330