### PR TITLE
Cleanup and small changes to tests related to BaseModelToHeaderPlugin

### DIFF
--- a/pkg/bbr/handlers/server_test.go
+++ b/pkg/bbr/handlers/server_test.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	basepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -89,7 +90,7 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 										{
 											Header: &basepb.HeaderValue{
 												Key:      contentLengthHeader,
-												RawValue: []byte("15"),
+												RawValue: []byte(strconv.Itoa(len(b))),
 											},
 										},
 										{

--- a/test/integration/bbr/body_mutation_test.go
+++ b/test/integration/bbr/body_mutation_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/basemodelextractor"
 	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
@@ -58,7 +59,8 @@ func TestBodyMutation_Unary(t *testing.T) {
 	ctx := context.Background()
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
-	h := NewBBRHarnessWithPlugins(t, ctx, false, []framework.RequestProcessor{plugin})
+	baseModelToHeaderPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
+	h := NewBBRHarnessWithPlugins(t, ctx, false, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin})
 
 	body := map[string]any{"prompt": "hello"}
 	bodyBytes, _ := json.Marshal(body)
@@ -124,7 +126,8 @@ func TestBodyMutation_Streaming(t *testing.T) {
 	ctx := context.Background()
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
-	h := NewBBRHarnessWithPlugins(t, ctx, true, []framework.RequestProcessor{plugin})
+	baseModelToHeaderPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
+	h := NewBBRHarnessWithPlugins(t, ctx, true, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin})
 
 	body := map[string]any{"prompt": "hello"}
 	bodyBytes, _ := json.Marshal(body)

--- a/test/integration/bbr/harness.go
+++ b/test/integration/bbr/harness.go
@@ -56,7 +56,10 @@ func NewBBRHarness(t *testing.T, ctx context.Context, streaming bool) *BBRHarnes
 	t.Helper()
 	modelToHeaderPlugin, err := plugins.NewBodyFieldToHeaderPlugin(handlers.ModelField, handlers.ModelHeader)
 	require.NoError(t, err, "failed to create body-field-to-header plugin")
-	return NewBBRHarnessWithPlugins(t, ctx, streaming, []framework.RequestProcessor{modelToHeaderPlugin})
+
+	baseModelToHeaderPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
+
+	return NewBBRHarnessWithPlugins(t, ctx, streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin})
 }
 
 // NewBBRHarnessWithPlugins boots up an isolated BBR server with custom request plugins.
@@ -67,59 +70,63 @@ func NewBBRHarnessWithPlugins(t *testing.T, ctx context.Context, streaming bool,
 	port, err := integration.GetFreePort()
 	require.NoError(t, err, "failed to acquire free port for BBR server")
 
-	// 2. Configure BBR Server with both plugins
+	// 2. Configure BBR Server with plugins
 	runner := runserver.NewDefaultExtProcServerRunner(port, false)
 	runner.SecureServing = false
 	runner.Streaming = streaming
-
-	// Create BaseModelToHeaderPlugin for X-Gateway-Base-Model-Name
-	baseModelPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
-
-	// Combine provided plugins with the base model plugin
-	// The base model plugin should run after other plugins to extract base model from the target model
-	requestPlugins = append(requestPlugins, baseModelPlugin)
 	runner.RequestPlugins = requestPlugins
 
-	// Configure the BaseModelToHeaderPlugin with test data
-	// Create a test ConfigMap with model mappings
-	testConfigMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-model-mappings",
-			Namespace: "default",
-			Labels: map[string]string{
-				"inference.networking.k8s.io/bbr-managed": "true",
+	// Find the BaseModelToHeaderPlugin in the requestPlugins to configure it
+	var baseModelToHeaderPlugin *basemodelextractor.BaseModelToHeaderPlugin
+	for _, plugin := range requestPlugins {
+		if p, ok := plugin.(*basemodelextractor.BaseModelToHeaderPlugin); ok {
+			baseModelToHeaderPlugin = p
+			break
+		}
+	}
+
+	// Configure the BaseModelToHeaderPlugin with test data if it exists
+	if baseModelToHeaderPlugin != nil {
+		// Create a test ConfigMap with model mappings
+		testConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-model-mappings",
+				Namespace: "default",
+				Labels: map[string]string{
+					"inference.networking.k8s.io/bbr-managed": "true",
+				},
 			},
-		},
-		Data: map[string]string{
-			"baseModel": "llama",
-			"adapters": `
+			Data: map[string]string{
+				"baseModel": "llama",
+				"adapters": `
 - sql-lora-sheddable
 - foo
 - 1
 `,
-		},
+			},
+		}
+
+		// Get the reconciler from the plugin and set it up with a fake manager
+		reconciler := baseModelToHeaderPlugin.GetReconciler()
+
+		// Create a fake client with the test ConfigMap
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(testConfigMap).
+			Build()
+
+		// Set the Reader on the reconciler
+		reconciler.Reader = fakeClient
+
+		// Call Reconcile() to update the adapters store with test data
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: testConfigMap.Namespace,
+				Name:      testConfigMap.Name,
+			},
+		}
+		_, err = reconciler.Reconcile(ctx, req)
+		require.NoError(t, err, "failed to configure base model plugin with test data via Reconcile")
 	}
-
-	// Get the reconciler from the plugin and set it up with a fake manager
-	reconciler := baseModelPlugin.GetReconciler()
-
-	// Create a fake client with the test ConfigMap
-	fakeClient := fake.NewClientBuilder().
-		WithObjects(testConfigMap).
-		Build()
-
-	// Set the Reader on the reconciler
-	reconciler.Reader = fakeClient
-
-	// Call Reconcile() to update the adapters store with test data
-	req := ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: testConfigMap.Namespace,
-			Name:      testConfigMap.Name,
-		},
-	}
-	_, err = reconciler.Reconcile(ctx, req)
-	require.NoError(t, err, "failed to configure base model plugin with test data via Reconcile")
 
 	// 3. Start Server in Background
 	serverCtx, serverCancel := context.WithCancel(ctx)


### PR DESCRIPTION
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

This PR addresses the post-approval comments for [PR #2417](https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2417)

**Which issue(s) this PR fixes**:

Fixes #2606

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
