### PR TITLE
[release-1.4] [fix] properly template extraContainerPorts

### DIFF
--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -142,7 +142,7 @@ spec:
             - name: metrics
               containerPort: 9090
         {{- if .Values.inferenceExtension.extraContainerPorts }}
-        {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 8 }}
+            {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 12 }}
         {{- end }}
           livenessProbe:
           {{- if gt (.Values.inferenceExtension.replicas | int) 1 }}


### PR DESCRIPTION
## Summary
- backport #2621 to release-1.4
- fix the indentation used when rendering inferenceExtension.extraContainerPorts
- preserve cherry-pick provenance for the original mainline change

## Testing
- git diff --check origin/release-1.4...HEAD
- helm template backport-smoke ./config/charts/inferencepool --dependency-update --set inferencePool.modelServers.matchLabels.app=vllm --set-json 'inferenceExtension.extraContainerPorts=[{"name":"foo","containerPort":1234}]'

Cherry-pick of 13ebb38dc1af90ddd58d78a222b7ab48a352b4cd from #2621.