### PR TITLE
[fix] properly template extraContainerPorts

### DIFF
--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -142,7 +142,7 @@ spec:
             - name: metrics
               containerPort: 9090
         {{- if .Values.inferenceExtension.extraContainerPorts }}
-        {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 8 }}
+            {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 12 }}
         {{- end }}
           livenessProbe:
           {{- if gt (.Values.inferenceExtension.replicas | int) 1 }}


### PR DESCRIPTION

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

In testing done: https://kubernetes.slack.com/archives/C08E3RZMT2P/p1772836360373429, it was identified that the RC was improperly templating the `extraContainerPorts`

cc @kfswain @danehans 