### PR TITLE
[release-1.4] [fix] properly template extraContainerPorts

### DIFF
--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -142,7 +142,7 @@ spec:
             - name: metrics
               containerPort: 9090
         {{- if .Values.inferenceExtension.extraContainerPorts }}
-        {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 8 }}
+            {{- toYaml .Values.inferenceExtension.extraContainerPorts | nindent 12 }}
         {{- end }}
           livenessProbe:
           {{- if gt (.Values.inferenceExtension.replicas | int) 1 }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Backports #2621 to `release-1.4` so `inferenceExtension.extraContainerPorts` renders at the correct indentation under the container `ports:` list.

**Which issue(s) this PR fixes**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```