### PR TITLE
refactor(bbr): move test helpers into plugins/test

### DIFF
--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/basemodelextractor"
-	bbrtest "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/test"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/test"
 	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
@@ -422,7 +422,7 @@ func TestHandleRequestBody(t *testing.T) {
 		},
 	}
 
-	baseModelToHeaderPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelToHeaderPlugin, err := test.NewTestBaseModelPlugin()
 	if err != nil {
 		t.Fatalf("failed to create base model plugin: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 
 	modelToHeaderPlugin, _ := plugins.NewBodyFieldToHeaderPlugin(ModelField, ModelHeader)
-	baseModelToHeaderPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelToHeaderPlugin, err := test.NewTestBaseModelPlugin()
 	if err != nil {
 		t.Fatalf("failed to create base model plugin: %v", err)
 	}
@@ -675,7 +675,7 @@ func TestHandleRequestBody_BodyMutation(t *testing.T) {
 		},
 	}
 
-	baseModelPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelPlugin, err := test.NewTestBaseModelPlugin()
 	if err != nil {
 		t.Fatalf("failed to create base model plugin: %v", err)
 	}

--- a/pkg/bbr/handlers/server_test.go
+++ b/pkg/bbr/handlers/server_test.go
@@ -29,7 +29,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
-	bbrtest "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/test"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/test"
 	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
@@ -130,7 +130,7 @@ func TestHandleRequestBodyStreaming(t *testing.T) {
 			},
 		},
 	}
-	baseModelToHeaderPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelToHeaderPlugin, err := test.NewTestBaseModelPlugin()
 	if err != nil {
 		t.Fatalf("failed to create base model plugin: %v", err)
 	}

--- a/pkg/bbr/plugins/test/base_model_plugin.go
+++ b/pkg/bbr/plugins/test/base_model_plugin.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package bbrtest
+package test
 
 import (
 	"fmt"

--- a/test/integration/bbr/body_mutation_test.go
+++ b/test/integration/bbr/body_mutation_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
-	bbrtest "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/test"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/test"
 	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
@@ -59,7 +59,7 @@ func TestBodyMutation_Unary(t *testing.T) {
 	ctx := context.Background()
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
-	baseModelToHeaderPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelToHeaderPlugin, err := test.NewTestBaseModelPlugin()
 	require.NoError(t, err, "failed to create base model plugin")
 	h := NewBBRHarnessWithPlugins(t, ctx, false, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin})
 
@@ -127,7 +127,7 @@ func TestBodyMutation_Streaming(t *testing.T) {
 	ctx := context.Background()
 
 	plugin := &bodyMutatingPlugin{fieldName: "injected", fieldValue: "test-value"}
-	baseModelToHeaderPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelToHeaderPlugin, err := test.NewTestBaseModelPlugin()
 	require.NoError(t, err, "failed to create base model plugin")
 	h := NewBBRHarnessWithPlugins(t, ctx, true, []framework.RequestProcessor{plugin, baseModelToHeaderPlugin})
 

--- a/test/integration/bbr/harness.go
+++ b/test/integration/bbr/harness.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/handlers"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/basemodelextractor"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/test"
 	runserver "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/server"
-	bbrtest "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/test"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
@@ -58,7 +58,7 @@ func NewBBRHarness(t *testing.T, ctx context.Context, streaming bool) *BBRHarnes
 	modelToHeaderPlugin, err := plugins.NewBodyFieldToHeaderPlugin(handlers.ModelField, handlers.ModelHeader)
 	require.NoError(t, err, "failed to create body-field-to-header plugin")
 
-	baseModelToHeaderPlugin, err := bbrtest.NewTestBaseModelPlugin()
+	baseModelToHeaderPlugin, err := test.NewTestBaseModelPlugin()
 	require.NoError(t, err, "failed to create base model plugin")
 
 	return NewBBRHarnessWithPlugins(t, ctx, streaming, []framework.RequestProcessor{modelToHeaderPlugin, baseModelToHeaderPlugin})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Move `pkg/bbr/test/` into `pkg/bbr/plugins/test/` so test helpers live alongside the plugin code they support. Rename `helpers.go` to `base_model_plugin.go` to reflect its content, and drop the `bbrtest` import alias in favor of the directory-derived `test` package name.

**Does this PR introduce a user-facing change?**:
`None`
