### PR TITLE
refactor: rename PodLocator to EndpointCandidates

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -329,10 +329,10 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 	// --- Admission Control Initialization ---
 	var admissionController requestcontrol.AdmissionController
-	var locator contracts.PodLocator
-	locator = requestcontrol.NewDatastorePodLocator(ds, requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter))
+	var endpointCandidates contracts.EndpointCandidates
+	endpointCandidates = requestcontrol.NewDatastoreEndpointCandidates(ds, requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter))
 	if r.featureGates[flowcontrol.FeatureGate] {
-		locator = requestcontrol.NewCachedPodLocator(ctx, locator, time.Millisecond*50)
+		endpointCandidates = requestcontrol.NewCachedEndpointCandidates(ctx, endpointCandidates, time.Millisecond*50)
 		setupLog.Info("Initializing experimental Flow Control layer")
 		registry, err := fcregistry.NewFlowRegistry(eppConfig.FlowControlConfig.Registry, setupLog)
 		if err != nil {
@@ -343,7 +343,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 			opts.PoolName,
 			eppConfig.FlowControlConfig.Controller,
 			registry, eppConfig.SaturationDetector,
-			locator, eppConfig.FlowControlConfig.UsageLimitPolicy,
+			endpointCandidates, eppConfig.FlowControlConfig.UsageLimitPolicy,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize Flow Controller: %w", err)
@@ -352,12 +352,11 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		admissionController = requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName)
 	} else {
 		setupLog.Info("Experimental Flow Control layer is disabled, using legacy admission control")
-		admissionController = requestcontrol.NewLegacyAdmissionController(eppConfig.SaturationDetector, locator)
+		admissionController = requestcontrol.NewLegacyAdmissionController(eppConfig.SaturationDetector, endpointCandidates)
 	}
 
-	director := requestcontrol.NewDirectorWithConfig(ds, scheduler, admissionController, r.parser, locator, r.requestControlConfig)
+	director := requestcontrol.NewDirectorWithConfig(ds, scheduler, admissionController, r.parser, endpointCandidates, r.requestControlConfig)
 
-	// --- Setup ExtProc Server Runner ---
 	serverRunner := &runserver.ExtProcServerRunner{
 		GrpcPort:                         opts.GRPCPort,
 		GKNN:                             *gknn,

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -276,7 +276,7 @@ func setupBenchmarkHarness(
 		}
 	}
 
-	fc, err := controller.NewFlowController(ctx, "benchmark", cfg, reg, detector, &mocks.MockPodLocator{}, usagelimits.DefaultPolicy())
+	fc, err := controller.NewFlowController(ctx, "benchmark", cfg, reg, detector, &mocks.MockEndpointCandidates{}, usagelimits.DefaultPolicy())
 	if err != nil {
 		b.Fatalf("Failed to init FlowController: %v", err)
 	}

--- a/pkg/epp/flowcontrol/contracts/dependencies.go
+++ b/pkg/epp/flowcontrol/contracts/dependencies.go
@@ -22,12 +22,12 @@ import (
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 )
 
-// PodLocator defines the contract for a component that resolves the set of candidate pods for a request based on its
-// metadata (e.g., subsetting).
+// EndpointCandidates defines the contract for a component that resolves the set of candidate endpoints for a request
+// based on its metadata (e.g., subsetting).
 //
-// This interface allows the Flow Controller to fetch a fresh list of pods dynamically during the dispatch cycle,
-// enabling support for "Scale-from-Zero" scenarios where pods may not exist when the request is first enqueued.
-type PodLocator interface {
-	// Locate returns a list of pod metrics that match the criteria defined in the request metadata.
+// This interface allows the Flow Controller to fetch a fresh list of candidates dynamically during the dispatch cycle,
+// enabling support for "Scale-from-Zero" scenarios where endpoints may not exist when the request is first enqueued.
+type EndpointCandidates interface {
+	// Locate returns a list of endpoint candidate metrics that match the criteria defined in the request metadata.
 	Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint
 }

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -108,25 +108,38 @@ var _ contracts.RegistryShard = &MockRegistryShard{}
 
 // --- Dependency Mocks ---
 
-// MockPodLocator provides a mock implementation of the contracts.PodLocator interface.
-// It allows tests to control the exact set of pods returned for a given request.
-type MockPodLocator struct {
-	// LocateFunc allows injecting custom logic.
-	LocateFunc func(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint
-	// Pods is a static return value used if LocateFunc is nil.
-	Pods []fwkdl.Endpoint
+// MockSaturationDetector is a simple "stub-style" mock for testing.
+type MockSaturationDetector struct {
+	SaturationFunc func(ctx context.Context, candidatePods []fwkdl.Endpoint) float64
 }
 
-func (m *MockPodLocator) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
+func (m *MockSaturationDetector) Saturation(ctx context.Context, candidatePods []fwkdl.Endpoint) float64 {
+	if m.SaturationFunc != nil {
+		return m.SaturationFunc(ctx, candidatePods)
+	}
+	return 0.0
+}
+
+// MockEndpointCandidates provides a mock implementation of the contracts.EndpointCandidates interface.
+// It allows tests to control the exact set of endpoint candidates returned for a given request.
+type MockEndpointCandidates struct {
+	// LocateFunc allows injecting custom logic.
+	LocateFunc func(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint
+	// Candidates is a static return value used if LocateFunc is nil.
+	Candidates []fwkdl.Endpoint
+}
+
+func (m *MockEndpointCandidates) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
 	if m.LocateFunc != nil {
 		return m.LocateFunc(ctx, requestMetadata)
 	}
 	// Return copy to be safe
-	if m.Pods == nil {
+	if m.Candidates == nil {
 		return nil
 	}
-	result := make([]fwkdl.Endpoint, len(m.Pods))
-	copy(result, m.Pods)
+
+	result := make([]fwkdl.Endpoint, len(m.Candidates))
+	copy(result, m.Candidates)
 	return result
 }
 

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -63,7 +63,7 @@ type shardProcessorFactory func(
 	ctx context.Context,
 	shard contracts.RegistryShard,
 	saturationDetector flowcontrol.SaturationDetector,
-	podLocator contracts.PodLocator,
+	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
 	clock clock.WithTicker,
 	cleanupSweepInterval time.Duration,
@@ -100,7 +100,7 @@ type FlowController struct {
 	config                *Config
 	registry              registryClient
 	saturationDetector    flowcontrol.SaturationDetector
-	podLocator            contracts.PodLocator
+	endpointCandidates    contracts.EndpointCandidates
 	usageLimitPolicy      flowcontrol.UsageLimitPolicy
 	clock                 clock.WithTicker
 	logger                logr.Logger
@@ -134,7 +134,7 @@ func NewFlowController(
 	config *Config,
 	registry contracts.FlowRegistry,
 	sd flowcontrol.SaturationDetector,
-	podLocator contracts.PodLocator,
+	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
 	opts ...flowControllerOption,
 ) (*FlowController, error) {
@@ -142,7 +142,7 @@ func NewFlowController(
 		config:             config,
 		registry:           registry,
 		saturationDetector: sd,
-		podLocator:         podLocator,
+		endpointCandidates: endpointCandidates,
 		usageLimitPolicy:   usageLimitPolicy,
 		clock:              clock.RealClock{},
 		logger:             log.FromContext(ctx).WithName("flow-controller"),
@@ -153,7 +153,7 @@ func NewFlowController(
 		ctx context.Context,
 		shard contracts.RegistryShard,
 		saturationDetector flowcontrol.SaturationDetector,
-		podLocator contracts.PodLocator,
+		endpointCandidates contracts.EndpointCandidates,
 		usageLimitPolicy flowcontrol.UsageLimitPolicy,
 		clock clock.WithTicker,
 		cleanupSweepInterval time.Duration,
@@ -165,12 +165,13 @@ func NewFlowController(
 			poolName,
 			shard,
 			saturationDetector,
-			podLocator,
+			endpointCandidates,
 			usageLimitPolicy,
 			clock,
 			cleanupSweepInterval,
 			enqueueChannelBufferSize,
-			logger)
+			logger,
+		)
 	}
 
 	for _, opt := range opts {
@@ -492,7 +493,7 @@ func (fc *FlowController) getOrStartWorker(shard contracts.RegistryShard) *manag
 		processorCtx,
 		shard,
 		fc.saturationDetector,
-		fc.podLocator,
+		fc.endpointCandidates,
 		fc.usageLimitPolicy,
 		fc.clock,
 		fc.config.ExpiryCleanupInterval,

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -126,7 +126,7 @@ func newUnitHarness(
 	}
 
 	mockDetector := &mockSaturationDetector{}
-	mockPodLocator := &mocks.MockPodLocator{}
+	mockEndpointCandidates := &mocks.MockEndpointCandidates{}
 
 	mockProcessorFactory := &mockShardProcessorFactory{
 		processors: make(map[string]*mockShardProcessor),
@@ -144,7 +144,7 @@ func newUnitHarness(
 		withClock(harnessOpts.clock),
 		withShardProcessorFactory(mockProcessorFactory.new),
 	}
-	fc, err := NewFlowController(ctx, "test-pool", cfg, registry, mockDetector, mockPodLocator, usageLimitPolicy, fcOpts...)
+	fc, err := NewFlowController(ctx, "test-pool", cfg, registry, mockDetector, mockEndpointCandidates, usageLimitPolicy, fcOpts...)
 	require.NoError(t, err, "failed to create FlowController for unit test harness")
 
 	h := &testHarness{
@@ -167,7 +167,7 @@ func newUnitHarness(
 func newIntegrationHarness(t *testing.T, ctx context.Context, cfg *Config, registry *mockRegistryClient) *testHarness {
 	t.Helper()
 	mockDetector := &mockSaturationDetector{}
-	mockPodLocator := &mocks.MockPodLocator{}
+	mockEndpointCandidates := &mocks.MockEndpointCandidates{}
 	usageLimitPolicy := usagelimits.DefaultPolicy()
 
 	// Align FakeClock with system time. See explanation in newUnitHarness.
@@ -180,7 +180,7 @@ func newIntegrationHarness(t *testing.T, ctx context.Context, cfg *Config, regis
 		withRegistryClient(registry),
 		withClock(mockClock),
 	}
-	fc, err := NewFlowController(ctx, "test-pool", cfg, registry, mockDetector, mockPodLocator, usageLimitPolicy, opts...)
+	fc, err := NewFlowController(ctx, "test-pool", cfg, registry, mockDetector, mockEndpointCandidates, usageLimitPolicy, opts...)
 	require.NoError(t, err, "failed to create FlowController for integration test harness")
 
 	h := &testHarness{
@@ -290,7 +290,7 @@ func (f *mockShardProcessorFactory) new(
 	_ context.Context, // The factory does not use the lifecycle context; it's passed to the processor's Run method later.
 	shard contracts.RegistryShard,
 	_ flowcontrol.SaturationDetector,
-	_ contracts.PodLocator,
+	_ contracts.EndpointCandidates,
 	_ flowcontrol.UsageLimitPolicy,
 	_ clock.WithTicker,
 	_ time.Duration,
@@ -1155,7 +1155,7 @@ func TestFlowController_WorkerManagement(t *testing.T) {
 			ctx context.Context, // The context created by getOrStartWorker for the potential new processor.
 			shard contracts.RegistryShard,
 			_ flowcontrol.SaturationDetector,
-			_ contracts.PodLocator,
+			_ contracts.EndpointCandidates,
 			_ flowcontrol.UsageLimitPolicy,
 			_ clock.WithTicker,
 			_ time.Duration,

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -68,7 +68,7 @@ type ShardProcessor struct {
 	poolName             string
 	shard                contracts.RegistryShard
 	saturationDetector   flowcontrol.SaturationDetector
-	podLocator           contracts.PodLocator
+	endpointCandidates   contracts.EndpointCandidates
 	usageLimitPolicy     flowcontrol.UsageLimitPolicy
 	clock                clock.WithTicker
 	cleanupSweepInterval time.Duration
@@ -92,7 +92,7 @@ func NewShardProcessor(
 	poolName string,
 	shard contracts.RegistryShard,
 	saturationDetector flowcontrol.SaturationDetector,
-	podLocator contracts.PodLocator,
+	endpointCandidates contracts.EndpointCandidates,
 	usageLimitPolicy flowcontrol.UsageLimitPolicy,
 	clock clock.WithTicker,
 	cleanupSweepInterval time.Duration,
@@ -103,7 +103,7 @@ func NewShardProcessor(
 		shard:                shard,
 		poolName:             poolName,
 		saturationDetector:   saturationDetector,
-		podLocator:           podLocator,
+		endpointCandidates:   endpointCandidates,
 		usageLimitPolicy:     usageLimitPolicy,
 		clock:                clock,
 		cleanupSweepInterval: cleanupSweepInterval,
@@ -317,7 +317,7 @@ func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
 		metrics.RecordFlowControlDispatchCycleDuration(time.Since(dispatchCycleStart))
 	}()
 
-	pool := sp.podLocator.Locate(ctx, nil)
+	pool := sp.endpointCandidates.Locate(ctx, nil)
 	saturation := sp.saturationDetector.Saturation(ctx, pool)
 
 	// Record pool saturation metric

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -88,7 +88,7 @@ type testHarness struct {
 	clock              *testclock.FakeClock
 	logger             logr.Logger
 	saturationDetector *mockSaturationDetector
-	podLocator         *mocks.MockPodLocator
+	endpointCandidates *mocks.MockEndpointCandidates
 
 	// --- Centralized Mock State ---
 	// The harness's mutex protects the single source of truth for all mock state.
@@ -109,7 +109,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 		clock:              testclock.NewFakeClock(time.Now()),
 		logger:             logr.Discard(),
 		saturationDetector: &mockSaturationDetector{},
-		podLocator:         &mocks.MockPodLocator{Pods: []fwkdl.Endpoint{&metrics.FakePodMetrics{}}},
+		endpointCandidates: &mocks.MockEndpointCandidates{Candidates: []fwkdl.Endpoint{&metrics.FakePodMetrics{}}},
 		startSignal:        make(chan struct{}),
 		queues:             make(map[flowcontrol.FlowKey]*mocks.MockManagedQueue),
 		priorityFlows:      make(map[int][]flowcontrol.FlowKey),
@@ -137,7 +137,7 @@ func newTestHarness(t *testing.T, expiryCleanupInterval time.Duration) *testHarn
 		"test-pool",
 		h,
 		h.saturationDetector,
-		h.podLocator,
+		h.endpointCandidates,
 		usagelimits.DefaultPolicy(),
 		h.clock,
 		expiryCleanupInterval,

--- a/pkg/epp/framework/interface/flowcontrol/request.go
+++ b/pkg/epp/framework/interface/flowcontrol/request.go
@@ -57,7 +57,7 @@ type FlowControlRequest interface {
 	ID() string
 
 	// GetMetadata returns the opaque metadata associated with the request (e.g., header-derived context, subset filters).
-	// This data is passed transparently to components like the contracts.PodLocator to resolve resources (candidate pods)
+	// This data is passed transparently to components like contracts.EndpointCandidates to resolve resources (endpoint candidates)
 	// lazily during the dispatch cycle.
 	GetMetadata() map[string]any
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
@@ -90,7 +91,7 @@ func (p *OpenAIParser) WithName(name string) *OpenAIParser {
 func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
 	bodyMap := make(map[string]any)
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
-		return nil, errors.New("error unmarshaling request bodyMap")
+		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
 	}
 	extractedBody, err := extractRequestBody(body, headers)
 	if err != nil {

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -65,13 +65,13 @@ type flowController interface {
 func rejectIfSheddableAndSaturated(
 	ctx context.Context,
 	sd flowcontrol.SaturationDetector,
-	locator contracts.PodLocator,
+	endpointCandidates contracts.EndpointCandidates,
 	reqCtx *handlers.RequestContext,
 	priority int,
 	logger logr.Logger,
 ) error {
 	if requtil.IsSheddable(priority) {
-		if sd.Saturation(ctx, locator.Locate(ctx, reqCtx.Request.Metadata)) >= 1.0 {
+		if sd.Saturation(ctx, endpointCandidates.Locate(ctx, reqCtx.Request.Metadata)) >= 1.0 {
 			logger.V(logutil.TRACE).Info("Request rejected: system saturated and request is sheddable",
 				"requestID", reqCtx.SchedulingRequest.RequestId)
 			return errcommon.Error{
@@ -90,17 +90,17 @@ func rejectIfSheddableAndSaturated(
 // saturated. Non-sheddable requests always bypass the saturation check.
 type LegacyAdmissionController struct {
 	saturationDetector flowcontrol.SaturationDetector
-	podLocator         contracts.PodLocator
+	endpointCandidates contracts.EndpointCandidates
 }
 
 // NewLegacyAdmissionController creates a new LegacyAdmissionController.
 func NewLegacyAdmissionController(
 	sd flowcontrol.SaturationDetector,
-	pl contracts.PodLocator,
+	endpointCandidates contracts.EndpointCandidates,
 ) *LegacyAdmissionController {
 	return &LegacyAdmissionController{
 		saturationDetector: sd,
-		podLocator:         pl,
+		endpointCandidates: endpointCandidates,
 	}
 }
 
@@ -117,7 +117,7 @@ func (lac *LegacyAdmissionController) Admit(
 	if err := rejectIfSheddableAndSaturated(
 		ctx,
 		lac.saturationDetector,
-		lac.podLocator,
+		lac.endpointCandidates,
 		reqCtx, priority,
 		logger,
 	); err != nil {

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -131,8 +131,8 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 					return 0.0
 				},
 			}
-			locator := &mocks.MockPodLocator{Pods: tc.locatorPods}
-			ac := NewLegacyAdmissionController(mockDetector, locator)
+			endpointCandidates := &mocks.MockEndpointCandidates{Candidates: tc.locatorPods}
+			ac := NewLegacyAdmissionController(mockDetector, endpointCandidates)
 
 			err := ac.Admit(ctx, reqCtx, tc.priority)
 

--- a/pkg/epp/requestcontrol/candidates.go
+++ b/pkg/epp/requestcontrol/candidates.go
@@ -34,78 +34,78 @@ import (
 )
 
 const (
-	// defaultCacheTTL is the duration for which a pod lookup result is considered valid.
-	// This trades off "Scale-from-Zero" responsiveness (latency to see new pods) against Datastore lock contention.
+	// defaultCacheTTL is the duration for which an endpoint candidate lookup result is considered valid.
+	// This trades off "Scale-from-Zero" responsiveness (latency to see new endpoints) against Datastore lock contention.
 	// 50ms aligns roughly with standard Prometheus scrape intervals or high-frequency control loops.
 	defaultCacheTTL = 50 * time.Millisecond
 
 	// cleanupInterval dictates how often we sweep the map for expired entries.
 	cleanupInterval = 1 * time.Minute
 
-	// defaultCacheKey is used when no subset filter is present (Return All Pods).
+	// defaultCacheKey is used when no subset filter is present (Return All Endpoints).
 	defaultCacheKey = "__default__"
 
-	// emptySubsetCacheKey is used when a subset filter is present but empty (Return No Pods).
+	// emptySubsetCacheKey is used when a subset filter is present but empty (Return No Endpoints).
 	emptySubsetCacheKey = "__explicit_empty__"
 )
 
-// --- DatastorePodLocator (The Delegate) ---
+// --- DatastoreEndpointCandidates (The Delegate) ---
 
-// PodLocatorConfig holds configuration for the DatastorePodLocator.
-type PodLocatorConfig struct {
+// EndpointCandidatesConfig holds configuration for the DatastoreEndpointCandidates.
+type EndpointCandidatesConfig struct {
 	DisableEndpointSubsetFilter bool
 }
 
-// LocatorOption is a function that configures the PodLocatorConfig.
-type LocatorOption func(*PodLocatorConfig)
+// EndpointCandidatesOption is a function that configures the EndpointCandidatesConfig.
+type EndpointCandidatesOption func(*EndpointCandidatesConfig)
 
 // WithDisableEndpointSubsetFilter sets the DisableEndpointSubsetFilter flag.
-func WithDisableEndpointSubsetFilter(disable bool) LocatorOption {
-	return func(c *PodLocatorConfig) {
+func WithDisableEndpointSubsetFilter(disable bool) EndpointCandidatesOption {
+	return func(c *EndpointCandidatesConfig) {
 		c.DisableEndpointSubsetFilter = disable
 	}
 }
 
-// DatastorePodLocator implements contracts.PodLocator by querying the EPP Datastore.
-// It centralizes the logic for resolving candidate pods based on request metadata (specifically Envoy subset filters).
-type DatastorePodLocator struct {
+// DatastoreEndpointCandidates implements contracts.EndpointCandidates by querying the EPP Datastore.
+// It centralizes the logic for resolving endpoint candidates based on request metadata (specifically Envoy subset filters).
+type DatastoreEndpointCandidates struct {
 	datastore Datastore
-	config    PodLocatorConfig
+	config    EndpointCandidatesConfig
 }
 
-var _ contracts.PodLocator = &DatastorePodLocator{}
+var _ contracts.EndpointCandidates = &DatastoreEndpointCandidates{}
 
-// NewDatastorePodLocator creates a new DatastorePodLocator.
-func NewDatastorePodLocator(ds Datastore, opts ...LocatorOption) *DatastorePodLocator {
-	cfg := PodLocatorConfig{
+// NewDatastoreEndpointCandidates creates a new DatastoreEndpointCandidates.
+func NewDatastoreEndpointCandidates(ds Datastore, opts ...EndpointCandidatesOption) *DatastoreEndpointCandidates {
+	cfg := EndpointCandidatesConfig{
 		DisableEndpointSubsetFilter: false,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &DatastorePodLocator{
+	return &DatastoreEndpointCandidates{
 		datastore: ds,
 		config:    cfg,
 	}
 }
 
-// Locate retrieves the list of candidate pods from the datastore that match the criteria defined in the request
+// Locate retrieves the list of endpoint candidates from the datastore that match the criteria defined in the request
 // metadata.
 //
 // It supports:
-// 1. Returning all pods if no specific subset filter is present.
-// 2. Returning a filtered list of pods if "x-gateway-destination-endpoint-subset" is present.
-func (d *DatastorePodLocator) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
+// 1. Returning all endpoint candidates if no specific subset filter is present.
+// 2. Returning a filtered list of endpoint candidates if "x-gateway-destination-endpoint-subset" is present.
+func (d *DatastoreEndpointCandidates) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 
-	// If the user explicitly disabled subset filtering, return the default pool (all pods).
+	// If the user explicitly disabled subset filtering, return the default pool (all endpoint candidates).
 	if d.config.DisableEndpointSubsetFilter {
-		loggerTrace.Info("endpoint subset filtering is explicitly disabled, returning all pods")
+		loggerTrace.Info("endpoint subset filtering is explicitly disabled, returning all endpoint candidates")
 		return d.datastore.PodList(datastore.AllPodsPredicate)
 	}
 
 	// Check if the subset filter namespace exists in metadata.
-	// If not, we assume the request targets the default pool (all pods).
+	// If not, we assume the request targets the default pool (all endpoint candidates).
 	if requestMetadata == nil {
 		return d.datastore.PodList(datastore.AllPodsPredicate)
 	}
@@ -124,7 +124,7 @@ func (d *DatastorePodLocator) Locate(ctx context.Context, requestMetadata map[st
 	// If the filter key exists but the list is empty, it implies a filter that matched nothing upstream (or malformed
 	// data), so we return nothing.
 	if len(endpointSubsetList) == 0 {
-		loggerTrace.Info("found empty subset filter in request metadata, returning empty pod list")
+		loggerTrace.Info("found empty subset filter in request metadata, returning empty endpoint candidate list")
 		return []fwkdl.Endpoint{}
 	}
 
@@ -160,29 +160,29 @@ func (d *DatastorePodLocator) Locate(ctx context.Context, requestMetadata map[st
 		return false
 	})
 
-	loggerTrace.Info("filtered candidate pods by subset filtering",
+	loggerTrace.Info("filtered endpoint candidates by subset filtering",
 		"podTotalCount", podTotalCount,
 		"filteredCount", len(podFilteredList))
 
 	return podFilteredList
 }
 
-// --- CachedPodLocator (The Decorator) ---
+// --- CachedEndpointCandidates (The Decorator) ---
 
-// cacheEntry represents a snapshot of pod metrics at a specific point in time.
+// cacheEntry represents a snapshot of endpoint candidate metrics at a specific point in time.
 type cacheEntry struct {
 	pods   []fwkdl.Endpoint
 	expiry time.Time
 }
 
-// CachedPodLocator is a decorator for contracts.PodLocator that caches resultscto reduce lock contention on the
+// CachedEndpointCandidates is a decorator for contracts.EndpointCandidates that caches results to reduce lock contention on the
 // underlying Datastore.
 //
 // It is designed for high-throughput paths (like the Flow Control dispatch loop)cwhere fetching fresh data every
 // millisecond is unnecessary and expensive.
-type CachedPodLocator struct {
-	// delegate is the underlying source of truth (usually the DatastorePodLocator).
-	delegate contracts.PodLocator
+type CachedEndpointCandidates struct {
+	// delegate is the underlying source of truth (usually the DatastoreEndpointCandidates).
+	delegate contracts.EndpointCandidates
 
 	// ttl defines how long a cache entry remains valid.
 	ttl time.Duration
@@ -192,16 +192,16 @@ type CachedPodLocator struct {
 	cache map[string]cacheEntry
 }
 
-var _ contracts.PodLocator = &CachedPodLocator{}
+var _ contracts.EndpointCandidates = &CachedEndpointCandidates{}
 
-// NewCachedPodLocator creates a new CachedPodLocator and starts a background cleanup routine.
+// NewCachedEndpointCandidates creates a new CachedEndpointCandidates and starts a background cleanup routine.
 // The provided context is used to control the lifecycle of the cleanup goroutine.
-func NewCachedPodLocator(ctx context.Context, delegate contracts.PodLocator, ttl time.Duration) *CachedPodLocator {
+func NewCachedEndpointCandidates(ctx context.Context, delegate contracts.EndpointCandidates, ttl time.Duration) *CachedEndpointCandidates {
 	if ttl <= 0 {
 		ttl = defaultCacheTTL
 	}
 
-	c := &CachedPodLocator{
+	c := &CachedEndpointCandidates{
 		delegate: delegate,
 		ttl:      ttl,
 		cache:    make(map[string]cacheEntry),
@@ -213,9 +213,9 @@ func NewCachedPodLocator(ctx context.Context, delegate contracts.PodLocator, ttl
 	return c
 }
 
-// Locate returns the list of candidate pods for the given request metadata, using a cached result if available and
+// Locate returns the list of endpoint candidates for the given request metadata, using a cached result if available and
 // fresh.
-func (c *CachedPodLocator) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
+func (c *CachedEndpointCandidates) Locate(ctx context.Context, requestMetadata map[string]any) []fwkdl.Endpoint {
 	key := c.generateCacheKey(requestMetadata)
 
 	// Fast Path: Read Lock
@@ -253,10 +253,10 @@ func (c *CachedPodLocator) Locate(ctx context.Context, requestMetadata map[strin
 	return freshPods
 }
 
-// generateCacheKey creates a deterministic string key representing the pod selection criteria.
+// generateCacheKey creates a deterministic string key representing the endpoint selection criteria.
 // It handles the "x-gateway-destination-endpoint-subset" structure specifically.
-func (c *CachedPodLocator) generateCacheKey(reqMetadata map[string]any) string {
-	// No Metadata -> All Pods
+func (c *CachedEndpointCandidates) generateCacheKey(reqMetadata map[string]any) string {
+	// No Metadata -> All Endpoints
 	if reqMetadata == nil {
 		return defaultCacheKey
 	}
@@ -270,12 +270,12 @@ func (c *CachedPodLocator) generateCacheKey(reqMetadata map[string]any) string {
 	// We must treat this list as a set (order independent).
 	endpointSubsetList, found := subsetMap[metadata.SubsetFilterKey].([]any)
 
-	// Namespace exists, but "subset" key is missing -> All Pods
+	// Namespace exists, but "subset" key is missing -> All Endpoints
 	if !found {
 		return defaultCacheKey
 	}
 
-	// "subset" key exists, but is empty list -> No Pods
+	// "subset" key exists, but is empty list -> No Endpoints
 	if len(endpointSubsetList) == 0 {
 		return emptySubsetCacheKey
 	}
@@ -301,8 +301,8 @@ func (c *CachedPodLocator) generateCacheKey(reqMetadata map[string]any) string {
 }
 
 // runCleanup periodically removes expired entries from the cache to prevent unbounded growth.
-func (c *CachedPodLocator) runCleanup(ctx context.Context) {
-	logger := log.FromContext(ctx).WithName("CachedPodLocatorCleanup")
+func (c *CachedEndpointCandidates) runCleanup(ctx context.Context) {
+	logger := log.FromContext(ctx).WithName("CachedEndpointCandidatesCleanup")
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
@@ -318,7 +318,7 @@ func (c *CachedPodLocator) runCleanup(ctx context.Context) {
 }
 
 // cleanup iterates over the map and removes expired entries.
-func (c *CachedPodLocator) cleanup() {
+func (c *CachedEndpointCandidates) cleanup() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/epp/requestcontrol/candidates_test.go
+++ b/pkg/epp/requestcontrol/candidates_test.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
-// --- DatastorePodLocator Tests ---
+// --- DatastoreEndpointCandidates Tests ---
 
-func TestDatastorePodLocator_Locate(t *testing.T) {
+func TestDatastoreEndpointCandidates_Locate(t *testing.T) {
 	t.Parallel()
 
 	endpointA := makeMockEndpoint("pod-a", "10.0.0.1")
@@ -45,7 +45,7 @@ func TestDatastorePodLocator_Locate(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		opts                []LocatorOption
+		opts                []EndpointCandidatesOption
 		metadata            map[string]any
 		expectedEndpointIPs []string
 	}{
@@ -107,7 +107,7 @@ func TestDatastorePodLocator_Locate(t *testing.T) {
 		},
 		{
 			name: "Subset filter with match (filter disabled)",
-			opts: []LocatorOption{
+			opts: []EndpointCandidatesOption{
 				WithDisableEndpointSubsetFilter(true),
 			},
 			metadata: makeMetadataWithSubset([]any{
@@ -117,7 +117,7 @@ func TestDatastorePodLocator_Locate(t *testing.T) {
 		},
 		{
 			name: "Subset filter is present but list is empty (filter disabled)",
-			opts: []LocatorOption{
+			opts: []EndpointCandidatesOption{
 				WithDisableEndpointSubsetFilter(true),
 			},
 			metadata:            makeMetadataWithSubset([]any{}),
@@ -125,7 +125,7 @@ func TestDatastorePodLocator_Locate(t *testing.T) {
 		},
 		{
 			name: "Subset filter with no matches (filter disabled)",
-			opts: []LocatorOption{
+			opts: []EndpointCandidatesOption{
 				WithDisableEndpointSubsetFilter(true),
 			},
 			metadata: makeMetadataWithSubset([]any{
@@ -138,30 +138,30 @@ func TestDatastorePodLocator_Locate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			locator := NewDatastorePodLocator(mockDS, tc.opts...)
-			result := locator.Locate(context.Background(), tc.metadata)
+			endpointCandidates := NewDatastoreEndpointCandidates(mockDS, tc.opts...)
+			result := endpointCandidates.Locate(context.Background(), tc.metadata)
 
 			var gotIPs []string
 			for _, ep := range result {
 				gotIPs = append(gotIPs, ep.GetMetadata().GetIPAddress())
 			}
-			assert.ElementsMatch(t, tc.expectedEndpointIPs, gotIPs, "Locate returned unexpected set of pods")
+			assert.ElementsMatch(t, tc.expectedEndpointIPs, gotIPs, "Locate returned unexpected set of endpoint candidates")
 		})
 	}
 }
 
-// --- CachedPodLocator Tests ---
+// --- CachedEndpointCandidates Tests ---
 
-func TestCachedPodLocator_CachingBehavior(t *testing.T) {
+func TestCachedEndpointCandidates_CachingBehavior(t *testing.T) {
 	t.Parallel()
 
-	mockDelegate := &mockPodLocator{
+	mockDelegate := &mockEndpointCandidates{
 		result: []fwkdl.Endpoint{makeMockEndpoint("p1", "1.1.1.1")},
 	}
 
 	// Use a short TTL for testing.
 	ttl := 20 * time.Millisecond
-	cached := NewCachedPodLocator(context.Background(), mockDelegate, ttl)
+	cached := NewCachedEndpointCandidates(context.Background(), mockDelegate, ttl)
 	meta := makeMetadataWithSubset([]any{"1.1.1.1:80"})
 
 	// 1. First Call: Should hit delegate
@@ -183,11 +183,11 @@ func TestCachedPodLocator_CachingBehavior(t *testing.T) {
 	assert.Equal(t, 2, mockDelegate.callCount(), "Expected delegate to be called after TTL expiry")
 }
 
-func TestCachedPodLocator_CacheKeyDeterminism(t *testing.T) {
+func TestCachedEndpointCandidates_CacheKeyDeterminism(t *testing.T) {
 	t.Parallel()
 
-	mockDelegate := &mockPodLocator{}
-	cached := NewCachedPodLocator(context.Background(), mockDelegate, time.Minute)
+	mockDelegate := &mockEndpointCandidates{}
+	cached := NewCachedEndpointCandidates(context.Background(), mockDelegate, time.Minute)
 
 	// Scenario: subset [A, B] should generate same cache key as [B, A].
 	metaOrder1 := makeMetadataWithSubset([]any{"10.0.0.1:80", "10.0.0.2:80"})
@@ -200,18 +200,18 @@ func TestCachedPodLocator_CacheKeyDeterminism(t *testing.T) {
 	assert.Equal(t, 1, mockDelegate.callCount(), "Different order of subset endpoints should hit the same cache entry")
 }
 
-func TestCachedPodLocator_Concurrency_ThunderingHerd(t *testing.T) {
+func TestCachedEndpointCandidates_Concurrency_ThunderingHerd(t *testing.T) {
 	t.Parallel()
 
 	// Simulate a slow delegate to exacerbate race conditions.
-	mockDelegate := &mockPodLocator{
+	mockDelegate := &mockEndpointCandidates{
 		delay: 10 * time.Millisecond,
 		result: []fwkdl.Endpoint{
 			makeMockEndpoint("p1", "1.1.1.1"),
 		},
 	}
 
-	cached := NewCachedPodLocator(context.Background(), mockDelegate, 100*time.Millisecond)
+	cached := NewCachedEndpointCandidates(context.Background(), mockDelegate, 100*time.Millisecond)
 	meta := makeMetadataWithSubset([]any{"1.1.1.1:80"})
 
 	concurrency := 50
@@ -238,11 +238,11 @@ func TestCachedPodLocator_Concurrency_ThunderingHerd(t *testing.T) {
 	assert.Equal(t, 1, mockDelegate.callCount(), "Delegate should be called exactly once despite concurrent access")
 }
 
-func TestCachedPodLocator_DifferentSubsetsAreIsolated(t *testing.T) {
+func TestCachedEndpointCandidates_DifferentSubsetsAreIsolated(t *testing.T) {
 	t.Parallel()
 
-	mockDelegate := &mockPodLocator{}
-	cached := NewCachedPodLocator(context.Background(), mockDelegate, time.Minute)
+	mockDelegate := &mockEndpointCandidates{}
+	cached := NewCachedEndpointCandidates(context.Background(), mockDelegate, time.Minute)
 
 	metaA := makeMetadataWithSubset([]any{"10.0.0.1:80"})
 	metaB := makeMetadataWithSubset([]any{"10.0.0.2:80"})
@@ -254,13 +254,13 @@ func TestCachedPodLocator_DifferentSubsetsAreIsolated(t *testing.T) {
 	assert.Equal(t, 2, mockDelegate.callCount(), "Different subsets must trigger distinct delegate calls")
 }
 
-func TestCachedPodLocator_CacheIsolation_EmptyVsDefault(t *testing.T) {
+func TestCachedEndpointCandidates_CacheIsolation_EmptyVsDefault(t *testing.T) {
 	t.Parallel()
 
-	mockDelegate := &mockPodLocator{
+	mockDelegate := &mockEndpointCandidates{
 		result: []fwkdl.Endpoint{makeMockEndpoint("p1", "1.1.1.1")},
 	}
-	cached := NewCachedPodLocator(context.Background(), mockDelegate, time.Minute)
+	cached := NewCachedEndpointCandidates(context.Background(), mockDelegate, time.Minute)
 
 	// 1. Request All Pods (No Metadata)
 	res1 := cached.Locate(context.Background(), nil)
@@ -276,15 +276,15 @@ func TestCachedPodLocator_CacheIsolation_EmptyVsDefault(t *testing.T) {
 
 // --- Helpers & Mocks ---
 
-// mockPodLocator implements contracts.PodLocator.
-type mockPodLocator struct {
+// mockEndpointCandidates implements contracts.EndpointCandidates.
+type mockEndpointCandidates struct {
 	mu     sync.Mutex
 	calls  int
 	delay  time.Duration
 	result []fwkdl.Endpoint
 }
 
-func (m *mockPodLocator) Locate(ctx context.Context, _ map[string]any) []fwkdl.Endpoint {
+func (m *mockEndpointCandidates) Locate(ctx context.Context, _ map[string]any) []fwkdl.Endpoint {
 	m.mu.Lock()
 	m.calls++
 	delay := m.delay
@@ -297,7 +297,7 @@ func (m *mockPodLocator) Locate(ctx context.Context, _ map[string]any) []fwkdl.E
 	return result
 }
 
-func (m *mockPodLocator) callCount() int {
+func (m *mockEndpointCandidates) callCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.calls

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -74,14 +74,14 @@ func NewDirectorWithConfig(
 	scheduler Scheduler,
 	admissionController AdmissionController,
 	parser fwkrh.Parser,
-	podLocator contracts.PodLocator,
+	endpointCandidates contracts.EndpointCandidates,
 	config *Config,
 ) *Director {
 	return &Director{
 		datastore:             datastore,
 		scheduler:             scheduler,
 		admissionController:   admissionController,
-		podLocator:            podLocator,
+		endpointCandidates:    endpointCandidates,
 		requestControlPlugins: *config,
 		parser:                parser,
 		defaultPriority:       0, // define default priority explicitly
@@ -101,7 +101,7 @@ type Director struct {
 	datastore             Datastore
 	scheduler             Scheduler
 	admissionController   AdmissionController
-	podLocator            contracts.PodLocator
+	endpointCandidates    contracts.EndpointCandidates
 	requestControlPlugins Config
 	// we just need a pointer to an int variable since priority is a pointer in InferenceObjective
 	// no need to set this in the constructor, since the value we want is the default int val
@@ -168,28 +168,29 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	if err := d.admissionController.Admit(ctx, reqCtx, *infObjective.Spec.Priority); err != nil {
 		return reqCtx, err
 	}
-	candidateEndpoints := d.podLocator.Locate(ctx, reqCtx.Request.Metadata)
-	if len(candidateEndpoints) == 0 {
+
+	endpointCandidates := d.endpointCandidates.Locate(ctx, reqCtx.Request.Metadata)
+	if len(endpointCandidates) == 0 {
 		return reqCtx, errcommon.Error{
 			Code: errcommon.ServiceUnavailable,
-			Msg:  "failed to find candidate endpoints for serving the request",
+			Msg:  "failed to find endpoint candidates for serving the request",
 		}
 	}
-	candidateSnapshot := d.toSchedulerEndpoints(candidateEndpoints)
 
+	snapshotOfCandidatePods := d.toSchedulerEndpoints(endpointCandidates)
 	// Prepare per request data by running PrepareData plugins.
-	err = d.runPrepareDataPlugins(ctx, reqCtx.SchedulingRequest, candidateSnapshot)
+	err = d.runPrepareDataPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if err != nil {
 		// Don't fail the request if PrepareData plugins fail.
 		logger.Error(err, "failed to prepare per request data")
 	}
 
 	// Run admit request plugins
-	if !d.runAdmissionPlugins(ctx, reqCtx.SchedulingRequest, candidateSnapshot) {
+	if !d.runAdmissionPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods) {
 		return reqCtx, errcommon.Error{Code: errcommon.Internal, Msg: "request cannot be admitted"}
 	}
 
-	result, err := d.scheduler.Schedule(ctx, reqCtx.SchedulingRequest, candidateSnapshot)
+	result, err := d.scheduler.Schedule(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if err != nil {
 		return reqCtx, errcommon.Error{Code: errcommon.ResourceExhausted, Msg: fmt.Errorf("failed to find target endpoint: %w", err).Error()}
 	}

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -655,15 +655,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 				}
 				config = config.WithAdmissionPlugins(newMockAdmissionPlugin("test-admit-plugin", test.admitRequestDenialError))
 
-				locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
-				director := NewDirectorWithConfig(ds, mockSched, test.mockAdmissionController, openai.NewOpenAIParser(), locator, config)
+				endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
+				director := NewDirectorWithConfig(ds, mockSched, test.mockAdmissionController, openai.NewOpenAIParser(), endpointCandidates, config)
 				if test.name == "successful request with model rewrite" {
 					mockDs := &mockDatastore{
 						pods:     ds.PodList(datastore.AllPodsPredicate),
 						rewrites: []*v1alpha2.InferenceModelRewrite{rewrite},
 					}
 					director.datastore = mockDs
-					director.podLocator = NewCachedPodLocator(context.Background(), NewDatastorePodLocator(mockDs), time.Minute)
+					director.endpointCandidates = NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(mockDs), time.Minute)
 				}
 
 				reqCtx := &handlers.RequestContext{
@@ -967,8 +967,8 @@ func TestDirector_ApplyWeightedModelRewrite(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockDs := &mockDatastore{rewrites: test.rewrites}
-			locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(mockDs), time.Minute)
-			director := NewDirectorWithConfig(mockDs, &mockScheduler{}, &mockAdmissionController{}, nil, locator, NewConfig())
+			endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(mockDs), time.Minute)
+			director := NewDirectorWithConfig(mockDs, &mockScheduler{}, &mockAdmissionController{}, nil, endpointCandidates, NewConfig())
 
 			reqCtx := &handlers.RequestContext{
 				IncomingModelName: test.incomingModel,
@@ -1068,13 +1068,13 @@ func TestDirector_HandleResponseReceived(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	ds := datastore.NewDatastore(t.Context(), nil, 0)
 	mockSched := &mockScheduler{}
-	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
+	endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
 	director := NewDirectorWithConfig(
 		ds,
 		mockSched,
 		&mockAdmissionController{},
 		nil,
-		locator,
+		endpointCandidates,
 		NewConfig().WithResponseReceivedPlugins(pr1),
 	)
 
@@ -1110,8 +1110,8 @@ func TestDirector_HandleResponseBody(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	ds := datastore.NewDatastore(t.Context(), nil, 0)
 	mockSched := &mockScheduler{}
-	locator := NewCachedPodLocator(context.Background(), NewDatastorePodLocator(ds), time.Minute)
-	director := NewDirectorWithConfig(ds, mockSched, nil, nil, locator, NewConfig().WithResponseStreamingPlugins(ps1))
+	endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
+	director := NewDirectorWithConfig(ds, mockSched, nil, nil, endpointCandidates, NewConfig().WithResponseStreamingPlugins(ps1))
 
 	reqCtx := &handlers.RequestContext{
 		Request: &handlers.Request{

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -215,7 +215,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 				P(1, 0, 0.1, "foo", modelSQLLoraTarget),
 			},
 			wantResponses: ExpectReject(envoyTypePb.StatusCode_ServiceUnavailable,
-				"inference error: ServiceUnavailable - failed to find candidate endpoints for serving the request"),
+				"inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request"),
 		},
 
 		// --- Response Processing (Non-streaming) ---

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -193,7 +193,7 @@ parser:
 					},
 					wantResponses: ExpectReject(
 						envoyTypePb.StatusCode_BadRequest,
-						"inference error: BadRequest - error unmarshaling request bodyMap",
+						"inference error: BadRequest - error unmarshaling request bodyMap: invalid character 'o' in literal null (expecting 'u')",
 					),
 				},
 				{
@@ -265,7 +265,7 @@ parser:
 						P(1, 0, 0.1, "foo", modelSQLLoraTarget),
 					},
 					wantResponses: ExpectReject(envoyTypePb.StatusCode_ServiceUnavailable,
-						"inference error: ServiceUnavailable - failed to find candidate endpoints for serving the request"),
+						"inference error: ServiceUnavailable - failed to find endpoint candidates for serving the request"),
 				},
 
 				// --- Request Modification (Passthrough & Rewrite) ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind feature

**What this PR does / why we need it**:

Rename the PodLocator interface and all related types to EndpointCandidates to better reflect that these components resolve candidate endpoints rather than just pods. Update variable names, comments, and documentation accordingly. This is a pure refactoring with no functional changes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1969

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
