### PR TITLE
feat(bbr): return ImmediateResponse on plugin errors

### DIFF
--- a/pkg/bbr/handlers/request.go
+++ b/pkg/bbr/handlers/request.go
@@ -29,36 +29,20 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
 	envoy "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
 // HandleRequestBody parses the raw body bytes into reqCtx.Request.Body and processes the request.
 func (s *Server) HandleRequestBody(ctx context.Context, reqCtx *RequestContext, requestBodyBytes []byte) ([]*eppb.ProcessingResponse, error) {
-	logger := log.FromContext(ctx)
 	var ret []*eppb.ProcessingResponse
 
 	if err := json.Unmarshal(requestBodyBytes, &reqCtx.Request.Body); err != nil {
-		return nil, err
+		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("failed to parse request body: %v", err)}
 	}
 
 	if err := s.runRequestPlugins(ctx, reqCtx.CycleState, reqCtx.Request); err != nil {
-		logger.V(logutil.DEFAULT).Error(err, "failed to execute request plugins")
-		if s.streaming {
-			ret = append(ret, &eppb.ProcessingResponse{
-				Response: &eppb.ProcessingResponse_RequestHeaders{
-					RequestHeaders: &eppb.HeadersResponse{},
-				},
-			})
-			ret = addStreamedBodyResponse(ret, requestBodyBytes)
-			return ret, nil
-		} else {
-			ret = append(ret, &eppb.ProcessingResponse{
-				Response: &eppb.ProcessingResponse_RequestBody{
-					RequestBody: &eppb.BodyResponse{},
-				},
-			})
-		}
-		return ret, nil
+		return nil, err
 	}
 
 	bodyMutated := reqCtx.Request.BodyMutated()
@@ -136,7 +120,8 @@ func (s *Server) runRequestPlugins(ctx context.Context, cycleState *framework.Cy
 		err = plugin.ProcessRequest(ctx, cycleState, request)
 		metrics.RecordPluginProcessingLatency(requestPluginExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		if err != nil {
-			return fmt.Errorf("failed to execute request plugin '%s' - %w", plugin.TypedName(), err)
+			log.FromContext(ctx).V(logutil.DEFAULT).Error(err, "Failed to execute request plugin", "plugin", plugin.TypedName())
+			return err
 		}
 	}
 

--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -152,63 +152,20 @@ func TestHandleRequestBody(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "model not found",
-			body: map[string]any{
-				"prompt": "Tell me a joke",
-			},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{},
-					},
-				},
-			},
+			name:    "model not found",
+			body:    map[string]any{"prompt": "Tell me a joke"},
+			wantErr: true,
 		},
 		{
-			name: "model not found with streaming",
-			body: map[string]any{
-				"prompt": "Tell me a joke",
-			},
+			name:      "model not found with streaming",
+			body:      map[string]any{"prompt": "Tell me a joke"},
 			streaming: true,
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestHeaders{
-						RequestHeaders: &extProcPb.HeadersResponse{},
-					},
-				},
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: &extProcPb.CommonResponse{
-								BodyMutation: &extProcPb.BodyMutation{
-									Mutation: &extProcPb.BodyMutation_StreamedResponse{
-										StreamedResponse: &extProcPb.StreamedBodyResponse{
-											Body: mapToBytes(t, map[string]any{
-												"prompt": "Tell me a joke",
-											}),
-											EndOfStream: true,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			wantErr:   true,
 		},
 		{
-			name: "model in body but empty",
-			body: map[string]any{
-				"model":  "",
-				"prompt": "Tell me a joke",
-			},
-			want: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{},
-					},
-				},
-			},
+			name:    "model in body but empty",
+			body:    map[string]any{"model": "", "prompt": "Tell me a joke"},
+			wantErr: true,
 		},
 		{
 			name: "model is not string, success after it's being auto converted to string",
@@ -513,14 +470,6 @@ func TestHandleRequestBodyWithPluginMetrics(t *testing.T) {
 	if pluginsWithMetrics != 2 {
 		t.Errorf("Expected 2 request plugins with metrics observations, got %d", pluginsWithMetrics)
 	}
-}
-
-func mapToBytes(t *testing.T, m map[string]any) []byte {
-	bytes, err := json.Marshal(m)
-	if err != nil {
-		t.Fatalf("Marshal(): %v", err)
-	}
-	return bytes
 }
 
 type bodyMutatingPlugin struct {

--- a/pkg/bbr/handlers/response.go
+++ b/pkg/bbr/handlers/response.go
@@ -88,7 +88,7 @@ func (s *Server) HandleResponseBody(ctx context.Context, reqCtx *RequestContext,
 	}
 
 	if err := s.runResponsePlugins(ctx, reqCtx.CycleState, reqCtx.Response); err != nil {
-		return nil, fmt.Errorf("failed to execute response plugins - %w", err)
+		return nil, err
 	}
 
 	bodyMutated := reqCtx.Response.BodyMutated()
@@ -185,7 +185,8 @@ func (s *Server) runResponsePlugins(ctx context.Context, cycleState *framework.C
 		err = plugin.ProcessResponse(ctx, cycleState, response)
 		metrics.RecordPluginProcessingLatency(responsePluginExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		if err != nil {
-			return fmt.Errorf("failed to execute response plugin '%s' - %w", plugin.TypedName(), err)
+			log.FromContext(ctx).V(logutil.DEFAULT).Error(err, "Failed to execute response plugin", "plugin", plugin.TypedName())
+			return err
 		}
 	}
 

--- a/pkg/bbr/handlers/server.go
+++ b/pkg/bbr/handlers/server.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	envoy "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
 	"sigs.k8s.io/gateway-api-inference-extension/version"
@@ -149,13 +150,22 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			return status.Error(codes.Unknown, "unknown request type")
 		}
 
+		// Handle the err and fire an immediate response.
 		if err != nil {
 			if logger.V(logutil.DEBUG).Enabled() {
 				logger.V(logutil.DEBUG).Error(err, "Failed to process request", "request", req)
 			} else {
 				logger.V(logutil.DEFAULT).Error(err, "Failed to process request")
 			}
-			return status.Errorf(status.Code(err), "failed to handle request: %v", err)
+			resp, err := errcommon.BuildErrResponse(err)
+			if err != nil {
+				return err
+			}
+			if sendErr := srv.Send(resp); sendErr != nil {
+				logger.V(logutil.DEFAULT).Error(sendErr, "Send failed")
+				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", sendErr)
+			}
+			return nil
 		}
 
 		for _, resp := range responses {

--- a/pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header.go
+++ b/pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
@@ -112,13 +113,13 @@ func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, _ *framewo
 	rawFieldValue, exists := request.Body[p.fieldName]
 	if !exists {
 		metrics.RecordBodyFieldNotFound(p.fieldName)
-		return fmt.Errorf("field '%s' not found in request body", p.fieldName)
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("field '%s' not found in request body", p.fieldName)}
 	}
 
 	fieldStr := fmt.Sprintf("%v", rawFieldValue) // convert any type to string
 	if fieldStr == "" {
 		metrics.RecordBodyFieldEmpty(p.fieldName)
-		return fmt.Errorf("field '%s' is empty and couldn't be processed", p.fieldName)
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("field '%s' is empty and couldn't be processed", p.fieldName)}
 	}
 
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("parsed field from body", "field", p.fieldName, "value", fieldStr)

--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -18,9 +18,13 @@ package error
 
 import (
 	"fmt"
+
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/grpc/status"
 )
 
-// Error is an error struct for errors returned by the epp server.
+// Error is an error struct for errors returned by the epp/bbr server.
 type Error struct {
 	Code string
 	Msg  string
@@ -29,6 +33,9 @@ type Error struct {
 const (
 	Unknown            = "Unknown"
 	BadRequest         = "BadRequest"
+	Unauthorized       = "Unauthorized"
+	Forbidden          = "Forbidden"
+	NotFound           = "NotFound"
 	Internal           = "Internal"
 	ServiceUnavailable = "ServiceUnavailable"
 	ModelServerError   = "ModelServerError"
@@ -47,4 +54,46 @@ func CanonicalCode(err error) string {
 		return e.Code
 	}
 	return Unknown
+}
+
+// BuildErrResponse maps an error to an Envoy ImmediateResponse with the appropriate
+// HTTP status code and error message body. If the error code is not recognized,
+// it returns a gRPC error instead of an ImmediateResponse.
+func BuildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
+	var httpCode envoyTypePb.StatusCode
+
+	switch CanonicalCode(err) {
+	case BadRequest:
+		httpCode = envoyTypePb.StatusCode_BadRequest
+	case Unauthorized:
+		httpCode = envoyTypePb.StatusCode_Unauthorized
+	case Forbidden:
+		httpCode = envoyTypePb.StatusCode_Forbidden
+	case NotFound:
+		httpCode = envoyTypePb.StatusCode_NotFound
+	case ResourceExhausted:
+		httpCode = envoyTypePb.StatusCode_TooManyRequests
+	case Internal:
+		httpCode = envoyTypePb.StatusCode_InternalServerError
+	case ServiceUnavailable:
+		httpCode = envoyTypePb.StatusCode_ServiceUnavailable
+	default:
+		return nil, status.Errorf(status.Code(err), "failed to handle request: %v", err)
+	}
+
+	resp := &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &extProcPb.ImmediateResponse{
+				Status: &envoyTypePb.HttpStatus{
+					Code: httpCode,
+				},
+			},
+		},
+	}
+
+	if err.Error() != "" {
+		resp.Response.(*extProcPb.ProcessingResponse_ImmediateResponse).ImmediateResponse.Body = []byte(err.Error())
+	}
+
+	return resp, nil
 }

--- a/pkg/common/error/error_test.go
+++ b/pkg/common/error/error_test.go
@@ -18,7 +18,10 @@ package error
 
 import (
 	"errors"
+	"strings"
 	"testing"
+
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 )
 
 func TestError_Error(t *testing.T) {
@@ -214,5 +217,97 @@ func TestErrorConstants(t *testing.T) {
 		if constant != expected {
 			t.Errorf("Constant value %q != expected %q", constant, expected)
 		}
+	}
+}
+
+func TestBuildErrResponse(t *testing.T) {
+	tests := []struct {
+		name             string
+		err              error
+		wantHTTPStatus   envoyTypePb.StatusCode
+		wantBodyContains string
+		wantGRPCErr      bool
+	}{
+		{
+			name:             "BadRequest returns 400",
+			err:              Error{Code: BadRequest, Msg: "invalid model name"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_BadRequest,
+			wantBodyContains: "invalid model name",
+		},
+		{
+			name:             "Unauthorized returns 401",
+			err:              Error{Code: Unauthorized, Msg: "missing token"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_Unauthorized,
+			wantBodyContains: "missing token",
+		},
+		{
+			name:             "Forbidden returns 403",
+			err:              Error{Code: Forbidden, Msg: "unsafe content blocked"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_Forbidden,
+			wantBodyContains: "unsafe content blocked",
+		},
+		{
+			name:             "NotFound returns 404",
+			err:              Error{Code: NotFound, Msg: "model not found"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_NotFound,
+			wantBodyContains: "model not found",
+		},
+		{
+			name:             "ResourceExhausted returns 429",
+			err:              Error{Code: ResourceExhausted, Msg: "no capacity"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_TooManyRequests,
+			wantBodyContains: "no capacity",
+		},
+		{
+			name:             "Internal returns 500",
+			err:              Error{Code: Internal, Msg: "unexpected failure"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_InternalServerError,
+			wantBodyContains: "unexpected failure",
+		},
+		{
+			name:             "ServiceUnavailable returns 503",
+			err:              Error{Code: ServiceUnavailable, Msg: "no endpoints"},
+			wantHTTPStatus:   envoyTypePb.StatusCode_ServiceUnavailable,
+			wantBodyContains: "no endpoints",
+		},
+		{
+			name:        "plain error returns gRPC error",
+			err:         errors.New("unknown problem"),
+			wantGRPCErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := BuildErrResponse(tt.err)
+
+			if tt.wantGRPCErr {
+				if err == nil {
+					t.Fatal("expected gRPC error, got nil")
+				}
+				if resp != nil {
+					t.Errorf("expected nil response on gRPC error, got %v", resp)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp == nil {
+				t.Fatal("expected response, got nil")
+			}
+
+			ir := resp.GetImmediateResponse()
+			if ir == nil {
+				t.Fatal("expected ImmediateResponse, got nil")
+			}
+			if ir.GetStatus().GetCode() != tt.wantHTTPStatus {
+				t.Errorf("HTTP status = %v, want %v", ir.GetStatus().GetCode(), tt.wantHTTPStatus)
+			}
+			if tt.wantBodyContains != "" && !strings.Contains(string(ir.GetBody()), tt.wantBodyContains) {
+				t.Errorf("body %q should contain %q", string(ir.GetBody()), tt.wantBodyContains)
+			}
+		})
 	}
 }

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -304,7 +303,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			} else {
 				logger.V(1).Error(err, "Failed to process request")
 			}
-			resp, err := buildErrResponse(err)
+			resp, err := errcommon.BuildErrResponse(err)
 			if err != nil {
 				return err
 			}
@@ -403,64 +402,4 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 		}
 	}
 	return nil
-}
-
-func buildErrResponse(err error) (*extProcPb.ProcessingResponse, error) {
-	var resp *extProcPb.ProcessingResponse
-
-	switch errcommon.CanonicalCode(err) {
-	// This code can be returned by scheduler when there is no capacity for sheddable
-	// requests.
-	case errcommon.ResourceExhausted:
-		resp = &extProcPb.ProcessingResponse{
-			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
-				ImmediateResponse: &extProcPb.ImmediateResponse{
-					Status: &envoyTypePb.HttpStatus{
-						Code: envoyTypePb.StatusCode_TooManyRequests,
-					},
-				},
-			},
-		}
-	// This code can be returned by when EPP processes the request and run into server-side errors.
-	case errcommon.Internal:
-		resp = &extProcPb.ProcessingResponse{
-			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
-				ImmediateResponse: &extProcPb.ImmediateResponse{
-					Status: &envoyTypePb.HttpStatus{
-						Code: envoyTypePb.StatusCode_InternalServerError,
-					},
-				},
-			},
-		}
-	// This code can be returned by the director when there are no candidate pods for the request scheduling.
-	case errcommon.ServiceUnavailable:
-		resp = &extProcPb.ProcessingResponse{
-			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
-				ImmediateResponse: &extProcPb.ImmediateResponse{
-					Status: &envoyTypePb.HttpStatus{
-						Code: envoyTypePb.StatusCode_ServiceUnavailable,
-					},
-				},
-			},
-		}
-	// This code can be returned when users provide invalid json request.
-	case errcommon.BadRequest:
-		resp = &extProcPb.ProcessingResponse{
-			Response: &extProcPb.ProcessingResponse_ImmediateResponse{
-				ImmediateResponse: &extProcPb.ImmediateResponse{
-					Status: &envoyTypePb.HttpStatus{
-						Code: envoyTypePb.StatusCode_BadRequest,
-					},
-				},
-			},
-		}
-	default:
-		return nil, status.Errorf(status.Code(err), "failed to handle request: %v", err)
-	}
-
-	if err.Error() != "" {
-		resp.Response.(*extProcPb.ProcessingResponse_ImmediateResponse).ImmediateResponse.Body = []byte(err.Error())
-	}
-
-	return resp, nil
 }

--- a/test/integration/bbr/hermetic_test.go
+++ b/test/integration/bbr/hermetic_test.go
@@ -19,9 +19,11 @@ package bbr
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -36,22 +38,23 @@ func TestBodyBasedRouting(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		req          *extProcPb.ProcessingRequest
-		wantResponse *extProcPb.ProcessingResponse
-		wantErr      bool
+		name             string
+		req              *extProcPb.ProcessingRequest
+		wantResponse     *extProcPb.ProcessingResponse
+		wantErr          bool
+		wantStatusCode   envoyTypePb.StatusCode
+		wantBodyContains string
 	}{
 		{
 			name:         "success: extracts model and sets header",
 			req:          integration.ReqLLMUnary(logger, "test", "llama"),
 			wantResponse: ExpectBBRUnaryResponse("llama", "llama", "test"),
-			wantErr:      false,
 		},
 		{
-			name:         "noop: no model parameter in body",
-			req:          integration.ReqLLMUnary(logger, "test1", ""),
-			wantResponse: ExpectBBRUnaryResponse("", "", "test1"), // Expect no headers.
-			wantErr:      false,
+			name:             "immediate response: no model parameter in body",
+			req:              integration.ReqLLMUnary(logger, "test1", ""),
+			wantStatusCode:   envoyTypePb.StatusCode_BadRequest,
+			wantBodyContains: "model",
 		},
 	}
 
@@ -66,8 +69,19 @@ func TestBodyBasedRouting(t *testing.T) {
 
 			if tc.wantErr {
 				require.Error(t, err, "expected error during request processing")
-			} else {
-				require.NoError(t, err, "unexpected error during request processing")
+				return
+			}
+			require.NoError(t, err, "unexpected error during request processing")
+
+			if tc.wantStatusCode != 0 {
+				ir := res.GetImmediateResponse()
+				require.NotNil(t, ir, "expected ImmediateResponse")
+				require.Equal(t, tc.wantStatusCode, ir.GetStatus().GetCode())
+				if tc.wantBodyContains != "" {
+					require.True(t, strings.Contains(string(ir.GetBody()), tc.wantBodyContains),
+						"ImmediateResponse body %s should contain %s", string(ir.GetBody()), tc.wantBodyContains)
+				}
+				return
 			}
 
 			// sort headers in responses for deterministic tests
@@ -86,10 +100,12 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		reqs          []*extProcPb.ProcessingRequest
-		wantResponses []*extProcPb.ProcessingResponse
-		wantErr       bool
+		name             string
+		reqs             []*extProcPb.ProcessingRequest
+		wantResponses    []*extProcPb.ProcessingResponse
+		wantErr          bool
+		wantStatusCode   envoyTypePb.StatusCode
+		wantBodyContains string
 	}{
 		{
 			name: "success: adds model header from simple body",
@@ -112,12 +128,10 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			},
 		},
 		{
-			name: "noop: handles missing model field gracefully",
-			reqs: integration.ReqLLM(logger, "test", "", ""),
-			wantResponses: []*extProcPb.ProcessingResponse{
-				ExpectBBRNoOpHeader(),
-				ExpectBBRBodyPassThrough("test", ""),
-			},
+			name:             "immediate response: handles missing model field",
+			reqs:             integration.ReqLLM(logger, "test", "", ""),
+			wantStatusCode:   envoyTypePb.StatusCode_BadRequest,
+			wantBodyContains: "model",
 		},
 	}
 
@@ -128,12 +142,29 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			ctx := context.Background()
 			h := NewBBRHarness(t, ctx, true)
 
-			responses, err := integration.StreamedRequest(t, h.Client, tc.reqs, len(tc.wantResponses))
+			expectedCount := len(tc.wantResponses)
+			if tc.wantStatusCode != 0 || tc.wantErr {
+				expectedCount = 1
+			}
+
+			responses, err := integration.StreamedRequest(t, h.Client, tc.reqs, expectedCount)
 
 			if tc.wantErr {
 				require.Error(t, err, "expected stream error")
-			} else {
-				require.NoError(t, err, "unexpected stream error")
+				return
+			}
+			require.NoError(t, err, "unexpected stream error")
+
+			if tc.wantStatusCode != 0 {
+				require.Len(t, responses, 1)
+				ir := responses[0].GetImmediateResponse()
+				require.NotNil(t, ir, "expected ImmediateResponse")
+				require.Equal(t, tc.wantStatusCode, ir.GetStatus().GetCode())
+				if tc.wantBodyContains != "" {
+					require.True(t, strings.Contains(string(ir.GetBody()), tc.wantBodyContains),
+						"ImmediateResponse body %s should contain %s", string(ir.GetBody()), tc.wantBodyContains)
+				}
+				return
 			}
 
 			// sort headers in responses for deterministic tests


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**

Previously, when a BBR request plugin returned an error the framework logged it but let the request pass through to the model unchanged. This is a problem for plugins like guardrails, api-key-injection, and api-translation that need to **block** requests and return a proper HTTP error to the client.

This change propagates plugin errors to the Process loop and converts them into Envoy `ImmediateResponse` messages with the appropriate HTTP status code, matching the pattern used by EPP.

**Key changes:**
- Add `Unauthorized` (401), `Forbidden` (403), `NotFound` (404) error codes to `pkg/common/error`
- Extract `BuildErrResponse` into `pkg/common/error/response.go` as a shared function consumed by both BBR and EPP (removes duplicate code)
- Use `CanonicalCode` for error-to-status mapping, with unrecognized codes falling back to a gRPC error (matching EPP's default behavior)
- Propagate plugin errors in `HandleRequestBody`/`HandleResponseBody` instead of swallowing them
- Log the failing plugin name inside `runRequestPlugins`/`runResponsePlugins` and return the raw error (no wrapping)
- Update `body-field-to-header` plugin to return `errcommon.Error{Code: BadRequest}` so `CanonicalCode` maps it correctly
- Wrap JSON unmarshal failures as `BadRequest` (400)
- Add unit tests for `BuildErrResponse` covering all status codes and the default gRPC fallback
- Update integration tests to validate `ImmediateResponse` status and body

**Which issue(s) this PR fixes:**
Fixes: #2629

**Does this PR introduce a user-facing change?**
```release-note
BBR plugins can now return immediate HTTP error responses to clients instead of silently passing through failed requests.
```