### PR TITLE
fix(release): backport latency predictor release updates

### DIFF
--- a/config/charts/epplib/values.yaml
+++ b/config/charts/epplib/values.yaml
@@ -3,9 +3,9 @@ latencyPredictor:
   # Training Server Configuration
   trainingServer:
     image:
-      hub: path/to/your/docker/repo # NOTE: Update with your Docker repository path for sidecars
-      name: latencypredictor-training-server
-      tag: latest
+      hub: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension
+      name: latency-training-server
+      tag: main
       pullPolicy: Always
     port: 8000
     resources:
@@ -29,43 +29,46 @@ latencyPredictor:
       periodSeconds: 10
     volumeSize: "20Gi"
     config:
-      LATENCY_RETRAINING_INTERVAL_SEC: "1"
+      LATENCY_RETRAINING_INTERVAL_SEC: "10"
       LATENCY_MIN_SAMPLES_FOR_RETRAIN: "100"
       LATENCY_TTFT_MODEL_PATH: "/models/ttft.joblib"
       LATENCY_TPOT_MODEL_PATH: "/models/tpot.joblib"
       LATENCY_TTFT_SCALER_PATH: "/models/ttft_scaler.joblib"
       LATENCY_TPOT_SCALER_PATH: "/models/tpot_scaler.joblib"
       LATENCY_MODEL_TYPE: "xgboost"
-      LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "5000"
-      LATENCY_QUANTILE_ALPHA: "0.9"
+      LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "500"
+      LATENCY_OBJECTIVE_TYPE: "mean"
 
   # Prediction Server Configuration
   predictionServers:
-    count: 10
+    count: 1
     startPort: 8001
     image:
-      hub: path/to/your/docker/repo # NOTE: Update with your Docker repository path for sidecars
-      name: latencypredictor-prediction-server
-      tag: latest
+      hub: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension
+      name: latency-prediction-server
+      tag: main
       pullPolicy: Always
     resources:
       requests:
-        cpu: "500m"
-        memory: "1Gi"
+        cpu: "8000m"
+        memory: "4Gi"
       limits:
-        cpu: "1000m"
-        memory: "2Gi"
+        cpu: "28000m"
+        memory: "8Gi"
     livenessProbe:
       httpGet:
         path: /healthz
       initialDelaySeconds: 15
       periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 5
     readinessProbe:
       httpGet:
         path: /readyz
       initialDelaySeconds: 10
-      periodSeconds: 5
-      failureThreshold: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
     volumeSize: "10Gi"
     config:
       LATENCY_MODEL_TYPE: "xgboost"
@@ -74,7 +77,13 @@ latencyPredictor:
       LOCAL_TPOT_MODEL_PATH: "/server_models/tpot.joblib"
       LOCAL_TTFT_SCALER_PATH: "/server_models/ttft_scaler.joblib"
       LOCAL_TPOT_SCALER_PATH: "/server_models/tpot_scaler.joblib"
+      UVICORN_WORKERS: "28"
+      OMP_NUM_THREADS: "1"
+      MODEL_SYNC_INTERVAL_SEC: "30"
+      LATENCY_OBJECTIVE_TYPE: "mean"
 
   # EPP Environment Variables for Latency Predictor
   eppEnv:
     LATENCY_MAX_SAMPLE_SIZE: "10000"
+    LATENCY_MAX_CONCURRENT_DISPATCHES: "36"
+    LATENCY_COALESCE_WINDOW_MS: "1"

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -76,13 +76,15 @@ sed -i.bak "s|kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-in
 # -----------------------------------------------------------------------------
 #TODO: Put all helm values files into an array to loop over
 EPP_HELM="config/charts/inferencepool/values.yaml"
+LATENCY_ROUTING_HELM="config/charts/epplib/values.yaml"
 BBR_HELM="config/charts/body-based-routing/values.yaml"
 STANDALONE_HELM="config/charts/standalone/values.yaml"
 CONFORMANCE_MANIFESTS="conformance/resources/base.yaml"
-echo "Updating ${EPP_HELM}, ${BBR_HELM}, ${STANDALONE_HELM} and ${CONFORMANCE_MANIFESTS} ..."
+echo "Updating ${EPP_HELM}, ${LATENCY_ROUTING_HELM}, ${BBR_HELM}, ${STANDALONE_HELM} and ${CONFORMANCE_MANIFESTS} ..."
 
 # Update the container tag.
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$EPP_HELM"
+sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$LATENCY_ROUTING_HELM"
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$BBR_HELM"
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$STANDALONE_HELM"
 # Update epp
@@ -92,6 +94,7 @@ sed -i.bak '/us-central1-docker.pkg.dev\/k8s-staging-images\/gateway-api-inferen
 
 # Update the container registry.
 sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io|g" "$EPP_HELM"
+sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io|g" "$LATENCY_ROUTING_HELM"
 sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io|g" "$BBR_HELM"
 sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io|g" "$STANDALONE_HELM"
 sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io|g" "$CONFORMANCE_MANIFESTS"
@@ -120,8 +123,8 @@ sed -i.bak "/llm-d\\/llm-d-inference-sim/{n;s|imagePullPolicy: .*|imagePullPolic
 # -----------------------------------------------------------------------------
 # Stage the changes
 # -----------------------------------------------------------------------------
-echo "Staging $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS $VLLM_GPU_DEPLOY $VLLM_CPU_DEPLOY $VLLM_SIM_DEPLOY files..."
-git add $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS $VLLM_GPU_DEPLOY $VLLM_CPU_DEPLOY $VLLM_SIM_DEPLOY
+echo "Staging $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS $VLLM_GPU_DEPLOY $VLLM_CPU_DEPLOY $VLLM_SIM_DEPLOY files..."
+git add $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS $VLLM_GPU_DEPLOY $VLLM_CPU_DEPLOY $VLLM_SIM_DEPLOY
 
 # -----------------------------------------------------------------------------
 # Cleanup backup files and finish


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind regression

**What this PR does / why we need it**:
Backports #2619 to `release-1.4` so the `v1.4.0` release includes the production-tuned latency predictor Helm defaults.

It also backports the matching `hack/release-quickstart.sh` update so release prep rewrites the latency routing chart image refs from the staging `main` images to `registry.k8s.io` plus the release tag.

The backport is applied manually instead of cherry-picking the whole script file so the existing `release-1.4`-specific release fixes remain intact.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Updates the latency predictor Helm defaults and release packaging used for the v1.4.0 release.
```
