### PR TITLE
fix(bbr): add read lock to GetBaseModel to prevent concurrent map crash

### DIFF
--- a/pkg/bbr/datastore/datastore.go
+++ b/pkg/bbr/datastore/datastore.go
@@ -128,6 +128,8 @@ func (ds *datastore) ConfigMapDelete(configmap *corev1.ConfigMap) {
 
 func (ds *datastore) GetBaseModel(modelName string) string {
 	trimmedModelName := strings.TrimSpace(modelName)
+	ds.lock.RLock()
+	defer ds.lock.RUnlock()
 	// if the given model name is a LoRA adapter, we should return its base model
 	if baseModel, ok := ds.loraAdapterToBaseModel[trimmedModelName]; ok {
 		return baseModel

--- a/pkg/bbr/datastore/datastore_test.go
+++ b/pkg/bbr/datastore/datastore_test.go
@@ -191,6 +191,21 @@ func TestConfigMapDelete_MissingBaseModel(t *testing.T) {
 	}
 }
 
+func TestGetBaseModel_ConcurrentRace(t *testing.T) {
+	ds := NewDatastore()
+	cm := makeConfigMap(cmName, baseModel, "- a1\n")
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			_ = ds.ConfigMapUpdateOrAddIfNotExist(cm)
+		}
+	}()
+
+	for i := 0; i < 10000; i++ {
+		ds.GetBaseModel("a1")
+	}
+}
+
 func TestConfigMapDelete_BaseModelCount(t *testing.T) {
 	ds := NewDatastore()
 	cm1 := makeConfigMap(cmName, baseModel, "- a1\n")


### PR DESCRIPTION
- `GetBaseModel()` reads `loraAdapterToBaseModel` and `baseModels` maps without holding a lock, while `ConfigMapUpdateOrAddIfNotExist()` and `ConfigMapDelete()` write to these maps under `ds.lock.Lock()`. In Go, concurrent map read and write causes `fatal error: concurrent map read and map write`, which crashes the process and cannot be recovered.
- Add `ds.lock.RLock()`/`RUnlock()` to `GetBaseModel()` to ensure safe concurrent access.
- Add a concurrent read/write test to prevent regression.
- go test -race ./pkg/bbr/datastore/... test passed.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NA
```
