### PR TITLE
[pluggable bbr] Initialize response plugins in runner based on configuration flags

### DIFF
--- a/cmd/bbr/runner/runner.go
+++ b/cmd/bbr/runner/runner.go
@@ -55,6 +55,7 @@ func NewRunner() *Runner {
 	return &Runner{
 		bbrExecutableName: "BBR",
 		requestPlugins:    []framework.RequestProcessor{},
+		responsePlugins:   []framework.ResponseProcessor{},
 		customCollectors:  []prometheus.Collector{},
 	}
 }
@@ -65,6 +66,9 @@ type Runner struct {
 	// The slice of BBR plugin instances executed by the request handler,
 	// in the same order the plugin flags are provided.
 	requestPlugins []framework.RequestProcessor
+	// The slice of BBR plugin instances executed by the response handler,
+	// in the same order the plugin flags are provided.
+	responsePlugins []framework.ResponseProcessor
 
 	customCollectors []prometheus.Collector
 }
@@ -211,15 +215,19 @@ func (r *Runner) Run(ctx context.Context) error {
 			if requestProcessor, ok := instance.(framework.RequestProcessor); ok {
 				r.requestPlugins = append(r.requestPlugins, requestProcessor)
 			}
+			if responseProcessor, ok := instance.(framework.ResponseProcessor); ok {
+				r.responsePlugins = append(r.responsePlugins, responseProcessor)
+			}
 		}
 	}
 
 	// Setup ExtProc Server Runner.
 	serverRunner := &runserver.ExtProcServerRunner{
-		GrpcPort:       opts.GRPCPort,
-		SecureServing:  opts.SecureServing,
-		Streaming:      opts.Streaming,
-		RequestPlugins: r.requestPlugins,
+		GrpcPort:        opts.GRPCPort,
+		SecureServing:   opts.SecureServing,
+		Streaming:       opts.Streaming,
+		RequestPlugins:  r.requestPlugins,
+		ResponsePlugins: r.responsePlugins,
 	}
 	if err := serverRunner.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to setup BBR controllers")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

The BBR runner wired request plugins but never initialized response plugins. The `Runner` struct had no `responsePlugins` field, the plugin instantiation loop only checked for `RequestProcessor`, and `ExtProcServerRunner.ResponsePlugins` was never set. This caused `HandleResponseBody` to always return an empty response without running any plugins — even when a `--plugin` flag specified a plugin implementing `ResponseProcessor`.

The following changes were made to `cmd/bbr/runner/runner.go`:

- A `responsePlugins` field is added to the `Runner` struct and initialized as an empty slice in `NewRunner()`, matching the existing `requestPlugins` pattern.
- Each plugin instance created from `--plugin` flags is checked for the `ResponseProcessor` interface, in addition to the existing `RequestProcessor` check. The two checks are separate (not else-if) since a single plugin may implement both interfaces.
- The populated `responsePlugins` slice is passed to `ExtProcServerRunner.ResponsePlugins`, completing the wiring to the ext-proc server where `HandleResponseBody` and `runResponsePlugins` already support executing them.

**Which issue(s) this PR fixes:**

Fixes #2586

**Does this PR introduce a user-facing change?**:

`None`