### PR TITLE
Minimal refactoring to have a single shard

### DIFF
--- a/pkg/epp/flowcontrol/registry/connection.go
+++ b/pkg/epp/flowcontrol/registry/connection.go
@@ -33,14 +33,10 @@ var _ contracts.ActiveFlowConnection = &connection{}
 
 // Shards returns a stable snapshot of accessors for all internal state shards.
 func (c *connection) ActiveShards() []contracts.RegistryShard {
-	c.registry.mu.RLock()
-	defer c.registry.mu.RUnlock()
-
 	// Return a copy to ensure the caller cannot modify the registry's internal slice.
-	shardsCopy := make([]contracts.RegistryShard, len(c.registry.activeShards))
-	for i, s := range c.registry.activeShards {
-		shardsCopy[i] = s
-	}
+	shardsCopy := make([]contracts.RegistryShard, 1)
+	shardsCopy[0] = c.registry.shard
+
 	return shardsCopy
 }
 

--- a/pkg/epp/flowcontrol/registry/managedqueue.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue.go
@@ -75,6 +75,8 @@ type managedQueue struct {
 	// Its state must only be modified while holding `mu`.
 	queue contracts.SafeQueue
 
+	flowQueueAccessor *flowQueueAccessor
+
 	// --- Concurrent-Safe State (Atomics) ---
 
 	// Queue-level statistics.
@@ -99,7 +101,7 @@ func newManagedQueue(
 		"flowKey", key,
 		"queueType", queue.Name(),
 	)
-	return &managedQueue{
+	mq := &managedQueue{
 		queue:        queue,
 		policy:       policy,
 		key:          key,
@@ -107,11 +109,13 @@ func newManagedQueue(
 		logger:       mqLogger,
 		isDraining:   isDraining,
 	}
+	mq.flowQueueAccessor = &flowQueueAccessor{mq: mq}
+	return mq
 }
 
 // FlowQueueAccessor returns a read-only, flow-aware view of this queue.
 func (mq *managedQueue) FlowQueueAccessor() flowcontrol.FlowQueueAccessor {
-	return &flowQueueAccessor{mq: mq}
+	return mq.flowQueueAccessor
 }
 
 // Add performs an atomic check on the parent shard's lifecycle state before adding the item to the underlying queue.

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -17,10 +17,8 @@ limitations under the License.
 package registry
 
 import (
-	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -105,11 +103,8 @@ type FlowRegistry struct {
 
 	// --- Administrative state (protected by `mu`) ---
 
-	mu             sync.RWMutex
-	activeShards   []*registryShard
-	drainingShards map[string]*registryShard
-	allShards      []*registryShard // Cached, sorted combination of Active and Draining shards
-	nextShardID    uint64
+	mu    sync.RWMutex
+	shard *registryShard
 }
 
 var _ contracts.FlowRegistry = &FlowRegistry{}
@@ -131,10 +126,8 @@ func withClock(clk clock.WithTickerAndDelayedExecution) RegistryOption {
 func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption) (*FlowRegistry, error) {
 	cfg := config.Clone()
 	fr := &FlowRegistry{
-		config:         cfg,
-		logger:         logger.WithName("flow-registry"),
-		activeShards:   []*registryShard{},
-		drainingShards: make(map[string]*registryShard),
+		config: cfg,
+		logger: logger.WithName("flow-registry"),
 	}
 
 	for _, opt := range opts {
@@ -148,8 +141,8 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 		fr.perPriorityBandStats.Store(prio, &bandStats{})
 	}
 
-	if err := fr.updateShardCount(cfg.InitialShardCount); err != nil {
-		return nil, fmt.Errorf("failed to initialize shards: %w", err)
+	if err := fr.createShard(); err != nil {
+		return nil, fmt.Errorf("failed to initialize shard: %w", err)
 	}
 	fr.logger.V(logging.DEFAULT).Info("FlowRegistry initialized successfully")
 	return fr, nil
@@ -261,14 +254,12 @@ func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error 
 	fr.mu.RLock()
 	defer fr.mu.RUnlock()
 
-	components, err := fr.buildFlowComponents(key, len(fr.allShards))
+	components, err := fr.buildFlowComponents(key, 1)
 	if err != nil {
 		return err
 	}
 
-	for i, shard := range fr.allShards {
-		shard.synchronizeFlow(key, components[i].policy, components[i].queue)
-	}
+	fr.shard.synchronizeFlow(key, components[0].policy, components[0].queue)
 
 	fr.logger.V(logging.DEBUG).Info("JIT provisioned flow infrastructure", "flowKey", key)
 	return nil
@@ -298,9 +289,7 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 
 	fr.repartitionShardConfigsLocked()
 
-	for _, shard := range fr.activeShards {
-		shard.addPriorityBand(priority)
-	}
+	fr.shard.addPriorityBand(priority)
 
 	return nil
 }
@@ -346,14 +335,8 @@ func (fr *FlowRegistry) Stats() contracts.AggregateStats {
 
 // ShardStats returns a slice of statistics, one for each internal shard.
 func (fr *FlowRegistry) ShardStats() []contracts.ShardStats {
-	fr.mu.RLock()
-	allShards := fr.allShards
-	fr.mu.RUnlock()
-
-	shardStats := make([]contracts.ShardStats, len(allShards))
-	for i, s := range allShards {
-		shardStats[i] = s.Stats()
-	}
+	shardStats := make([]contracts.ShardStats, 1)
+	shardStats[0] = fr.shard.Stats()
 	return shardStats
 }
 
@@ -364,7 +347,6 @@ func (fr *FlowRegistry) executeGCCycle() {
 	fr.logger.V(logging.DEBUG).Info("Starting periodic GC scan")
 	fr.gcFlows()
 	fr.gcPriorityBands()
-	fr.sweepDrainingShards()
 }
 
 // gcFlows removes idle flows.
@@ -400,9 +382,7 @@ func (fr *FlowRegistry) cleanupFlowResources(keys []flowcontrol.FlowKey) {
 		if _, exists := fr.flowStates.Load(key); exists {
 			continue // 'Zombie' flow
 		}
-		for _, shard := range fr.allShards {
-			shard.deleteFlow(key)
-		}
+		fr.shard.deleteFlow(key)
 	}
 }
 
@@ -442,78 +422,24 @@ func (fr *FlowRegistry) cleanupPriorityBandResources(priorities []int) {
 		// Delete from stats tracking
 		fr.perPriorityBandStats.Delete(priority)
 
-		// Delete from all shards (both active and draining)
-		for _, shard := range fr.allShards {
-			shard.deletePriorityBand(priority)
-		}
+		// Delete from the shard
+		fr.shard.deletePriorityBand(priority)
 
 		fr.logger.V(logging.DEFAULT).Info("Successfully deleted priority band", "priority", priority)
 	}
 }
 
-// sweepDrainingShards finalizes the removal of drained shards.
-func (fr *FlowRegistry) sweepDrainingShards() {
-	// Acquire a full write lock on the registry as we may be modifying the shard topology.
-	fr.mu.Lock()
-	defer fr.mu.Unlock()
-
-	var shardsToDelete []string
-	for id, shard := range fr.drainingShards {
-		// A Draining shard is ready for GC once it is completely empty.
-		// Draining shards do not accept new work (enforced at `managedQueue.Add`), so `shard.totalLen.Load()` can only
-		// monotonically decrease.
-		if shard.totalLen.Load() == 0 {
-			shardsToDelete = append(shardsToDelete, id)
-		}
-	}
-
-	if len(shardsToDelete) > 0 {
-		fr.logger.V(logging.DEBUG).Info("Garbage collecting drained shards", "shardIDs", shardsToDelete)
-		for _, id := range shardsToDelete {
-			delete(fr.drainingShards, id)
-		}
-		fr.updateAllShardsCacheLocked()
-	}
-}
-
 // --- Shard Management (Scaling) ---
 
-// updateShardCount dynamically adjusts the number of internal state shards.
-func (fr *FlowRegistry) updateShardCount(n int) error {
-	if n <= 0 {
-		return fmt.Errorf("%w: shard count must be a positive integer, but got %d", contracts.ErrInvalidShardCount, n)
-	}
-
+// createShard creates the shard.
+func (fr *FlowRegistry) createShard() error {
 	// Use a full write lock as this is a major structural change to the shard topology.
 	fr.mu.Lock()
 	defer fr.mu.Unlock()
 
-	currentActiveShards := len(fr.activeShards)
-	if n == currentActiveShards {
-		return nil
-	}
-
-	if n > currentActiveShards {
-		return fr.executeScaleUpLocked(n)
-	}
-	fr.executeScaleDownLocked(n)
-	return nil
-}
-
-// executeScaleUpLocked handles adding new shards.
-// It pre-provisions all existing active flows onto the new shards to ensure continuity.
-func (fr *FlowRegistry) executeScaleUpLocked(newTotalActive int) error {
-	currentActive := len(fr.activeShards)
-	numToAdd := newTotalActive - currentActive
-	fr.logger.V(logging.DEFAULT).Info("Scaling up shards", "currentActive", currentActive, "newTotalActive", newTotalActive)
-
-	// Prepare All New Shard Objects (Infallible):
-	newShards := make([]*registryShard, numToAdd)
-	for i := range numToAdd {
-		shardID := fmt.Sprintf("shard-%04d", fr.nextShardID+uint64(i))
-		partitionedConfig := fr.config.partition(currentActive+i, newTotalActive)
-		newShards[i] = newShard(shardID, partitionedConfig, fr.logger, fr.propagateStatsDelta)
-	}
+	// Prepare Shard Object (Infallible)
+	partitionedConfig := fr.config.partition(0, 1)
+	shard := newShard("shard-0", partitionedConfig, fr.logger, fr.propagateStatsDelta)
 
 	// Prepare All Components for All New Shards (Fallible):
 	// Pre-build every component for every existing flow on every new shard.
@@ -523,7 +449,7 @@ func (fr *FlowRegistry) executeScaleUpLocked(newTotalActive int) error {
 	var rangeErr error
 	fr.flowStates.Range(func(key, _ any) bool {
 		flowKey := key.(flowcontrol.FlowKey)
-		components, err := fr.buildFlowComponents(flowKey, len(newShards))
+		components, err := fr.buildFlowComponents(flowKey, 1)
 		if err != nil {
 			rangeErr = fmt.Errorf("failed to prepare components for flow %s on new shards: %w", flowKey, err)
 			return false
@@ -536,43 +462,19 @@ func (fr *FlowRegistry) executeScaleUpLocked(newTotalActive int) error {
 	}
 
 	// Commit (Infallible):
-	for i, shard := range newShards {
-		for key, components := range allComponents {
-			shard.synchronizeFlow(key, components[i].policy, components[i].queue)
-		}
+	for key, components := range allComponents {
+		shard.synchronizeFlow(key, components[0].policy, components[0].queue)
 	}
-	fr.activeShards = append(fr.activeShards, newShards...)
-	fr.nextShardID += uint64(numToAdd)
+	fr.shard = shard
 	fr.repartitionShardConfigsLocked()
-	fr.updateAllShardsCacheLocked()
 	return nil
-}
-
-// executeScaleDownLocked handles marking shards for graceful draining.
-// Expects the registry's write lock to be held.
-func (fr *FlowRegistry) executeScaleDownLocked(newTotalActive int) {
-	currentActive := len(fr.activeShards)
-	fr.logger.V(logging.DEFAULT).Info("Scaling down shards", "currentActive", currentActive, "newTotalActive", newTotalActive)
-
-	shardsToDrain := fr.activeShards[newTotalActive:]
-	fr.activeShards = fr.activeShards[:newTotalActive]
-	for _, shard := range shardsToDrain {
-		fr.drainingShards[shard.id] = shard
-		shard.markAsDraining()
-	}
-
-	fr.repartitionShardConfigsLocked()
-	fr.updateAllShardsCacheLocked()
 }
 
 // repartitionShardConfigsLocked updates the configuration for all active shards.
 // Expects the registry's write lock to be held.
 func (fr *FlowRegistry) repartitionShardConfigsLocked() {
-	numActive := len(fr.activeShards)
-	for i, shard := range fr.activeShards {
-		newPartitionedConfig := fr.config.partition(i, numActive)
-		shard.updateConfig(newPartitionedConfig)
-	}
+	newPartitionedConfig := fr.config.partition(0, 1)
+	fr.shard.updateConfig(newPartitionedConfig)
 }
 
 // --- Internal Helpers ---
@@ -601,27 +503,6 @@ func (fr *FlowRegistry) buildFlowComponents(key flowcontrol.FlowKey, numInstance
 		allComponents[i] = flowComponents{policy: bandConfig.OrderingPolicy, queue: q}
 	}
 	return allComponents, nil
-}
-
-// updateAllShardsCacheLocked recalculates the cached `allShards` slice.
-// It ensures the slice is sorted by shard ID to maintain a deterministic order.
-// Expects the registry's write lock to be held.
-func (fr *FlowRegistry) updateAllShardsCacheLocked() {
-	allShards := make([]*registryShard, 0, len(fr.activeShards)+len(fr.drainingShards))
-	allShards = append(allShards, fr.activeShards...)
-	for _, shard := range fr.drainingShards {
-		allShards = append(allShards, shard)
-	}
-
-	// Sort the combined slice by shard ID.
-	// This provides a stable, deterministic order for all consumers of the shard list, which is critical because map
-	// iteration for `drainingShards` is non-deterministic.
-	// While this is a lexicographical sort, our shard ID format is padded with leading zeros (e.g., "shard-0001"),
-	// ensuring that the string sort produces the same result as a natural numerical sort.
-	slices.SortFunc(allShards, func(a, b *registryShard) int {
-		return cmp.Compare(a.id, b.id)
-	})
-	fr.allShards = allShards
 }
 
 // propagateStatsDelta is the top-level, lock-free aggregator for all statistics.

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -109,19 +109,19 @@ func newRegistryTestHarness(t *testing.T, opts harnessOptions) *registryTestHarn
 // assertFlowExists synchronously checks if a flow's queue exists on the first shard.
 func (h *registryTestHarness) assertFlowExists(key flowcontrol.FlowKey, msgAndArgs ...any) {
 	h.t.Helper()
-	require.NotEmpty(h.t, h.fr.allShards, "Cannot check for flow existence when no shards are present")
-	_, err := h.fr.allShards[0].ManagedQueue(key)
+	require.NotNil(h.t, h.fr.shard, "Cannot check for flow existence when the shard doesn't exist")
+	_, err := h.fr.shard.ManagedQueue(key)
 	assert.NoError(h.t, err, msgAndArgs...)
 }
 
 // assertFlowDoesNotExist synchronously checks if a flow's queue does not exist.
 func (h *registryTestHarness) assertFlowDoesNotExist(key flowcontrol.FlowKey, msgAndArgs ...any) {
 	h.t.Helper()
-	if len(h.fr.allShards) == 0 {
-		assert.True(h.t, true, "Flow correctly does not exist because no shards exist")
+	if h.fr.shard == nil {
+		assert.True(h.t, true, "Flow correctly does not exist because shard doesn't exist")
 		return
 	}
-	_, err := h.fr.allShards[0].ManagedQueue(key)
+	_, err := h.fr.shard.ManagedQueue(key)
 	require.Error(h.t, err, "Expected an error when getting a non-existent flow, but got none")
 	assert.ErrorIs(h.t, err, contracts.ErrFlowInstanceNotFound, msgAndArgs...)
 }
@@ -206,18 +206,16 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 
 	t.Run("Handle_Shards_ShouldReturnAllActiveShardsAndBeACopy", func(t *testing.T) {
 		t.Parallel()
-		// Create a registry with a known mixed topology of Active and Draining shards.
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 3})
-		err := h.fr.updateShardCount(2) // This leaves one shard in the Draining state.
-		require.NoError(t, err, "Test setup: scaling down to create a draining shard should not fail")
-		require.Len(t, h.fr.allShards, 3, "Test setup: should have 2 active and 1 draining shard")
+		// Create a registry with one shard.
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+		require.NotNil(t, h.fr.shard, "Test setup: should have one shard")
 
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: highPriority}
 
-		err = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
 			shards := conn.ActiveShards()
 
-			assert.Len(t, shards, 2, "ActiveShards() must only return the Active shards")
+			assert.Len(t, shards, 1, "ActiveShards() must only return the Active shards")
 
 			// Assert it's a copy by maliciously modifying it.
 			require.NotEmpty(t, shards, "Test setup assumes shards are present")
@@ -228,7 +226,7 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 		require.NoError(t, err)
 
 		// Prove the registry's internal state was not mutated by the modification.
-		assert.NotNil(t, h.fr.activeShards[0],
+		assert.NotNil(t, h.fr.shard,
 			"Modifying the slice returned by ActiveShards() must not affect the registry's internal state")
 	})
 }
@@ -238,32 +236,28 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 func TestFlowRegistry_Stats(t *testing.T) {
 	t.Parallel()
 
-	h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+	h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
 	keyHigh := flowcontrol.FlowKey{ID: "high-pri-flow", Priority: highPriority}
 	keyLow := flowcontrol.FlowKey{ID: "low-pri-flow", Priority: lowPriority}
 	h.openConnectionOnFlow(keyHigh)
 	h.openConnectionOnFlow(keyLow)
 
-	shards := h.fr.allShards
-	require.Len(t, shards, 2, "Test setup assumes 2 shards")
-	mqHigh0, _ := shards[0].ManagedQueue(keyHigh)
-	mqHigh1, _ := shards[1].ManagedQueue(keyHigh)
-	mqLow1, _ := shards[1].ManagedQueue(keyLow)
-	require.NoError(t, mqHigh0.Add(mocks.NewMockQueueItemAccessor(10, "req1", keyHigh)),
+	require.NotNil(t, h.fr.shard, "Test setup assumes one shard")
+	mqHigh, _ := h.fr.shard.ManagedQueue(keyHigh)
+	mqLow, _ := h.fr.shard.ManagedQueue(keyLow)
+	require.NoError(t, mqHigh.Add(mocks.NewMockQueueItemAccessor(10, "req1", keyHigh)),
 		"Adding item to queue should not fail")
-	require.NoError(t, mqHigh1.Add(mocks.NewMockQueueItemAccessor(20, "req2", keyHigh)),
-		"Adding item to queue should not fail")
-	require.NoError(t, mqLow1.Add(mocks.NewMockQueueItemAccessor(30, "req3", keyLow)),
+	require.NoError(t, mqLow.Add(mocks.NewMockQueueItemAccessor(30, "req3", keyLow)),
 		"Adding item to queue should not fail")
 
 	// Although the production `Stats()` method provides a 'fuzzy snapshot' under high contention, our test validates it
 	// in a quiescent state, so these assertions can and must be exact.
 	globalStats := h.fr.Stats()
-	assert.Equal(t, uint64(3), globalStats.TotalLen, "Global TotalLen should be the sum of all items")
-	assert.Equal(t, uint64(60), globalStats.TotalByteSize, "Global TotalByteSize should be the sum of all item sizes")
+	assert.Equal(t, uint64(2), globalStats.TotalLen, "Global TotalLen should be the sum of all items")
+	assert.Equal(t, uint64(40), globalStats.TotalByteSize, "Global TotalByteSize should be the sum of all item sizes")
 
 	shardStats := h.fr.ShardStats()
-	require.Len(t, shardStats, 2, "Should return stats for 2 shards")
+	require.Len(t, shardStats, 1, "Should return stats for one shard")
 	var totalShardLen, totalShardBytes uint64
 	for _, ss := range shardStats {
 		assert.True(t, ss.IsActive, "All shards should be active in this test")
@@ -365,150 +359,6 @@ func TestFlowRegistry_GarbageCollection(t *testing.T) {
 		// The GC should have seen the leaseCount > 0 and skipped the deletion, despite the expired timestamp.
 		h.assertFlowExists(key, "Flow must not be collected if lease > 0, even if idle timer is expired")
 	})
-
-	t.Run("ShouldCollectDrainingShard_OnlyWhenEmpty", func(t *testing.T) {
-		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
-		key := flowcontrol.FlowKey{ID: "flow-on-draining-shard", Priority: highPriority}
-		h.openConnectionOnFlow(key)
-
-		// Add an item to a queue on the soon-to-be Draining shard to keep it busy.
-		drainingShard := h.fr.activeShards[1] // The shard that will become draining.
-		mq, err := drainingShard.ManagedQueue(key)
-		require.NoError(t, err, "Test setup: getting queue on draining shard failed")
-		item := mocks.NewMockQueueItemAccessor(100, "req1", key)
-		require.NoError(t, mq.Add(item), "Adding item to non-active shard should be allowed for in-flight requests")
-
-		// Scale down to mark one shard as Draining.
-		require.NoError(t, h.fr.updateShardCount(1), "Test setup: scale down should succeed")
-		require.Len(t, h.fr.drainingShards, 1, "Test setup: one shard should be draining")
-
-		// Trigger a GC cycle while the shard is not empty.
-		h.fr.sweepDrainingShards()
-		require.Len(t, h.fr.drainingShards, 1, "Draining shard should not be collected while it is not empty")
-
-		// Empty the shard and trigger GC again.
-		_, err = mq.Remove(item.Handle())
-		require.NoError(t, err, "Test setup: removing item from draining shard failed")
-		h.fr.sweepDrainingShards()
-		assert.Empty(t, h.fr.drainingShards, "Draining shard should be collected after it becomes empty")
-	})
-}
-
-// --- Shard Management Tests ---
-
-func TestFlowRegistry_UpdateShardCount(t *testing.T) {
-	t.Parallel()
-	const (
-		globalCapacity = 100
-		bandCapacity   = 50
-	)
-	testCases := []struct {
-		name                                string
-		initialShardCount                   int
-		targetShardCount                    int
-		expectedActiveCount                 int
-		expectedPartitionedGlobalCapacities map[uint64]int
-		expectedPartitionedBandCapacities   map[uint64]int
-		expectErrIs                         error // Optional
-	}{
-		{
-			name:                                "NoOp_ScaleToSameCount",
-			initialShardCount:                   2,
-			targetShardCount:                    2,
-			expectedActiveCount:                 2,
-			expectedPartitionedGlobalCapacities: map[uint64]int{50: 2},
-			expectedPartitionedBandCapacities:   map[uint64]int{25: 2},
-		},
-		{
-			name:                                "Succeeds_ScaleUp_FromOne",
-			initialShardCount:                   1,
-			targetShardCount:                    4,
-			expectedActiveCount:                 4,
-			expectedPartitionedGlobalCapacities: map[uint64]int{25: 4},
-			expectedPartitionedBandCapacities:   map[uint64]int{12: 2, 13: 2},
-		},
-		{
-			name:                                "Succeeds_ScaleDown_ToOne",
-			initialShardCount:                   3,
-			targetShardCount:                    1,
-			expectedActiveCount:                 1,
-			expectedPartitionedGlobalCapacities: map[uint64]int{100: 1},
-			expectedPartitionedBandCapacities:   map[uint64]int{50: 1},
-		},
-		{
-			name:                                "Error_ScaleDown_ToZero",
-			initialShardCount:                   2,
-			targetShardCount:                    0,
-			expectedActiveCount:                 2,
-			expectErrIs:                         contracts.ErrInvalidShardCount,
-			expectedPartitionedGlobalCapacities: map[uint64]int{50: 2},
-			expectedPartitionedBandCapacities:   map[uint64]int{25: 2},
-		},
-		{
-			name:                                "Error_ScaleDown_ToNegative",
-			initialShardCount:                   1,
-			targetShardCount:                    -1,
-			expectedActiveCount:                 1,
-			expectErrIs:                         contracts.ErrInvalidShardCount,
-			expectedPartitionedGlobalCapacities: map[uint64]int{100: 1},
-			expectedPartitionedBandCapacities:   map[uint64]int{50: 1},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			handle := newTestPluginsHandle(t)
-			band, err := NewPriorityBandConfig(handle, highPriority, WithBandMaxBytes(bandCapacity))
-			require.NoError(t, err)
-
-			config, err := NewConfig(
-				handle,
-				WithMaxBytes(globalCapacity),
-				WithInitialShardCount(tc.initialShardCount),
-				WithPriorityBand(band),
-			)
-			require.NoError(t, err, "Test setup: creating config should not fail")
-
-			h := newRegistryTestHarness(t, harnessOptions{config: config})
-			key := flowcontrol.FlowKey{ID: "flow", Priority: highPriority}
-			h.openConnectionOnFlow(key)
-
-			err = h.fr.updateShardCount(tc.targetShardCount)
-			if tc.expectErrIs != nil {
-				require.Error(t, err, "UpdateShardCount should have returned an error")
-				assert.ErrorIs(t, err, tc.expectErrIs, "Error should be the expected type")
-			} else {
-				require.NoError(t, err, "UpdateShardCount should not have returned an error")
-			}
-
-			globalCapacities := make(map[uint64]int)
-			bandCapacities := make(map[uint64]int)
-
-			h.fr.mu.RLock()
-			finalActiveCount := len(h.fr.activeShards)
-			finalDrainingCount := len(h.fr.drainingShards)
-			for _, shard := range h.fr.activeShards {
-				stats := shard.Stats()
-				globalCapacities[stats.TotalCapacityBytes]++
-				bandCapacities[stats.PerPriorityBandStats[highPriority].CapacityBytes]++
-				h.assertFlowExists(key, "Shard %s should contain the existing flow", shard.ID())
-			}
-			h.fr.mu.RUnlock()
-
-			expectedDrainingCount := 0
-			if tc.initialShardCount > tc.expectedActiveCount {
-				expectedDrainingCount = tc.initialShardCount - tc.expectedActiveCount
-			}
-			assert.Equal(t, tc.expectedActiveCount, finalActiveCount, "Final active shard count is incorrect")
-			assert.Equal(t, expectedDrainingCount, finalDrainingCount, "Final draining shard count in registry is incorrect")
-			assert.Equal(t, tc.expectedPartitionedGlobalCapacities, globalCapacities,
-				"Global capacity re-partitioning incorrect")
-			assert.Equal(t, tc.expectedPartitionedBandCapacities, bandCapacities, "Band capacity re-partitioning incorrect")
-		})
-	}
 }
 
 // --- Dynamic Provisioning Tests ---
@@ -538,10 +388,8 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		_, existsInStats := stats.PerPriorityBandStats[dynamicPrio]
 		assert.True(t, existsInStats, "Dynamic priority must appear in global stats")
 
-		for _, shard := range h.fr.activeShards {
-			_, err := shard.ManagedQueue(key)
-			assert.NoError(t, err, "Dynamic band must be provisioned on shard %s", shard.ID())
-		}
+		_, err = h.fr.shard.ManagedQueue(key)
+		assert.NoError(t, err, "Dynamic band must be provisioned on shard %s", h.fr.shard.ID())
 	})
 
 	t.Run("ShouldHandleConcurrentDynamicCreation", func(t *testing.T) {
@@ -569,7 +417,7 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		assert.True(t, exists, "Band should exist after concurrent creation attempts")
 	})
 
-	t.Run("ShouldPersistDynamicBands_AcrossScalingEvents", func(t *testing.T) {
+	t.Run("ShouldPersistDynamicBands", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
 		dynamicPrio := 88
@@ -578,20 +426,11 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		// Create dynamic band on Shard 0.
 		h.openConnectionOnFlow(key)
 
-		// Scale Up -> Shard 1 created.
-		err := h.fr.updateShardCount(2)
-		require.NoError(t, err)
-
-		// The repartition logic should have carried the dynamic band definition to the new shard config.
-		h.fr.mu.RLock()
-		newShard := h.fr.activeShards[1]
-		h.fr.mu.RUnlock()
-
-		_, policyErr := newShard.FairnessPolicy(dynamicPrio)
+		_, policyErr := h.fr.shard.FairnessPolicy(dynamicPrio)
 		assert.NoError(t, policyErr, "New shard must have the dynamic priority band configured")
 
-		mq, err := newShard.ManagedQueue(key)
-		require.NoError(t, err, "Existing flows should be auto-synced to new shards during scale-up")
+		mq, err := h.fr.shard.ManagedQueue(key)
+		require.NoError(t, err, "Existing flows should be auto-synced")
 		require.NotNil(t, mq)
 	})
 }
@@ -723,52 +562,6 @@ func TestFlowRegistry_Concurrency(t *testing.T) {
 		assert.NotSame(t, originalState, newVal, "Should have created a new flow object, not reused the marked one")
 	})
 
-	t.Run("MixedAdminAndDataPlaneWorkload", func(t *testing.T) {
-		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
-		const (
-			numWorkers    = 10
-			opsPerWorker  = 50
-			maxShardCount = 4
-		)
-
-		var wg sync.WaitGroup
-		wg.Add(numWorkers + 1) // +1 for the scaling goroutine
-
-		// Data Plane Workers: Constantly creating new flows.
-		for i := range numWorkers {
-			workerID := i
-			go func() {
-				defer wg.Done()
-				for j := range opsPerWorker {
-					key := flowcontrol.FlowKey{ID: fmt.Sprintf("flow-%d-%d", workerID, j), Priority: highPriority}
-					_ = h.fr.WithConnection(key, func(contracts.ActiveFlowConnection) error { return nil })
-				}
-			}()
-		}
-
-		// Admin Worker: Constantly scaling the number of shards up and down.
-		go func() {
-			defer wg.Done()
-			for i := 1; i < maxShardCount; i++ {
-				_ = h.fr.updateShardCount(i + 1)
-				_ = h.fr.updateShardCount(i)
-			}
-		}()
-
-		wg.Wait()
-
-		// The test completing without a race condition is the primary assertion.
-		// We can also assert a consistent final state.
-		assert.Len(t, h.fr.activeShards, maxShardCount-1, "Final active shard count should be consistent")
-		flowCount := 0
-		h.fr.flowStates.Range(func(_, _ any) bool {
-			flowCount++
-			return true
-		})
-		assert.Equal(t, numWorkers*opsPerWorker, flowCount, "All concurrently registered flows must be present")
-	})
-
 	t.Run("ConcurrentDynamicBandProvisioning_WithGC", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{})
@@ -843,7 +636,7 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 
 	t.Run("ShouldDeleteDynamicBandFromAllShards", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 3})
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
 
 		// Create a dynamic priority band via JIT provisioning
 		err := h.fr.ensurePriorityBand(dynamicPrio)
@@ -855,20 +648,15 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 		h.fr.mu.RUnlock()
 		require.True(t, exists, "Dynamic band should exist in registry config")
 
-		// Verify band exists in all shards
-		h.fr.mu.RLock()
-		shards := h.fr.allShards
-		h.fr.mu.RUnlock()
+		// Verify band exists in shard
 
-		for i, shard := range shards {
-			_, ok := shard.priorityBands.Load(dynamicPrio)
-			require.True(t, ok, "Band should exist in shard %d", i)
+		_, ok := h.fr.shard.priorityBands.Load(dynamicPrio)
+		require.True(t, ok, "Band should exist in the shard")
 
-			shard.mu.RLock()
-			_, ok = shard.config.PriorityBands[dynamicPrio]
-			shard.mu.RUnlock()
-			require.True(t, ok, "Band should exist in shard %d config", i)
-		}
+		h.fr.shard.mu.RLock()
+		_, ok = h.fr.shard.config.PriorityBands[dynamicPrio]
+		h.fr.shard.mu.RUnlock()
+		require.True(t, ok, "Band should exist in shard config")
 
 		// Delete the band
 		h.fr.deletePriorityBand(dynamicPrio)
@@ -883,23 +671,21 @@ func TestFlowRegistry_deletePriorityBand(t *testing.T) {
 		_, exists = h.fr.perPriorityBandStats.Load(dynamicPrio)
 		assert.False(t, exists, "Band should be removed from stats tracking")
 
-		// Verify band removed from all shards
-		for i, shard := range shards {
-			_, ok := shard.priorityBands.Load(dynamicPrio)
-			assert.False(t, ok, "Band should be removed from shard %d", i)
+		// Verify band removed from shard
+		_, ok = h.fr.shard.priorityBands.Load(dynamicPrio)
+		assert.False(t, ok, "Band should be removed from shard")
 
-			shard.mu.RLock()
-			_, ok = shard.config.PriorityBands[dynamicPrio]
-			shard.mu.RUnlock()
-			assert.False(t, ok, "Band should be removed from shard %d config", i)
+		h.fr.shard.mu.RLock()
+		_, ok = h.fr.shard.config.PriorityBands[dynamicPrio]
+		h.fr.shard.mu.RUnlock()
+		assert.False(t, ok, "Band should be removed from shard config")
 
-			// Verify removed from ordered list
-			shard.mu.RLock()
-			orderedList := shard.orderedPriorityLevels
-			shard.mu.RUnlock()
-			for _, p := range orderedList {
-				assert.NotEqual(t, dynamicPrio, p, "Band priority should be removed from ordered list in shard %d", i)
-			}
+		// Verify removed from ordered list
+		h.fr.shard.mu.RLock()
+		orderedList := h.fr.shard.orderedPriorityLevels
+		h.fr.shard.mu.RUnlock()
+		for _, p := range orderedList {
+			assert.NotEqual(t, dynamicPrio, p, "Band priority should be removed from ordered list in shard")
 		}
 	})
 
@@ -1045,22 +831,17 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 
 	t.Run("ShouldCollectBand_AcrossMultipleShards", func(t *testing.T) {
 		t.Parallel()
-		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 3})
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 
 		// Create flow on all shards
 		h.openConnectionOnFlow(key)
 
-		// Verify band exists on all shards
-		h.fr.mu.RLock()
-		shards := h.fr.allShards
-		h.fr.mu.RUnlock()
-		require.Len(t, shards, 3, "Should have 3 shards")
+		// Verify band exists on shard
+		require.NotNil(t, h.fr.shard, "Should have a shard")
 
-		for i, shard := range shards {
-			_, ok := shard.priorityBands.Load(dynamicPrio)
-			require.True(t, ok, "Band should exist on shard %d", i)
-		}
+		_, ok := h.fr.shard.priorityBands.Load(dynamicPrio)
+		require.True(t, ok, "Band should exist on shard")
 
 		// Collect the flow
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
@@ -1076,17 +857,15 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		h.fr.mu.RUnlock()
 		assert.False(t, exists, "Band should be removed from registry config")
 
-		// Verify band is removed from all shards
-		for i, shard := range shards {
-			_, ok := shard.priorityBands.Load(dynamicPrio)
-			assert.False(t, ok, "Band should be removed from shard %d", i)
+		// Verify band is removed from the shard
+		_, ok = h.fr.shard.priorityBands.Load(dynamicPrio)
+		assert.False(t, ok, "Band should be removed from the shard")
 
-			// Verify config also cleaned up
-			shard.mu.RLock()
-			_, configExists := shard.config.PriorityBands[dynamicPrio]
-			shard.mu.RUnlock()
-			assert.False(t, configExists, "Band should be removed from shard %d config", i)
-		}
+		// Verify config also cleaned up
+		h.fr.shard.mu.RLock()
+		_, configExists := h.fr.shard.config.PriorityBands[dynamicPrio]
+		h.fr.shard.mu.RUnlock()
+		assert.False(t, configExists, "Band should be removed from the shard config")
 	})
 
 	t.Run("ShouldHandleConcurrentFlowCreation_DuringBandGC", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The Flow Control component is a critical component in the Endpoint Picker (EPP), enabling it to throttle workloads thus preventing over committing Model Server resources.

Issue #2628 was created to describe a set of simplifications to the Flow Control layer. This PR is the first in a series to implement issue #2628.

In particular this PR changes the Flow Control layer to only have a single shard.

**Which issue(s) this PR fixes**:
Refs #2628

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
