### PR TITLE
fix duplicate responseBody call with Eos true for streaming response

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -23,6 +23,7 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 
 	envoy "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
@@ -42,6 +43,8 @@ import (
 //	body as a single "stream" event.
 func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *RequestContext, responseBytes []byte, endOfStream bool) *RequestContext {
 	logger := log.FromContext(ctx)
+	logger.V(logutil.DEBUG).Info("HandleResponseBody is triggered", "len(responseBytes)", len(responseBytes), "endOfStream", endOfStream)
+
 	parsedResp, err := s.parser.ParseResponse(ctx, responseBytes, reqCtx.Response.Headers, endOfStream)
 	if err != nil {
 		logger.Error(err, "parsing response")

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -272,16 +272,18 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			chunk := v.ResponseBody.Body
 
 			if reqCtx.modelServerStreaming {
+				if endOfStream {
+					reqCtx.ResponseComplete = true
+					reqCtx.ResponseCompleteTimestamp = time.Now()
+				}
 				s.HandleResponseBody(ctx, reqCtx, chunk, endOfStream)
 				// For streaming response, we send response chunk back to envoy every time we received it.
 				reqCtx.respBodyResp = generateResponseBodyResponses(chunk, endOfStream, reqCtx.Response.DynamicMetadata)
 			} else {
 				body = append(body, chunk...)
-			}
-
-			// If this chunk marks the end of the stream, trigger the finalization logic.
-			if endOfStream {
-				s.finishResponse(ctx, reqCtx, body, reqCtx.modelServerStreaming)
+				if endOfStream {
+					s.finishResponse(ctx, reqCtx, body, reqCtx.modelServerStreaming)
+				}
 			}
 		case *extProcPb.ProcessingRequest_ResponseTrailers:
 			// For HTTP, the response trailer is not sent. Thus, this case will not be triggered.
@@ -330,7 +332,6 @@ func (s *StreamingServer) finishResponse(ctx context.Context, reqCtx *RequestCon
 
 	reqCtx.ResponseComplete = true
 	reqCtx.ResponseCompleteTimestamp = time.Now()
-	reqCtx.ResponseSize = len(body)
 	reqCtx = s.HandleResponseBody(ctx, reqCtx, body, true)
 	if !modelStreaming {
 		// For non-streaming response, we send response back to envoy after receiving all the response body.

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -240,6 +240,10 @@ func runStreamingTest(t *testing.T, streamingResponse bool, hasTrailers bool) {
 		}
 	}
 
+	if director.handleResponseBodyEndStreamCount != 1 {
+		t.Errorf("HandleResponseBody was called with endOfStream=true %d times, expected 1", director.handleResponseBodyEndStreamCount)
+	}
+
 	cancel()
 	<-errChan
 	testListener.Close()
@@ -295,7 +299,8 @@ func recvResponseTrailers(stream pb.ExternalProcessor_ProcessClient) error {
 }
 
 type testDirector struct {
-	requestHeaders map[string]string
+	requestHeaders                   map[string]string
+	handleResponseBodyEndStreamCount int
 }
 
 func (ts *testDirector) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext) (*handlers.RequestContext, error) {
@@ -320,7 +325,11 @@ func (ts *testDirector) HandleRequest(ctx context.Context, reqCtx *handlers.Requ
 func (ts *testDirector) HandleResponseHeader(ctx context.Context, reqCtx *handlers.RequestContext) *handlers.RequestContext {
 	return reqCtx
 }
+
 func (ts *testDirector) HandleResponseBody(ctx context.Context, reqCtx *handlers.RequestContext, endOfStream bool) *handlers.RequestContext {
+	if endOfStream {
+		ts.handleResponseBodyEndStreamCount++
+	}
 	return reqCtx
 }
 func (ts *testDirector) GetRandomEndpoint() *fwkdl.EndpointMetadata {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:

reported by @kaushikmitr , in the streaming case, the responseBody with EoS true are called twice.

```
Line 275 in server.go, for streaming, every chunk (including the last one with endOfStream=true) calls s.HandleResponseBody. Then line 283-284 calls finishResponse which calls s.HandleResponseBody again at line 334.
```
This PR sets the ResponseComplete early instead of waiting for calling finishResponse in the streaming case.

Added a unittest in server_test.go to strictly checking the handleResponseBodyEndStreamCount is exactly 1.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
