### PR TITLE
fix: race condition in PodUpdateOrAddIfNotExist reading pool without lock

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -272,11 +272,20 @@ func (ds *datastore) PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.Endpoi
 }
 
 func (ds *datastore) PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool {
-	// Snapshot pool under read lock to avoid racing with PoolSet().
+	// Take a reference to pool under read lock to avoid racing with PoolSet().
+	// This is safe because PoolSet() replaces the entire pool struct rather than
+	// updating it in-place.
 	ds.mu.RLock()
 	pool := ds.pool
 	ds.mu.RUnlock()
 
+	return ds.podUpdateOrAddIfNotExist(pod, pool)
+}
+
+// podUpdateOrAddIfNotExist is the lock-free inner implementation.
+// Callers must ensure pool is a consistent snapshot (either read under lock
+// or already held, as in podResyncAll which runs under ds.mu.Lock via PoolSet).
+func (ds *datastore) podUpdateOrAddIfNotExist(pod *corev1.Pod, pool *datalayer.EndpointPool) bool {
 	if pool == nil {
 		return true
 	}
@@ -291,8 +300,8 @@ func (ds *datastore) PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool {
 		modelServerMetricsPort = int(ds.modelServerMetricsPort)
 	}
 	pods := []*fwkdl.EndpointMetadata{}
-	activePorts := ds.extractActivePorts(pod)
-	for idx, port := range ds.pool.TargetPorts {
+	activePorts := extractActivePorts(pod, pool.TargetPorts)
+	for idx, port := range pool.TargetPorts {
 		if !activePorts.Has(port) {
 			continue
 		}
@@ -377,7 +386,7 @@ func (ds *datastore) podResyncAll(ctx context.Context, reader client.Reader) err
 		for idx := range ds.pool.TargetPorts {
 			activeEndpoints.Insert(createEndpointNamespacedName(&pod, idx))
 		}
-		if !ds.PodUpdateOrAddIfNotExist(&pod) {
+		if !ds.podUpdateOrAddIfNotExist(&pod, ds.pool) {
 			logger.V(logutil.DEFAULT).Info("Pod added", "name", namespacedName)
 		} else {
 			logger.V(logutil.DEFAULT).Info("Pod already exists", "name", namespacedName)
@@ -400,8 +409,8 @@ func (ds *datastore) podResyncAll(ctx context.Context, reader client.Reader) err
 }
 
 // extractActivePorts extracts the active ports from a pod's annotations.
-func (ds *datastore) extractActivePorts(pod *corev1.Pod) sets.Set[int] {
-	allPorts := sets.New(ds.pool.TargetPorts...)
+func extractActivePorts(pod *corev1.Pod, targetPorts []int) sets.Set[int] {
+	allPorts := sets.New(targetPorts...)
 	annotations := pod.GetAnnotations()
 	portsAnnotation, ok := annotations[activePortsAnnotation]
 	if !ok {

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -1276,10 +1276,7 @@ func TestExtractActivePorts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ds := NewDatastore(context.Background(), nil, 0).WithEndpointPool(&datalayer.EndpointPool{
-				TargetPorts: tt.validPorts,
-			})
-			activePorts := ds.extractActivePorts(tt.pod)
+			activePorts := extractActivePorts(tt.pod, tt.validPorts)
 			if !reflect.DeepEqual(activePorts, tt.expectedPorts) {
 				t.Errorf("ExtractActivePorts() ports = %v, want %v", activePorts, tt.expectedPorts)
 			}


### PR DESCRIPTION


`PodUpdateOrAddIfNotExist()` accessed `ds.pool` (nil check, `TargetPorts` iteration) at some call sites without acquiring `ds.mu.RLock()`. Meanwhile, `PoolSet()` replaces `ds.pool` under `ds.mu.Lock()`. Under concurrent pod reconciliation and pool updates, this causes:

1. **Nil pointer panic**: `PoolSet(ctx, reader, nil)` sets `ds.pool = nil` between the nil check and `ds.pool.TargetPorts` access.
2. **Inconsistent reads**: the first half of the function reads old pool's `TargetPorts` while the second half reads the new pool's, leading to orphaned or missing endpoints.

**Fix**: Reference `ds.pool` under `RLock` at function entry and use the local copy throughout.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

/kind bug

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
