### PR TITLE
fix: log warning when pod ports don't match InferencePool targetPorts

### DIFF
--- a/pkg/epp/controller/pod_reconciler.go
+++ b/pkg/epp/controller/pod_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -58,7 +57,7 @@ func (c *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, fmt.Errorf("unable to get pod - %w", err)
 	}
 
-	c.updateDatastore(logger, pod)
+	c.updateDatastore(ctx, pod)
 	return ctrl.Result{}, nil
 }
 
@@ -88,12 +87,13 @@ func (c *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(c)
 }
 
-func (c *PodReconciler) updateDatastore(logger logr.Logger, pod *corev1.Pod) {
+func (c *PodReconciler) updateDatastore(ctx context.Context, pod *corev1.Pod) {
+	logger := log.FromContext(ctx)
 	if !podutil.IsPodReady(pod) || !c.Datastore.PoolLabelsMatch(pod.Labels) {
 		logger.V(logutil.DEBUG).Info("Pod removed or not added")
 		c.Datastore.PodDelete(pod.Name)
 	} else {
-		if c.Datastore.PodUpdateOrAddIfNotExist(pod) {
+		if c.Datastore.PodUpdateOrAddIfNotExist(ctx, pod) {
 			logger.V(logutil.DEFAULT).Info("Pod added")
 		} else {
 			logger.V(logutil.DEFAULT).Info("Pod already exists")

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -207,7 +207,7 @@ func TestPodReconciler(t *testing.T) {
 				store := datastore.NewDatastore(t.Context(), epf, 0)
 				_ = store.PoolSet(t.Context(), fakeClient, pool.InferencePoolToEndpointPool(test.pool))
 				for _, pod := range test.existingPods {
-					store.PodUpdateOrAddIfNotExist(pod)
+					store.PodUpdateOrAddIfNotExist(t.Context(), pod)
 				}
 
 				podReconciler := &PodReconciler{Reader: fakeClient, Datastore: store}

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -78,7 +78,7 @@ type Datastore interface {
 
 	// PodList lists pods matching the given predicate.
 	PodList(predicate func(backendmetrics.PodMetrics) bool) []backendmetrics.PodMetrics
-	PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool
+	PodUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.Pod) bool
 	PodDelete(podName string)
 
 	// Clears the store state, happens when the pool gets deleted.
@@ -271,7 +271,7 @@ func (ds *datastore) PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.Endpoi
 	return res
 }
 
-func (ds *datastore) PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool {
+func (ds *datastore) PodUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.Pod) bool {
 	// Take a reference to pool under read lock to avoid racing with PoolSet().
 	// This is safe because PoolSet() replaces the entire pool struct rather than
 	// updating it in-place.
@@ -279,13 +279,13 @@ func (ds *datastore) PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool {
 	pool := ds.pool
 	ds.mu.RUnlock()
 
-	return ds.podUpdateOrAddIfNotExist(pod, pool)
+	return ds.podUpdateOrAddIfNotExist(ctx, pod, pool)
 }
 
 // podUpdateOrAddIfNotExist is the lock-free inner implementation.
 // Callers must ensure pool is a consistent snapshot (either read under lock
 // or already held, as in podResyncAll which runs under ds.mu.Lock via PoolSet).
-func (ds *datastore) podUpdateOrAddIfNotExist(pod *corev1.Pod, pool *datalayer.EndpointPool) bool {
+func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.Pod, pool *datalayer.EndpointPool) bool {
 	if pool == nil {
 		return true
 	}
@@ -318,6 +318,12 @@ func (ds *datastore) podUpdateOrAddIfNotExist(pod *corev1.Pod, pool *datalayer.E
 				MetricsHost:    net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(metricsPort)),
 				Labels:         labels,
 			})
+	}
+
+	if len(pods) == 0 {
+		logger := log.FromContext(ctx)
+		logger.V(logutil.VERBOSE).Info("No container ports match pool targetPorts, pod will not receive traffic",
+			"pod", pod.Name, "namespace", pod.Namespace, "targetPorts", pool.TargetPorts)
 	}
 
 	result := true
@@ -386,7 +392,7 @@ func (ds *datastore) podResyncAll(ctx context.Context, reader client.Reader) err
 		for idx := range ds.pool.TargetPorts {
 			activeEndpoints.Insert(createEndpointNamespacedName(&pod, idx))
 		}
-		if !ds.podUpdateOrAddIfNotExist(&pod, ds.pool) {
+		if !ds.podUpdateOrAddIfNotExist(ctx, &pod, ds.pool) {
 			logger.V(logutil.DEFAULT).Info("Pod added", "name", namespacedName)
 		} else {
 			logger.V(logutil.DEFAULT).Info("Pod already exists", "name", namespacedName)

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -380,7 +380,7 @@ func TestMetrics(t *testing.T) {
 				ds := NewDatastore(ctx, epf, 0)
 				_ = ds.PoolSet(ctx, fakeClient, pooltuil.InferencePoolToEndpointPool(inferencePool))
 				for _, pod := range test.storePods {
-					ds.PodUpdateOrAddIfNotExist(pod)
+					ds.PodUpdateOrAddIfNotExist(ctx, pod)
 				}
 				time.Sleep(1 * time.Second) // Give some time for the metrics to be fetched.
 				if test.predict == nil {
@@ -414,7 +414,7 @@ func TestPods(t *testing.T) {
 			existingPods: []*corev1.Pod{},
 			wantPods:     []*corev1.Pod{pod1},
 			op: func(ctx context.Context, ds Datastore) {
-				ds.PodUpdateOrAddIfNotExist(pod1)
+				ds.PodUpdateOrAddIfNotExist(ctx, pod1)
 			},
 		},
 		{
@@ -422,7 +422,7 @@ func TestPods(t *testing.T) {
 			existingPods: []*corev1.Pod{pod1},
 			wantPods:     []*corev1.Pod{pod1, pod2},
 			op: func(ctx context.Context, ds Datastore) {
-				ds.PodUpdateOrAddIfNotExist(pod2)
+				ds.PodUpdateOrAddIfNotExist(ctx, pod2)
 			},
 		},
 		{
@@ -457,7 +457,7 @@ func TestPods(t *testing.T) {
 					t.Error(err)
 				}
 				for _, pod := range test.existingPods {
-					ds.PodUpdateOrAddIfNotExist(pod)
+					ds.PodUpdateOrAddIfNotExist(ctx, pod)
 				}
 
 				test.op(ctx, ds)
@@ -613,7 +613,7 @@ func TestEndpointMetadata(t *testing.T) {
 				},
 			},
 			op: func(ctx context.Context, ds Datastore) {
-				ds.PodUpdateOrAddIfNotExist(pod1)
+				ds.PodUpdateOrAddIfNotExist(ctx, pod1)
 			},
 			pool: inferencePool,
 		},
@@ -647,7 +647,7 @@ func TestEndpointMetadata(t *testing.T) {
 				},
 			},
 			op: func(ctx context.Context, ds Datastore) {
-				ds.PodUpdateOrAddIfNotExist(pod1)
+				ds.PodUpdateOrAddIfNotExist(ctx, pod1)
 			},
 			pool: inferencePoolMultiTarget,
 		},
@@ -705,7 +705,7 @@ func TestEndpointMetadata(t *testing.T) {
 				},
 			},
 			op: func(ctx context.Context, ds Datastore) {
-				ds.PodUpdateOrAddIfNotExist(pod2)
+				ds.PodUpdateOrAddIfNotExist(ctx, pod2)
 			},
 			pool: inferencePoolMultiTarget,
 		},
@@ -760,7 +760,7 @@ func TestEndpointMetadata(t *testing.T) {
 					t.Error(err)
 				}
 				for _, pod := range test.existingPods {
-					ds.PodUpdateOrAddIfNotExist(pod)
+					ds.PodUpdateOrAddIfNotExist(ctx, pod)
 				}
 
 				test.op(ctx, ds)
@@ -919,7 +919,7 @@ func TestActivePortFiltering(t *testing.T) {
 
 				// Add all pods
 				for _, pod := range test.pods {
-					ds.PodUpdateOrAddIfNotExist(pod)
+					ds.PodUpdateOrAddIfNotExist(ctx, pod)
 				}
 
 				// Check final endpoint count
@@ -1019,7 +1019,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 			operations: []func(Datastore){
 				// Update the pod to reduce active ports from 3 to 1
 				func(ds Datastore) {
-					ds.PodUpdateOrAddIfNotExist(updatedPod1)
+					ds.PodUpdateOrAddIfNotExist(context.Background(), updatedPod1)
 				},
 			},
 			wantEndpointCount: 1, // Only port 8000 should remain active
@@ -1035,7 +1035,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 			operations: []func(Datastore){
 				// Update the pod to have no active ports
 				func(ds Datastore) {
-					ds.PodUpdateOrAddIfNotExist(inactivePod1)
+					ds.PodUpdateOrAddIfNotExist(context.Background(), inactivePod1)
 				},
 			},
 			wantEndpointCount: 0, // No ports should remain active
@@ -1068,7 +1068,7 @@ func TestActivePortEndpointRemoval(t *testing.T) {
 				}
 
 				// Add the initial pod
-				ds.PodUpdateOrAddIfNotExist(test.initialPod)
+				ds.PodUpdateOrAddIfNotExist(ctx, test.initialPod)
 
 				// Wait a bit for the datastore to process the pod
 				time.Sleep(100 * time.Millisecond)
@@ -1150,7 +1150,7 @@ func TestPodUpdateOrAddIfNotExist_ConcurrentPoolSet(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range 1000 {
-			ds.PodUpdateOrAddIfNotExist(pod)
+			ds.PodUpdateOrAddIfNotExist(ctx, pod)
 		}
 	}()
 

--- a/pkg/epp/metrics/collectors/inference_pool_test.go
+++ b/pkg/epp/metrics/collectors/inference_pool_test.go
@@ -97,7 +97,7 @@ func TestMetricsCollected(t *testing.T) {
 			Build()
 
 		_ = ds.PoolSet(context.Background(), fakeClient, poolutil.InferencePoolToEndpointPool(inferencePool))
-		_ = ds.PodUpdateOrAddIfNotExist(pod1)
+		_ = ds.PodUpdateOrAddIfNotExist(context.Background(), pod1)
 
 		time.Sleep(1 * time.Second)
 

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -641,7 +641,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 					Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 				},
 			}
-			ds.PodUpdateOrAddIfNotExist(testPod)
+			ds.PodUpdateOrAddIfNotExist(ctx, testPod)
 		}
 
 		for _, test := range tests {
@@ -786,7 +786,7 @@ func TestGetRandomEndpoint(t *testing.T) {
 					t.Errorf("unexpected error setting pool: %s", err)
 				}
 				for _, pod := range test.storePods {
-					ds.PodUpdateOrAddIfNotExist(pod)
+					ds.PodUpdateOrAddIfNotExist(context.Background(), pod)
 				}
 				d := &Director{datastore: ds}
 				gotEndpoint := d.GetRandomEndpoint()

--- a/test/utils/server.go
+++ b/test/utils/server.go
@@ -60,7 +60,7 @@ func PrepareForTestStreamingServer(objectives []*v1alpha2.InferenceObjective, po
 	}
 	for _, pod := range pods {
 		initObjs = append(initObjs, pod)
-		ds.PodUpdateOrAddIfNotExist(pod)
+		ds.PodUpdateOrAddIfNotExist(ctx, pod)
 	}
 
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds a warning log when a pod matches an InferencePool's label selector but none of its container ports intersect with the pool's `targetPorts`. Previously the pod was silently ignored with no diagnostic output.

Also threads `ctx` through `PodUpdateOrAddIfNotExist` to follow the controller-runtime `log.FromContext(ctx)` pattern consistently.

**Which issue(s) this PR fixes**:

Fixes #2562

**Does this PR introduce a user-facing change?**:

```release-note
Log warning when pod matches InferencePool label selector but has no matching targetPorts
```
