### PR TITLE
fix: extract usage from ResponsesAPI streaming events

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -304,9 +304,22 @@ func extractUsageByAPIType(usg map[string]any, objectType string) fwkrc.Usage {
 //
 // If include_usage is not included in the request, `data: [DONE]` is returned separately, which
 // indicates end of streaming.
+//
+// For ResponsesAPI streaming, usage is nested in the response object:
+//
+//	event: response.completed
+//	data: {"response":{"usage":{"input_tokens":31,..},...},"type":"response.completed"}
+//
+// It extracts usage from events with type="response.completed".
 func extractUsageStreaming(responseText string) *fwkrc.Usage {
-	var response struct {
-		Usage *fwkrc.Usage `json:"usage"`
+
+	var streamResponse struct {
+		Usage    *fwkrc.Usage `json:"usage"`
+		Response struct {
+			Usage  map[string]any `json:"usage"`
+			Object string         `json:"object"`
+		} `json:"response"`
+		Type string `json:"type"`
 	}
 
 	lines := strings.SplitSeq(responseText, "\n")
@@ -320,9 +333,24 @@ func extractUsageStreaming(responseText string) *fwkrc.Usage {
 		}
 
 		byteSlice := []byte(content)
-		if err := json.Unmarshal(byteSlice, &response); err != nil {
+		if err := json.Unmarshal(byteSlice, &streamResponse); err != nil {
 			continue
 		}
+		// Standard ChatCompletion / vLLM usage format
+		if streamResponse.Usage != nil {
+			return streamResponse.Usage
+		}
+		// Responses API streaming format
+		if streamResponse.Response.Usage != nil && streamResponse.Type == "response.completed" {
+			// Convert map[string]any to JSON and parse
+			jsonBytes, _ := json.Marshal(map[string]any{
+				"usage":  streamResponse.Response.Usage,
+				"object": streamResponse.Response.Object,
+			})
+			if usage, err := extractUsage(jsonBytes); err == nil && usage != nil {
+				return usage
+			}
+		}
 	}
-	return response.Usage
+	return nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -793,6 +793,35 @@ func TestOpenAIParser_ParseResponse_Streaming(t *testing.T) {
 				Usage: nil,
 			},
 		},
+		{
+			name:  "ResponsesAPI streaming with full response",
+			chunk: []byte("event: response.completed\ndata: {\"response\":{\"id\":\"resp_8e38bd02b4f56572\",\"model\":\"Qwen/Qwen3-32B\",\"object\":\"response\",\"usage\":{\"input_tokens\":31,\"input_tokens_details\":{\"cached_tokens\":16},\"output_tokens\":3,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":34}},\"type\":\"response.completed\"}"),
+			want: &fwkrh.ParsedResponse{
+				Usage: &fwkrc.Usage{
+					PromptTokens:     31,
+					CompletionTokens: 3,
+					TotalTokens:      34,
+				},
+			},
+		},
+		{
+			name:  "ResponsesAPI without response.completed type returns nil",
+			chunk: []byte("event: response.in_progress\ndata: {\"response\":{\"usage\":{\"input_tokens\":31,\"output_tokens\":3}},\"type\":\"response.in_progress\"}"),
+			want: &fwkrh.ParsedResponse{
+				Usage: nil,
+			},
+		},
+		{
+			name:  "ResponsesAPI with multiple events extracts from completed",
+			chunk: []byte("event: response.output_text.delta\ndata: {\"delta\":\"Hello\",\"type\":\"response.output_text.delta\"}\n\nevent: response.completed\ndata: {\"response\":{\"usage\":{\"input_tokens\":39,\"output_tokens\":10,\"total_tokens\":49}},\"type\":\"response.completed\"}"),
+			want: &fwkrh.ParsedResponse{
+				Usage: &fwkrc.Usage{
+					PromptTokens:     39,
+					CompletionTokens: 10,
+					TotalTokens:      49,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Responses API returns usage under `response.usage`, which was not previously handled by the streaming parser. This change adds support for that format while keeping compatibility with existing ChatCompletions and vLLM streaming responses.

**Which issue(s) this PR fixes**:
Fixes #2482 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
