### PR TITLE
fix(bbr): scope Istio EnvoyFilter to the selected inference gateway

### DIFF
--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -6,10 +6,14 @@ metadata:
   name: {{ .Values.bbr.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  targetRefs:
+  - group: "gateway.networking.k8s.io"
+    kind: Gateway
+    name: {{ .Values.inferenceGateway.name }}
   configPatches:
   - applyTo: HTTP_FILTER
     match:
-      # context omitted so that this applies to both sidecars and gateways
+      context: GATEWAY
       listener:
         filterChain:
           filter:
@@ -28,7 +32,7 @@ spec:
             request_body_mode: "FULL_DUPLEX_STREAMED"
             response_body_mode: "FULL_DUPLEX_STREAMED"
             request_trailer_mode: "SEND"
-            response_trailer_mode: "SKIP"
+            response_trailer_mode: "SEND"
           grpc_service:
             envoy_grpc:
               cluster_name: outbound|{{ .Values.bbr.port }}||{{ .Values.bbr.name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/pkg/bbr/handlers/response.go
+++ b/pkg/bbr/handlers/response.go
@@ -41,19 +41,29 @@ func (s *Server) HandleResponseHeaders(reqCtx *RequestContext, headers *eppb.Htt
 		}
 	}
 
-	return []*eppb.ProcessingResponse{
-		{
-			Response: &eppb.ProcessingResponse_ResponseHeaders{
-				ResponseHeaders: &eppb.HeadersResponse{},
+	if !s.streaming || headers.GetEndOfStream() {
+		return []*eppb.ProcessingResponse{
+			{
+				Response: &eppb.ProcessingResponse_ResponseHeaders{
+					ResponseHeaders: &eppb.HeadersResponse{},
+				},
 			},
-		},
-	}, nil
+		}, nil
+	}
+
+	// In streaming mode with a body pending, defer the response —
+	// HandleResponseBody will send it together with the body response,
+	// mirroring the request-side pattern.
+	return nil, nil
 }
 
 // HandleResponseBody handles response bodies by executing response plugins in order.
 func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext, responseBodyBytes []byte) ([]*eppb.ProcessingResponse, error) {
 	logger := log.FromContext(ctx)
 	if len(s.responsePlugins) == 0 {
+		if s.streaming {
+			return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
+		}
 		return []*eppb.ProcessingResponse{
 			{
 				Response: &eppb.ProcessingResponse_ResponseBody{
@@ -65,6 +75,9 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 
 	if err := json.Unmarshal(responseBodyBytes, &reqCtx.Response.Body); err != nil {
 		logger.Error(err, "Failed to parse response body as JSON, skipping response plugins")
+		if s.streaming {
+			return s.generateEmptyResponseBodyResponse(responseBodyBytes), nil
+		}
 		return []*eppb.ProcessingResponse{
 			{
 				Response: &eppb.ProcessingResponse_ResponseBody{
@@ -136,6 +149,20 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 			},
 		},
 	}, nil
+}
+
+// generateEmptyResponseBodyResponse builds a streaming response with an empty
+// ResponseHeaders followed by chunked body responses via AddStreamedResponseBody.
+func (s *Server) generateEmptyResponseBodyResponse(responseBodyBytes []byte) []*eppb.ProcessingResponse {
+	responses := []*eppb.ProcessingResponse{
+		{
+			Response: &eppb.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &eppb.HeadersResponse{},
+			},
+		},
+	}
+	responses = envoy.AddStreamedResponseBody(responses, responseBodyBytes)
+	return responses
 }
 
 // HandleResponseTrailers handles response trailers.

--- a/pkg/bbr/handlers/response_test.go
+++ b/pkg/bbr/handlers/response_test.go
@@ -62,24 +62,63 @@ func newTestRequestContext() *RequestContext {
 func TestHandleResponseBody_NoPlugins(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
-	server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
-	responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
-	resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
-	if err != nil {
-		t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
-	}
+	t.Run("unary", func(t *testing.T) {
+		server := NewServer(false, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+		responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
+		resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
+		if err != nil {
+			t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
+		}
 
-	want := []*extProcPb.ProcessingResponse{
-		{
-			Response: &extProcPb.ProcessingResponse_ResponseBody{
-				ResponseBody: &extProcPb.BodyResponse{},
+		want := []*extProcPb.ProcessingResponse{
+			{
+				Response: &extProcPb.ProcessingResponse_ResponseBody{
+					ResponseBody: &extProcPb.BodyResponse{},
+				},
 			},
-		},
-	}
+		}
 
-	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-		t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
-	}
+		if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+			t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		server := NewServer(true, []framework.RequestProcessor{}, []framework.ResponseProcessor{})
+		responseBody := []byte(`{"choices":[{"text":"Hello!"}]}`)
+		resp, err := server.HandleResponseBody(ctx, newTestRequestContext(), responseBody)
+		if err != nil {
+			t.Fatalf("HandleResponseBody returned unexpected error: %v", err)
+		}
+
+		want := []*extProcPb.ProcessingResponse{
+			{
+				Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+					ResponseHeaders: &extProcPb.HeadersResponse{},
+				},
+			},
+			{
+				Response: &extProcPb.ProcessingResponse_ResponseBody{
+					ResponseBody: &extProcPb.BodyResponse{
+						Response: &extProcPb.CommonResponse{
+							BodyMutation: &extProcPb.BodyMutation{
+								Mutation: &extProcPb.BodyMutation_StreamedResponse{
+									StreamedResponse: &extProcPb.StreamedBodyResponse{
+										Body:        responseBody,
+										EndOfStream: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+			t.Errorf("HandleResponseBody returned unexpected response, diff(-want, +got): %v", diff)
+		}
+	})
 }
 
 func TestHandleResponseBody_SinglePlugin(t *testing.T) {
@@ -376,7 +415,7 @@ func expectedResponseBodyMutation(bodyBytes []byte) *extProcPb.ProcessingRespons
 }
 
 // expectedStreamedResponseBodyMutation builds the expected streamed response for a mutated body:
-// first a ResponseHeaders with the header mutation, then ResponseBody chunks with body data.
+// a deferred ResponseHeaders with header mutation, then a ResponseBody with StreamedBodyResponse.
 func expectedStreamedResponseBodyMutation(bodyBytes []byte) []*extProcPb.ProcessingResponse {
 	return []*extProcPb.ProcessingResponse{
 		{

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -144,6 +144,8 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		case *extProcPb.ProcessingRequest_ResponseBody:
 			loggerVerbose.Info("Incoming response body chunk", "EoS", v.ResponseBody.EndOfStream)
 			responses, err = s.processResponseBody(ctx, reqCtx, req.GetResponseBody(), respStreamedBody)
+		case *extProcPb.ProcessingRequest_ResponseTrailers:
+			responses, err = s.HandleResponseTrailers(req.GetResponseTrailers())
 		default:
 			logger.V(logutil.DEFAULT).Error(nil, "Unknown Request type", "request", v)
 			return status.Error(codes.Unknown, "unknown request type")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The BBR Istio EnvoyFilter was not explicitly associated with the selected Kubernetes Gateway API Gateway, causing it to potentially apply to all proxies in the mesh (including sidecars) instead of only the intended gateway. Additionally, `response_trailer_mode` was set to `"SKIP"`, which caused Envoy to reject the listener config when paired with `FULL_DUPLEX_STREAMED` response body mode — meaning the ext_proc filter was never actually applied.

This PR adds:
- `targetRefs` to scope the EnvoyFilter to the specific Gateway resource referenced by `inferenceGateway.name`
- `context: GATEWAY` in the match section to restrict the filter to gateway listeners only
- `response_trailer_mode: "SEND"` to fix the LDS rejection and enable bi-directional API translation (response body processing for api-translation use cases)
- `ResponseTrailers` switch case wired into BBR's `server.go` `Process` loop — the `HandleResponseTrailers` function already existed in `response.go` but was never connected to the dispatch loop (dead code), which would cause BBR to error on any response trailer message from Envoy
- Streaming response fix: `HandleResponseHeaders` defers in streaming mode (returns nil) unless `EndOfStream` is true (no body expected, e.g. HEAD requests), and `HandleResponseBody` sends the deferred `ResponseHeaders` + `ResponseBody` together. This mirrors the request-side pattern used by `HandleRequestBody` and eliminates the duplicate `ResponseHeaders` that caused Envoy to flag "Spurious response message 4"
- `generateEmptyResponseBodyResponse` helper for streaming paths without plugins (no-plugins and JSON-parse-error paths) — sends deferred `ResponseHeaders` followed by properly chunked body via `envoy.AddStreamedResponseBody`, which splits at Envoy's 62KB `BodyByteLimit`. The plugins+streaming path uses the existing upstream logic with `AddStreamedResponseBody` directly

The `targetRefs` and `context: GATEWAY` changes mirror the existing behavior in the GKE template (`gke.yaml`), which already uses `targetRefs` to scope its `GCPTrafficExtension` to the correct gateway.

**Why `targetRefs` (not `workloadSelector`)**:

- `workloadSelector` targets pods by label — it scopes to the gateway pod but applies to ALL gateways hosted by that pod, and doesn't reference a specific Gateway API `Gateway` resource
- `targetRefs` with `kind: Gateway` directly references a specific Gateway API resource by name ([Istio EnvoyFilter docs](https://istio.io/latest/docs/reference/config/networking/envoy-filter/))
- The two are mutually exclusive; `targetRefs` is the Istio-recommended mechanism for Gateway API resources
- Proper `targetRefs` matching requires Istio 1.27+ ([istio/istio#56476](https://github.com/istio/istio/pull/56476)); this project's conformance tests and getting-started guide use Istio 1.27-alpha / 1.28.0

**Why `response_trailer_mode: "SEND"`**:

- With `response_body_mode: "FULL_DUPLEX_STREAMED"`, Envoy requires `response_trailer_mode` to be `"SEND"` — otherwise the listener config is rejected (`ACK ERROR: If the ext_proc filter has the response_body_mode set to FULL_DUPLEX_STREAMED, then the response_trailer_mode has to be set to SEND`)
- This is required for bi-directional API translation, where both request and response bodies are processed by the ext_proc filter
- With `response_trailer_mode: "SEND"`, Envoy delivers `ProcessingRequest_ResponseTrailers` to the ext_proc server, so the server must handle it — hence the `HandleResponseTrailers` wiring fix

**Why defer `ResponseHeaders` in streaming mode**:

- In streaming mode, `HandleResponseHeaders` was sending an immediate `ResponseHeaders` response, then `HandleResponseBody` was sending another `ResponseHeaders` with header mutations — Envoy expects `ResponseHeaders` exactly once and flagged the duplicate as "Spurious response message 4"
- The fix mirrors the request-side pattern: defer the response-header reply until the body arrives, then send both `ResponseHeaders` + `ResponseBody` together from `HandleResponseBody`
- `HandleResponseHeaders` responds immediately when `EndOfStream` is true (no body expected) to prevent deadlock on HEAD / 204 responses
- `FULL_DUPLEX_STREAMED` mode also requires body responses to use `StreamedBodyResponse` wrapping — plain `BodyResponse` is rejected as spurious — so all streaming paths use `envoy.AddStreamedResponseBody` for correct chunking

**Which issue(s) this PR fixes**:

Fixes #2567

**Verification**:

- `helm lint` passes for both `istio` and `gke` providers
- `helm template` renders correct `targetRefs`, `context: GATEWAY`, and `response_trailer_mode: "SEND"` for Istio
- `make verify` passes (0 lint issues, all helm chart test cases, all CRD/manifest validation)
- All BBR unit tests pass (including new streaming sub-tests for deferred ResponseHeaders + StreamedBodyResponse)
- `go vet ./pkg/bbr/...` clean

**E2E validation** (Kind + Istio 1.28.0):

Deployed both the upstream (main) and this PR's template to a Kind cluster with Istio 1.28.0 and a `Programmed=True` Gateway API Gateway.

| | Upstream (main) | This PR |
|---|---|---|
| `targetRefs` | absent | `[{group: gateway.networking.k8s.io, kind: Gateway, name: inference-gateway}]` |
| `context` | absent | `GATEWAY` |
| `response_trailer_mode` | `SKIP` | `SEND` |
| `ResponseTrailers` handler | dead code (not wired) | wired in `server.go` switch |
| Streaming ResponseHeaders | sent twice (duplicate) | deferred once from HandleResponseBody (immediate on EndOfStream) |
| Streaming BodyResponse | plain `BodyResponse` (rejected) | `StreamedBodyResponse` via `AddStreamedResponseBody` (proper 62KB chunking) |
| Istiod LDS push | **Rejected** (`ACK ERROR`) | Accepted |
| ext_proc applied to gateway | **No** (rejected config) | Yes, at position 0 |
| Request with model header | 200 OK (routed without ext_proc) | 200 OK (routed via ext_proc) |
| Body extraction path | N/A (filter never applied) | 200 OK, model extracted from body |
| HEAD request (EndOfStream) | N/A | 404 in <5ms (immediate response, no hang) |
| Spurious response errors | N/A (filter never applied) | Zero |

The upstream template's ext_proc filter was **never actually applied** due to the LDS rejection. This PR fixes that — the filter is now accepted by Envoy and applied at the correct position. Both header-based and body-extraction paths return 200 OK end-to-end with zero spurious errors.

**Does this PR introduce a user-facing change?**:
```release-note
Fix BBR Istio EnvoyFilter to scope to the selected inference gateway using targetRefs and context: GATEWAY, fix response_trailer_mode to enable bi-directional API translation, wire HandleResponseTrailers into the ext_proc dispatch loop, and fix duplicate ResponseHeaders / StreamedBodyResponse wrapping in streaming mode.
```
