### PR TITLE
Fix request headers not captured in streaming mode

### DIFF
--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -122,15 +122,17 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 		var err error
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
+			if requestId := envoy.ExtractHeaderValue(v, reqcommon.RequestIdHeaderKey); len(requestId) > 0 {
+				logger = logger.WithValues(reqcommon.RequestIdHeaderKey, requestId)
+				loggerVerbose = logger.V(logutil.VERBOSE)
+				ctx = log.IntoContext(ctx, logger)
+			}
+
 			if s.streaming && !v.RequestHeaders.GetEndOfStream() {
-				// If streaming and the body is not empty, then headers are handled when processing request body.
-				loggerVerbose.Info("Received headers, passing off header processing until body arrives...")
+				// Capture headers now, but defer the response until body arrives.
+				_, err = s.HandleRequestHeaders(reqCtx, v.RequestHeaders)
+				loggerVerbose.Info("Captured headers, deferring response until body arrives...")
 			} else {
-				if requestId := envoy.ExtractHeaderValue(v, reqcommon.RequestIdHeaderKey); len(requestId) > 0 {
-					logger = logger.WithValues(reqcommon.RequestIdHeaderKey, requestId)
-					loggerVerbose = logger.V(logutil.VERBOSE)
-					ctx = log.IntoContext(ctx, logger)
-				}
 				responses, err = s.HandleRequestHeaders(reqCtx, v.RequestHeaders)
 			}
 		case *extProcPb.ProcessingRequest_RequestBody:


### PR DESCRIPTION
/kind bug

**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

In streaming mode, when a request includes a body, the `HandleRequestHeaders` call was entirely skipped in the `RequestHeaders` case of the ext_proc `Process` loop. This meant request headers were never captured into `reqCtx.Request.Headers`, and the `request-id` was never extracted for structured logging.

This fix ensures that:
1. The `request-id` is always extracted for logging, regardless of streaming mode.
2. `HandleRequestHeaders` is always called to populate `reqCtx.Request.Headers`, so downstream plugins have access to request headers during body processing.
3. In streaming mode, the ext_proc *response* is still deferred (not sent back to Envoy) — only the body processing phase produces the actual response, preserving the existing streaming contract.

**Which issue(s) this PR fixes**:

Fixes #2585

**Does this PR introduce a user-facing change?**:
