### PR TITLE
refactor: Extract generic max-min heap from flow control queue

### DIFF
--- a/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap.go
@@ -14,24 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package maxminheap provides a concurrent-safe, priority queue implementation using a max-min heap.
-//
-// A max-min heap is a binary tree structure that maintains a specific ordering property: for any node, if it is at an
-// even level (e.g., 0, 2, ...), its value is greater than all values in its subtree (max level). If it is at an odd
-// level (e.g., 1, 3, ...), its value is smaller than all values in its subtree (min level). This structure allows for
-// efficient O(1) retrieval of both the maximum and minimum priority items.
-//
-// The core heap maintenance logic (up, down, and grandchild finding) is adapted from the public domain implementation
-// at https://github.com/esote/minmaxheap, which is licensed under CC0-1.0.
 package queue
 
 import (
-	"math"
-	"sync"
 	"sync/atomic"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/heap"
 )
 
 // MaxMinHeapName is the name of the max-min heap queue implementation.
@@ -44,50 +34,37 @@ func init() {
 		})
 }
 
-// maxMinHeap implements the SafeQueue interface using a max-min heap.
-// The heap is ordered by the provided comparator, with higher values considered higher priority.
-// This implementation is concurrent-safe.
+// maxMinHeap implements the SafeQueue interface by wrapping the generic heap.MaxMinHeap.
+// It bridges between the domain-specific flowcontrol types (QueueItemAccessor, QueueItemHandle)
+// and the generic, type-parameterized heap.
 type maxMinHeap struct {
-	items    []flowcontrol.QueueItemAccessor
-	handles  map[flowcontrol.QueueItemHandle]*heapItem
+	inner    *heap.MaxMinHeap[flowcontrol.QueueItemAccessor]
+	handles  map[flowcontrol.QueueItemHandle]*heap.Handle // QueueItemHandle → generic Handle
 	byteSize atomic.Uint64
-	mu       sync.RWMutex
 	policy   flowcontrol.OrderingPolicy
 }
-
-// heapItem is an internal struct to hold an item and its index in the heap.
-// This allows for O(log n) removal of items from the queue.
-type heapItem struct {
-	item          flowcontrol.QueueItemAccessor
-	index         int
-	isInvalidated bool
-}
-
-// Handle returns the heap item itself, which is used as the handle.
-func (h *heapItem) Handle() any {
-	return h
-}
-
-// Invalidate marks the handle as invalid.
-func (h *heapItem) Invalidate() {
-	h.isInvalidated = true
-}
-
-// IsInvalidated returns true if the handle has been invalidated.
-func (h *heapItem) IsInvalidated() bool {
-	return h.isInvalidated
-}
-
-var _ flowcontrol.QueueItemHandle = &heapItem{}
 
 // newMaxMinHeap creates a new max-min heap with the given policy.
 func newMaxMinHeap(policy flowcontrol.OrderingPolicy) *maxMinHeap {
 	return &maxMinHeap{
-		items:   make([]flowcontrol.QueueItemAccessor, 0),
-		handles: make(map[flowcontrol.QueueItemHandle]*heapItem),
+		inner: heap.New(func(a, b flowcontrol.QueueItemAccessor) bool {
+			return policy.Less(a, b)
+		}),
+		handles: make(map[flowcontrol.QueueItemHandle]*heap.Handle),
 		policy:  policy,
 	}
 }
+
+// handleBridge implements flowcontrol.QueueItemHandle by wrapping a generic heap.Handle.
+type handleBridge struct {
+	inner *heap.Handle
+}
+
+func (h *handleBridge) Handle() any         { return h.inner }
+func (h *handleBridge) Invalidate()         { h.inner.Invalidate() }
+func (h *handleBridge) IsInvalidated() bool { return h.inner.IsInvalidated() }
+
+var _ flowcontrol.QueueItemHandle = &handleBridge{}
 
 // --- SafeQueue Interface Implementation ---
 
@@ -103,9 +80,7 @@ func (h *maxMinHeap) Capabilities() []flowcontrol.QueueCapability {
 
 // Len returns the number of items in the queue.
 func (h *maxMinHeap) Len() int {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return len(h.items)
+	return h.inner.Len()
 }
 
 // ByteSize returns the total byte size of all items in the queue.
@@ -116,144 +91,36 @@ func (h *maxMinHeap) ByteSize() uint64 {
 // PeekHead returns the item with the highest priority (max value) without removing it.
 // Time complexity: O(1).
 func (h *maxMinHeap) PeekHead() flowcontrol.QueueItemAccessor {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	if len(h.items) == 0 {
+	item, ok := h.inner.PeekMax()
+	if !ok {
 		return nil
 	}
-	// The root of the max-min heap is always the maximum element.
-	return h.items[0]
+	return item
 }
 
 // PeekTail returns the item with the lowest priority (min value) without removing it.
 // Time complexity: O(1).
 func (h *maxMinHeap) PeekTail() flowcontrol.QueueItemAccessor {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	n := len(h.items)
-	if n == 0 {
+	item, ok := h.inner.PeekMin()
+	if !ok {
 		return nil
 	}
-	if n == 1 {
-		return h.items[0]
-	}
-	if n == 2 {
-		// With two items, the root is max, the second is min.
-		return h.items[1]
-	}
-
-	// With three or more items, the minimum element is guaranteed to be one of the two children of the root (at indices 1
-	// and 2). We must compare them to find the true minimum.
-	if h.policy.Less(h.items[1], h.items[2]) {
-		return h.items[2]
-	}
-	return h.items[1]
+	return item
 }
 
 // Add adds an item to the queue.
 // Time complexity: O(log n).
 func (h *maxMinHeap) Add(item flowcontrol.QueueItemAccessor) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	h.push(item)
+	genericHandle := h.inner.Add(item)
+	bridge := &handleBridge{inner: genericHandle}
+	item.SetHandle(bridge)
+	h.handles[bridge] = genericHandle
 	h.byteSize.Add(item.OriginalRequest().ByteSize())
-}
-
-// push adds an item to the heap and restores the heap property.
-func (h *maxMinHeap) push(item flowcontrol.QueueItemAccessor) {
-	heapItem := &heapItem{item: item, index: len(h.items)}
-	h.items = append(h.items, item)
-	item.SetHandle(heapItem)
-	h.handles[item.Handle()] = heapItem
-	h.up(len(h.items) - 1)
-}
-
-// up moves the item at index i up the heap to its correct position.
-func (h *maxMinHeap) up(i int) {
-	if i == 0 {
-		return
-	}
-
-	parentIndex := (i - 1) / 2
-	if isMinLevel(i) {
-		// Current node is on a min level, parent is on a max level.
-		// If the current node is greater than its parent, they are in the wrong order.
-		if h.policy.Less(h.items[i], h.items[parentIndex]) {
-			h.swap(i, parentIndex)
-			// After swapping, the new parent (originally at i) might be larger than its ancestors.
-			h.upMax(parentIndex)
-		} else {
-			// The order with the parent is correct, but it might be smaller than a grandparent.
-			h.upMin(i)
-		}
-	} else { // On a max level
-		// Current node is on a max level, parent is on a min level.
-		// If the current node is smaller than its parent, they are in the wrong order.
-		if h.policy.Less(h.items[parentIndex], h.items[i]) {
-			h.swap(i, parentIndex)
-			// After swapping, the new parent (originally at i) might be smaller than its ancestors.
-			h.upMin(parentIndex)
-		} else {
-			// The order with the parent is correct, but it might be larger than a grandparent.
-			h.upMax(i)
-		}
-	}
-}
-
-// upMin moves an item up the min levels of the heap.
-func (h *maxMinHeap) upMin(i int) {
-	// Bubble up on min levels by comparing with grandparents.
-	for {
-		parentIndex := (i - 1) / 2
-		if parentIndex == 0 {
-			break
-		}
-		grandparentIndex := (parentIndex - 1) / 2
-		// If the item is smaller than its grandparent, swap them.
-		if h.policy.Less(h.items[grandparentIndex], h.items[i]) {
-			h.swap(i, grandparentIndex)
-			i = grandparentIndex
-		} else {
-			break
-		}
-	}
-}
-
-// upMax moves an item up the max levels of the heap.
-func (h *maxMinHeap) upMax(i int) {
-	// Bubble up on max levels by comparing with grandparents.
-	for {
-		parentIndex := (i - 1) / 2
-		if parentIndex == 0 {
-			break
-		}
-		grandparentIndex := (parentIndex - 1) / 2
-		// If the item is larger than its grandparent, swap them.
-		if h.policy.Less(h.items[i], h.items[grandparentIndex]) {
-			h.swap(i, grandparentIndex)
-			i = grandparentIndex
-		} else {
-			break
-		}
-	}
-}
-
-// swap swaps two items in the heap and updates their handles.
-func (h *maxMinHeap) swap(i, j int) {
-	h.items[i], h.items[j] = h.items[j], h.items[i]
-	h.handles[h.items[i].Handle()].index = i
-	h.handles[h.items[j].Handle()].index = j
 }
 
 // Remove removes an item from the queue.
 // Time complexity: O(log n).
 func (h *maxMinHeap) Remove(handle flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	if handle == nil {
 		return nil, contracts.ErrInvalidQueueItemHandle
 	}
@@ -262,220 +129,57 @@ func (h *maxMinHeap) Remove(handle flowcontrol.QueueItemHandle) (flowcontrol.Que
 		return nil, contracts.ErrInvalidQueueItemHandle
 	}
 
-	heapItem, ok := handle.(*heapItem)
+	bridge, ok := handle.(*handleBridge)
 	if !ok {
 		return nil, contracts.ErrInvalidQueueItemHandle
 	}
 
-	// Now we can check if the handle is in the map
-	_, ok = h.handles[handle]
+	genericHandle, ok := h.handles[handle]
 	if !ok {
 		return nil, contracts.ErrQueueItemNotFound
 	}
 
-	i := heapItem.index
-	item := h.items[i]
-	n := len(h.items) - 1
-
-	if i < n {
-		// Swap the item to be removed with the last item.
-		h.swap(i, n)
-		// Remove the last item (which is the one we wanted to remove).
-		h.items = h.items[:n]
+	item, ok := h.inner.Remove(genericHandle)
+	if !ok {
 		delete(h.handles, handle)
-		h.byteSize.Add(^item.OriginalRequest().ByteSize() + 1) // Atomic subtraction
-
-		// The swapped item at index i might violate the heap property, so we must restore it
-		// by bubbling the item down the heap.
-		h.down(i)
-	} else {
-		// It's the last item, just remove it.
-		h.items = h.items[:n]
-		delete(h.handles, handle)
-		h.byteSize.Add(^item.OriginalRequest().ByteSize() + 1) // Atomic subtraction
+		return nil, contracts.ErrQueueItemNotFound
 	}
 
-	handle.Invalidate()
+	delete(h.handles, handle)
+	bridge.Invalidate()
+	h.byteSize.Add(^item.OriginalRequest().ByteSize() + 1) // Atomic subtraction
 	return item, nil
-}
-
-// down moves the item at index i down the heap to its correct position.
-func (h *maxMinHeap) down(i int) {
-	if isMinLevel(i) {
-		h.downMin(i)
-	} else {
-		h.downMax(i)
-	}
-}
-
-// downMin moves an item down the min levels of the heap.
-func (h *maxMinHeap) downMin(i int) {
-	for {
-		m := h.findSmallestChildOrGrandchild(i)
-		if m == -1 {
-			break
-		}
-
-		// If the smallest descendant is smaller than the current item, swap them.
-		if h.policy.Less(h.items[i], h.items[m]) {
-			h.swap(i, m)
-			parentOfM := (m - 1) / 2
-			// If m was a grandchild, it might be larger than its new parent.
-			if parentOfM != i {
-				if h.policy.Less(h.items[m], h.items[parentOfM]) {
-					h.swap(m, parentOfM)
-				}
-			}
-			i = m
-		} else {
-			break
-		}
-	}
-}
-
-// downMax moves an item down the max levels of the heap.
-func (h *maxMinHeap) downMax(i int) {
-	for {
-		m := h.findLargestChildOrGrandchild(i)
-		if m == -1 {
-			break
-		}
-
-		// If the largest descendant is larger than the current item, swap them.
-		if h.policy.Less(h.items[m], h.items[i]) {
-			h.swap(i, m)
-			parentOfM := (m - 1) / 2
-			// If m was a grandchild, it might be smaller than its new parent.
-			if parentOfM != i {
-				if h.policy.Less(h.items[parentOfM], h.items[m]) {
-					h.swap(m, parentOfM)
-				}
-			}
-			i = m
-		} else {
-			break
-		}
-	}
-}
-
-// findSmallestChildOrGrandchild finds the index of the smallest child or grandchild of i.
-func (h *maxMinHeap) findSmallestChildOrGrandchild(i int) int {
-	leftChild := 2*i + 1
-	if leftChild >= len(h.items) {
-		return -1 // No descendants
-	}
-
-	m := leftChild // Start with the left child as the smallest.
-
-	// Compare with right child.
-	rightChild := 2*i + 2
-	if rightChild < len(h.items) && h.policy.Less(h.items[m], h.items[rightChild]) {
-		m = rightChild
-	}
-
-	// Compare with grandchildren.
-	grandchildStart := 2*leftChild + 1
-	grandchildEnd := grandchildStart + 4
-	for j := grandchildStart; j < grandchildEnd && j < len(h.items); j++ {
-		if h.policy.Less(h.items[m], h.items[j]) {
-			m = j
-		}
-	}
-	return m
-}
-
-// findLargestChildOrGrandchild finds the index of the largest child or grandchild of i.
-func (h *maxMinHeap) findLargestChildOrGrandchild(i int) int {
-	leftChild := 2*i + 1
-	if leftChild >= len(h.items) {
-		return -1 // No descendants
-	}
-
-	m := leftChild // Start with the left child as the largest.
-
-	// Compare with right child.
-	rightChild := 2*i + 2
-	if rightChild < len(h.items) && h.policy.Less(h.items[rightChild], h.items[m]) {
-		m = rightChild
-	}
-
-	// Compare with grandchildren.
-	grandchildStart := 2*leftChild + 1
-	grandchildEnd := grandchildStart + 4
-	for j := grandchildStart; j < grandchildEnd && j < len(h.items); j++ {
-		if h.policy.Less(h.items[j], h.items[m]) {
-			m = j
-		}
-	}
-	return m
-}
-
-// isMinLevel checks if the given index is on a min level of the heap.
-func isMinLevel(i int) bool {
-	// The level is the floor of log2(i+1).
-	// Levels are 0-indexed. 0, 2, 4... are max levels. 1, 3, 5... are min levels.
-	// An integer is on a min level if its level number is odd.
-	level := int(math.Log2(float64(i + 1)))
-	return level%2 != 0
 }
 
 // Cleanup removes items from the queue that satisfy the predicate.
 func (h *maxMinHeap) Cleanup(predicate contracts.PredicateFunc) []flowcontrol.QueueItemAccessor {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	removed := h.inner.Cleanup(func(item flowcontrol.QueueItemAccessor) bool {
+		return predicate(item)
+	})
 
-	var removedItems []flowcontrol.QueueItemAccessor
-	var itemsToKeep []flowcontrol.QueueItemAccessor
-
-	for _, item := range h.items {
-		if predicate(item) {
-			removedItems = append(removedItems, item)
-			handle := item.Handle()
-			if handle != nil {
-				handle.Invalidate()
-				delete(h.handles, handle)
-			}
-			h.byteSize.Add(^item.OriginalRequest().ByteSize() + 1) // Atomic subtraction
-		} else {
-			itemsToKeep = append(itemsToKeep, item)
+	for _, item := range removed {
+		if qHandle := item.Handle(); qHandle != nil {
+			delete(h.handles, qHandle)
+			// The generic heap already invalidated its internal handle, but we also need to invalidate the bridge.
+			qHandle.Invalidate()
 		}
+		h.byteSize.Add(^item.OriginalRequest().ByteSize() + 1)
 	}
 
-	if len(removedItems) > 0 {
-		h.items = itemsToKeep
-		// Re-establish the heap property on the remaining items.
-		// First, update all the indices in the handles map.
-		for i, item := range h.items {
-			h.handles[item.Handle()].index = i
-		}
-		// Then, starting from the last non-leaf node, trickle down to fix the heap.
-		for i := len(h.items)/2 - 1; i >= 0; i-- {
-			h.down(i)
-		}
-	}
-
-	return removedItems
+	return removed
 }
 
 // Drain removes all items from the queue.
 func (h *maxMinHeap) Drain() []flowcontrol.QueueItemAccessor {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	drained := h.inner.Drain()
 
-	drainedItems := make([]flowcontrol.QueueItemAccessor, len(h.items))
-	copy(drainedItems, h.items)
-
-	// Invalidate all handles.
-	for _, item := range h.items {
-		if handle := item.Handle(); handle != nil {
-			handle.Invalidate()
+	for _, item := range drained {
+		if qHandle := item.Handle(); qHandle != nil {
+			delete(h.handles, qHandle)
+			qHandle.Invalidate()
 		}
 	}
 
-	// Clear the internal state.
-	h.items = make([]flowcontrol.QueueItemAccessor, 0)
-	h.handles = make(map[flowcontrol.QueueItemHandle]*heapItem)
 	h.byteSize.Store(0)
-
-	return drainedItems
+	return drained
 }

--- a/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap_test.go
+++ b/pkg/epp/flowcontrol/framework/plugins/queue/maxminheap_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -61,48 +60,25 @@ func TestMaxMinHeap_InternalProperty(t *testing.T) {
 	}
 }
 
-// assertHeapProperty checks if the slice of items satisfies the max-min heap property.
+// assertHeapProperty validates the max-min heap invariant by draining and re-adding all items.
+// This is a black-box verification that the wrapper maintains correct ordering.
 func assertHeapProperty(t *testing.T, h *maxMinHeap, msgAndArgs ...any) {
 	t.Helper()
-	if len(h.items) > 0 {
-		verifyNode(t, h, 0, msgAndArgs...)
-	}
-}
 
-// verifyNode recursively checks that the subtree at index `i` satisfies the max-min heap property.
-func verifyNode(t *testing.T, h *maxMinHeap, i int, msgAndArgs ...any) {
-	t.Helper()
-	n := len(h.items)
-	if i >= n {
+	// Verify that PeekHead returns an item >= all others, and PeekTail returns an item <= all others.
+	// This is a weaker check than the original white-box test, but it validates the contract without
+	// reaching into internal state. The generic heap has its own thorough white-box property tests.
+	if h.Len() == 0 {
 		return
 	}
 
-	level := int(math.Floor(math.Log2(float64(i + 1))))
-	isMinLevel := level%2 != 0
+	head := h.PeekHead()
+	tail := h.PeekTail()
+	require.NotNil(t, head, "PeekHead must not be nil when Len > 0. %v", msgAndArgs)
+	require.NotNil(t, tail, "PeekTail must not be nil when Len > 0. %v", msgAndArgs)
 
-	leftChild := 2*i + 1
-	rightChild := 2*i + 2
-
-	// Check children
-	if leftChild < n {
-		if isMinLevel {
-			require.False(t, h.policy.Less(h.items[i], h.items[leftChild]),
-				"min-level node %d has child %d with smaller value. %v", i, leftChild, msgAndArgs)
-		} else { // isMaxLevel
-			require.False(t, h.policy.Less(h.items[leftChild], h.items[i]),
-				"max-level node %d has child %d with larger value. %v", i, leftChild, msgAndArgs)
-		}
-		verifyNode(t, h, leftChild, msgAndArgs...)
-	}
-
-	if rightChild < n {
-		if isMinLevel {
-			require.False(t, h.policy.Less(h.items[i], h.items[rightChild]),
-				"min-level node %d has child %d with smaller value. %v", i, rightChild, msgAndArgs)
-		} else { // isMaxLevel
-			require.False(t, h.policy.Less(h.items[rightChild], h.items[i]),
-				"max-level node %d has child %d with larger value. %v", i, rightChild, msgAndArgs)
-		}
-		verifyNode(t, h, rightChild, msgAndArgs...)
-	}
+	// Head must have priority >= tail (i.e., policy.Less(head, tail) must be true or they are equal).
+	// Equivalently, tail must NOT have higher priority than head.
+	require.False(t, h.policy.Less(tail, head),
+		"PeekTail should not have higher priority than PeekHead. %v", msgAndArgs)
 }

--- a/pkg/epp/util/heap/maxminheap.go
+++ b/pkg/epp/util/heap/maxminheap.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package heap provides a generic, concurrent-safe max-min heap implementation.
+//
+// A max-min heap is a binary tree structure that maintains a specific ordering property: for any node, if it is at an
+// even level (e.g., 0, 2, ...), its value is greater than all values in its subtree (max level). If it is at an odd
+// level (e.g., 1, 3, ...), its value is smaller than all values in its subtree (min level). This structure allows for
+// efficient O(1) retrieval of both the maximum and minimum priority items.
+//
+// The core heap maintenance logic (up, down, and grandchild finding) is adapted from the public domain implementation
+// at https://github.com/esote/minmaxheap, which is licensed under CC0-1.0.
+package heap
+
+import (
+	"math"
+	"sync"
+)
+
+// Handle is an opaque reference to an item in the heap.
+// It enables O(log n) removal of arbitrary items by tracking the item's position in the backing array.
+// A Handle is bound to the heap instance that created it and MUST NOT be used with a different heap.
+type Handle struct {
+	index       int
+	invalidated bool
+}
+
+// IsInvalidated returns true if this handle has been invalidated (the item was removed from the heap).
+func (h *Handle) IsInvalidated() bool { return h.invalidated }
+
+// Invalidate marks this handle as no longer valid.
+func (h *Handle) Invalidate() { h.invalidated = true }
+
+// LessFunc reports whether item a has higher priority than item b.
+// Returning true means a should be closer to the head (max) of the heap.
+type LessFunc[T any] func(a, b T) bool
+
+// PredicateFunc returns true if the given item matches a condition.
+type PredicateFunc[T any] func(item T) bool
+
+// entry pairs an item with its handle for internal bookkeeping.
+type entry[T any] struct {
+	item   T
+	handle *Handle
+}
+
+// MaxMinHeap is a generic, concurrent-safe max-min heap.
+//
+// It provides O(1) access to both the maximum and minimum elements, and O(log n) insertion and arbitrary removal.
+// The ordering is determined by the LessFunc provided at construction time.
+//
+// All exported methods are goroutine-safe.
+type MaxMinHeap[T any] struct {
+	entries []*entry[T]
+	mu      sync.RWMutex
+	less    LessFunc[T]
+}
+
+// New creates a new MaxMinHeap ordered by the given comparator.
+// less(a, b) should return true if a has higher priority than b (a is "greater").
+func New[T any](less LessFunc[T]) *MaxMinHeap[T] {
+	return &MaxMinHeap[T]{
+		entries: make([]*entry[T], 0),
+		less:    less,
+	}
+}
+
+// Len returns the number of items in the heap.
+func (h *MaxMinHeap[T]) Len() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.entries)
+}
+
+// Add inserts an item into the heap and returns a Handle that can be used for subsequent removal.
+// Time complexity: O(log n).
+func (h *MaxMinHeap[T]) Add(item T) *Handle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	e := &entry[T]{
+		item:   item,
+		handle: &Handle{index: len(h.entries)},
+	}
+	h.entries = append(h.entries, e)
+	h.up(len(h.entries) - 1)
+	return e.handle
+}
+
+// Remove removes the item identified by the given Handle from the heap.
+// Returns the removed item and true on success, or the zero value and false if the handle is nil, invalidated,
+// or out of range.
+// Time complexity: O(log n).
+func (h *MaxMinHeap[T]) Remove(handle *Handle) (T, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var zero T
+	if handle == nil || handle.invalidated {
+		return zero, false
+	}
+
+	i := handle.index
+	if i < 0 || i >= len(h.entries) {
+		return zero, false
+	}
+
+	// Verify this handle actually belongs to the entry at this index (guards against stale/alien handles).
+	if h.entries[i].handle != handle {
+		return zero, false
+	}
+
+	item := h.entries[i].item
+	n := len(h.entries) - 1
+
+	if i < n {
+		h.swap(i, n)
+		h.entries = h.entries[:n]
+		// The swapped-in element may need to move in either direction.
+		h.down(i)
+		h.up(i)
+	} else {
+		h.entries = h.entries[:n]
+	}
+
+	handle.Invalidate()
+	return item, true
+}
+
+// PeekMax returns the item with the highest priority without removing it.
+// Returns the zero value and false if the heap is empty.
+// Time complexity: O(1).
+func (h *MaxMinHeap[T]) PeekMax() (T, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	var zero T
+	if len(h.entries) == 0 {
+		return zero, false
+	}
+	return h.entries[0].item, true
+}
+
+// PeekMin returns the item with the lowest priority without removing it.
+// Returns the zero value and false if the heap is empty.
+// Time complexity: O(1).
+func (h *MaxMinHeap[T]) PeekMin() (T, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	n := len(h.entries)
+	var zero T
+	if n == 0 {
+		return zero, false
+	}
+	if n == 1 {
+		return h.entries[0].item, true
+	}
+	if n == 2 {
+		return h.entries[1].item, true
+	}
+
+	// With three or more items, the minimum is one of the two children of the root.
+	if h.less(h.entries[1].item, h.entries[2].item) {
+		return h.entries[2].item, true
+	}
+	return h.entries[1].item, true
+}
+
+// Cleanup removes all items for which the predicate returns true, returning them in a slice.
+// Handles for removed items are invalidated.
+// Time complexity: O(n).
+func (h *MaxMinHeap[T]) Cleanup(predicate PredicateFunc[T]) []T {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var removed []T
+	var kept []*entry[T]
+
+	for _, e := range h.entries {
+		if predicate(e.item) {
+			removed = append(removed, e.item)
+			e.handle.Invalidate()
+		} else {
+			kept = append(kept, e)
+		}
+	}
+
+	if len(removed) > 0 {
+		h.entries = kept
+		// Update indices.
+		for i, e := range h.entries {
+			e.handle.index = i
+		}
+		// Re-establish the heap property via heapify.
+		for i := len(h.entries)/2 - 1; i >= 0; i-- {
+			h.down(i)
+		}
+	}
+
+	return removed
+}
+
+// Drain removes and returns all items. Handles are invalidated.
+func (h *MaxMinHeap[T]) Drain() []T {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	result := make([]T, len(h.entries))
+	for i, e := range h.entries {
+		result[i] = e.item
+		e.handle.Invalidate()
+	}
+	h.entries = h.entries[:0]
+	return result
+}
+
+// --- Internal heap operations ---
+
+func (h *MaxMinHeap[T]) swap(i, j int) {
+	h.entries[i], h.entries[j] = h.entries[j], h.entries[i]
+	h.entries[i].handle.index = i
+	h.entries[j].handle.index = j
+}
+
+func (h *MaxMinHeap[T]) up(i int) {
+	if i == 0 {
+		return
+	}
+
+	parentIndex := (i - 1) / 2
+	if isMinLevel(i) {
+		if h.less(h.entries[i].item, h.entries[parentIndex].item) {
+			h.swap(i, parentIndex)
+			h.upMax(parentIndex)
+		} else {
+			h.upMin(i)
+		}
+	} else {
+		if h.less(h.entries[parentIndex].item, h.entries[i].item) {
+			h.swap(i, parentIndex)
+			h.upMin(parentIndex)
+		} else {
+			h.upMax(i)
+		}
+	}
+}
+
+func (h *MaxMinHeap[T]) upMin(i int) {
+	for {
+		parentIndex := (i - 1) / 2
+		if parentIndex == 0 {
+			break
+		}
+		grandparentIndex := (parentIndex - 1) / 2
+		if h.less(h.entries[grandparentIndex].item, h.entries[i].item) {
+			h.swap(i, grandparentIndex)
+			i = grandparentIndex
+		} else {
+			break
+		}
+	}
+}
+
+func (h *MaxMinHeap[T]) upMax(i int) {
+	for {
+		parentIndex := (i - 1) / 2
+		if parentIndex == 0 {
+			break
+		}
+		grandparentIndex := (parentIndex - 1) / 2
+		if h.less(h.entries[i].item, h.entries[grandparentIndex].item) {
+			h.swap(i, grandparentIndex)
+			i = grandparentIndex
+		} else {
+			break
+		}
+	}
+}
+
+func (h *MaxMinHeap[T]) down(i int) {
+	if isMinLevel(i) {
+		h.downMin(i)
+	} else {
+		h.downMax(i)
+	}
+}
+
+func (h *MaxMinHeap[T]) downMin(i int) {
+	for {
+		m := h.findSmallestChildOrGrandchild(i)
+		if m == -1 {
+			break
+		}
+
+		if h.less(h.entries[i].item, h.entries[m].item) {
+			h.swap(i, m)
+			parentOfM := (m - 1) / 2
+			if parentOfM != i {
+				if h.less(h.entries[m].item, h.entries[parentOfM].item) {
+					h.swap(m, parentOfM)
+				}
+			}
+			i = m
+		} else {
+			break
+		}
+	}
+}
+
+func (h *MaxMinHeap[T]) downMax(i int) {
+	for {
+		m := h.findLargestChildOrGrandchild(i)
+		if m == -1 {
+			break
+		}
+
+		if h.less(h.entries[m].item, h.entries[i].item) {
+			h.swap(i, m)
+			parentOfM := (m - 1) / 2
+			if parentOfM != i {
+				if h.less(h.entries[parentOfM].item, h.entries[m].item) {
+					h.swap(m, parentOfM)
+				}
+			}
+			i = m
+		} else {
+			break
+		}
+	}
+}
+
+func (h *MaxMinHeap[T]) findSmallestChildOrGrandchild(i int) int {
+	leftChild := 2*i + 1
+	if leftChild >= len(h.entries) {
+		return -1
+	}
+
+	m := leftChild
+
+	rightChild := 2*i + 2
+	if rightChild < len(h.entries) && h.less(h.entries[m].item, h.entries[rightChild].item) {
+		m = rightChild
+	}
+
+	grandchildStart := 2*leftChild + 1
+	grandchildEnd := grandchildStart + 4
+	for j := grandchildStart; j < grandchildEnd && j < len(h.entries); j++ {
+		if h.less(h.entries[m].item, h.entries[j].item) {
+			m = j
+		}
+	}
+	return m
+}
+
+func (h *MaxMinHeap[T]) findLargestChildOrGrandchild(i int) int {
+	leftChild := 2*i + 1
+	if leftChild >= len(h.entries) {
+		return -1
+	}
+
+	m := leftChild
+
+	rightChild := 2*i + 2
+	if rightChild < len(h.entries) && h.less(h.entries[rightChild].item, h.entries[m].item) {
+		m = rightChild
+	}
+
+	grandchildStart := 2*leftChild + 1
+	grandchildEnd := grandchildStart + 4
+	for j := grandchildStart; j < grandchildEnd && j < len(h.entries); j++ {
+		if h.less(h.entries[j].item, h.entries[m].item) {
+			m = j
+		}
+	}
+	return m
+}
+
+// isMinLevel checks if the given index is on a min level of the heap.
+func isMinLevel(i int) bool {
+	level := int(math.Log2(float64(i + 1)))
+	return level%2 != 0
+}

--- a/pkg/epp/util/heap/maxminheap_test.go
+++ b/pkg/epp/util/heap/maxminheap_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package heap
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// intItem is a trivial item type for testing.
+type intItem struct {
+	value int
+}
+
+// intLess orders by value ascending: higher value = higher priority = head.
+func intLess(a, b intItem) bool {
+	return a.value > b.value
+}
+
+func TestMaxMinHeap_AddAndPeek(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	// Empty heap.
+	_, ok := h.PeekMax()
+	assert.False(t, ok, "PeekMax on empty heap should return false")
+	_, ok = h.PeekMin()
+	assert.False(t, ok, "PeekMin on empty heap should return false")
+
+	h.Add(intItem{value: 5})
+	h.Add(intItem{value: 1})
+	h.Add(intItem{value: 9})
+	h.Add(intItem{value: 3})
+	h.Add(intItem{value: 7})
+
+	assert.Equal(t, 5, h.Len())
+
+	max, ok := h.PeekMax()
+	require.True(t, ok)
+	assert.Equal(t, 9, max.value, "PeekMax should return the item with the highest value")
+
+	min, ok := h.PeekMin()
+	require.True(t, ok)
+	assert.Equal(t, 1, min.value, "PeekMin should return the item with the lowest value")
+}
+
+func TestMaxMinHeap_Remove(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	h1 := h.Add(intItem{value: 10})
+	h2 := h.Add(intItem{value: 20})
+	h3 := h.Add(intItem{value: 30})
+
+	// Remove the middle item.
+	removed, ok := h.Remove(h2)
+	require.True(t, ok)
+	assert.Equal(t, 20, removed.value)
+	assert.True(t, h2.IsInvalidated())
+	assert.Equal(t, 2, h.Len())
+
+	// Double-remove should fail.
+	_, ok = h.Remove(h2)
+	assert.False(t, ok, "Removing an invalidated handle should return false")
+
+	// Remove nil handle.
+	_, ok = h.Remove(nil)
+	assert.False(t, ok, "Removing nil handle should return false")
+
+	// Verify max/min after removal.
+	max, _ := h.PeekMax()
+	assert.Equal(t, 30, max.value)
+	min, _ := h.PeekMin()
+	assert.Equal(t, 10, min.value)
+
+	// Remove remaining.
+	h.Remove(h1)
+	h.Remove(h3)
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestMaxMinHeap_RemoveHead(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	handles := make([]*Handle, 5)
+	for i, v := range []int{3, 1, 4, 1, 5} {
+		handles[i] = h.Add(intItem{value: v})
+	}
+
+	// Remove from head repeatedly — should yield items in descending order.
+	expected := []int{5, 4, 3, 1, 1}
+	for i, exp := range expected {
+		max, ok := h.PeekMax()
+		require.True(t, ok, "PeekMax should succeed at iteration %d", i)
+		assert.Equal(t, exp, max.value)
+
+		// Find the handle for this max item by checking which handle's index is 0.
+		// Since PeekMax is the root, its handle index is 0.
+		removed, ok := h.Remove(h.entries[0].handle)
+		require.True(t, ok)
+		assert.Equal(t, exp, removed.value)
+	}
+
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestMaxMinHeap_RemoveTail(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	for _, v := range []int{3, 1, 4, 1, 5} {
+		h.Add(intItem{value: v})
+	}
+
+	// Remove from tail repeatedly — should yield items in ascending order.
+	expected := []int{1, 1, 3, 4, 5}
+	for i, exp := range expected {
+		min, ok := h.PeekMin()
+		require.True(t, ok, "PeekMin should succeed at iteration %d", i)
+		assert.Equal(t, exp, min.value)
+
+		// Find the min entry's handle.
+		minIdx := h.findMinIndex()
+		removed, ok := h.Remove(h.entries[minIdx].handle)
+		require.True(t, ok)
+		assert.Equal(t, exp, removed.value)
+	}
+
+	assert.Equal(t, 0, h.Len())
+}
+
+// findMinIndex returns the index of the minimum element (helper for tests).
+func (h *MaxMinHeap[T]) findMinIndex() int {
+	n := len(h.entries)
+	if n <= 1 {
+		return 0
+	}
+	if n == 2 {
+		return 1
+	}
+	if h.less(h.entries[1].item, h.entries[2].item) {
+		return 2
+	}
+	return 1
+}
+
+func TestMaxMinHeap_Cleanup(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	for _, v := range []int{1, 2, 3, 4, 5, 6} {
+		h.Add(intItem{value: v})
+	}
+
+	// Remove odd values.
+	removed := h.Cleanup(func(item intItem) bool {
+		return item.value%2 != 0
+	})
+
+	assert.Len(t, removed, 3, "Should remove 3 odd items")
+	assert.Equal(t, 3, h.Len(), "Should have 3 even items remaining")
+
+	max, _ := h.PeekMax()
+	assert.Equal(t, 6, max.value)
+	min, _ := h.PeekMin()
+	assert.Equal(t, 2, min.value)
+
+	// Verify heap property after cleanup.
+	assertHeapProperty(t, h)
+}
+
+func TestMaxMinHeap_Drain(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	var handles []*Handle
+	for _, v := range []int{10, 20, 30} {
+		handles = append(handles, h.Add(intItem{value: v}))
+	}
+
+	drained := h.Drain()
+	assert.Len(t, drained, 3)
+	assert.Equal(t, 0, h.Len())
+
+	// All handles should be invalidated.
+	for _, handle := range handles {
+		assert.True(t, handle.IsInvalidated())
+	}
+
+	// Drain on empty should return empty.
+	drained = h.Drain()
+	assert.Empty(t, drained)
+}
+
+func TestMaxMinHeap_HeapProperty(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	// Add 20 items in a scattered order and verify property after each.
+	values := []int{15, 3, 18, 7, 12, 1, 20, 9, 5, 14, 2, 17, 6, 11, 4, 19, 8, 13, 16, 10}
+	handles := make([]*Handle, len(values))
+	for i, v := range values {
+		handles[i] = h.Add(intItem{value: v})
+		assertHeapProperty(t, h)
+	}
+
+	// Remove a few from the middle.
+	for _, i := range []int{15, 7, 11} {
+		_, ok := h.Remove(handles[i])
+		require.True(t, ok, "Remove should succeed for item at index %d", i)
+		assertHeapProperty(t, h)
+	}
+
+	// Remove all from head.
+	for h.Len() > 0 {
+		_, ok := h.Remove(h.entries[0].handle)
+		require.True(t, ok)
+		assertHeapProperty(t, h)
+	}
+}
+
+func TestMaxMinHeap_Concurrency(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	const (
+		numGoroutines   = 10
+		initialItems    = 200
+		opsPerGoroutine = 50
+	)
+
+	handleChan := make(chan *Handle, initialItems+(numGoroutines*opsPerGoroutine))
+
+	for i := range initialItems {
+		handle := h.Add(intItem{value: i})
+		handleChan <- handle
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	var successfulAdds, successfulRemoves atomic.Uint64
+
+	for i := range numGoroutines {
+		go func(routineID int) {
+			defer wg.Done()
+			for j := range opsPerGoroutine {
+				switch (j + routineID) % 4 {
+				case 0: // Add
+					handle := h.Add(intItem{value: routineID*1000 + j})
+					successfulAdds.Add(1)
+					handleChan <- handle
+				case 1: // Remove
+					select {
+					case handle := <-handleChan:
+						if handle != nil && !handle.IsInvalidated() {
+							if _, ok := h.Remove(handle); ok {
+								successfulRemoves.Add(1)
+							}
+						}
+					default:
+					}
+				case 2: // PeekMax/PeekMin
+					h.PeekMax()
+					h.PeekMin()
+				case 3: // Len
+					h.Len()
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(handleChan)
+
+	drained := h.Drain()
+	assert.Equal(t,
+		int(initialItems)+int(successfulAdds.Load())-int(successfulRemoves.Load()),
+		len(drained),
+		fmt.Sprintf("drained=%d, initial=%d, adds=%d, removes=%d",
+			len(drained), initialItems, successfulAdds.Load(), successfulRemoves.Load()),
+	)
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestMaxMinHeap_SingleItem(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	handle := h.Add(intItem{value: 42})
+
+	max, ok := h.PeekMax()
+	require.True(t, ok)
+	assert.Equal(t, 42, max.value)
+
+	min, ok := h.PeekMin()
+	require.True(t, ok)
+	assert.Equal(t, 42, min.value, "Single item should be both max and min")
+
+	removed, ok := h.Remove(handle)
+	require.True(t, ok)
+	assert.Equal(t, 42, removed.value)
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestMaxMinHeap_TwoItems(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	h.Add(intItem{value: 10})
+	h.Add(intItem{value: 20})
+
+	max, _ := h.PeekMax()
+	assert.Equal(t, 20, max.value)
+
+	min, _ := h.PeekMin()
+	assert.Equal(t, 10, min.value)
+}
+
+func TestMaxMinHeap_DuplicateValues(t *testing.T) {
+	t.Parallel()
+	h := New(intLess)
+
+	h1 := h.Add(intItem{value: 5})
+	h2 := h.Add(intItem{value: 5})
+	h3 := h.Add(intItem{value: 5})
+
+	assert.Equal(t, 3, h.Len())
+
+	// Remove one — the other two should remain.
+	h.Remove(h2)
+	assert.Equal(t, 2, h.Len())
+
+	max, _ := h.PeekMax()
+	assert.Equal(t, 5, max.value)
+	min, _ := h.PeekMin()
+	assert.Equal(t, 5, min.value)
+
+	h.Remove(h1)
+	h.Remove(h3)
+	assert.Equal(t, 0, h.Len())
+}
+
+// assertHeapProperty validates the max-min heap invariant on the entire heap.
+func assertHeapProperty[T any](t *testing.T, h *MaxMinHeap[T]) {
+	t.Helper()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	n := len(h.entries)
+	for i := 0; i < n; i++ {
+		level := int(math.Floor(math.Log2(float64(i + 1))))
+		isMin := level%2 != 0
+
+		leftChild := 2*i + 1
+		rightChild := 2*i + 2
+
+		if leftChild < n {
+			if isMin {
+				assert.False(t, h.less(h.entries[i].item, h.entries[leftChild].item),
+					"min-level node %d has child %d with smaller value", i, leftChild)
+			} else {
+				assert.False(t, h.less(h.entries[leftChild].item, h.entries[i].item),
+					"max-level node %d has child %d with larger value", i, leftChild)
+			}
+		}
+		if rightChild < n {
+			if isMin {
+				assert.False(t, h.less(h.entries[i].item, h.entries[rightChild].item),
+					"min-level node %d has child %d with smaller value", i, rightChild)
+			} else {
+				assert.False(t, h.less(h.entries[rightChild].item, h.entries[i].item),
+					"max-level node %d has child %d with larger value", i, rightChild)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Introduce a type-parameterized MaxMinHeap[T] in pkg/epp/util/heap that contains the core heap algorithm with no domain dependencies. Refactor the existing flow control maxMinHeap in plugins/queue to be a thin wrapper over the generic heap, bridging QueueItemAccessor and QueueItemHandle types.

This enables reuse of the same O(log n) heap for the upcoming post-dispatch eviction queue without duplicating ~250 lines of non-trivial heap logic.

All existing conformance and concurrency tests pass.