### PR TITLE
fix(epp): avoid nested RLock in PoolGet to prevent potential deadlock

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -170,7 +170,7 @@ func (ds *datastore) PoolSet(ctx context.Context, reader client.Reader, endpoint
 func (ds *datastore) PoolGet() (*datalayer.EndpointPool, error) {
 	ds.mu.RLock()
 	defer ds.mu.RUnlock()
-	if !ds.PoolHasSynced() {
+	if ds.pool == nil {
 		return nil, errPoolNotSynced
 	}
 	return ds.pool, nil

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -46,6 +46,35 @@ import (
 	testutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
 )
 
+func TestPoolGet_NoDeadlockWithConcurrentWrite(t *testing.T) {
+	pool := &datalayer.EndpointPool{
+		Namespace:   "default",
+		Selector:    map[string]string{"app": "vllm"},
+		TargetPorts: []int{8000},
+	}
+	ds := &datastore{pool: pool}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 1000; i++ {
+			ds.mu.Lock()
+			ds.pool = pool
+			ds.mu.Unlock()
+		}
+	}()
+
+	for i := 0; i < 1000; i++ {
+		_, _ = ds.PoolGet()
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock detected: PoolGet and concurrent writer did not complete within timeout")
+	}
+}
+
 func TestPool(t *testing.T) {
 	pool1Selector := map[string]string{"app": "vllm_v1"}
 	pool1 := testutil.MakeInferencePool("pool1").


### PR DESCRIPTION
- `PoolGet()` holds `ds.mu.RLock()` and then calls `PoolHasSynced()`, which attempts to acquire `ds.mu.RLock()` again. Go's `sync.RWMutex` is not reentrant — when a writer (e.g. `PoolSet()`, `Clear()`) is waiting for `Lock()`, the second `RLock()` inside `PoolHasSynced()` blocks indefinitely, creating a three-way deadlock:
  - `PoolGet` holds RLock, waits for `PoolHasSynced`'s RLock
  - `PoolHasSynced`'s RLock is blocked because a writer is waiting
  - The writer's `Lock` is blocked by `PoolGet`'s RLock
- Replace `ds.PoolHasSynced()` with an inline `ds.pool == nil` check, which is safe since we already hold the read lock.
- Add a concurrent deadlock-detection test that times out if the nested RLock regression is reintroduced.

/kind bug

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
