### PR TITLE
agentgateway: update v1.4.0 conformance report and guides

### DIFF
--- a/conformance/reports/v1.4.0/gateway/agentgateway/README.md
+++ b/conformance/reports/v1.4.0/gateway/agentgateway/README.md
@@ -2,9 +2,9 @@
 
 ## Table of Contents
 
-| Extension Version Tested | Profile Tested | Implementation Version | Mode    | Report                                                |
-|--------------------------|----------------|------------------------|---------|-------------------------------------------------------|
-| v1.4.0-rc.2              | Gateway        | [v1.0.0-alpha.4](https://github.com/agentgateway/agentgateway/releases/tag/v1.0.0-alpha.4) | default | [inference-v1.0.0-alpha.4 report](./inference-v1.0.0-alpha.4-report.yaml) |
+| Extension Version Tested | Profile Tested | Implementation Version | Mode    | Report                                      |
+|--------------------------|----------------|------------------------|---------|---------------------------------------------|
+| v1.4.0                   | Gateway        | [v1.0.0](https://github.com/agentgateway/agentgateway/releases/tag/v1.0.0) | default | [inference-v1.0.0 report](./inference-v1.0.0-report.yaml) |
 
 ## Reproduce
 
@@ -15,7 +15,7 @@ This follows the upstream [Agentgateway Gateway API conformance report](https://
 1. Clone the agentgateway repository and check out the tested release:
 
    ```sh
-   export VERSION=v1.0.0-alpha.4
+   export VERSION=v1.0.0
    git clone https://github.com/agentgateway/agentgateway.git
    cd agentgateway
    git checkout tags/$VERSION
@@ -24,7 +24,7 @@ This follows the upstream [Agentgateway Gateway API conformance report](https://
 2. Bootstrap a KinD cluster with the required Gateway API and Gateway API Inference Extension components:
 
    ```sh
-   export GIE_CRD_VERSION=v1.4.0-rc.2
+   export GIE_CRD_VERSION=v1.4.0
    ./controller/test/setup/setup-kind-ci.sh
    ```
 

--- a/conformance/reports/v1.4.0/gateway/agentgateway/inference-v1.0.0-report.yaml
+++ b/conformance/reports/v1.4.0/gateway/agentgateway/inference-v1.0.0-report.yaml
@@ -1,6 +1,6 @@
-GatewayAPIInferenceExtensionVersion: v1.4.0-rc.2
+GatewayAPIInferenceExtensionVersion: v1.4.0
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-03-13T03:44:24Z"
+date: "2026-03-20T05:14:59Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.5.0
 implementation:
@@ -9,7 +9,7 @@ implementation:
   organization: agentgateway
   project: agentgateway
   url: github.com/agentgateway/agentgateway
-  version: v1.0.0-alpha.4
+  version: v1.0.0
 kind: ConformanceReport
 mode: default
 profiles:

--- a/site-src/guides/getting-started-latest.md
+++ b/site-src/guides/getting-started-latest.md
@@ -96,7 +96,7 @@ kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extens
       1. Set the Agentgateway version and install the Agentgateway CRDs:
 
          ```bash
-         AGW_VERSION=v1.0.0-alpha.4
+         AGW_VERSION=v1.0.0
          helm upgrade -i --create-namespace --namespace agentgateway-system --version $AGW_VERSION agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds
          ```
 

--- a/site-src/guides/implementers.md
+++ b/site-src/guides/implementers.md
@@ -142,7 +142,7 @@ Supporting this broad range of extension capabilities (including for inference, 
 Several implementations can be used as references:
 
 - A fully featured [reference implementation](https://github.com/envoyproxy/envoy/tree/main/source/extensions/filters/http/ext_proc) (C++) can be found in the Envoy GitHub repository.
-- A second implementation (Rust, non-Envoy) is available in [agentgateway](https://github.com/agentgateway/agentgateway/blob/v0.7.2/crates/agentgateway/src/http/ext_proc.rs).
+- A second implementation (Rust, non-Envoy) is available in [agentgateway](https://github.com/agentgateway/agentgateway/blob/v1.0.0/crates/agentgateway/src/http/ext_proc.rs).
 
 #### Portable Implementation
 

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -96,7 +96,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extens
       1. Set the Agentgateway version and install the Agentgateway CRDs:
 
          ```bash
-         AGW_VERSION=v1.0.0-alpha.4
+         AGW_VERSION=v1.0.0
          helm upgrade -i --create-namespace --namespace agentgateway-system --version $AGW_VERSION agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds
          ```
 


### PR DESCRIPTION
## Summary
- Replace the Agentgateway v1.4.0-rc.2/v1.0.0-alpha.4 conformance report with the stable v1.4.0/v1.0.0 report
- Update the getting started guides to install Agentgateway v1.0.0
- Refresh the implementers guide link to the Agentgateway v1.0.0 ext_proc implementation