### PR TITLE
fix(epp): correct composite-least strategy in negative headroom selection

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -798,4 +799,53 @@ func TestSloContextStoreEviction(t *testing.T) {
 	item = pl.sloContextStore.Get(requestID)
 	assert.Nil(t, item, "Item should have been evicted from cache")
 	assert.False(t, queue.Contains(requestID), "Request should be removed from queue via OnEviction")
+}
+
+// TestCompositeLeastVsMost_NegativeHeadroom verifies that composite-least and
+// composite-most produce different endpoint selections when endpoints have
+// clearly different composite scores. This catches the copy-paste bug where
+// selectFromNegativeHeadroomEndpointsInternal passes the wrong strategy.
+func TestCompositeLeastVsMost_NegativeHeadroom(t *testing.T) {
+	// Two endpoints with very different KV cache usage so their composite
+	// scores diverge significantly.
+	//   podLow:  10% KV usage → 90% free → high composite weight
+	//   podHigh: 90% KV usage → 10% free → low composite weight
+	podLow := createTestEndpoint("pod-low-kv", 0.1, 1, 0)
+	podHigh := createTestEndpoint("pod-high-kv", 0.9, 1, 0)
+
+	candidates := []endpointPredictionResult{
+		{Endpoint: podLow, Headroom: -0.5, TTFTHeadroom: -0.5, IsValid: true},
+		{Endpoint: podHigh, Headroom: -0.3, TTFTHeadroom: -0.3, IsValid: true},
+	}
+
+	// Use "max" selection mode so the result is deterministic (always picks
+	// the endpoint with the highest weight, no randomness).
+	cfgMost := DefaultConfig
+	cfgMost.HeadroomSelectionStrategy = string(headroomStrategyCompositeMost)
+	cfgMost.SelectionMode = string(podSelectionMax)
+	routerMost := NewPredictedLatency(cfgMost, nil)
+
+	cfgLeast := DefaultConfig
+	cfgLeast.HeadroomSelectionStrategy = string(headroomStrategyCompositeLeast)
+	cfgLeast.SelectionMode = string(podSelectionMax)
+	routerLeast := NewPredictedLatency(cfgLeast, nil)
+
+	ctx := context.Background()
+	rng := rand.New(rand.NewSource(42))
+
+	selectedMost := routerMost.selectFromNegativeHeadroomEndpointsInternal(ctx, candidates, rng)
+	selectedLeast := routerLeast.selectFromNegativeHeadroomEndpointsInternal(ctx, candidates, rng)
+
+	assert.NotNil(t, selectedMost)
+	assert.NotNil(t, selectedLeast)
+
+	// composite-most should prefer higher composite score (pod-low-kv has
+	// more free KV cache → higher weight).
+	assert.Equal(t, "pod-low-kv", selectedMost.GetMetadata().NamespacedName.Name,
+		"composite-most should prefer the endpoint with more free KV cache")
+
+	// composite-least inverts the weights, so it should prefer the endpoint
+	// with the lower composite score (pod-high-kv has less free KV cache).
+	assert.Equal(t, "pod-high-kv", selectedLeast.GetMetadata().NamespacedName.Name,
+		"composite-least should prefer the endpoint with less free KV cache")
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/selection.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/selection.go
@@ -114,7 +114,7 @@ func (s *PredictedLatency) selectFromNegativeHeadroomEndpointsInternal(ctx conte
 	case headroomStrategyCompositeMost:
 		return s.selectFromCompositeScores(ctx, candidates, r, headroomStrategyCompositeMost)
 	case headroomStrategyCompositeLeast:
-		return s.selectFromCompositeScores(ctx, candidates, r, headroomStrategyCompositeMost)
+		return s.selectFromCompositeScores(ctx, candidates, r, headroomStrategyCompositeLeast)
 	}
 
 	// Build weighted choices for selection


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

/kind bug
