### PR TITLE
fix(test): Add unit test for random picker

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/picker/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/picker_test.go
@@ -136,6 +136,98 @@ func TestPickMaxScorePicker(t *testing.T) {
 	}
 }
 
+func TestPickRandomPicker(t *testing.T) {
+	const (
+		testIterations = 10000
+		tolerance      = 0.05 // Verify within tolerance ±5%
+	)
+
+	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
+	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)
+	endpoint3 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil)
+
+	tests := []struct {
+		name    string
+		picker  fwksched.Picker
+		input   []*fwksched.ScoredEndpoint
+		numPods int // expected number of returned endpoints
+	}{
+		{
+			name:   "Single endpoint returned from multiple candidates",
+			picker: NewRandomPicker(1),
+			input: []*fwksched.ScoredEndpoint{
+				{Endpoint: endpoint1, Score: 10},
+				{Endpoint: endpoint2, Score: 20},
+				{Endpoint: endpoint3, Score: 30},
+			},
+			numPods: 1,
+		},
+		{
+			name:   "Multiple endpoints returned, more candidates than needed",
+			picker: NewRandomPicker(2),
+			input: []*fwksched.ScoredEndpoint{
+				{Endpoint: endpoint1, Score: 10},
+				{Endpoint: endpoint2, Score: 20},
+				{Endpoint: endpoint3, Score: 30},
+			},
+			numPods: 2,
+		},
+		{
+			name:   "Fewer candidates than maxNumOfEndpoints",
+			picker: NewRandomPicker(5),
+			input: []*fwksched.ScoredEndpoint{
+				{Endpoint: endpoint1, Score: 10},
+				{Endpoint: endpoint2, Score: 20},
+			},
+			numPods: 2,
+		},
+		{
+			name:   "Exact number of candidates as maxNumOfEndpoints",
+			picker: NewRandomPicker(3),
+			input: []*fwksched.ScoredEndpoint{
+				{Endpoint: endpoint1, Score: 10},
+				{Endpoint: endpoint2, Score: 20},
+				{Endpoint: endpoint3, Score: 30},
+			},
+			numPods: 3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Verify correct number of endpoints returned
+			result := test.picker.Pick(context.Background(), fwksched.NewCycleState(), test.input)
+			got := result.TargetEndpoints
+			if len(got) != test.numPods {
+				t.Errorf("Expected %d endpoints, got %d", test.numPods, len(got))
+			}
+
+			// Verify uniform distribution: each endpoint's selection probability
+			// should be min(numPods/numCandidates, 1.0), regardless of scores.
+			selectionCounts := make(map[string]int)
+			for _, ep := range test.input {
+				selectionCounts[ep.GetMetadata().NamespacedName.Name] = 0
+			}
+
+			for range testIterations {
+				res := test.picker.Pick(context.Background(), fwksched.NewCycleState(), test.input)
+				for _, ep := range res.TargetEndpoints {
+					selectionCounts[ep.GetMetadata().NamespacedName.Name]++
+				}
+			}
+
+			expectedProb := math.Min(float64(test.numPods)/float64(len(test.input)), 1.0)
+			for name, count := range selectionCounts {
+				actualProb := float64(count) / float64(testIterations)
+				if math.Abs(actualProb-expectedProb) > tolerance {
+					t.Errorf("Endpoint %s: expected probability %.3f ±%.1f%%, got %.3f (count: %d/%d)",
+						name, expectedProb, tolerance*100, actualProb, count, testIterations)
+				}
+			}
+		})
+	}
+}
+
 func TestPickWeightedRandomPicker(t *testing.T) {
 	const (
 		testIterations = 10000


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
/kind test
