### PR TITLE
fix(flaky) increase the timeout for setting up the ext_proc conn in integration test

### DIFF
--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -46,6 +46,12 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
+const (
+	headerKeyContentLength       = "Content-Length"
+	extprocConnSetupTimeout      = 10 * time.Second
+	extPorcConnSetupPollInterval = 50 * time.Millisecond
+)
+
 // --- Request Builders (Protocol Level) ---
 
 // ReqLLM creates a sequence of gRPC messages representing a standard, streamed LLM inference request.
@@ -486,7 +492,7 @@ func ExtProcServerClient(
 		}
 		conn.Close()
 		return true
-	}, 5*time.Second, 50*time.Millisecond, "Server failed to bind port %s", serverAddr)
+	}, extprocConnSetupTimeout, extPorcConnSetupPollInterval, "Server failed to bind port %s", serverAddr)
 
 	// Connect client.
 	// Blocking dial is safe because we know the port is open.
@@ -544,7 +550,3 @@ func makeDestinationMetadata(endpoint string) *structpb.Struct {
 		},
 	}
 }
-
-const (
-	headerKeyContentLength = "Content-Length"
-)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test

**What this PR does / why we need it**:
increase the extprocConnSetupTimeout to make the test less flaky

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes error similar to ![this](https://private-user-images.githubusercontent.com/118311804/561211203-891fc149-7014-4992-955c-59400767902d.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzMxOTQ2NzksIm5iZiI6MTc3MzE5NDM3OSwicGF0aCI6Ii8xMTgzMTE4MDQvNTYxMjExMjAzLTg5MWZjMTQ5LTcwMTQtNDk5Mi05NTVjLTU5NDAwNzY3OTAyZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMzExJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDMxMVQwMTU5MzlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1lMTExZjI0ZTljNDVhYjg0MjM4MjBjNmIyNWEyOTVjMWRiNTQ1NzVlYzQxMDQwOWJkZDRhODAyMmM0Mjg4ZDY3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.47tcMAc_iSvgyLdBirDkMngmKivnKzPQdOlgeqPJPEQ) 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
