### PR TITLE
[bbr] Apply request body mutations to ext_proc response

### DIFF
--- a/pkg/bbr/handlers/request.go
+++ b/pkg/bbr/handlers/request.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	eppb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -65,6 +66,13 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 	reqCtx.Request.SetHeader(BaseModelHeader, baseModel)
 	logger.Info("Base model from datastore", "baseModel", baseModel)
 
+	// TODO: check and do this only if the request body actually changed.
+	mutatedBodyBytes, err := json.Marshal(reqCtx.Request.Body)
+	if err != nil {
+		return nil, err
+	}
+	reqCtx.Request.SetHeader(contentLengthHeader, strconv.Itoa(len(mutatedBodyBytes)))
+
 	metrics.RecordSuccessCounter()
 
 	if s.streaming {
@@ -81,7 +89,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 				},
 			},
 		})
-		ret = addStreamedBodyResponse(ret, requestBodyBytes)
+		ret = addStreamedBodyResponse(ret, mutatedBodyBytes)
 		return ret, nil
 	}
 
@@ -95,6 +103,11 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 						HeaderMutation: &eppb.HeaderMutation{
 							SetHeaders:    envoy.GenerateHeadersMutation(reqCtx.Request.MutatedHeaders()),
 							RemoveHeaders: reqCtx.Request.RemovedHeaders(),
+						},
+						BodyMutation: &eppb.BodyMutation{
+							Mutation: &eppb.BodyMutation_Body{
+								Body: mutatedBodyBytes,
+							},
 						},
 					},
 				},

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -211,34 +212,47 @@ func TestHandleRequestBody(t *testing.T) {
 				"model":  1,
 				"prompt": "Tell me a joke",
 			},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								// Necessary so that the new headers are used in the routing decision.
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      ModelHeader,
-												RawValue: []byte("1"),
+			want: func() []*extProcPb.ProcessingResponse {
+				b, _ := json.Marshal(map[string]any{"model": 1, "prompt": "Tell me a joke"})
+				return []*extProcPb.ProcessingResponse{
+					{
+						Response: &extProcPb.ProcessingResponse_RequestBody{
+							RequestBody: &extProcPb.BodyResponse{
+								Response: &extProcPb.CommonResponse{
+									ClearRouteCache: true,
+									HeaderMutation: &extProcPb.HeaderMutation{
+										SetHeaders: []*basepb.HeaderValueOption{
+											{
+												Header: &basepb.HeaderValue{
+													Key:      ModelHeader,
+													RawValue: []byte("1"),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      BaseModelHeader,
+													RawValue: []byte(""),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      contentLengthHeader,
+													RawValue: []byte(strconv.Itoa(len(b))),
+												},
 											},
 										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      BaseModelHeader,
-												RawValue: []byte(""),
-											},
+									},
+									BodyMutation: &extProcPb.BodyMutation{
+										Mutation: &extProcPb.BodyMutation_Body{
+											Body: b,
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-			},
+				}
+			}(),
 		},
 		{
 			name: "success",
@@ -246,34 +260,47 @@ func TestHandleRequestBody(t *testing.T) {
 				"model":  "foo",
 				"prompt": "Tell me a joke",
 			},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								// Necessary so that the new headers are used in the routing decision.
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      ModelHeader,
-												RawValue: []byte("foo"),
+			want: func() []*extProcPb.ProcessingResponse {
+				b, _ := json.Marshal(map[string]any{"model": "foo", "prompt": "Tell me a joke"})
+				return []*extProcPb.ProcessingResponse{
+					{
+						Response: &extProcPb.ProcessingResponse_RequestBody{
+							RequestBody: &extProcPb.BodyResponse{
+								Response: &extProcPb.CommonResponse{
+									ClearRouteCache: true,
+									HeaderMutation: &extProcPb.HeaderMutation{
+										SetHeaders: []*basepb.HeaderValueOption{
+											{
+												Header: &basepb.HeaderValue{
+													Key:      ModelHeader,
+													RawValue: []byte("foo"),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      BaseModelHeader,
+													RawValue: []byte(""),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      contentLengthHeader,
+													RawValue: []byte(strconv.Itoa(len(b))),
+												},
 											},
 										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      BaseModelHeader,
-												RawValue: []byte(""),
-											},
+									},
+									BodyMutation: &extProcPb.BodyMutation{
+										Mutation: &extProcPb.BodyMutation_Body{
+											Body: b,
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-			},
+				}
+			}(),
 		},
 		{
 			name: "success-with-streaming",
@@ -282,24 +309,33 @@ func TestHandleRequestBody(t *testing.T) {
 				"prompt": "Tell me a joke",
 			},
 			streaming: true,
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestHeaders{
-						RequestHeaders: &extProcPb.HeadersResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*basepb.HeaderValueOption{
-										{
-											Header: &basepb.HeaderValue{
-												Key:      ModelHeader,
-												RawValue: []byte("foo"),
+			want: func() []*extProcPb.ProcessingResponse {
+				b, _ := json.Marshal(map[string]any{"model": "foo", "prompt": "Tell me a joke"})
+				return []*extProcPb.ProcessingResponse{
+					{
+						Response: &extProcPb.ProcessingResponse_RequestHeaders{
+							RequestHeaders: &extProcPb.HeadersResponse{
+								Response: &extProcPb.CommonResponse{
+									ClearRouteCache: true,
+									HeaderMutation: &extProcPb.HeaderMutation{
+										SetHeaders: []*basepb.HeaderValueOption{
+											{
+												Header: &basepb.HeaderValue{
+													Key:      ModelHeader,
+													RawValue: []byte("foo"),
+												},
 											},
-										},
-										{
-											Header: &basepb.HeaderValue{
-												Key:      BaseModelHeader,
-												RawValue: []byte(""),
+											{
+												Header: &basepb.HeaderValue{
+													Key:      BaseModelHeader,
+													RawValue: []byte(""),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      contentLengthHeader,
+													RawValue: []byte(strconv.Itoa(len(b))),
+												},
 											},
 										},
 									},
@@ -307,27 +343,24 @@ func TestHandleRequestBody(t *testing.T) {
 							},
 						},
 					},
-				},
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								BodyMutation: &extProcPb.BodyMutation{
-									Mutation: &extProcPb.BodyMutation_StreamedResponse{
-										StreamedResponse: &extProcPb.StreamedBodyResponse{
-											Body: mapToBytes(t, map[string]any{
-												"model":  "foo",
-												"prompt": "Tell me a joke",
-											}),
-											EndOfStream: true,
+					{
+						Response: &extProcPb.ProcessingResponse_RequestBody{
+							RequestBody: &extProcPb.BodyResponse{
+								Response: &extProcPb.CommonResponse{
+									BodyMutation: &extProcPb.BodyMutation{
+										Mutation: &extProcPb.BodyMutation_StreamedResponse{
+											StreamedResponse: &extProcPb.StreamedBodyResponse{
+												Body:        b,
+												EndOfStream: true,
+											},
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-			},
+				}
+			}(),
 		},
 		{
 			name: "success-with-streaming-large-body",
@@ -363,6 +396,12 @@ func TestHandleRequestBody(t *testing.T) {
 												Header: &basepb.HeaderValue{
 													Key:      BaseModelHeader,
 													RawValue: []byte(""),
+												},
+											},
+											{
+												Header: &basepb.HeaderValue{
+													Key:      contentLengthHeader,
+													RawValue: []byte(strconv.Itoa(len(b))),
 												},
 											},
 										},

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -38,6 +38,8 @@ const (
 	ModelHeader     = "X-Gateway-Model-Name"
 	BaseModelHeader = "X-Gateway-Base-Model-Name"
 
+	contentLengthHeader = "Content-Length"
+
 	requestPluginExtensionPoint  = "request"
 	responsePluginExtensionPoint = "response"
 )

--- a/pkg/bbr/handlers/server_test.go
+++ b/pkg/bbr/handlers/server_test.go
@@ -18,6 +18,8 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 	"testing"
 
 	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -34,6 +36,7 @@ import (
 func TestHandleRequestBodyStreaming(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
+	b, _ := json.Marshal(map[string]any{"model": "foo"})
 	cases := []struct {
 		desc      string
 		streaming bool
@@ -42,9 +45,7 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 	}{
 		{
 			desc: "no-streaming",
-			body: mapToBytes(t, map[string]any{
-				"model": "foo",
-			}),
+			body: b,
 			want: []*extProcPb.ProcessingResponse{
 				{
 					Response: &extProcPb.ProcessingResponse_RequestBody{
@@ -66,6 +67,17 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 												RawValue: []byte(""),
 											},
 										},
+										{
+											Header: &basepb.HeaderValue{
+												Key:      contentLengthHeader,
+												RawValue: []byte(strconv.Itoa(len(b))),
+											},
+										},
+									},
+								},
+								BodyMutation: &extProcPb.BodyMutation{
+									Mutation: &extProcPb.BodyMutation_Body{
+										Body: b,
 									},
 								},
 							},
@@ -77,9 +89,7 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 		{
 			desc:      "streaming",
 			streaming: true,
-			body: mapToBytes(t, map[string]any{
-				"model": "foo",
-			}),
+			body:      b,
 			want: []*extProcPb.ProcessingResponse{
 				{
 					Response: &extProcPb.ProcessingResponse_RequestHeaders{
@@ -100,6 +110,12 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 												RawValue: []byte(""),
 											},
 										},
+										{
+											Header: &basepb.HeaderValue{
+												Key:      contentLengthHeader,
+												RawValue: []byte(strconv.Itoa(len(b))),
+											},
+										},
 									},
 								},
 							},
@@ -113,9 +129,7 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 								BodyMutation: &extProcPb.BodyMutation{
 									Mutation: &extProcPb.BodyMutation_StreamedResponse{
 										StreamedResponse: &extProcPb.StreamedBodyResponse{
-											Body: mapToBytes(t, map[string]any{
-												"model": "foo",
-											}),
+											Body:        b,
 											EndOfStream: true,
 										},
 									},

--- a/test/integration/bbr/hermetic_test.go
+++ b/test/integration/bbr/hermetic_test.go
@@ -44,13 +44,13 @@ func TestBodyBasedRouting(t *testing.T) {
 		{
 			name:         "success: extracts model and sets header",
 			req:          integration.ReqLLMUnary(logger, "test", "llama"),
-			wantResponse: ExpectBBRUnaryResponse("llama"),
+			wantResponse: ExpectBBRUnaryResponse("llama", "test"),
 			wantErr:      false,
 		},
 		{
 			name:         "noop: no model parameter in body",
 			req:          integration.ReqLLMUnary(logger, "test1", ""),
-			wantResponse: ExpectBBRUnaryResponse(""), // Expect no headers.
+			wantResponse: ExpectBBRUnaryResponse("", ""), // Expect no headers.
 			wantErr:      false,
 		},
 	}
@@ -95,7 +95,7 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			name: "success: adds model header from simple body",
 			reqs: integration.ReqLLM(logger, "test", "foo", "bar"),
 			wantResponses: []*extProcPb.ProcessingResponse{
-				ExpectBBRHeader("foo"),
+				ExpectBBRHeader("foo", "test"),
 				ExpectBBRBodyPassThrough("test", "foo"),
 			},
 		},
@@ -107,7 +107,7 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 				`ra-sheddable","prompt":"test","temperature":0}`,
 			),
 			wantResponses: []*extProcPb.ProcessingResponse{
-				ExpectBBRHeader("sql-lora-sheddable"),
+				ExpectBBRHeader("sql-lora-sheddable", "test"),
 				ExpectBBRBodyPassThrough("test", "sql-lora-sheddable"),
 			},
 		},

--- a/test/integration/bbr/util.go
+++ b/test/integration/bbr/util.go
@@ -18,6 +18,7 @@ package bbr
 
 import (
 	"encoding/json"
+	"strconv"
 
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -26,7 +27,9 @@ import (
 // --- Response Expectations (Streaming) ---
 
 // ExpectBBRHeader asserts that BBR set the specific model header and cleared the route cache.
-func ExpectBBRHeader(modelName string) *extProcPb.ProcessingResponse {
+func ExpectBBRHeader(modelName, prompt string) *extProcPb.ProcessingResponse {
+	b := marshalExpectedBody(prompt, modelName)
+
 	return &extProcPb.ProcessingResponse{
 		Response: &extProcPb.ProcessingResponse_RequestHeaders{
 			RequestHeaders: &extProcPb.HeadersResponse{
@@ -34,6 +37,12 @@ func ExpectBBRHeader(modelName string) *extProcPb.ProcessingResponse {
 					ClearRouteCache: true,
 					HeaderMutation: &extProcPb.HeaderMutation{
 						SetHeaders: []*envoyCorev3.HeaderValueOption{
+							{
+								Header: &envoyCorev3.HeaderValue{
+									Key:      "Content-Length",
+									RawValue: []byte(strconv.Itoa(len(b))),
+								},
+							},
 							{
 								Header: &envoyCorev3.HeaderValue{
 									Key:      "X-Gateway-Model-Name",
@@ -95,17 +104,25 @@ func ExpectBBRNoOpHeader() *extProcPb.ProcessingResponse {
 // --- Response Expectations (Unary) ---
 
 // ExpectBBRUnaryResponse creates expected response for unary tests where the body is mutated directly.
-func ExpectBBRUnaryResponse(modelName string) *extProcPb.ProcessingResponse {
+func ExpectBBRUnaryResponse(modelName, prompt string) *extProcPb.ProcessingResponse {
 	resp := &extProcPb.ProcessingResponse{}
 
-	// If modelName is present, we expect header mutations.
+	// If modelName is present, we expect header mutations and body mutation.
 	if modelName != "" {
+		b := marshalExpectedBody(prompt, modelName)
+
 		resp.Response = &extProcPb.ProcessingResponse_RequestBody{
 			RequestBody: &extProcPb.BodyResponse{
 				Response: &extProcPb.CommonResponse{
 					ClearRouteCache: true,
 					HeaderMutation: &extProcPb.HeaderMutation{
 						SetHeaders: []*envoyCorev3.HeaderValueOption{
+							{
+								Header: &envoyCorev3.HeaderValue{
+									Key:      "Content-Length",
+									RawValue: []byte(strconv.Itoa(len(b))),
+								},
+							},
 							{
 								Header: &envoyCorev3.HeaderValue{
 									Key:      "X-Gateway-Model-Name",
@@ -120,6 +137,11 @@ func ExpectBBRUnaryResponse(modelName string) *extProcPb.ProcessingResponse {
 							},
 						},
 					},
+					BodyMutation: &extProcPb.BodyMutation{
+						Mutation: &extProcPb.BodyMutation_Body{
+							Body: b,
+						},
+					},
 				},
 			},
 		}
@@ -130,4 +152,15 @@ func ExpectBBRUnaryResponse(modelName string) *extProcPb.ProcessingResponse {
 		}
 	}
 	return resp
+}
+
+func marshalExpectedBody(prompt, model string) []byte {
+	j := map[string]any{
+		"max_tokens": 100, "prompt": prompt, "temperature": 0,
+	}
+	if model != "" {
+		j["model"] = model
+	}
+	b, _ := json.Marshal(j)
+	return b
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Previously, after BBR request plugins ran (potentially mutating `reqCtx.Request.Body`), the original pre-plugin request body bytes were forwarded to Envoy — silently discarding any body mutations. Additionally, the `Content-Length` header was never updated to reflect the new body size, and the non-streaming path included no body mutation at all.

This PR ensures the mutated body is marshaled, the `Content-Length` header is updated, and the mutated bytes are sent back to Envoy in both streaming and non-streaming paths.

Key changes:
- After plugins run, marshal `reqCtx.Request.Body` back to bytes
- Set `Content-Length` header to the new body size
- **Streaming path**: pass mutated bytes to `addStreamedBodyResponse` (was passing original `requestBodyBytes`)
- **Non-streaming path**: include `BodyMutation_Body` in the `CommonResponse` (was omitting body mutation entirely)
- Update unit and integration test expectations to verify Content-Length header and body mutation

This is the request-side complement to #2477 (which applies response plugin mutations).

**What's NOT included:**
- Conditional body mutation (only re-serialize if body was actually mutated) — planned as a follow-up to avoid unnecessary marshaling when plugins don't modify the body.

**Does this PR introduce a user-facing change?**

Users writing BBR request plugins that mutate the request body will now see their mutations
applied to the upstream request. Previously, body mutations were silently discarded.