### PR TITLE
token_estimator: handles Responses and Conversations API

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator.go
@@ -55,18 +55,9 @@ func (e *SimpleTokenEstimator) Estimate(request *framework.LLMRequest) int64 {
 	case request.RequestSizeBytes > 0:
 		inputTokens = max(int64(request.RequestSizeBytes)/4, 1)
 	case request.Body != nil:
-		// Fallback: character count from prompt or chat messages.
-		var chars int
-		switch {
-		case request.Body.Completions != nil:
-			chars = len(request.Body.Completions.Prompt.PlainText())
-		case request.Body.ChatCompletions != nil:
-			for _, m := range request.Body.ChatCompletions.Messages {
-				chars += len(m.Content.PlainText())
-			}
-		default:
-			chars = 0
-		}
+		// Fallback: character count from prompt text across all API types
+		// (completions, chat/completions, responses, conversations).
+		chars := len(request.Body.PromptText())
 		inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
 	default:
 		return 0

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator_test.go
@@ -160,7 +160,9 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 					},
 				},
 			},
-			expected: 5,
+			// PromptText() joins messages with a trailing space separator ("Hi Hello " = 9 chars),
+			// so the estimate is higher than summing per-message lengths individually (7 chars).
+			expected: 8,
 		},
 		{
 			name: "Chat Completions with empty messages",
@@ -172,6 +174,43 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 				},
 			},
 			expected: 3,
+		},
+		{
+			name: "Responses API with string input",
+			request: &framework.LLMRequest{
+				Body: &framework.LLMRequestBody{
+					Responses: &framework.ResponsesRequest{
+						Input: "Tell me a story about a brave knight.",
+					},
+				},
+			},
+			expected: 23,
+		},
+		{
+			name: "Responses API with structured input",
+			request: &framework.LLMRequest{
+				Body: &framework.LLMRequestBody{
+					Responses: &framework.ResponsesRequest{
+						Input: []any{
+							map[string]any{"role": "user", "content": "Hello"},
+						},
+					},
+				},
+			},
+			expected: 23,
+		},
+		{
+			name: "Conversations API",
+			request: &framework.LLMRequest{
+				Body: &framework.LLMRequestBody{
+					Conversations: &framework.ConversationsRequest{
+						Items: []framework.ConversationItem{
+							{Type: "message", Role: "user", Content: "Hi there"},
+						},
+					},
+				},
+			},
+			expected: 35,
 		},
 	}
 


### PR DESCRIPTION
Use PromptText() for character counting instead of API-specific switch, fixing zero token estimates for Responses/Conversations requests.
