### PR TITLE
fix(prefix): prevent evicted hashes from being re-added to hashToPos in indexer

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/indexer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/indexer.go
@@ -71,9 +71,13 @@ func (i *indexer) Add(hashes []BlockHash, pod Server) {
 		lruForPod.Add(hash, struct{}{})
 	}
 
-	// Update hashToPods once under lock
+	// Update hashToPods once under lock, but only for hashes that survived eviction.
 	i.mu.Lock()
 	for _, hash := range hashes {
+		if !lruForPod.Contains(hash) {
+			// This hash was evicted by a later Add in the loop above; skip it.
+			continue
+		}
 		podIDs := i.hashToPods[hash]
 		if podIDs == nil {
 			podIDs = make(podSet)

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/indexer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/indexer_test.go
@@ -51,6 +51,36 @@ func TestIndexer_AddAndGet(t *testing.T) {
 	assert.Empty(t, servers, "Cache should not contain non-existent hash")
 }
 
+func TestIndexer_AddEvictsWithinSingleCall(t *testing.T) {
+	// LRU capacity is 2, but we add 4 hashes in one call.
+	// H1 and H2 should be evicted by H3 and H4 and must NOT appear in hashToPods.
+	server := Server{
+		ServerID:       ServerID{Namespace: "default", Name: "server1"},
+		numOfGPUBlocks: 2,
+	}
+	i := newIndexer(context.Background(), 2)
+
+	hashes := []BlockHash{BlockHash(1), BlockHash(2), BlockHash(3), BlockHash(4)}
+	i.Add(hashes, server)
+
+	// Only the last 2 hashes should survive in the LRU.
+	assert.Equal(t, 2, i.podToLRU[server.ServerID].Len(), "LRU should contain exactly 2 entries")
+
+	// hashToPods should have exactly 2 entries, matching the LRU.
+	assert.Len(t, i.hashToPods, 2, "hashToPods should contain exactly 2 entries matching LRU size")
+
+	// Evicted hashes must not be in hashToPods; surviving hashes must be present.
+	for _, h := range hashes {
+		inLRU := i.podToLRU[server.ServerID].Contains(h)
+		pods := i.Get(h)
+		if inLRU {
+			assert.Contains(t, pods, server.ServerID, "hash %v is in LRU and should be in hashToPods", h)
+		} else {
+			assert.NotContains(t, pods, server.ServerID, "hash %v was evicted from LRU and should NOT be in hashToPods", h)
+		}
+	}
+}
+
 func TestIndexer_RemovePodAndEviction(t *testing.T) {
 	const indexerSize = 10
 


### PR DESCRIPTION

- Fix a race condition in `indexer.Add()` where the split-lock pattern (unlock between LRU insertion and `hashToPods` update) allows evicted hashes to be re-added to `hashToPods`. When a single `Add` call passes more hashes than the LRU capacity, later insertions evict earlier ones. The eviction callback correctly removes entries from `hashToPods`, but the second lock section unconditionally re-adds all input hashes — including the evicted ones. This causes `hashToPods` to reference hashes no longer present in the LRU, leading to incorrect prefix-aware routing decisions.
- Add `lruForPod.Contains(hash)` check before inserting into `hashToPods` to skip evicted hashes.
- Add `TestIndexer_AddEvictsWithinSingleCall` to cover the intra-call eviction scenario.


/kind bug

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
