### PR TITLE
fix(release): select newest staging digest for tag

### DIFF
--- a/hack/release-staging-digests.sh
+++ b/hack/release-staging-digests.sh
@@ -20,6 +20,11 @@ if ! command -v gcloud >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
 : "${MAJOR:?MAJOR must be set}"
 : "${MINOR:?MINOR must be set}"
 : "${PATCH:?PATCH must be set}"
@@ -53,22 +58,17 @@ find_digest() {
     gcloud artifacts docker images list "${resource}" \
       --include-tags \
       --limit="${LIMIT}" \
-      --format='value(version,tags)' 2>/dev/null | grep '^sha256:' || true
+      --format=json 2>/dev/null || true
   )"
 
-  local digest tags tag
-  while IFS=$'\t' read -r digest tags; do
-    [[ -z "${digest}" || -z "${tags}" ]] && continue
-    IFS=',' read -r -a tag_list <<< "${tags}"
-    for tag in "${tag_list[@]}"; do
-      if [[ "${tag}" == "${RELEASE_TAG}" ]]; then
-        echo "${digest}"
-        return 0
-      fi
-    done
-  done <<< "${rows}"
+  jq -er --arg tag "${RELEASE_TAG}" '
+    map(select((.tags // []) | index($tag)))
+    | sort_by(.updateTime // .createTime // "")
+    | last
+    | .version
+  ' <<< "${rows}" 2>/dev/null || return 1
 
-  return 1
+  return 0
 }
 
 echo "Release tag: ${RELEASE_TAG}"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
This updates `hack/release-staging-digests.sh` to select the newest matching digest for a release tag instead of the first matching digest returned by Artifact Registry.

This matters when a tag has been reused and multiple digests carry the same release tag. In that case, the previous implementation could return a stale digest and produce an incorrect `k8s.io` promotion PR.

The script now:
- requires `jq`
- queries Artifact Registry as JSON
- filters entries by the requested release tag
- sorts matching entries by `updateTime`/`createTime`
- returns the newest matching digest

**Which issue(s) this PR fixes**:
Fixes #2630

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
