### PR TITLE
[Fix] typo in pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -87,7 +87,7 @@ type Config struct {
 	// The input prompt is broken into sizes of BlockSizeTokens to calculate block hashes. Requests
 	// with length shorter than the block size will be ignored.
 	BlockSizeTokens int `json:"blockSizeTokens"`
-	// Depricated: Legacy block size defined in number of characters.
+	// Deprecated: Legacy block size defined in number of characters.
 	// In case only BlockSize is defined in the configuration - plugin initialization will fail.
 	// In case both BlockSize and BlockSizeTokens are defined - BlockSizeTokens is used.
 	BlockSize int `json:"blockSize"`
@@ -185,7 +185,7 @@ func PrefixCachePluginFactory(name string, rawParameters json.RawMessage, handle
 func New(ctx context.Context, config Config) (*Plugin, error) {
 	// invalid configuration: only BlockSize is defined
 	if config.BlockSize > 0 && config.BlockSizeTokens <= 0 {
-		err := errors.New("BlockSize is depricated, use BlockSizeTokens instead, the value should be defined in tokens")
+		err := errors.New("BlockSize is deprecated, use BlockSizeTokens instead, the value should be defined in tokens")
 		log.FromContext(ctx).V(logutil.DEFAULT).Error(err, "invalid prefix plugin configuration")
 		return nil, err
 	}


### PR DESCRIPTION
Replace `depricated` with `deprecated`

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind cleanup 
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
