### PR TITLE
fix(bbr): enable response header/body processing in Istio EnvoyFilter

### DIFF
--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -24,9 +24,9 @@ spec:
           allow_mode_override: true
           processing_mode:
             request_header_mode: "SEND"
-            response_header_mode: "SKIP"
+            response_header_mode: "SEND"
             request_body_mode: "FULL_DUPLEX_STREAMED"
-            response_body_mode: "NONE"
+            response_body_mode: "FULL_DUPLEX_STREAMED"
             request_trailer_mode: "SEND"
             response_trailer_mode: "SKIP"
           grpc_service:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Istio EnvoyFilter configuration for BBR had `response_header_mode: "SKIP"` and `response_body_mode: "NONE"`, which meant Envoy never forwarded response headers or body to the BBR ext_proc server. This prevented response plugins (added in #2369, #2477) from being invoked at all.

This PR updates the processing mode to:
- `response_header_mode: "SEND"`
- `response_body_mode: "FULL_DUPLEX_STREAMED"`

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
