### PR TITLE
fix: keep EndpointPickerConfig logging on the string path

### DIFF
--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -64,11 +64,11 @@ func LoadRawConfig(configBytes []byte, logger logr.Logger) (*configapi.EndpointP
 		if err != nil {
 			return nil, nil, err
 		}
-		logger.Info("Loaded raw configuration", "config", rawConfig.String())
+		logger.Info("Loaded raw configuration", "config", configForLog(rawConfig))
 	} else {
 		logger.Info("A configuration wasn't specified. A default one is being used.")
 		rawConfig = loadDefaultConfig()
-		logger.Info("Default raw configuration used", "config", rawConfig.String())
+		logger.Info("Default raw configuration used", "config", configForLog(rawConfig))
 	}
 
 	applyStaticDefaults(rawConfig)
@@ -97,7 +97,7 @@ func InstantiateAndConfigure(
 	if err := applySystemDefaults(rawConfig, handle); err != nil {
 		return nil, fmt.Errorf("system default application failed: %w", err)
 	}
-	logger.Info("Instantiated all plugins and applied system defaults. Effective raw configuration", "config", rawConfig.String())
+	logger.Info("Instantiated all plugins and applied system defaults. Effective raw configuration", "config", configForLog(rawConfig))
 
 	if err := validateConfig(rawConfig); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
@@ -144,6 +144,15 @@ func decodeRawConfig(configBytes []byte) (*configapi.EndpointPickerConfig, error
 		return nil, fmt.Errorf("failed to decode configuration JSON/YAML: %w", err)
 	}
 	return cfg, nil
+}
+
+// configForLog converts EndpointPickerConfig to a plain string so controller-runtime's
+// Kubernetes-aware zap encoder does not try to treat it as an object with metadata.
+func configForLog(cfg *configapi.EndpointPickerConfig) string {
+	if cfg == nil {
+		return "<nil>"
+	}
+	return cfg.String()
 }
 
 func instantiatePlugins(configuredPlugins []configapi.PluginSpec, handle fwkplugin.Handle) error {

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -17,17 +17,22 @@ limitations under the License.
 package loader
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	configapi "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
@@ -525,6 +530,33 @@ func TestInstantiateAndConfigure(t *testing.T) {
 	}
 }
 
+func TestInstantiateAndConfigureLogsConfigWithoutConfigError(t *testing.T) {
+	registerTestPlugins(t)
+
+	RegisterFeatureGate(datalayer.ExperimentalDatalayerFeatureGate)
+	RegisterFeatureGate(flowcontrol.FeatureGate)
+
+	var logOutput testLogBuffer
+	logger := ctrlzap.New(ctrlzap.UseFlagOptions(&ctrlzap.Options{
+		DestWriter:  &logOutput,
+		Development: true,
+		Level:       zapcore.Level(-5),
+	}))
+
+	rawConfig, _, err := LoadRawConfig([]byte(successSchedulerConfigText), logger)
+	require.NoError(t, err)
+
+	handle := utils.NewTestHandle(context.Background())
+	_, err = InstantiateAndConfigure(rawConfig, handle, logger)
+	require.NoError(t, err)
+
+	logs := logOutput.String()
+	require.Contains(t, logs, "Effective raw configuration")
+	require.Contains(t, logs, "FeatureGates:")
+	require.NotContains(t, strings.ToLower(logs), "configerror")
+	require.NotContains(t, logs, "got runtime.Object without object metadata")
+}
+
 // Verify the SaturationConfig builder specifically.
 func TestBuildSaturationConfig(t *testing.T) {
 	t.Parallel()
@@ -594,6 +626,23 @@ func hasPluginType(handle fwkplugin.Handle, typeName string) bool {
 
 type mockPlugin struct {
 	t fwkplugin.TypedName
+}
+
+type testLogBuffer struct {
+	buf bytes.Buffer
+	mu  sync.Mutex
+}
+
+func (b *testLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *testLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func (m *mockPlugin) TypedName() fwkplugin.TypedName { return m.t }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Route `EndpointPickerConfig` logging through a helper that always emits a
plain string, and add a controller-runtime logger regression test for the
phase-two loader path.

**Which issue(s) this PR fixes**:
Fixes: #2622

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```