### PR TITLE
Revert "Support arm64 builds (#2350)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 ## Multistage build
 FROM ${BUILDER_IMAGE} AS builder
-ARG TARGETARCH
 ENV CGO_ENABLED=0
 ENV GOOS=linux
-ENV GOARCH=${TARGETARCH}
+ENV GOARCH=amd64
 ARG COMMIT_SHA=unknown
 ARG BUILD_REF
 

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,6 @@ image-build: ## Build the EPP image using Docker Buildx.
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
 		--build-arg COMMIT_SHA=${GIT_COMMIT_SHA} \
 		--build-arg BUILD_REF=${BUILD_REF} \
 		$(PUSH) \
@@ -310,7 +309,6 @@ bbr-image-build: ## Build the image using Docker Buildx.
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
 		$(PUSH) \
 		$(LOAD) \
 		$(BBR_IMAGE_BUILD_EXTRA_OPTS) ./

--- a/bbr.Dockerfile
+++ b/bbr.Dockerfile
@@ -5,10 +5,9 @@ ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 ## Multistage build
 FROM ${BUILDER_IMAGE} AS builder
-ARG TARGETARCH
 ENV CGO_ENABLED=0
 ENV GOOS=linux
-ENV GOARCH=${TARGETARCH}
+ENV GOARCH=amd64
 ARG COMMIT_SHA=unknown
 ARG BUILD_REF
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,6 @@ steps:
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
     - GIT_COMMIT_SHA=$_PULL_BASE_SHA
-    - PLATFORMS=linux/amd64,linux/arm64
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
     entrypoint: make
     args:
@@ -22,7 +21,6 @@ steps:
     - GIT_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
-    - PLATFORMS=linux/amd64,linux/arm64
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
     entrypoint: make
     args:
@@ -40,7 +38,6 @@ steps:
     - GIT_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
-    - PLATFORMS=linux/amd64,linux/arm64
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
     entrypoint: make
     args:
@@ -51,7 +48,6 @@ steps:
     - GIT_TAG=$_GIT_TAG
     - EXTRA_TAG=$_PULL_BASE_REF
     - DOCKER_BUILDX_CMD=/buildx-entrypoint
-    - PLATFORMS=linux/amd64,linux/arm64
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
This reverts commit 9a034510da2ba4a1f201fc328265a3de58c49203.

**What this PR does / why we need it**:
Unfortunately the builds started failing with a timeout after this PR merged.

<img width="2694" height="1248" alt="image" src="https://github.com/user-attachments/assets/8251b602-793e-4ea6-ac9b-dfb1881e4a5d" />


This PR is just a band-aid to get the builds unblocked, we should investigate more deeply here. We recently added a few different artifacts to this repo, so its possible that this simply hit the timeout limit, or there is a breaking change. Created https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2555 as a followup