### PR TITLE
refactor: saturation plugins config loading

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -330,7 +330,11 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		return nil, nil, err
 	}
 
-	saturationDetector := utilizationdetector.NewDetector(eppConfig.SaturationDetectorConfig, setupLog)
+	saturationDetector := utilizationdetector.NewDetector(
+		utilizationdetector.UtilizationDetectorType,
+		*eppConfig.SaturationDetectorConfig,
+		setupLog,
+	)
 
 	// --- Admission Control Initialization ---
 	var admissionController requestcontrol.AdmissionController

--- a/pkg/epp/saturationdetector/framework/plugins/concurrencydetector/config.go
+++ b/pkg/epp/saturationdetector/framework/plugins/concurrencydetector/config.go
@@ -16,77 +16,157 @@ limitations under the License.
 
 package concurrencydetector
 
-// Config holds the configuration for the Concurrency Detector.
-type Config struct {
-	// MaxConcurrency defines the saturation threshold for a backend.
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/utils/ptr"
+)
+
+// apiConfig represents the external configuration schema for the concurrency detector.
+// It dictates how the plugin calculates pool-level saturation (to trigger backpressure) and
+// endpoint-level limits (to filter out overloaded candidates during routing).
+//
+// It is designed to be deserialized from JSON via the plugin's raw parameters.
+type apiConfig struct {
+	// MaxConcurrency defines the request-based saturation threshold for an endpoint.
 	//
-	// This limit serves as the "ideal" capacity for a backend. When the number of active requests on a replica reaches
-	// this value, that specific backend is considered "full" for the purpose of global saturation detection. If all
-	// available replicas are full (>= MaxConcurrency), the Detector signals saturation to the Flow Controller, which will
-	// trigger backpressure.
+	// This limit serves as the "ideal" request capacity for a single endpoint. The plugin aggregates
+	// the active requests across all endpoints and compares them against the aggregate pool capacity
+	// (Total Endpoints * MaxConcurrency) to compute PoolSaturation. When the pool approaches or
+	// exceeds this aggregate capacity, the Flow Controller triggers backpressure to buffer new
+	// traffic until capacity becomes available.
 	//
 	// Defaults to 100 if unset.
-	MaxConcurrency int64 `json:"maxConcurrency"`
+	MaxConcurrency *int64 `json:"maxConcurrency,omitempty"`
 
-	// Headroom defines the allowed burst capacity above MaxConcurrency for specific pod scheduling, expressed as a
-	// fraction in [0.0, 1.0].
+	// Headroom defines the allowed burst capacity above the ideal threshold (MaxConcurrency or
+	// MaxTokenConcurrency), expressed as a multiplier (e.g., 0.2 for 20%).
 	//
-	// While IsSaturated uses MaxConcurrency as the "ideal" capacity limit per pod to determine if the pool is full
-	// (rejecting admission if ALL pods are >= MaxConcurrency), the Filter logic uses (MaxConcurrency * (1 + Headroom))
-	// to determine if a specific pod is capable of accepting more work.
+	// This parameter decouples pool-level backpressure from individual endpoint routing. While
+	// PoolSaturation uses the strict ideal capacity to manage overall pool load, the Filter logic
+	// uses EndpointLimit (Capacity * (1 + Headroom)) to determine if a specific endpoint can accept
+	// more work.
 	//
-	// Example: MaxConcurrency=100 (per pod), Headroom=0.2.
-	// - Global Saturation: Triggered when all pods have >= 100 active requests.
-	//   This stops new requests from entering the scheduling loop, enforcing pool-average concurrency.
-	// - Pod Filter Limit: 120 active requests.
-	//   The scheduler can still assign a request to a pod with 110 requests to satisfy affinity rules, as long as it
-	//   stays under 120.
+	// Example: MaxConcurrency=100, Headroom=0.2.
 	//
-	// This allows the system to maintain a target average load (100) while giving the scheduler flexibility to handle
-	// hot-spots or affinity (up to 120).
+	//   - Backpressure: An endpoint with 110 requests is considered 110% full, pushing pool averages up.
+	//   - Routing: The endpoint's hard filter limit is 120. The scheduling layer can still send it
+	//     requests (e.g., to satisfy high affinity) until it hits 120.
 	//
-	// Defaults to 0.0 (no burst allowed).
-	Headroom float64 `json:"headroom"`
+	// Defaults to 0.0 (no burst allowed) if unset.
+	Headroom *float64 `json:"headroom,omitempty"`
 
 	// ConcurrencyMode defines the mode of concurrency detection.
 	//
 	// Valid values are:
-	// - "requests": use request count for concurrency detection.
-	// - "tokens": use token count for concurrency detection.
+	// - "requests": use discrete request counts for capacity accounting.
+	// - "tokens": use estimated token counts for capacity accounting.
 	//
-	// When nil (unset), defaults to "requests".
-	ConcurrencyMode *ConcurrencyMode `json:"concurrencyMode"`
+	// Defaults to "requests" if unset.
+	ConcurrencyMode *concurrencyMode `json:"concurrencyMode,omitempty"`
 
-	// MaxTokenConcurrency defines the maximum number of tokens allowed for an inference pool.
+	// MaxTokenConcurrency defines the token-based saturation threshold for an endpoint.
 	//
-	// This limit is used to prevent requests from consuming too many tokens.
+	// This is the "tokens" mode equivalent of MaxConcurrency. It represents the "ideal" token
+	// capacity per endpoint. It drives both the pool saturation calculation (for backpressure) and,
+	// combined with Headroom, the per-endpoint filtering limits (for routing).
 	//
 	// Defaults to 1000000 if unset.
-	MaxTokenConcurrency int64 `json:"maxTokenConcurrency"`
+	MaxTokenConcurrency *int64 `json:"maxTokenConcurrency,omitempty"`
 }
 
-// ConcurrencyMode is the concurrency detection mode. A pointer in Config distinguishes unset (nil) from explicit.
-type ConcurrencyMode string
+// concurrencyMode is the concurrency detection mode.
+type concurrencyMode string
 
 const (
-	// Requests uses request count for concurrency detection.
-	Requests ConcurrencyMode = "requests"
-	// Tokens uses token count for concurrency detection.
-	Tokens ConcurrencyMode = "tokens"
+	// modeRequests uses request count for concurrency detection.
+	modeRequests concurrencyMode = "requests"
+	// modeTokens uses token count for concurrency detection.
+	modeTokens concurrencyMode = "tokens"
 )
 
-// modePtr returns a pointer to m for use in Config.ConcurrencyMode.
-func modePtr(m ConcurrencyMode) *ConcurrencyMode {
-	return &m
+const (
+	// defaultMaxConcurrency is the safe baseline for many LLM serving engines.
+	defaultMaxConcurrency int64 = 100
+	// defaultHeadroom is the default burst allowance (0%).
+	defaultHeadroom float64 = 0.0
+	// defaultConcurrencyMode is used when ConcurrencyMode is unset.
+	defaultConcurrencyMode = modeRequests
+	// defaultMaxTokenConcurrency is the default maximum number of tokens allowed per endpoint.
+	defaultMaxTokenConcurrency int64 = 1000000
+)
+
+// config is the internal, fully-validated configuration used by the detector.
+type config struct {
+	maxConcurrency      int64
+	headroom            float64
+	mode                concurrencyMode
+	maxTokenConcurrency int64
 }
 
-const (
-	// DefaultMaxConcurrency is the safe baseline for many LLM serving engines.
-	DefaultMaxConcurrency = 100
-	// DefaultHeadroom is the default burst allowance (0%).
-	DefaultHeadroom = 0.0
-	// DefaultConcurrencyMode is used when ConcurrencyMode is nil.
-	DefaultConcurrencyMode = Requests
-	// DefaultMaxTokenConcurrency is the maximum number of tokens allowed for a request.
-	DefaultMaxTokenConcurrency = 1000000
-)
+// buildConfig applies the configuration lifecycle (defaulting and validation) and translates the
+// external schema into the internal domain model.
+// The provided apiConfig is copied to prevent mutation side-effects.
+func buildConfig(apiCfg *apiConfig) (*config, error) {
+	var safeCfg apiConfig
+	if apiCfg != nil {
+		safeCfg = *apiCfg
+	}
+
+	applyDefaults(&safeCfg)
+
+	if err := validateConfig(&safeCfg); err != nil {
+		return nil, fmt.Errorf("invalid concurrency detector configuration: %w", err)
+	}
+
+	return &config{
+		maxConcurrency:      *safeCfg.MaxConcurrency,
+		headroom:            *safeCfg.Headroom,
+		mode:                *safeCfg.ConcurrencyMode,
+		maxTokenConcurrency: *safeCfg.MaxTokenConcurrency,
+	}, nil
+}
+
+// applyDefaults populates unset fields in the external configuration with their standard defaults.
+func applyDefaults(cfg *apiConfig) {
+	if cfg.MaxConcurrency == nil {
+		cfg.MaxConcurrency = ptr.To(defaultMaxConcurrency)
+	}
+	if cfg.Headroom == nil {
+		cfg.Headroom = ptr.To(defaultHeadroom)
+	}
+	if cfg.ConcurrencyMode == nil {
+		cfg.ConcurrencyMode = ptr.To(defaultConcurrencyMode)
+	}
+	if cfg.MaxTokenConcurrency == nil {
+		cfg.MaxTokenConcurrency = ptr.To(defaultMaxTokenConcurrency)
+	}
+}
+
+// validateConfig checks the constraints of the fully defaulted configuration.
+// It aggregates all validation failures.
+func validateConfig(cfg *apiConfig) error {
+	var errs []error
+
+	if cfg.MaxConcurrency != nil && *cfg.MaxConcurrency <= 0 {
+		errs = append(errs, fmt.Errorf("maxConcurrency must be strictly positive, got %d", *cfg.MaxConcurrency))
+	}
+	if cfg.Headroom != nil && *cfg.Headroom < 0.0 {
+		errs = append(errs, fmt.Errorf("headroom must be a non-negative value, got %f", *cfg.Headroom))
+	}
+	if cfg.MaxTokenConcurrency != nil && *cfg.MaxTokenConcurrency <= 0 {
+		errs = append(errs, fmt.Errorf("maxTokenConcurrency must be strictly positive, got %d", *cfg.MaxTokenConcurrency))
+	}
+
+	if cfg.ConcurrencyMode != nil {
+		switch *cfg.ConcurrencyMode {
+		case modeRequests, modeTokens:
+			// Valid
+		default:
+			errs = append(errs, fmt.Errorf("unsupported concurrencyMode: %q", *cfg.ConcurrencyMode))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/epp/saturationdetector/framework/plugins/concurrencydetector/detector.go
+++ b/pkg/epp/saturationdetector/framework/plugins/concurrencydetector/detector.go
@@ -57,69 +57,87 @@ import (
 	"sync"
 	"sync/atomic"
 
-	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
-const ConcurrencyDetectorType = "concurrency-detector"
+const (
+	ConcurrencyDetectorType = "concurrency-detector"
+)
 
-func ConcurrencyDetectorFactory(_ string, params json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
-	var cfg Config
+// ConcurrencyDetectorFactory instantiates the detector plugin using the provided JSON parameters.
+func ConcurrencyDetectorFactory(
+	name string,
+	params json.RawMessage,
+	handle fwkplugin.Handle,
+) (fwkplugin.Plugin, error) {
+	var apiCfg apiConfig
 	if len(params) > 0 {
-		if err := json.Unmarshal(params, &cfg); err != nil {
+		if err := json.Unmarshal(params, &apiCfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal concurrency detector config: %w", err)
 		}
 	}
-	return NewDetector(cfg), nil
+	cfg, err := buildConfig(&apiCfg)
+	if err != nil {
+		return nil, err
+	}
+	return newDetector(name, *cfg, log.FromContext(handle.Context())), nil
 }
 
 var (
-	_ requestcontrol.PreRequest   = &Detector{}
-	_ requestcontrol.ResponseBody = &Detector{}
-	_ framework.Filter            = &Detector{}
+	_ requestcontrol.PreRequest   = &detector{}
+	_ requestcontrol.ResponseBody = &detector{}
+	_ framework.Filter            = &detector{}
 )
 
-// Detector implements a saturation detector and scheduling filter based on active request concurrency.
-type Detector struct {
+// detector implements a saturation detector and scheduling filter based on active request concurrency.
+type detector struct {
 	requestTracker *concurrencyTracker // requests in flight per endpoint
 	tokenTracker   *concurrencyTracker // tokens in flight per endpoint
 	tokenEstimator TokenEstimator      // SimpleTokenEstimator with CharactersPerToken
-	config         Config
+	config         config
+	typedName      fwkplugin.TypedName
 }
 
-// NewDetector creates a new instance of the Concurrency Detector.
-func NewDetector(config Config) *Detector {
-	// TODO: Replace with more robust validation and defaulting logic once Saturation Detector becomes an official
-	// extension point.
-	if config.MaxConcurrency <= 0 {
-		config.MaxConcurrency = DefaultMaxConcurrency
-	}
-	if config.Headroom < 0 {
-		config.Headroom = DefaultHeadroom
-	}
-	if config.ConcurrencyMode == nil || (*config.ConcurrencyMode != Requests && *config.ConcurrencyMode != Tokens) {
-		config.ConcurrencyMode = modePtr(DefaultConcurrencyMode)
-	}
-	if config.MaxTokenConcurrency < 0 {
-		config.MaxTokenConcurrency = DefaultMaxTokenConcurrency
+// newDetector creates a new instance of the Concurrency Detector.
+func newDetector(name string, cfg config, logger logr.Logger) *detector {
+	typedName := fwkplugin.TypedName{
+		Type: ConcurrencyDetectorType,
+		Name: name,
 	}
 
-	return &Detector{
+	pluginLogger := logger.WithName(typedName.String())
+	pluginLogger.V(logutil.DEFAULT).Info("Creating new ConcurrencyDetector",
+		"mode", cfg.mode,
+		"maxConcurrency", cfg.maxConcurrency,
+		"maxTokenConcurrency", cfg.maxTokenConcurrency,
+		"headroom", cfg.headroom)
+
+	if cfg.headroom > 1.0 {
+		pluginLogger.Info("Unusually high headroom configured; verify value is a fraction, not a percentage",
+			"headroom", cfg.headroom,
+			"effectiveBurst", fmt.Sprintf("%.0f%%", cfg.headroom*100))
+	}
+
+	return &detector{
 		requestTracker: newConcurrencyTracker(),
 		tokenTracker:   newConcurrencyTracker(),
 		tokenEstimator: NewSimpleTokenEstimator(),
-		config:         config,
+		config:         cfg,
+		typedName:      typedName,
 	}
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (d *Detector) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{
-		Type: ConcurrencyDetectorType,
-		Name: ConcurrencyDetectorType,
-	}
+func (d *detector) TypedName() fwkplugin.TypedName {
+	return d.typedName
 }
 
 // Saturation calculates the saturation level of the pool.
@@ -127,22 +145,22 @@ func (d *Detector) TypedName() fwkplugin.TypedName {
 // It returns an aggregate saturation signal where:
 //
 //	Saturation = Total Inflight Requests / Total MaxConcurrency Capacity.
-func (d *Detector) Saturation(_ context.Context, candidateEndpoints []fwkdl.Endpoint) float64 {
+func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint) float64 {
 	var totalInflight, totalCapacity int64
-	for _, endpoint := range candidateEndpoints {
-		if endpoint.GetMetadata() == nil {
+	for _, e := range endpoints {
+		if e.GetMetadata() == nil {
 			continue
 		}
-		endpointID := endpoint.GetMetadata().NamespacedName.String()
+		endpointID := e.GetMetadata().NamespacedName.String()
 
-		if *d.config.ConcurrencyMode == Tokens {
+		if d.config.mode == modeTokens {
 			tokenCount := d.tokenTracker.get(endpointID)
 			totalInflight += tokenCount
-			totalCapacity += d.config.MaxTokenConcurrency
+			totalCapacity += d.config.maxTokenConcurrency
 		} else {
 			inflight := d.requestTracker.get(endpointID)
 			totalInflight += inflight
-			totalCapacity += d.config.MaxConcurrency
+			totalCapacity += d.config.maxConcurrency
 		}
 	}
 
@@ -156,7 +174,7 @@ func (d *Detector) Saturation(_ context.Context, candidateEndpoints []fwkdl.Endp
 // Filter blocks traffic to specific endpoints that are physically saturated or exceeding their safety limits.
 //
 // It applies a relaxed limit (MaxConcurrency * (1 + Headroom)) to allow for scheduling flexibility and burst tolerance.
-func (d *Detector) Filter(
+func (d *detector) Filter(
 	_ context.Context,
 	_ *framework.CycleState,
 	_ *framework.LLMRequest,
@@ -166,21 +184,21 @@ func (d *Detector) Filter(
 	filtered := make([]framework.Endpoint, 0, len(endpoints))
 
 	var limit int64
-	if *d.config.ConcurrencyMode == Tokens {
-		limit = int64(float64(d.config.MaxTokenConcurrency) * (1.0 + d.config.Headroom))
+	if d.config.mode == modeTokens {
+		limit = int64(float64(d.config.maxTokenConcurrency) * (1.0 + d.config.headroom))
 	} else {
-		limit = int64(float64(d.config.MaxConcurrency) * (1.0 + d.config.Headroom))
+		limit = int64(float64(d.config.maxConcurrency) * (1.0 + d.config.headroom))
 	}
 
-	for _, endpoint := range endpoints {
-		endpointID := endpoint.GetMetadata().NamespacedName.String()
-		if *d.config.ConcurrencyMode == Tokens {
+	for _, e := range endpoints {
+		endpointID := e.GetMetadata().NamespacedName.String()
+		if d.config.mode == modeTokens {
 			if d.tokenTracker.get(endpointID) < limit {
-				filtered = append(filtered, endpoint)
+				filtered = append(filtered, e)
 			}
 		} else {
 			if d.requestTracker.get(endpointID) < limit {
-				filtered = append(filtered, endpoint)
+				filtered = append(filtered, e)
 			}
 		}
 	}
@@ -189,9 +207,9 @@ func (d *Detector) Filter(
 
 // PreRequest increments the atomic in-flight counter for the target endpoint.
 // We assume the scheduling result is valid based on the Director's contract.
-func (d *Detector) PreRequest(_ context.Context, request *framework.LLMRequest, result *framework.SchedulingResult) {
+func (d *detector) PreRequest(_ context.Context, request *framework.LLMRequest, result *framework.SchedulingResult) {
 	eid := result.ProfileResults[result.PrimaryProfileName].TargetEndpoints[0].GetMetadata().NamespacedName.String()
-	if *d.config.ConcurrencyMode == Tokens {
+	if d.config.mode == modeTokens {
 		tokens := d.tokenEstimator.Estimate(request)
 		d.tokenTracker.add(eid, tokens)
 	} else {
@@ -202,17 +220,17 @@ func (d *Detector) PreRequest(_ context.Context, request *framework.LLMRequest, 
 // ResponseBody decrements the atomic in-flight counter for the target endpoint when the response is endOfStream.
 // For token mode, the estimate is recalculated from the request; request may be nil in some paths and
 // TokenEstimator.Estimate returns 0 in that case (may contribute to drift).
-func (d *Detector) ResponseBody(
+func (d *detector) ResponseBody(
 	_ context.Context,
 	request *framework.LLMRequest,
 	resp *requestcontrol.Response,
-	targetEndpoint *fwkdl.EndpointMetadata,
+	targetEndpoint *datalayer.EndpointMetadata,
 ) {
 	if targetEndpoint == nil || resp == nil || !resp.EndOfStream {
 		return
 	}
 	eid := targetEndpoint.NamespacedName.String()
-	if *d.config.ConcurrencyMode == Tokens {
+	if d.config.mode == modeTokens {
 		tokens := d.tokenEstimator.Estimate(request)
 		d.tokenTracker.add(eid, -tokens)
 	} else {
@@ -222,8 +240,8 @@ func (d *Detector) ResponseBody(
 
 // DeleteEndpoint removes an endpoint from the concurrency tracker to prevent memory leaks.
 // This should be called by the controller when a backend is removed from the pool.
-func (d *Detector) DeleteEndpoint(endpointID string) {
-	if *d.config.ConcurrencyMode == Tokens {
+func (d *detector) DeleteEndpoint(endpointID string) {
+	if d.config.mode == modeTokens {
 		d.tokenTracker.delete(endpointID)
 	} else {
 		d.requestTracker.delete(endpointID)

--- a/pkg/epp/saturationdetector/framework/plugins/concurrencydetector/detector_test.go
+++ b/pkg/epp/saturationdetector/framework/plugins/concurrencydetector/detector_test.go
@@ -22,107 +22,173 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
-	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
-// TestNewPlugin_Configuration validates that the plugin correctly applies defaults and respects explicit configuration
-// values.
-func TestNewPlugin_Configuration(t *testing.T) {
+// TestConcurrencyDetectorFactory validates the initialization of the concurrency detector plugin.
+// It ensures that valid configuration blocks successfully instantiate the plugin while malformed or
+// semantically invalid configurations are rejected with descriptive errors.
+func TestConcurrencyDetectorFactory(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                   string
-		config                 Config
-		effectiveMax           int64
-		effectiveHeadroomBurst int64
+		name       string
+		configJSON []byte
+		wantError  bool
 	}{
 		{
-			name:                   "defaults_applied_on_zero_values",
-			config:                 Config{}, // Zero values
-			effectiveMax:           100,      // DefaultMaxConcurrency
-			effectiveHeadroomBurst: 100,      // Default Headroom is 0.0, so limit == max
+			name:       "valid configuration",
+			configJSON: []byte(`{"mode": "requests", "maxConcurrency": 50, "headroom": 0.2}`),
+			wantError:  false,
 		},
 		{
-			name: "explicit_values_respected",
-			config: Config{
-				MaxConcurrency: 50,
-				Headroom:       0.2, // 20% burst
-			},
-			effectiveMax:           50,
-			effectiveHeadroomBurst: 60, // 50 * 1.2 = 60
+			name:       "invalid schema",
+			configJSON: []byte(`{"maxConcurrency": "invalid_type"}`),
+			wantError:  true,
 		},
 		{
-			name: "negative_max_resets_to_default",
-			config: Config{
-				MaxConcurrency: -10,
-			},
-			effectiveMax:           100,
-			effectiveHeadroomBurst: 100,
+			name:       "empty config applies defaults",
+			configJSON: []byte(`{}`),
+			wantError:  false,
 		},
 		{
-			name: "negative_headroom_resets_to_default",
-			config: Config{
-				MaxConcurrency: 10,
-				Headroom:       -0.5,
-			},
-			effectiveMax:           10,
-			effectiveHeadroomBurst: 10, // Headroom resets to 0.0
+			name:       "invalid max concurrency",
+			configJSON: []byte(`{"maxConcurrency": 0}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid max token concurrency",
+			configJSON: []byte(`{"maxTokenConcurrency": 0}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid headroom",
+			configJSON: []byte(`{"headroom": -0.5}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid mode",
+			configJSON: []byte(`{"concurrencyMode": "magic"}`),
+			wantError:  true,
+		},
+		{
+			name:       "high headroom warning",
+			configJSON: []byte(`{"headroom": 2.0}`),
+			wantError:  false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
-			detector := NewDetector(tc.config)
-			endpointName := "test-endpoint"
 
-			// 1. Verify MaxConcurrency via Saturation
-
-			// A. Drive load to just below the limit (Max - 1)
-			// Expected Saturation = (Max - 1) / Max
-			driveLoad(ctx, detector, endpointName, int(tc.effectiveMax-1))
-			expectedSat := float64(tc.effectiveMax-1) / float64(tc.effectiveMax)
-			actualSat := detector.Saturation(ctx, []fwkdl.Endpoint{newFakeEndpoint(endpointName)})
-			require.InDelta(t, expectedSat, actualSat, 1e-6, "expected saturation gradient to reflect partial load")
-
-			// B. Increment to exactly the limit (Max)
-			// Expected Saturation = 1.0
-			driveLoad(ctx, detector, endpointName, 1)
-			actualSat = detector.Saturation(ctx, []fwkdl.Endpoint{newFakeEndpoint(endpointName)})
-			require.InDelta(t, 1.0, actualSat, 1e-6, `expected 100% saturation at MaxConcurrency`)
-
-			// 2. Verify Headroom via Filter
-
-			// Reset state first.
-			detector.DeleteEndpoint(fullEndpointName(endpointName))
-
-			// A. Drive load to just below the burst limit (Limit - 1)
-			driveLoad(ctx, detector, endpointName, int(tc.effectiveHeadroomBurst-1))
-			kept := detector.Filter(ctx, nil, nil, []schedulingtypes.Endpoint{newStubSchedulingEndpoint(endpointName)})
-			require.Len(t, kept, 1, "expected endpoint to be KEPT at BurstLimit-1")
-
-			// B. Reach the burst limit (Limit)
-			driveLoad(ctx, detector, endpointName, 1)
-			kept = detector.Filter(ctx, nil, nil, []schedulingtypes.Endpoint{newStubSchedulingEndpoint(endpointName)})
-			require.Len(t, kept, 0, "expected endpoint to be FILTERED at BurstLimit")
+			plugin, err := ConcurrencyDetectorFactory("test-concurrency-detector",
+				tc.configJSON, utils.NewTestHandle(t.Context()))
+			if tc.wantError {
+				require.Error(t, err, "Expected initialization to fail on invalid configuration")
+				require.Nil(t, plugin, "Plugin must be nil when initialization fails")
+			} else {
+				require.NoError(t, err, "Expected initialization to succeed with valid configuration")
+				require.NotNil(t, plugin, "Plugin must not be nil on success")
+			}
 		})
 	}
 }
 
-// TestDetector_Saturation verifies the global saturation gradient logic.
-// It ensures saturation is reported as an aggregate ratio of TotalInflight / TotalCapacity.
+// TestDetector_Configuration evaluates the internal mechanics of the configuration parameters.
+// It verifies that gradients are correctly mapped over limits and that fallback logic respects
+// maximum capacities under synthetic traffic load.
+func TestDetector_Configuration(t *testing.T) {
+	t.Parallel()
+
+	tc := struct {
+		config                 config
+		effectiveMax           int64
+		effectiveHeadroomBurst int64
+	}{
+		config: config{
+			maxConcurrency: 50,
+			headroom:       0.2, // 20% burst
+		},
+		effectiveMax:           50,
+		effectiveHeadroomBurst: 60, // 50 * 1.2 = 60
+	}
+
+	t.Run("verify max concurrency saturation gradient", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		detector := newDetector("test-detector", tc.config, logr.Discard())
+		endpointName := "test-endpoint"
+
+		// Drive load to just below the limit (Max - 1).
+		// Expected Saturation = (Max - 1) / Max
+		driveLoad(ctx, detector, endpointName, int(tc.effectiveMax-1))
+		expectedSat := float64(tc.effectiveMax-1) / float64(tc.effectiveMax)
+		actualSat := detector.Saturation(ctx, []datalayer.Endpoint{newFakeEndpoint(endpointName)})
+		require.InDelta(t, expectedSat, actualSat, 1e-6, "Saturation must linearly reflect partial load")
+
+		// Increment to exactly the limit (Max).
+		// Expected Saturation = 1.0
+		driveLoad(ctx, detector, endpointName, 1)
+		actualSat = detector.Saturation(ctx, []datalayer.Endpoint{newFakeEndpoint(endpointName)})
+		require.InDelta(t, 1.0, actualSat, 1e-6, "Saturation must cap at 1.0 at maxConcurrency limit")
+	})
+
+	t.Run("verify headroom filter limits", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		detector := newDetector("test-detector", tc.config, logr.Discard())
+		endpointName := "test-endpoint"
+
+		// Drive load to just below the burst limit (Limit - 1).
+		driveLoad(ctx, detector, endpointName, int(tc.effectiveHeadroomBurst-1))
+		kept := detector.Filter(ctx, nil, nil, []schedulingtypes.Endpoint{newStubSchedulingEndpoint(endpointName)})
+		require.Len(t, kept, 1, "Endpoint should be retained when operating below burst capacity")
+
+		// Reach the burst limit (Limit).
+		driveLoad(ctx, detector, endpointName, 1)
+
+		t.Run("fallback to clean endpoint", func(t *testing.T) {
+			cleanEndpoint := "clean-endpoint"
+			kept = detector.Filter(ctx, nil, nil, []schedulingtypes.Endpoint{
+				newStubSchedulingEndpoint(endpointName),
+				newStubSchedulingEndpoint(cleanEndpoint),
+			})
+			require.Len(t, kept, 1, "Filter should drop the overloaded endpoint")
+			require.Equal(t, cleanEndpoint, kept[0].GetMetadata().NamespacedName.Name,
+				"Filter should retain the clean fallback endpoint")
+		})
+	})
+}
+
+// TestDetector_TypedName verifies that the runtime type identification of the plugin is populated
+// correctly during instantiation and accurately reflects the hardcoded concurrency-detector type.
+func TestDetector_TypedName(t *testing.T) {
+	t.Parallel()
+	plugin, err := ConcurrencyDetectorFactory("test-plugin", []byte(`{}`), utils.NewTestHandle(t.Context()))
+	require.NoError(t, err, "Plugin initialization should succeed")
+	require.Equal(t, "test-plugin", plugin.TypedName().Name,
+		"TypedName must match the name provided during initialization")
+	require.Equal(t, "concurrency-detector", plugin.TypedName().Type,
+		"TypedName.Type must be exactly 'concurrency-detector'")
+}
+
+// TestDetector_Saturation evaluates the quantitative scaling of the saturation output.
+// It verifies that 0, partial, overloaded, and over-saturated loads return exact mathematical
+// representations, protecting upper layers from incorrect metrics.
 func TestDetector_Saturation(t *testing.T) {
 	t.Parallel()
 
 	const maxConcurrency = 10
-	config := Config{MaxConcurrency: maxConcurrency}
+	config := config{maxConcurrency: maxConcurrency}
 
 	tests := []struct {
 		name               string
@@ -184,7 +250,7 @@ func TestDetector_Saturation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			detector := NewDetector(config)
+			detector := newDetector("test-detector", config, logr.Discard())
 
 			// Setup load.
 			for endpointName, load := range tc.endpointLoadSetup {
@@ -192,7 +258,7 @@ func TestDetector_Saturation(t *testing.T) {
 			}
 
 			// Build candidates.
-			candidates := make([]fwkdl.Endpoint, 0, len(tc.candidateEndpoints))
+			candidates := make([]datalayer.Endpoint, 0, len(tc.candidateEndpoints))
 			for _, name := range tc.candidateEndpoints {
 				candidates = append(candidates, newFakeEndpoint(name))
 			}
@@ -209,10 +275,10 @@ func TestDetector_Lifecycle(t *testing.T) {
 	t.Parallel()
 
 	// MaxConcurrency 1 makes math simple.
-	detector := NewDetector(Config{MaxConcurrency: 1})
+	detector := newDetector("test", config{maxConcurrency: 1}, logr.Discard())
 	ctx := context.Background()
 	endpointName := "lifecycle-endpoint"
-	candidates := []fwkdl.Endpoint{newFakeEndpoint(endpointName)}
+	candidates := []datalayer.Endpoint{newFakeEndpoint(endpointName)}
 
 	// 1. Initially Empty
 	require.InDelta(t, 0.0, detector.Saturation(ctx, candidates), 1e-6, "expected initially 0.0")
@@ -242,9 +308,9 @@ func TestDetector_TokenSaturation(t *testing.T) {
 
 	// MaxTokenConcurrency set to 100 for simple testing
 	const maxTokenConcurrency = 100
-	config := Config{
-		ConcurrencyMode:     modePtr(Tokens),
-		MaxTokenConcurrency: maxTokenConcurrency,
+	config := config{
+		mode:                modeTokens,
+		maxTokenConcurrency: maxTokenConcurrency,
 	}
 
 	tests := []struct {
@@ -315,11 +381,11 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			detector := NewDetector(config)
+			detector := newDetector("test-detector", config, logr.Discard())
 
 			driveTokenLoad(ctx, detector, "endpoint-a", tc.requests)
 
-			candidates := make([]fwkdl.Endpoint, 0, len(tc.candidateEndpoints))
+			candidates := make([]datalayer.Endpoint, 0, len(tc.candidateEndpoints))
 			for _, name := range tc.candidateEndpoints {
 				candidates = append(candidates, newFakeEndpoint(name))
 			}
@@ -334,14 +400,14 @@ func TestDetector_TokenSaturation(t *testing.T) {
 func TestDetector_TokenFilter(t *testing.T) {
 	t.Parallel()
 
-	config := Config{
-		ConcurrencyMode:     modePtr(Tokens),
-		MaxTokenConcurrency: 100,
-		Headroom:            0.2, // Burst limit = 100 * 1.2 = 120 tokens
+	config := config{
+		mode:                modeTokens,
+		maxTokenConcurrency: 100,
+		headroom:            0.2, // Burst limit = 100 * 1.2 = 120 tokens
 	}
 
 	ctx := context.Background()
-	detector := NewDetector(config)
+	detector := newDetector("test-detector", config, logr.Discard())
 	endpointName := "token-filter-endpoint"
 	endpoints := []schedulingtypes.Endpoint{newStubSchedulingEndpoint(endpointName)}
 
@@ -369,14 +435,14 @@ func TestDetector_TokenFilter(t *testing.T) {
 func TestDetector_TokenLifecycle(t *testing.T) {
 	t.Parallel()
 
-	config := Config{
-		ConcurrencyMode:     modePtr(Tokens),
-		MaxTokenConcurrency: 100,
+	config := config{
+		mode:                modeTokens,
+		maxTokenConcurrency: 100,
 	}
 	ctx := context.Background()
-	detector := NewDetector(config)
+	detector := newDetector("test-detector", config, logr.Discard())
 	endpointName := "token-lifecycle-endpoint"
-	candidates := []fwkdl.Endpoint{newFakeEndpoint(endpointName)}
+	candidates := []datalayer.Endpoint{newFakeEndpoint(endpointName)}
 	targetEndpoint := newStubSchedulingEndpoint(endpointName)
 
 	// PreRequest adds tokens ("1234567890123456" = 10 tokens)
@@ -406,14 +472,14 @@ func TestDetector_TokenLifecycle(t *testing.T) {
 func TestDetector_TokenDeleteEndpoint(t *testing.T) {
 	t.Parallel()
 
-	config := Config{
-		ConcurrencyMode:     modePtr(Tokens),
-		MaxTokenConcurrency: 100,
+	config := config{
+		mode:                modeTokens,
+		maxTokenConcurrency: 100,
 	}
 	ctx := context.Background()
-	detector := NewDetector(config)
+	detector := newDetector("test-detector", config, logr.Discard())
 	endpointName := "token-delete-endpoint"
-	candidates := []fwkdl.Endpoint{newFakeEndpoint(endpointName)}
+	candidates := []datalayer.Endpoint{newFakeEndpoint(endpointName)}
 
 	req := makeTokenRequest("req1", "1234567890123456")
 	req.RequestId = "req1"
@@ -430,7 +496,7 @@ func TestDetector_ConcurrencyStress(t *testing.T) {
 	t.Parallel()
 
 	// Config doesn't matter much here as we check internal state, but keep it consistent.
-	detector := NewDetector(Config{MaxConcurrency: 10000})
+	detector := newDetector("test-detector", config{maxConcurrency: 10000}, logr.Discard())
 	ctx := context.Background()
 	endpointName := "stress-endpoint"
 	fullID := fullEndpointName(endpointName)
@@ -483,7 +549,7 @@ func TestDetector_ConcurrencyStress(t *testing.T) {
 
 // --- Test Helpers & Mocks ---
 
-func driveLoad(ctx context.Context, detector *Detector, endpointName string, count int) {
+func driveLoad(ctx context.Context, detector *detector, endpointName string, count int) {
 	res := makeSchedulingResult(endpointName)
 	for range count {
 		detector.PreRequest(ctx, nil, res)
@@ -508,7 +574,7 @@ func makeSchedulingResult(endpointName string) *schedulingtypes.SchedulingResult
 
 func newFakeEndpoint(name string) *backendmetrics.FakePodMetrics {
 	return &backendmetrics.FakePodMetrics{
-		Metadata: &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
+		Metadata: &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
 	}
 }
 
@@ -516,16 +582,16 @@ func newFakeEndpoint(name string) *backendmetrics.FakePodMetrics {
 // It embeds the interface to satisfy the compiler but only implements GetMetadata.
 type stubSchedulingEndpoint struct {
 	schedulingtypes.Endpoint
-	metadata *fwkdl.EndpointMetadata
+	metadata *datalayer.EndpointMetadata
 }
 
 func newStubSchedulingEndpoint(name string) *stubSchedulingEndpoint {
 	return &stubSchedulingEndpoint{
-		metadata: &fwkdl.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}},
 	}
 }
 
-func (f *stubSchedulingEndpoint) GetMetadata() *fwkdl.EndpointMetadata { return f.metadata }
+func (f *stubSchedulingEndpoint) GetMetadata() *datalayer.EndpointMetadata { return f.metadata }
 
 // makeTokenRequest creates an LLMRequest with a prompt.
 func makeTokenRequest(requestID, prompt string) *schedulingtypes.LLMRequest {
@@ -538,7 +604,7 @@ func makeTokenRequest(requestID, prompt string) *schedulingtypes.LLMRequest {
 }
 
 // driveTokenLoad drives token based load by issuing PreRequest with the given requests.
-func driveTokenLoad(ctx context.Context, detector *Detector, endpointName string, requests []*schedulingtypes.LLMRequest) {
+func driveTokenLoad(ctx context.Context, detector *detector, endpointName string, requests []*schedulingtypes.LLMRequest) {
 	res := makeSchedulingResult(endpointName)
 	for i, req := range requests {
 		if req != nil && req.RequestId == "" {

--- a/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/config.go
+++ b/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/config.go
@@ -17,20 +17,149 @@ limitations under the License.
 package utilizationdetector
 
 import (
+	"errors"
+	"fmt"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // Default configuration values
 const (
-	// DefaultQueueDepthThreshold is the default backend waiting queue size threshold.
-	DefaultQueueDepthThreshold = 5
+	// DefaultQueueDepthThreshold is the default waiting queue size threshold.
+	DefaultQueueDepthThreshold int = 5
 	// DefaultKVCacheUtilThreshold is the default KV cache utilization (0.0 to 1.0) threshold.
-	DefaultKVCacheUtilThreshold = 0.8
-	// DefaultMetricsStalenessThreshold defines how old metrics can be before they
-	// are considered stale.
-	// Given the pod metrics refresh interval is 50ms, a threshold slightly above
-	// that should be fine.
-	DefaultMetricsStalenessThreshold = 200 * time.Millisecond
-	// DefaultHeadroom is the default burst allowance (0%).
-	DefaultHeadroom = 0.0
+	DefaultKVCacheUtilThreshold float64 = 0.8
+	// DefaultMetricsStalenessThreshold defines how old metrics can be before they are considered
+	// stale.
+	DefaultMetricsStalenessThreshold time.Duration = 200 * time.Millisecond
+	// defaultHeadroom is the default burst allowance (0%).
+	defaultHeadroom float64 = 0.0
 )
+
+// apiConfig represents the external configuration schema for the utilization detector.
+// It dictates how the plugin calculates pool-level saturation (to trigger backpressure) and
+// endpoint-level limits (to filter out overloaded candidates during routing).
+//
+// It is designed to be deserialized from JSON via the plugin's raw parameters.
+type apiConfig struct {
+	// QueueDepthThreshold defines the saturation threshold for an endpoint's waiting queue depth.
+	//
+	// This limit serves as the "ideal" queue capacity for a single endpoint.
+	// When combined with the KV Cache threshold, it defines PoolSaturation. When the pool
+	// approaches or exceeds this aggregate capacity, the Flow Controller triggers backpressure
+	// to buffer new traffic until capacity becomes available.
+	//
+	// Defaults to 5 if unset.
+	QueueDepthThreshold *int `json:"queueDepthThreshold,omitempty"`
+
+	// KVCacheUtilThreshold defines the saturation threshold for an endpoint's KV cache memory
+	// utilization, expressed as a fraction in [0.0, 1.0].
+	//
+	// This limit serves as the "ideal" memory capacity for a single endpoint. The detector uses
+	// a roofline model, taking the maximum of either the QueueDepth ratio or the KVCache ratio to
+	// determine the endpoint's true saturation score.
+	//
+	// Defaults to 0.8 (80%) if unset.
+	KVCacheUtilThreshold *float64 `json:"kvCacheUtilThreshold,omitempty"`
+
+	// MetricsStalenessThreshold defines how old an endpoint's metrics can be before they are
+	// considered stale. Stale endpoints are treated as 100% saturated to prevent routing traffic into
+	// unobservable black holes.
+	//
+	// WARNING: In continuous batching architectures, the KV cache grows rapidly during the decode
+	// phase. A high staleness threshold combined with a high KV cache utilization limit can lead to
+	// routing traffic to an endpoint whose memory is silently expanding within the telemetry blind
+	// spot.
+	//
+	// Defaults to 200ms if unset.
+	MetricsStalenessThreshold *metav1.Duration `json:"metricsStalenessThreshold,omitempty"`
+
+	// Headroom defines the allowed burst capacity above the ideal thresholds, expressed as a
+	// multiplier (e.g., 0.2 for 20%).
+	//
+	// This parameter decouples pool-level backpressure from individual endpoint routing. While
+	// PoolSaturation uses the strict ideal capacity to manage overall pool load, the Filter logic
+	// evaluates relaxed limits (Threshold * (1 + Headroom)) to determine if a specific endpoint can
+	// accept more work.
+	//
+	// Example: QueueDepthThreshold=5, Headroom=0.2.
+	//
+	//   - Backpressure: An endpoint with 6 queued requests is considered 120% full, pushing pool
+	//     averages up.
+	//   - Routing: The endpoint's hard filter limit is 6. The router can still send it requests
+	//     (e.g., to satisfy high affinity) until it hits 6.
+	//
+	// Defaults to 0.0 (no burst allowed) if unset.
+	Headroom *float64 `json:"headroom,omitempty"`
+}
+
+// Config is the internal, fully-validated configuration used by the detector.
+type Config struct {
+	QueueDepthThreshold       int
+	KVCacheUtilThreshold      float64
+	MetricsStalenessThreshold time.Duration
+	Headroom                  float64
+}
+
+// buildConfig applies the configuration lifecycle (defaulting and validation) and translates the
+// external schema into the internal domain model.
+// The provided apiConfig is copied to prevent mutation side-effects.
+func buildConfig(apiCfg *apiConfig) (*Config, error) {
+	var safeCfg apiConfig
+	if apiCfg != nil {
+		safeCfg = *apiCfg
+	}
+
+	applyDefaults(&safeCfg)
+
+	if err := validateConfig(&safeCfg); err != nil {
+		return nil, fmt.Errorf("invalid utilization detector configuration: %w", err)
+	}
+
+	return &Config{
+		QueueDepthThreshold:       *safeCfg.QueueDepthThreshold,
+		KVCacheUtilThreshold:      *safeCfg.KVCacheUtilThreshold,
+		MetricsStalenessThreshold: safeCfg.MetricsStalenessThreshold.Duration,
+		Headroom:                  *safeCfg.Headroom,
+	}, nil
+}
+
+// applyDefaults populates unset fields in the external configuration with their standard defaults.
+func applyDefaults(cfg *apiConfig) {
+	if cfg.QueueDepthThreshold == nil {
+		cfg.QueueDepthThreshold = ptr.To(DefaultQueueDepthThreshold)
+	}
+	if cfg.KVCacheUtilThreshold == nil {
+		cfg.KVCacheUtilThreshold = ptr.To(DefaultKVCacheUtilThreshold)
+	}
+	if cfg.MetricsStalenessThreshold == nil {
+		cfg.MetricsStalenessThreshold = &metav1.Duration{Duration: DefaultMetricsStalenessThreshold}
+	}
+	if cfg.Headroom == nil {
+		cfg.Headroom = ptr.To(defaultHeadroom)
+	}
+}
+
+// validateConfig checks the constraints of the fully defaulted configuration.
+// It aggregates all validation failures rather than failing on the first error.
+func validateConfig(cfg *apiConfig) error {
+	var errs []error
+
+	if cfg.QueueDepthThreshold != nil && *cfg.QueueDepthThreshold <= 0 {
+		errs = append(errs, fmt.Errorf("queueDepthThreshold must be strictly positive, got %d", *cfg.QueueDepthThreshold))
+	}
+	if cfg.KVCacheUtilThreshold != nil && (*cfg.KVCacheUtilThreshold <= 0.0 || *cfg.KVCacheUtilThreshold > 1.0) {
+		errs = append(errs, fmt.Errorf("kvCacheUtilThreshold must be in (0.0, 1.0], got %f", *cfg.KVCacheUtilThreshold))
+	}
+	if cfg.MetricsStalenessThreshold != nil && cfg.MetricsStalenessThreshold.Duration <= 0 {
+		errs = append(errs, fmt.Errorf("metricsStalenessThreshold must be strictly positive, got %v",
+			cfg.MetricsStalenessThreshold.Duration))
+	}
+	if cfg.Headroom != nil && *cfg.Headroom < 0.0 {
+		errs = append(errs, fmt.Errorf("headroom must be a non-negative value, got %f", *cfg.Headroom))
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector.go
+++ b/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector.go
@@ -39,50 +39,33 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
-	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
 const (
-	// loggerName is the name to use for loggers created by this package.
-	loggerName = "SaturationDetector"
-
 	// UtilizationDetectorType is the unique identifier for this plugin.
 	UtilizationDetectorType = "utilization-detector"
 )
 
-// Config holds the configuration for the SaturationDetector.
-type Config struct {
-	// QueueDepthThreshold defines the backend waiting queue size above which a
-	// pod is considered to have insufficient capacity for new requests.
-	QueueDepthThreshold int
-	// KVCacheUtilThreshold defines the KV cache utilization (0.0 to 1.0) above
-	// which a pod is considered to have insufficient capacity.
-	KVCacheUtilThreshold float64
-	// MetricsStalenessThreshold defines how old a pod's metrics can be.
-	// If a pod's metrics are older than this, it might be excluded from
-	// "good capacity" considerations or treated as having no capacity for
-	// safety.
-	MetricsStalenessThreshold time.Duration
-	// Headroom defines the allowed burst capacity above thresholds for specific pod scheduling,
-	// expressed as a fraction in [0.0, 1.0].
-	Headroom float64
-}
-
-func UtilizationDetectorFactory(_ string, params json.RawMessage, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
-	config := &Config{
-		QueueDepthThreshold:       DefaultQueueDepthThreshold,
-		KVCacheUtilThreshold:      DefaultKVCacheUtilThreshold,
-		MetricsStalenessThreshold: DefaultMetricsStalenessThreshold,
-		Headroom:                  DefaultHeadroom,
-	}
+// UtilizationDetectorFactory instantiates the detector plugin using the provided JSON parameters.
+func UtilizationDetectorFactory(
+	name string,
+	params json.RawMessage,
+	handle fwkplugin.Handle,
+) (fwkplugin.Plugin, error) {
+	var apiCfg apiConfig
 	if len(params) > 0 {
-		if err := json.Unmarshal(params, config); err != nil {
+		if err := json.Unmarshal(params, &apiCfg); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal utilization detector config: %w", err)
 		}
 	}
-	return NewDetector(config, log.FromContext(handle.Context())), nil
+	cfg, err := buildConfig(&apiCfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewDetector(name, *cfg, log.FromContext(handle.Context())), nil
 }
 
 var (
@@ -91,29 +74,40 @@ var (
 
 // Detector determines system saturation based on metrics of the given candidate pods.
 type Detector struct {
-	config *Config
+	config    Config
+	typedName fwkplugin.TypedName
 }
 
-// NewDetector creates a new SaturationDetector.
+// NewDetector creates a new instance of the Utilization Detector.
 // The config provides the thresholds for determining saturation.
-func NewDetector(config *Config, logger logr.Logger) *Detector {
-	logger.WithName(loggerName).V(logutil.DEFAULT).Info("Creating new SaturationDetector",
-		"queueDepthThreshold", config.QueueDepthThreshold,
-		"kvCacheUtilThreshold", config.KVCacheUtilThreshold,
-		"metricsStalenessThreshold", config.MetricsStalenessThreshold.String(),
-		"headroom", config.Headroom)
+func NewDetector(name string, cfg Config, logger logr.Logger) *Detector {
+	typedName := fwkplugin.TypedName{
+		Type: UtilizationDetectorType,
+		Name: name,
+	}
+
+	pluginLogger := logger.WithName(typedName.String())
+	pluginLogger.V(logutil.DEFAULT).Info("Creating new UtilizationDetector",
+		"queueDepthThreshold", cfg.QueueDepthThreshold,
+		"kvCacheUtilThreshold", cfg.KVCacheUtilThreshold,
+		"metricsStalenessThreshold", cfg.MetricsStalenessThreshold.String(),
+		"headroom", cfg.Headroom)
+
+	if cfg.Headroom > 1.0 {
+		pluginLogger.Info("Unusually high headroom configured; verify value is a fraction, not a percentage",
+			"headroom", cfg.Headroom,
+			"effectiveBurst", fmt.Sprintf("%.0f%%", cfg.Headroom*100))
+	}
 
 	return &Detector{
-		config: config,
+		config:    cfg,
+		typedName: typedName,
 	}
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
 func (d *Detector) TypedName() fwkplugin.TypedName {
-	return fwkplugin.TypedName{
-		Type: UtilizationDetectorType,
-		Name: UtilizationDetectorType,
-	}
+	return d.typedName
 }
 
 // Saturation calculates the saturation level of the pool.
@@ -125,14 +119,14 @@ func (d *Detector) TypedName() fwkplugin.TypedName {
 // For each pod, the score is determined by the most constrained resource (Compute or Memory):
 //
 //	PodScore = Max(WaitingQueue / QueueThreshold, KVCacheUsage / KVCacheThreshold)
-func (d *Detector) Saturation(_ context.Context, candidatePods []fwkdl.Endpoint) float64 {
-	if len(candidatePods) == 0 {
+func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint) float64 {
+	if len(candidates) == 0 {
 		return 1.0
 	}
 
 	var totalScore float64
-	for _, podMetric := range candidatePods {
-		metrics := podMetric.GetMetrics()
+	for _, e := range candidates {
+		metrics := e.GetMetrics()
 
 		if metrics == nil || time.Since(metrics.UpdateTime) > d.config.MetricsStalenessThreshold {
 			totalScore += 1.0
@@ -146,7 +140,7 @@ func (d *Detector) Saturation(_ context.Context, candidatePods []fwkdl.Endpoint)
 		totalScore += max(qRatio, kvRatio)
 	}
 
-	return totalScore / float64(len(candidatePods))
+	return totalScore / float64(len(candidates))
 }
 
 // Filter blocks traffic to specific pods that are physically saturated or exceeding their safety limits.

--- a/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector_test.go
+++ b/pkg/epp/saturationdetector/framework/plugins/utilizationdetector/detector_test.go
@@ -28,6 +28,7 @@ import (
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/test/utils"
 )
 
 func makePodMetric(name string, queueDepth int, kvUsage float64, updateTime time.Time) *backendmetrics.FakePodMetrics {
@@ -41,6 +42,90 @@ func makePodMetric(name string, queueDepth int, kvUsage float64, updateTime time
 			UpdateTime:          updateTime,
 		},
 	}
+}
+
+// TestUtilizationDetectorFactory evaluates instantiation properties and config parsing constraints.
+// It guards against improper configuration block parameters failing initialization correctly.
+func TestUtilizationDetectorFactory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configJSON []byte
+		wantError  bool
+	}{
+		{
+			name:       "valid configuration",
+			configJSON: []byte(`{"queueDepthThreshold": 5, "kvCacheUtilThreshold": 0.8}`),
+			wantError:  false,
+		},
+		{
+			name:       "invalid schema",
+			configJSON: []byte(`{"queueDepthThreshold": "invalid_type"}`),
+			wantError:  true,
+		},
+		{
+			name:       "empty config applies defaults",
+			configJSON: []byte(`{}`),
+			wantError:  false,
+		},
+		{
+			name:       "invalid queue depth",
+			configJSON: []byte(`{"queueDepthThreshold": 0}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid kv cache high",
+			configJSON: []byte(`{"kvCacheUtilThreshold": 1.5}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid kv cache low",
+			configJSON: []byte(`{"kvCacheUtilThreshold": 0.0}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid metrics staleness",
+			configJSON: []byte(`{"metricsStalenessThreshold": "0s"}`),
+			wantError:  true,
+		},
+		{
+			name:       "invalid headroom",
+			configJSON: []byte(`{"headroom": -0.5}`),
+			wantError:  true,
+		},
+		{
+			name:       "high headroom warning",
+			configJSON: []byte(`{"headroom": 2.0}`),
+			wantError:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plugin, err := UtilizationDetectorFactory("test-util-detector", tc.configJSON, utils.NewTestHandle(t.Context()))
+			if tc.wantError {
+				require.Error(t, err, "Expected initialization to fail on invalid configuration")
+				require.Nil(t, plugin, "Plugin must be nil when initialization fails")
+			} else {
+				require.NoError(t, err, "Expected initialization to succeed with valid configuration")
+				require.NotNil(t, plugin, "Plugin must not be nil on success")
+			}
+		})
+	}
+}
+
+// TestDetector_TypedName provides structural assurance that initialization assigns proper types.
+func TestDetector_TypedName(t *testing.T) {
+	t.Parallel()
+	plugin, err := UtilizationDetectorFactory("test-plugin", []byte(`{}`), utils.NewTestHandle(t.Context()))
+	require.NoError(t, err, "Plugin initialization should succeed")
+	require.Equal(t, "test-plugin", plugin.TypedName().Name,
+		"TypedName must match the name provided during initialization")
+	require.Equal(t, "utilization-detector", plugin.TypedName().Type,
+		"TypedName.Type must be exactly 'utilization-detector'")
 }
 
 func TestDetector_Saturation(t *testing.T) {
@@ -178,7 +263,7 @@ func TestDetector_Saturation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			detector := NewDetector(config, logr.Discard())
+			detector := NewDetector("test-detector", *config, logr.Discard())
 
 			got := detector.Saturation(context.Background(), tc.pods)
 			require.InDelta(t, tc.wantSaturation, got, 1e-4, "Saturation mismatch")
@@ -268,7 +353,7 @@ func TestDetector_Filter(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			detector := NewDetector(config, logr.Discard())
+			detector := NewDetector("test-detector", *config, logr.Discard())
 			got := detector.Filter(context.Background(), nil, nil, tc.endpoints)
 			require.Len(t, got, tc.wantLen)
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature

**What this PR does / why we need it**:

This PR serves as preparatory work to promote saturation detection to an EPP extension point. Before handling config loading from the top-level `EndpointPickerConfig` API and integration into the plugin registry, I wanted to make the required implementation-local changes so that these can be seamlessly transitioned to plugins in a follow-up PR.

I tried to keep the diff tightly scoped to the config and instantiation logic. I did however, spend some time polishing the config documentation for each future plugin.

**Which issue(s) this PR fixes**:

Part of #1405 

Will rebase #2605 onto this once it is merged. While working on #2605, the diffbase was getting unwieldy, so I wanted to split this piece out,

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```