### PR TITLE
[pluggable bbr] wire CycleState into plugin interfaces

### DIFF
--- a/pkg/bbr/framework/plugins.go
+++ b/pkg/bbr/framework/plugins.go
@@ -30,12 +30,12 @@ type RequestProcessor interface {
 	BBRPlugin
 	// ProcessRequest runs the RequestProcessor plugin.
 	// RequestProcessor can mutate the headers and/or the body of the request.
-	ProcessRequest(ctx context.Context, request *InferenceRequest) error
+	ProcessRequest(ctx context.Context, cycleState *CycleState, request *InferenceRequest) error
 }
 
 type ResponseProcessor interface {
 	BBRPlugin
 	// ProcessResponse runs the ResponseProcessor plugin.
 	// ResponseProcessor can mutate the headers and/or the body of the response.
-	ProcessResponse(ctx context.Context, response *InferenceResponse) error
+	ProcessResponse(ctx context.Context, cycleState *CycleState, response *InferenceResponse) error
 }

--- a/pkg/bbr/handlers/request.go
+++ b/pkg/bbr/handlers/request.go
@@ -41,7 +41,7 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 		return nil, err
 	}
 
-	if err := s.runRequestPlugins(ctx, reqCtx.Request); err != nil {
+	if err := s.runRequestPlugins(ctx, reqCtx.CycleState, reqCtx.Request); err != nil {
 		logger.V(logutil.DEFAULT).Error(err, "failed to execute request plugins")
 		if s.streaming {
 			ret = append(ret, &eppb.ProcessingResponse{
@@ -128,12 +128,12 @@ func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, 
 }
 
 // runRequestPlugins executes request plugins in the order they were registered.
-func (s *Server) runRequestPlugins(ctx context.Context, request *framework.InferenceRequest) error {
+func (s *Server) runRequestPlugins(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
 	var err error
 	for _, plugin := range s.requestPlugins {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Executing request plugin", "plugin", plugin.TypedName())
 		before := time.Now()
-		err = plugin.ProcessRequest(ctx, request)
+		err = plugin.ProcessRequest(ctx, cycleState, request)
 		metrics.RecordPluginProcessingLatency(requestPluginExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		if err != nil {
 			return fmt.Errorf("failed to execute request plugin '%s' - %w", plugin.TypedName(), err)

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -427,7 +427,8 @@ func TestHandleRequestBody(t *testing.T) {
 			baseModelToHeaderPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
 			server := NewServer(test.streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 			reqCtx := &RequestContext{
-				Request: framework.NewInferenceRequest(),
+				CycleState: framework.NewCycleState(),
+				Request:    framework.NewInferenceRequest(),
 			}
 			bodyBytes, _ := json.Marshal(test.body)
 			resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)
@@ -474,7 +475,8 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 	baseModelToHeaderPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
 	server := NewServer(false, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 	reqCtx := &RequestContext{
-		Request: framework.NewInferenceRequest(),
+		CycleState: framework.NewCycleState(),
+		Request:    framework.NewInferenceRequest(),
 	}
 
 	bodyBytes, _ := json.Marshal(map[string]any{
@@ -539,15 +541,15 @@ func mapToBytes(t *testing.T, m map[string]any) []byte {
 
 type bodyMutatingPlugin struct {
 	name     string
-	mutateFn func(ctx context.Context, request *framework.InferenceRequest) error
+	mutateFn func(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error
 }
 
 func (p *bodyMutatingPlugin) TypedName() epp.TypedName {
 	return epp.TypedName{Type: "fake", Name: p.name}
 }
 
-func (p *bodyMutatingPlugin) ProcessRequest(ctx context.Context, request *framework.InferenceRequest) error {
-	return p.mutateFn(ctx, request)
+func (p *bodyMutatingPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	return p.mutateFn(ctx, cycleState, request)
 }
 
 var _ framework.RequestProcessor = &bodyMutatingPlugin{}
@@ -558,7 +560,7 @@ func TestHandleRequestBody_BodyMutation(t *testing.T) {
 
 	plugin := &bodyMutatingPlugin{
 		name: "body-mutator",
-		mutateFn: func(_ context.Context, request *framework.InferenceRequest) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
 			request.SetBodyField("injected", "value")
 			return nil
 		},
@@ -671,7 +673,8 @@ func TestHandleRequestBody_BodyMutation(t *testing.T) {
 			baseModelPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
 			server := NewServer(tc.streaming, []framework.RequestProcessor{plugin, baseModelPlugin}, []framework.ResponseProcessor{})
 			reqCtx := &RequestContext{
-				Request: framework.NewInferenceRequest(),
+				CycleState: framework.NewCycleState(),
+				Request:    framework.NewInferenceRequest(),
 			}
 			bodyBytes, _ := json.Marshal(tc.body)
 			resp, err := server.HandleRequestBody(ctx, reqCtx, bodyBytes)

--- a/pkg/bbr/handlers/response.go
+++ b/pkg/bbr/handlers/response.go
@@ -87,7 +87,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 		}, nil
 	}
 
-	if err := s.runResponsePlugins(ctx, reqCtx.Response); err != nil {
+	if err := s.runResponsePlugins(ctx, reqCtx.CycleState, reqCtx.Response); err != nil {
 		return nil, fmt.Errorf("failed to execute response plugins - %w", err)
 	}
 
@@ -177,12 +177,12 @@ func (s *Server) HandleResponseTrailers(trailers *eppb.HttpTrailers) ([]*eppb.Pr
 }
 
 // runResponsePlugins executes response plugins in the order they were registered.
-func (s *Server) runResponsePlugins(ctx context.Context, response *framework.InferenceResponse) error {
+func (s *Server) runResponsePlugins(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error {
 	var err error
 	for _, plugin := range s.responsePlugins {
 		log.FromContext(ctx).V(logutil.VERBOSE).Info("Executing response plugin", "plugin", plugin.TypedName())
 		before := time.Now()
-		err = plugin.ProcessResponse(ctx, response)
+		err = plugin.ProcessResponse(ctx, cycleState, response)
 		metrics.RecordPluginProcessingLatency(responsePluginExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		if err != nil {
 			return fmt.Errorf("failed to execute response plugin '%s' - %w", plugin.TypedName(), err)

--- a/pkg/bbr/handlers/response_test.go
+++ b/pkg/bbr/handlers/response_test.go
@@ -39,23 +39,24 @@ const testPluginValue = "done"
 // fakeResponsePlugin implements framework.PayloadProcessor for testing response plugin execution.
 type fakeResponsePlugin struct {
 	name     string
-	mutateFn func(ctx context.Context, response *framework.InferenceResponse) error
+	mutateFn func(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error
 }
 
 func (p *fakeResponsePlugin) TypedName() epp.TypedName {
 	return epp.TypedName{Type: "fake", Name: p.name}
 }
 
-func (p *fakeResponsePlugin) ProcessResponse(ctx context.Context, response *framework.InferenceResponse) error {
-	return p.mutateFn(ctx, response)
+func (p *fakeResponsePlugin) ProcessResponse(ctx context.Context, cycleState *framework.CycleState, response *framework.InferenceResponse) error {
+	return p.mutateFn(ctx, cycleState, response)
 }
 
 var _ framework.ResponseProcessor = &fakeResponsePlugin{}
 
 func newTestRequestContext() *RequestContext {
 	return &RequestContext{
-		Request:  framework.NewInferenceRequest(),
-		Response: framework.NewInferenceResponse(),
+		CycleState: framework.NewCycleState(),
+		Request:    framework.NewInferenceRequest(),
+		Response:   framework.NewInferenceResponse(),
 	}
 }
 
@@ -126,7 +127,7 @@ func TestHandleResponseBody_SinglePlugin(t *testing.T) {
 
 	mutatePlugin := &fakeResponsePlugin{
 		name: "mutator",
-		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 			response.SetBodyField("mutated", true)
 			return nil
 		},
@@ -159,14 +160,14 @@ func TestHandleResponseBody_MultiplePlugins(t *testing.T) {
 
 	plugin1 := &fakeResponsePlugin{
 		name: "plugin1",
-		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 			response.SetBodyField("p1", testPluginValue)
 			return nil
 		},
 	}
 	plugin2 := &fakeResponsePlugin{
 		name: "plugin2",
-		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 			response.SetBodyField("p2", testPluginValue)
 			return nil
 		},
@@ -200,7 +201,7 @@ func TestHandleResponseBody_PluginError(t *testing.T) {
 
 	failingPlugin := &fakeResponsePlugin{
 		name: "failing",
-		mutateFn: func(_ context.Context, _ *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, _ *framework.InferenceResponse) error {
 			return errors.New("failed to execute plugin")
 		},
 	}
@@ -222,7 +223,7 @@ func TestHandleResponseBody_StreamingWithPlugin(t *testing.T) {
 
 	mutatePlugin := &fakeResponsePlugin{
 		name: "mutator",
-		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 			response.SetBodyField("mutated", true)
 			return nil
 		},
@@ -286,7 +287,7 @@ func TestHandleResponseBody_PluginNoBodyMutation(t *testing.T) {
 
 	headerOnlyPlugin := &fakeResponsePlugin{
 		name: "header-only",
-		mutateFn: func(_ context.Context, response *framework.InferenceResponse) error {
+		mutateFn: func(_ context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 			response.SetHeader("X-Custom-Response", "added")
 			return nil
 		},

--- a/pkg/bbr/handlers/server_test.go
+++ b/pkg/bbr/handlers/server_test.go
@@ -136,7 +136,8 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 			baseModelToHeaderPlugin := basemodelextractor.NewBaseModelToHeaderPlugin()
 			srv := NewServer(tc.streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin}, []framework.ResponseProcessor{})
 			reqCtx := &RequestContext{
-				Request: framework.NewInferenceRequest(),
+				CycleState: framework.NewCycleState(),
+				Request:    framework.NewInferenceRequest(),
 			}
 			got, err := srv.HandleRequestBody(ctx, reqCtx, tc.body)
 			if err != nil {

--- a/pkg/bbr/plugins/basemodelextractor/base_model_to_header.go
+++ b/pkg/bbr/plugins/basemodelextractor/base_model_to_header.go
@@ -68,7 +68,7 @@ func (p *BaseModelToHeaderPlugin) WithName(name string) *BaseModelToHeaderPlugin
 }
 
 // ProcessRequest sets base model name on the header
-func (p *BaseModelToHeaderPlugin) ProcessRequest(ctx context.Context, request *framework.InferenceRequest) error {
+func (p *BaseModelToHeaderPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
 	if request == nil || request.Headers == nil || request.Body == nil {
 		return nil // this shouldn't happen
 	}

--- a/pkg/bbr/plugins/body_field_to_header.go
+++ b/pkg/bbr/plugins/body_field_to_header.go
@@ -102,7 +102,7 @@ func (p *BodyFieldToHeaderPlugin) WithName(name string) *BodyFieldToHeaderPlugin
 }
 
 // ProcessRequest extracts value from a given body field and sets it as HTTP header.
-func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, request *framework.InferenceRequest) error {
+func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
 	if request == nil || request.Headers == nil || request.Body == nil {
 		return nil // this shouldn't happen
 	}

--- a/pkg/bbr/plugins/body_field_to_header_test.go
+++ b/pkg/bbr/plugins/body_field_to_header_test.go
@@ -296,7 +296,7 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 				t.Fatalf("failed to create plugin: %v", err)
 			}
 
-			err = p.ProcessRequest(context.Background(), tt.request)
+			err = p.ProcessRequest(context.Background(), nil, tt.request)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -324,7 +324,7 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest_MutatedHeaders(t *testing.T) {
 	request := framework.NewInferenceRequest()
 	request.Body["model"] = testModelValue
 
-	if err := p.ProcessRequest(context.Background(), request); err != nil {
+	if err := p.ProcessRequest(context.Background(), nil, request); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/bbr/body_mutation_test.go
+++ b/test/integration/bbr/body_mutation_test.go
@@ -45,7 +45,7 @@ func (p *bodyMutatingPlugin) TypedName() epp.TypedName {
 	return epp.TypedName{Type: "test-body-mutator", Name: "test-body-mutator"}
 }
 
-func (p *bodyMutatingPlugin) ProcessRequest(_ context.Context, request *framework.InferenceRequest) error {
+func (p *bodyMutatingPlugin) ProcessRequest(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
 	request.SetBodyField(p.fieldName, p.fieldValue)
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Following up on #2612, this PR wires `CycleState` into the BBR plugin interfaces so that plugins can actually access the per-request shared state.

- Update `ProcessRequest` and `ProcessResponse` signatures to accept `cycleState *CycleState`.
- Pass `reqCtx.CycleState` from `runRequestPlugins`/`runResponsePlugins` to each plugin.
- Update existing plugins (`BodyFieldToHeaderPlugin`, `BaseModelToHeaderPlugin`) with the new signature.
- Update all unit, handler, and integration tests accordingly.

**Which issue(s) this PR fixes**:

Fix for #2611

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
