### PR TITLE
Adding missing information about BBR plugins to the README.md

### DIFF
--- a/config/charts/body-based-routing/README.md
+++ b/config/charts/body-based-routing/README.md
@@ -82,7 +82,7 @@ The following table list the configurable parameters of the chart.
 | `bbr.image.tag`              | Image tag.                                                                                                        |
 | `bbr.image.pullPolicy`       | Image pull policy for the container. Possible values: `Always`, `IfNotPresent`, or `Never`. Defaults to `Always`. |
 | `bbr.flags`                  | map of flags which are passed through to bbr. Refer to [runner.go](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/cmd/bbr/runner/runner.go) for complete list. |
-| `bbr.plugins`   |  Custom ordered plugins array to set for BBR. each plugin have fields: type, name and optionally json (which represents parameters of the plugin). If not specified, BBR will use by default the `body-field-to-header` to extract the `model field`, and `base-model-to-header` (in that order).  |
+| `bbr.plugins`   |  Custom ordered plugins array to set for BBR. each plugin have fields: type, name and optionally json (which represents parameters of the plugin). If not specified, BBR will use by default the `body-field-to-header` to extract the `model` field, and `base-model-to-header` (in that order).  |
 | `provider.name`              | Name of the Inference Gateway implementation being used. Possible values: `istio`, `gke`. Defaults to `none`.     |
 | `inferenceGateway.name`      | The name of the Gateway. Defaults to `inference-gateway`.                                                                                 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Adds missing information about BBR plugins configuration to the README.md
Per reviewers' comment on [PR#2604](https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2604).

**Which issue(s) this PR fixes**:

Fixes #2654 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
