### PR TITLE
feat(bbr): add explicit plugin configuration to Helm chart values.yaml

### DIFF
--- a/config/charts/body-based-routing/values.yaml
+++ b/config/charts/body-based-routing/values.yaml
@@ -14,6 +14,19 @@ bbr:
     # Log verbosity
     v: 3
 
+  # BBR plugins configuration.
+  # When plugins are explicitly specified, the runner's default auto-load is skipped.
+  # Both plugins below replicate the default behavior.
+  # Format: type (registered plugin type), name (instance name), json (optional config object)
+  plugins:
+    - type: body-field-to-header
+      name: model-extractor
+      json:
+        field_name: model
+        header_name: X-Gateway-Model-Name
+    - type: base-model-to-header
+      name: base-model-mapper
+
   tracing:
     enabled: false
     otelServiceName: "gateway-api-inference-extension/bbr"


### PR DESCRIPTION
add explicit plugin configuration to Helm chart values.yaml                                                                                                                                            
Expose BBR plugin configuration in values.yaml so users can see and                                                                                                                                               
customize the default plugins (body-field-to-header, base-model-to-header)
instead of relying on the runner's implicit auto-load behavior.
