### PR TITLE
fix(bbr): enable response header/body processing in Istio EnvoyFilter

### DIFF
--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -24,9 +24,9 @@ spec:
           allow_mode_override: true
           processing_mode:
             request_header_mode: "SEND"
-            response_header_mode: "SKIP"
+            response_header_mode: "SEND"
             request_body_mode: "FULL_DUPLEX_STREAMED"
-            response_body_mode: "NONE"
+            response_body_mode: "FULL_DUPLEX_STREAMED"
             request_trailer_mode: "SEND"
             response_trailer_mode: "SKIP"
           grpc_service:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Remove debug log statements in `pkg/bbr/handlers/server.go` that log raw request and response body content. Logging user payloads is a security/data-leak risk. The verbose-level log lines that only log the `EoS` (end-of-stream) flag are kept.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2477#discussion_r2031736041

**Does this PR introduce a user-facing change?**:
