### PR TITLE
fix(release): stop publishing a lora-syncer tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,14 +16,6 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
     entrypoint: make
     args:
-      - syncer-image-push
-    env:
-    - GIT_TAG=$_GIT_TAG
-    - EXTRA_TAG=$_PULL_BASE_REF
-    - DOCKER_BUILDX_CMD=/buildx-entrypoint
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
-    entrypoint: make
-    args:
       - inferencepool-helm-chart-push
       - bbr-helm-chart-push
       - standalone-helm-chart-push

--- a/config/manifests/regression-testing/vllm/multi-lora-deployment.yaml
+++ b/config/manifests/regression-testing/vllm/multi-lora-deployment.yaml
@@ -155,9 +155,9 @@ spec:
         - name: lora-adapter-syncer
           tty: true
           stdin: true 
-          image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main
+          image: registry.k8s.io/gateway-api-inference-extension/lora-syncer:v1.2.1
           restartPolicy: Always
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env: 
             - name: DYNAMIC_LORA_ROLLOUT_CONFIG
               value: "/config/configmap.yaml"
@@ -284,7 +284,6 @@ data:
             source: nvidia/llama-3.1-nemoguard-8b-topic-control
           - id: adapter-14  
             source: nvidia/llama-3.1-nemoguard-8b-topic-control
-
 
 
 

--- a/config/manifests/vllm/cpu-deployment.yaml
+++ b/config/manifests/vllm/cpu-deployment.yaml
@@ -78,9 +78,9 @@ spec:
         - name: lora-adapter-syncer
           tty: true
           stdin: true
-          image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main
+          image: registry.k8s.io/gateway-api-inference-extension/lora-syncer:v1.2.1
           restartPolicy: Always
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: DYNAMIC_LORA_ROLLOUT_CONFIG
               value: "/config/configmap.yaml"

--- a/config/manifests/vllm/gpu-deployment.yaml
+++ b/config/manifests/vllm/gpu-deployment.yaml
@@ -156,9 +156,9 @@ spec:
         - name: lora-adapter-syncer
           tty: true
           stdin: true 
-          image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main
+          image: registry.k8s.io/gateway-api-inference-extension/lora-syncer:v1.2.1
           restartPolicy: Always
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env: 
             - name: DYNAMIC_LORA_ROLLOUT_CONFIG
               value: "/config/configmap.yaml"

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -128,13 +128,8 @@ sed -i.bak -E "s|(llm-d/llm-d-inference-sim:)[^\"[:space:]]+|\1v${VLLM_SIM}|g" "
 # Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM image.
 sed -i.bak '/llm-d\/llm-d-inference-sim/{n;s/Always/IfNotPresent/;}' "$VLLM_SIM_DEPLOY"
 
-# Update the container tag for lora-syncer in vLLM CPU and GPU deployment manifests.
-sed -i.bak -E "s|(gateway-api-inference-extension/lora-syncer:)[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$VLLM_GPU_DEPLOY" "$VLLM_CPU_DEPLOY"
-# Update the container image pull policy for lora-syncer in vLLM CPU and GPU deployment manifests.
-sed -i.bak '/us-central1-docker.pkg.dev\/k8s-staging-images\/gateway-api-inference-extension\/lora-syncer/{n;s/Always/IfNotPresent/;}' "$VLLM_GPU_DEPLOY" "$VLLM_CPU_DEPLOY"
-
-# Update the container registry for lora-syncer in vLLM CPU and GPU deployment manifests.
-sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io|g" "$VLLM_GPU_DEPLOY" "$VLLM_CPU_DEPLOY"
+# lora-syncer is deprecated and no longer receives release-tagged images.
+# Keep the manifests pinned to the latest promoted public image.
 
 # -----------------------------------------------------------------------------
 # Stage the changes

--- a/tools/dynamic-lora-sidecar/deployment.yaml
+++ b/tools/dynamic-lora-sidecar/deployment.yaml
@@ -66,9 +66,9 @@ spec:
         - name: lora-adapter-syncer
           tty: true
           stdin: true 
-          image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/lora-syncer:main
+          image: registry.k8s.io/gateway-api-inference-extension/lora-syncer:v1.2.1
           restartPolicy: Always
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 8080
             name: metrics


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
This retires the lora-syncer image publishing to the staging registry and stops release prep from trying to retag it. This PR removes the `syncer-image-push` step in `cloudbuild.yaml`, updates the checked in lora-syncer references to the latest promoted public image (`registry.k8s.io/gateway-api-inference-extension/lora-syncer:v1.2.1`), and removes the release-script logic that rewrote lora-syncer to the current release tag.

**Which issue(s) this PR fixes**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
