### PR TITLE
feat: Add unit test for single_profile_handler.go

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+type fakeSchedulerProfile struct{}
+
+func (f *fakeSchedulerProfile) Run(_ context.Context, _ *framework.LLMRequest, _ *framework.CycleState, _ []framework.Endpoint) (*framework.ProfileRunResult, error) {
+	return &framework.ProfileRunResult{}, nil
+}
+
+func TestNewSingleProfileHandler(t *testing.T) {
+	handler := NewSingleProfileHandler()
+
+	wantTypedName := fwkplugin.TypedName{
+		Type: SingleProfileHandlerType,
+		Name: SingleProfileHandlerType,
+	}
+	if diff := cmp.Diff(wantTypedName, handler.TypedName()); diff != "" {
+		t.Errorf("Unexpected TypedName (-want +got): %s", diff)
+	}
+}
+
+func TestSingleProfileHandlerFactory(t *testing.T) {
+	plugin, err := SingleProfileHandlerFactory("custom-name", nil, nil)
+	if err != nil {
+		t.Fatalf("SingleProfileHandlerFactory() returned unexpected error: %v", err)
+	}
+
+	handler, ok := plugin.(*SingleProfileHandler)
+	if !ok {
+		t.Fatalf("Expected *SingleProfileHandler, got %T", plugin)
+	}
+
+	wantTypedName := fwkplugin.TypedName{
+		Type: SingleProfileHandlerType,
+		Name: "custom-name",
+	}
+	if diff := cmp.Diff(wantTypedName, handler.TypedName()); diff != "" {
+		t.Errorf("Unexpected TypedName (-want +got): %s", diff)
+	}
+}
+
+func TestWithName(t *testing.T) {
+	handler := NewSingleProfileHandler().WithName("renamed")
+
+	if handler.TypedName().Name != "renamed" {
+		t.Errorf("Expected Name to be %q, got %q", "renamed", handler.TypedName().Name)
+	}
+	if handler.TypedName().Type != SingleProfileHandlerType {
+		t.Errorf("Expected Type to remain %q, got %q", SingleProfileHandlerType, handler.TypedName().Type)
+	}
+}
+
+func TestPick(t *testing.T) {
+	fakeProfile := &fakeSchedulerProfile{}
+
+	tests := []struct {
+		name           string
+		profiles       map[string]framework.SchedulerProfile
+		profileResults map[string]*framework.ProfileRunResult
+		wantCount      int
+	}{
+		{
+			name:           "no profiles executed yet, returns all",
+			profiles:       map[string]framework.SchedulerProfile{"default": fakeProfile},
+			profileResults: map[string]*framework.ProfileRunResult{},
+			wantCount:      1,
+		},
+		{
+			name:     "all profiles already executed, returns empty",
+			profiles: map[string]framework.SchedulerProfile{"default": fakeProfile},
+			profileResults: map[string]*framework.ProfileRunResult{
+				"default": {TargetEndpoints: nil},
+			},
+			wantCount: 0,
+		},
+		{
+			name:           "no profiles configured, returns empty",
+			profiles:       map[string]framework.SchedulerProfile{},
+			profileResults: map[string]*framework.ProfileRunResult{},
+			wantCount:      0,
+		},
+	}
+
+	handler := NewSingleProfileHandler()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.Pick(context.Background(), framework.NewCycleState(), nil, tt.profiles, tt.profileResults)
+			if len(got) != tt.wantCount {
+				t.Errorf("Pick() returned %d profiles, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestProcessResults(t *testing.T) {
+	successResult := &framework.ProfileRunResult{
+		TargetEndpoints: nil,
+	}
+
+	tests := []struct {
+		name           string
+		profileResults map[string]*framework.ProfileRunResult
+		wantResult     *framework.SchedulingResult
+		wantErr        bool
+	}{
+		{
+			name: "single successful profile",
+			profileResults: map[string]*framework.ProfileRunResult{
+				"default": successResult,
+			},
+			wantResult: &framework.SchedulingResult{
+				ProfileResults: map[string]*framework.ProfileRunResult{
+					"default": successResult,
+				},
+				PrimaryProfileName: "default",
+			},
+		},
+		{
+			name:           "no profiles returns error",
+			profileResults: map[string]*framework.ProfileRunResult{},
+			wantErr:        true,
+		},
+		{
+			name: "multiple profiles returns error",
+			profileResults: map[string]*framework.ProfileRunResult{
+				"profile-a": successResult,
+				"profile-b": successResult,
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil result (profile execution failure) returns error",
+			profileResults: map[string]*framework.ProfileRunResult{
+				"default": nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	handler := NewSingleProfileHandler()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handler.ProcessResults(context.Background(), framework.NewCycleState(), nil, tt.profileResults)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ProcessResults() expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ProcessResults() unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantResult, got); diff != "" {
+				t.Errorf("Unexpected SchedulingResult (-want +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep


Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
/kind test
