### PR TITLE
Generalize the request type passed down the framework plugins: rename LLM->Inference

### DIFF
--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -640,7 +640,7 @@ func (m *mockScorer) Category() framework.ScorerCategory {
 	return framework.Distribution
 }
 
-func (m *mockScorer) Score(context.Context, *framework.CycleState, *framework.LLMRequest, []framework.Endpoint) map[framework.Endpoint]float64 {
+func (m *mockScorer) Score(context.Context, *framework.CycleState, *framework.InferenceRequest, []framework.Endpoint) map[framework.Endpoint]float64 {
 	return nil
 }
 
@@ -660,11 +660,11 @@ type mockHandler struct{ mockPlugin }
 // compile-time type assertion
 var _ framework.ProfileHandler = &mockHandler{}
 
-func (m *mockHandler) Pick(context.Context, *framework.CycleState, *framework.LLMRequest, map[string]framework.SchedulerProfile,
+func (m *mockHandler) Pick(context.Context, *framework.CycleState, *framework.InferenceRequest, map[string]framework.SchedulerProfile,
 	map[string]*framework.ProfileRunResult) map[string]framework.SchedulerProfile {
 	return nil
 }
-func (m *mockHandler) ProcessResults(context.Context, *framework.CycleState, *framework.LLMRequest,
+func (m *mockHandler) ProcessResults(context.Context, *framework.CycleState, *framework.InferenceRequest,
 	map[string]*framework.ProfileRunResult) (*framework.SchedulingResult, error) {
 	return nil, nil
 }

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -58,7 +58,7 @@ func (m *mockPrepareRequestDataP) Consumes() map[string]any {
 	return m.consumes
 }
 
-func (m *mockPrepareRequestDataP) PrepareRequestData(ctx context.Context, request *fwksch.LLMRequest, endpoints []fwksch.Endpoint) error {
+func (m *mockPrepareRequestDataP) PrepareRequestData(ctx context.Context, request *fwksch.InferenceRequest, endpoints []fwksch.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, &mockProducedDataType{value: 42})
 	return nil
 }

--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -179,16 +179,16 @@ type benchRequest struct {
 }
 
 // --- stubs required by FlowControlRequest interface ---
-func (r *benchRequest) FlowKey() flowcontrol.FlowKey             { return r.key }
-func (r *benchRequest) ByteSize() uint64                         { return r.byteSize }
-func (r *benchRequest) InitialEffectiveTTL() time.Duration       { return 5 * time.Minute }
-func (r *benchRequest) ID() string                               { return "bench-req" }
-func (r *benchRequest) GetMetadata() map[string]any              { return nil }
-func (r *benchRequest) InferencePoolName() string                { return "bench-pool" }
-func (r *benchRequest) ModelName() string                        { return "bench-model" }
-func (r *benchRequest) TargetModelName() string                  { return "bench-target" }
-func (r *benchRequest) InferenceRequest() *scheduling.LLMRequest { return nil }
-func (r *benchRequest) ReceivedTimestamp() time.Time             { return time.Now() }
+func (r *benchRequest) FlowKey() flowcontrol.FlowKey                   { return r.key }
+func (r *benchRequest) ByteSize() uint64                               { return r.byteSize }
+func (r *benchRequest) InitialEffectiveTTL() time.Duration             { return 5 * time.Minute }
+func (r *benchRequest) ID() string                                     { return "bench-req" }
+func (r *benchRequest) GetMetadata() map[string]any                    { return nil }
+func (r *benchRequest) InferencePoolName() string                      { return "bench-pool" }
+func (r *benchRequest) ModelName() string                              { return "bench-model" }
+func (r *benchRequest) TargetModelName() string                        { return "bench-target" }
+func (r *benchRequest) InferenceRequest() *scheduling.InferenceRequest { return nil }
+func (r *benchRequest) ReceivedTimestamp() time.Time                   { return time.Now() }
 
 // setupRegistry provisions the concrete FlowRegistry.
 func setupRegistry(

--- a/pkg/epp/flowcontrol/eviction/plugin.go
+++ b/pkg/epp/flowcontrol/eviction/plugin.go
@@ -61,7 +61,7 @@ func (p *Plugin) TypedName() plugin.TypedName {
 // It tracks the request and, if the filter policy accepts it, adds it to the eviction queue.
 func (p *Plugin) PreRequest(
 	ctx context.Context,
-	request *scheduling.LLMRequest,
+	request *scheduling.InferenceRequest,
 	result *scheduling.SchedulingResult,
 ) {
 	if request == nil || result == nil || len(result.ProfileResults) == 0 {
@@ -110,7 +110,7 @@ func (p *Plugin) PreRequest(
 // On the final call (EndOfStream == true), it removes the request from tracking and the eviction queue.
 func (p *Plugin) ResponseBody(
 	ctx context.Context,
-	request *scheduling.LLMRequest,
+	request *scheduling.InferenceRequest,
 	response *requestcontrol.Response,
 	targetEndpoint *datalayer.EndpointMetadata,
 ) {

--- a/pkg/epp/framework/interface/flowcontrol/eviction.go
+++ b/pkg/epp/framework/interface/flowcontrol/eviction.go
@@ -36,7 +36,7 @@ type EvictionItem struct {
 	// TargetURL is the base URL of the model server serving this request.
 	TargetURL string
 	// Request is the original scheduling request.
-	Request *scheduling.LLMRequest
+	Request *scheduling.InferenceRequest
 	// TargetEndpoint is the metadata of the endpoint serving this request.
 	TargetEndpoint *datalayer.EndpointMetadata
 }

--- a/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
+++ b/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
@@ -29,7 +29,7 @@ import (
 type MockFlowControlRequest struct {
 	FlowKeyV             flowcontrol.FlowKey
 	ByteSizeV            uint64
-	InferenceRequestV    *scheduling.LLMRequest
+	InferenceRequestV    *scheduling.InferenceRequest
 	ReceivedTimestampV   time.Time
 	InitialEffectiveTTLV time.Duration
 	IDV                  string
@@ -65,7 +65,7 @@ func NewMockFlowControlRequest(
 
 func (m *MockFlowControlRequest) FlowKey() flowcontrol.FlowKey { return m.FlowKeyV }
 func (m *MockFlowControlRequest) ByteSize() uint64             { return m.ByteSizeV }
-func (m *MockFlowControlRequest) InferenceRequest() *scheduling.LLMRequest {
+func (m *MockFlowControlRequest) InferenceRequest() *scheduling.InferenceRequest {
 	return m.InferenceRequestV
 }
 func (m *MockFlowControlRequest) ReceivedTimestamp() time.Time       { return m.ReceivedTimestampV }

--- a/pkg/epp/framework/interface/flowcontrol/request.go
+++ b/pkg/epp/framework/interface/flowcontrol/request.go
@@ -40,7 +40,7 @@ type FlowControlRequest interface {
 	ByteSize() uint64
 
 	// InferenceRequest returns the inference request passed to the scheduling layer.
-	InferenceRequest() *scheduling.LLMRequest
+	InferenceRequest() *scheduling.InferenceRequest
 
 	// ReceivedTimestamp returns the timestamp when the request was received by the server.
 	ReceivedTimestamp() time.Time

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -35,7 +35,7 @@ const (
 // before a request is sent to the selected model server.
 type PreRequest interface {
 	plugin.Plugin
-	PreRequest(ctx context.Context, request *types.LLMRequest, schedulingResult *types.SchedulingResult)
+	PreRequest(ctx context.Context, request *types.InferenceRequest, schedulingResult *types.SchedulingResult)
 }
 
 // ResponseHeader is called by the director after the response headers are successfully received
@@ -43,7 +43,7 @@ type PreRequest interface {
 // The given pod argument is the pod that served the request.
 type ResponseHeader interface {
 	plugin.Plugin
-	ResponseHeader(ctx context.Context, request *types.LLMRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
+	ResponseHeader(ctx context.Context, request *types.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
 // ResponseBody is the primary hook for processing response data.
@@ -61,7 +61,7 @@ type ResponseHeader interface {
 // between success, errors, and disconnects.
 type ResponseBody interface {
 	plugin.Plugin
-	ResponseBody(ctx context.Context, request *types.LLMRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
+	ResponseBody(ctx context.Context, request *types.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
 // PrepareRequestData is called by the director before scheduling requests.
@@ -69,7 +69,7 @@ type ResponseBody interface {
 type PrepareDataPlugin interface {
 	plugin.ProducerPlugin
 	plugin.ConsumerPlugin
-	PrepareRequestData(ctx context.Context, request *types.LLMRequest, pods []types.Endpoint) error
+	PrepareRequestData(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error
 }
 
 // AdmissionPlugin is called by the director after the prepare data phase and before scheduling.
@@ -79,5 +79,5 @@ type AdmissionPlugin interface {
 	plugin.Plugin
 	// AdmitRequest returns the denial reason, wrapped as error if the request is denied.
 	// If the request is allowed, it returns nil.
-	AdmitRequest(ctx context.Context, request *types.LLMRequest, pods []types.Endpoint) error
+	AdmitRequest(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error
 }

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package requesthandle
+package requesthandling
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 type Parser interface {
 	fwkplugin.Plugin
 	// ParseRequest parses the request body and headers and returns a map representation.
-	ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error)
+	ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.InferenceRequestBody, error)
 
 	// ParseResponse parses the response payload.
 	// For streaming responses , this method is invoked multiple times (once per chunk),

--- a/pkg/epp/framework/interface/scheduling/plugins.go
+++ b/pkg/epp/framework/interface/scheduling/plugins.go
@@ -44,21 +44,21 @@ type ProfileHandler interface {
 	plugin.Plugin
 	// Pick selects the SchedulingProfiles to run from a list of candidate profiles, while taking into consideration the request properties
 	// and the previously executed SchedluderProfile cycles along with their results.
-	Pick(ctx context.Context, cycleState *CycleState, request *LLMRequest, profiles map[string]SchedulerProfile,
+	Pick(ctx context.Context, cycleState *CycleState, request *InferenceRequest, profiles map[string]SchedulerProfile,
 		profileResults map[string]*ProfileRunResult) map[string]SchedulerProfile
 
 	// ProcessResults handles the outcome of the profile runs after all profiles ran.
 	// It may aggregate results, log test profile outputs, or apply custom logic. It specifies in the SchedulingResult the
 	// key of the primary profile that should be used to get the request selected destination.
 	// When a profile run fails, its result in the profileResults map is nil.
-	ProcessResults(ctx context.Context, cycleState *CycleState, request *LLMRequest,
+	ProcessResults(ctx context.Context, cycleState *CycleState, request *InferenceRequest,
 		profileResults map[string]*ProfileRunResult) (*SchedulingResult, error)
 }
 
 // Filter defines the interface for filtering a list of pods based on context.
 type Filter interface {
 	plugin.Plugin
-	Filter(ctx context.Context, cycleState *CycleState, request *LLMRequest, pods []Endpoint) []Endpoint
+	Filter(ctx context.Context, cycleState *CycleState, request *InferenceRequest, pods []Endpoint) []Endpoint
 }
 
 // Scorer defines the interface for scoring a list of pods based on context.
@@ -68,7 +68,7 @@ type Filter interface {
 type Scorer interface {
 	plugin.Plugin
 	Category() ScorerCategory
-	Score(ctx context.Context, cycleState *CycleState, request *LLMRequest, pods []Endpoint) map[Endpoint]float64
+	Score(ctx context.Context, cycleState *CycleState, request *InferenceRequest, pods []Endpoint) map[Endpoint]float64
 }
 
 // Picker picks the final pod(s) to send the request to.

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -41,14 +41,14 @@ type RequestObjectives struct {
 	Priority int
 }
 
-// LLMRequest is a structured representation of the fields we parse out of the LLMRequest body.
-type LLMRequest struct {
+// InferenceRequest is a structured representation of the fields we parse out of the InferenceRequest body.
+type InferenceRequest struct {
 	// RequestId is the Envoy generated Id for the request being processed
 	RequestId string
 	// TargetModel is the final target model after traffic split.
 	TargetModel string
 	// Data contains the request-body fields that we parse out as user input.
-	Body *LLMRequestBody
+	Body *InferenceRequestBody
 	// Headers is a map of the request headers.
 	Headers map[string]string
 	// Request Objective
@@ -87,7 +87,7 @@ type MultiModalFeature struct {
 	Length int
 }
 
-func (r *LLMRequest) String() string {
+func (r *InferenceRequest) String() string {
 	if r == nil {
 		return nilString
 	}
@@ -122,10 +122,10 @@ type RawPayload []byte
 func (RawPayload) isRequestPayload() {}
 func (RawPayload) IsParsed() bool    { return false }
 
-// LLMRequestBody contains the request-body fields that we parse out as user input,
+// InferenceRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
-// An LLMRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, or EmbeddingsRequest.
-type LLMRequestBody struct {
+// An InferenceRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, or EmbeddingsRequest.
+type InferenceRequestBody struct {
 	// CompletionsRequest is the representation of the OpenAI /v1/completions request body.
 	Completions *CompletionsRequest `json:"completions,omitempty"`
 	// ChatCompletionsRequest is the representation of the OpenAI /v1/chat/completions request body.
@@ -148,7 +148,7 @@ type LLMRequestBody struct {
 
 // PromptText returns a plain-text representation of the prompt from whichever
 // API type is populated, analogous to CacheSalt().
-func (r *LLMRequestBody) PromptText() string {
+func (r *InferenceRequestBody) PromptText() string {
 	switch {
 	case r.Completions != nil:
 		return r.Completions.Prompt.PlainText()
@@ -176,7 +176,7 @@ func (r *LLMRequestBody) PromptText() string {
 	}
 }
 
-func (r *LLMRequestBody) CacheSalt() string {
+func (r *InferenceRequestBody) CacheSalt() string {
 	if r.Conversations != nil {
 		return r.Conversations.CacheSalt
 	}
@@ -521,5 +521,5 @@ type SchedulingResult struct {
 }
 
 type SchedulerProfile interface {
-	Run(ctx context.Context, request *LLMRequest, cycleState *CycleState, candidateEndpoints []Endpoint) (*ProfileRunResult, error)
+	Run(ctx context.Context, request *InferenceRequest, cycleState *CycleState, candidateEndpoints []Endpoint) (*ProfileRunResult, error)
 }

--- a/pkg/epp/framework/interface/scheduling/types_test.go
+++ b/pkg/epp/framework/interface/scheduling/types_test.go
@@ -22,15 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLLMRequestBody_PromptText(t *testing.T) {
+func TestInferenceRequestBody_PromptText(t *testing.T) {
 	tests := []struct {
 		name     string
-		body     *LLMRequestBody
+		body     *InferenceRequestBody
 		expected string
 	}{
 		{
 			name: "completions request returns prompt directly",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				Completions: &CompletionsRequest{
 					Prompt: Prompt{Raw: "What is the meaning of life?"},
 				},
@@ -39,7 +39,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "completions request with array of strings prompt",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				Completions: &CompletionsRequest{
 					Prompt: Prompt{Strings: []string{"Why is", "the sky blue?"}},
 				},
@@ -48,7 +48,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "chat completions with single raw message",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				ChatCompletions: &ChatCompletionsRequest{
 					Messages: []Message{
 						{Role: "user", Content: Content{Raw: "Hello, how are you?"}},
@@ -59,7 +59,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "chat completions with multiple messages",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				ChatCompletions: &ChatCompletionsRequest{
 					Messages: []Message{
 						{Role: "system", Content: Content{Raw: "You are a helpful assistant."}},
@@ -71,7 +71,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "chat completions with structured content blocks",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				ChatCompletions: &ChatCompletionsRequest{
 					Messages: []Message{
 						{
@@ -90,7 +90,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "responses request with string input",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				Responses: &ResponsesRequest{
 					Input: "Some response input",
 				},
@@ -99,7 +99,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "responses request with non-string input",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				Responses: &ResponsesRequest{
 					Input: map[string]any{"key": "value"},
 				},
@@ -108,7 +108,7 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name: "conversations request",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				Conversations: &ConversationsRequest{
 					Items: []ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -119,12 +119,12 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 		},
 		{
 			name:     "empty body returns empty string",
-			body:     &LLMRequestBody{},
+			body:     &InferenceRequestBody{},
 			expected: "",
 		},
 		{
 			name: "chat completions with no messages",
-			body: &LLMRequestBody{
+			body: &InferenceRequestBody{
 				ChatCompletions: &ChatCompletionsRequest{
 					Messages: []Message{},
 				},

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline_test.go
@@ -54,7 +54,7 @@ func TestSLODeadlinePolicy_RequiredQueueCapabilities(t *testing.T) {
 func makeSLOItem(id string, received time.Time, sloTTFTMs string) flowcontrol.QueueItemAccessor {
 	req := mocks.NewMockFlowControlRequest(10, id, testFlowKey)
 	req.ReceivedTimestampV = received
-	req.InferenceRequestV = &scheduling.LLMRequest{Headers: map[string]string{sloTtftHeader: sloTTFTMs}}
+	req.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{sloTtftHeader: sloTTFTMs}}
 	return &mocks.MockQueueItemAccessor{
 		EffectiveTTLV:    0,
 		OriginalRequestV: req,
@@ -76,7 +76,7 @@ func TestSLODeadline_Less(t *testing.T) {
 	// D: no header → far-future deadline
 	reqD := mocks.NewMockFlowControlRequest(10, "d", testFlowKey)
 	reqD.ReceivedTimestampV = now
-	reqD.InferenceRequestV = &scheduling.LLMRequest{Headers: map[string]string{}}
+	reqD.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{}}
 	itemD := &mocks.MockQueueItemAccessor{EffectiveTTLV: 0, OriginalRequestV: reqD}
 	// E: same deadline as B (received 1s earlier + 1050ms SLO = now+50ms), earlier ReceivedTimestamp → wins tie-breaker
 	itemE := makeSLOItem("e", now.Add(-time.Second), "1050")
@@ -115,24 +115,24 @@ func TestCalculateSLODeadline(t *testing.T) {
 	// Valid header
 	reqValid := mocks.NewMockFlowControlRequest(1, "valid", testFlowKey)
 	reqValid.ReceivedTimestampV = now
-	reqValid.InferenceRequestV = &scheduling.LLMRequest{Headers: map[string]string{sloTtftHeader: "200"}}
+	reqValid.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{sloTtftHeader: "200"}}
 	accValid := &mocks.MockQueueItemAccessor{OriginalRequestV: reqValid}
 	deadline := calculateSLODeadline(accValid)
 	assert.Equal(t, now.Add(200*time.Millisecond), deadline)
 
 	// Missing header
 	reqNoHeader := mocks.NewMockFlowControlRequest(2, "no", testFlowKey)
-	reqNoHeader.InferenceRequestV = &scheduling.LLMRequest{Headers: map[string]string{}}
+	reqNoHeader.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{}}
 	accNoHeader := &mocks.MockQueueItemAccessor{OriginalRequestV: reqNoHeader}
 	assert.Equal(t, sloMaxDeadlineTime, calculateSLODeadline(accNoHeader))
 
-	reqNoHeader.InferenceRequestV = &scheduling.LLMRequest{Headers: map[string]string{"x-some-header": "200"}}
+	reqNoHeader.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{"x-some-header": "200"}}
 	accNoHeader = &mocks.MockQueueItemAccessor{OriginalRequestV: reqNoHeader}
 	assert.Equal(t, sloMaxDeadlineTime, calculateSLODeadline(accNoHeader))
 
 	// Invalid value
 	reqInvalid := mocks.NewMockFlowControlRequest(3, "inv", testFlowKey)
-	reqInvalid.InferenceRequestV = &scheduling.LLMRequest{Headers: map[string]string{sloTtftHeader: "x"}}
+	reqInvalid.InferenceRequestV = &scheduling.InferenceRequest{Headers: map[string]string{sloTtftHeader: "x"}}
 	accInvalid := &mocks.MockQueueItemAccessor{OriginalRequestV: reqInvalid}
 	assert.Equal(t, sloMaxDeadlineTime, calculateSLODeadline(accInvalid))
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -146,7 +146,7 @@ func (d *detector) Saturation(_ context.Context, endpoints []datalayer.Endpoint)
 func (d *detector) Filter(
 	_ context.Context,
 	_ *framework.CycleState,
-	_ *framework.LLMRequest,
+	_ *framework.InferenceRequest,
 	endpoints []framework.Endpoint,
 ) []framework.Endpoint {
 	// Pre-allocate assuming most endpoints will pass the filter to minimize allocations.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -335,7 +335,7 @@ func TestDetector_TokenSaturation(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		requests           []*schedulingtypes.LLMRequest
+		requests           []*schedulingtypes.InferenceRequest
 		candidateEndpoints []string
 		wantSaturation     float64
 	}{
@@ -347,7 +347,7 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "single_endpoint_partial_tokens",
-			requests: []*schedulingtypes.LLMRequest{
+			requests: []*schedulingtypes.InferenceRequest{
 				makeTokenRequest("r1", "1234"), // 3 tokens with default estimator
 			},
 			candidateEndpoints: []string{"endpoint-a"},
@@ -355,10 +355,10 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "single_endpoint_half_full",
-			requests: func() []*schedulingtypes.LLMRequest {
+			requests: func() []*schedulingtypes.InferenceRequest {
 				// "1234567890123456" (16 chars) = 10 tokens. 5 requests = 50 tokens.
 				prompt := "1234567890123456"
-				reqs := make([]*schedulingtypes.LLMRequest, 0, 5)
+				reqs := make([]*schedulingtypes.InferenceRequest, 0, 5)
 				for i := range 5 {
 					reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 				}
@@ -369,10 +369,10 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "single_endpoint_full",
-			requests: func() []*schedulingtypes.LLMRequest {
+			requests: func() []*schedulingtypes.InferenceRequest {
 				// 10 tokens per request * 10 requests = 100 tokens.
 				prompt := "1234567890123456"
-				reqs := make([]*schedulingtypes.LLMRequest, 0, 10)
+				reqs := make([]*schedulingtypes.InferenceRequest, 0, 10)
 				for i := range 10 {
 					reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 				}
@@ -383,10 +383,10 @@ func TestDetector_TokenSaturation(t *testing.T) {
 		},
 		{
 			name: "multiple_endpoints_mixed_token_load",
-			requests: func() []*schedulingtypes.LLMRequest {
+			requests: func() []*schedulingtypes.InferenceRequest {
 				// endpoint-a: 50 tokens, endpoint-b: 0 (driveTokenLoad targets endpoint-a only)
 				prompt := "1234567890123456"
-				reqs := make([]*schedulingtypes.LLMRequest, 0, 5)
+				reqs := make([]*schedulingtypes.InferenceRequest, 0, 5)
 				for i := range 5 {
 					reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 				}
@@ -436,7 +436,7 @@ func TestDetector_TokenFilter(t *testing.T) {
 	// Drive 110 tokens (just below 120 burst limit) -> endpoint should pass filter
 	// "1234567890123456" = 10 tokens. 11 requests = 110 tokens.
 	prompt := "1234567890123456"
-	reqs := make([]*schedulingtypes.LLMRequest, 0, 11)
+	reqs := make([]*schedulingtypes.InferenceRequest, 0, 11)
 	for i := range 11 {
 		reqs = append(reqs, makeTokenRequest(fmt.Sprintf("r%d", i+1), prompt))
 	}
@@ -446,7 +446,7 @@ func TestDetector_TokenFilter(t *testing.T) {
 	require.Len(t, kept, 1, "endpoint should pass filter below burst limit")
 
 	// Add one more request to reach 120 tokens -> filtered out
-	driveTokenLoad(ctx, reg, detector, endpointName, []*schedulingtypes.LLMRequest{
+	driveTokenLoad(ctx, reg, detector, endpointName, []*schedulingtypes.InferenceRequest{
 		makeTokenRequest("r12", prompt),
 	})
 	kept = detector.Filter(ctx, nil, nil, endpoints)
@@ -539,7 +539,7 @@ func TestDetector_ConcurrencyStress(t *testing.T) {
 
 // --- Test Helpers & Mocks ---
 
-func simulatePreRequest(_ context.Context, reg *localRegistry, req *schedulingtypes.LLMRequest, result *schedulingtypes.SchedulingResult) {
+func simulatePreRequest(_ context.Context, reg *localRegistry, req *schedulingtypes.InferenceRequest, result *schedulingtypes.SchedulingResult) {
 	endpointName := result.ProfileResults[result.PrimaryProfileName].TargetEndpoints[0].GetMetadata().NamespacedName.Name
 	id := fullEndpointName(endpointName)
 	reg.update(id, func(load *attrconcurrency.InFlightLoad) {
@@ -550,7 +550,7 @@ func simulatePreRequest(_ context.Context, reg *localRegistry, req *schedulingty
 	})
 }
 
-func simulateResponseBody(_ context.Context, reg *localRegistry, req *schedulingtypes.LLMRequest, resp *requestcontrol.Response, metadata *datalayer.EndpointMetadata) {
+func simulateResponseBody(_ context.Context, reg *localRegistry, req *schedulingtypes.InferenceRequest, resp *requestcontrol.Response, metadata *datalayer.EndpointMetadata) {
 	if metadata == nil || resp == nil || !resp.EndOfStream {
 		return
 	}
@@ -574,7 +574,7 @@ func driveLoad(_ context.Context, reg *localRegistry, _ *detector, endpointName 
 	})
 }
 
-func driveTokenLoad(_ context.Context, reg *localRegistry, _ *detector, endpointName string, requests []*schedulingtypes.LLMRequest) {
+func driveTokenLoad(_ context.Context, reg *localRegistry, _ *detector, endpointName string, requests []*schedulingtypes.InferenceRequest) {
 	id := fullEndpointName(endpointName)
 	var total int64
 	estimator := inflightload.NewSimpleTokenEstimator()
@@ -664,10 +664,10 @@ func (f *liveSchedulingEndpoint) Keys() []string                  { return []str
 func (f *liveSchedulingEndpoint) String() string                  { return f.id }
 func (f *liveSchedulingEndpoint) Clone() datalayer.AttributeMap   { return f }
 
-func makeTokenRequest(requestID, prompt string) *schedulingtypes.LLMRequest {
-	return &schedulingtypes.LLMRequest{
+func makeTokenRequest(requestID, prompt string) *schedulingtypes.InferenceRequest {
+	return &schedulingtypes.InferenceRequest{
 		RequestId: requestID,
-		Body: &schedulingtypes.LLMRequestBody{
+		Body: &schedulingtypes.InferenceRequestBody{
 			Completions: &schedulingtypes.CompletionsRequest{Prompt: schedulingtypes.Prompt{Raw: prompt}},
 		},
 	}

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -142,7 +142,7 @@ func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint
 func (d *Detector) Filter(
 	_ context.Context,
 	_ *framework.CycleState,
-	_ *framework.LLMRequest,
+	_ *framework.InferenceRequest,
 	endpoints []framework.Endpoint,
 ) []framework.Endpoint {
 	qLimit := float64(d.config.QueueDepthThreshold) * (1.0 + d.config.Headroom)

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -96,7 +96,7 @@ func (p *LatencyAdmission) Consumes() map[string]any {
 //   - No endpoint has a valid prediction (all violate SLO)
 //   - No endpoint is idle (all have running requests)
 //   - No cold pod exists (predictions are reliable)
-func (p *LatencyAdmission) AdmitRequest(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func (p *LatencyAdmission) AdmitRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		return nil

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
@@ -38,8 +38,8 @@ func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests 
 	)
 }
 
-func makeSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.LLMRequest {
-	return &schedulingtypes.LLMRequest{
+func makeSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.InferenceRequest {
+	return &schedulingtypes.InferenceRequest{
 		Headers: map[string]string{
 			ttftSLOHeaderKey: ttftSLO,
 			tpotSLOHeaderKey: tpotSLO,
@@ -48,8 +48,8 @@ func makeSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.LLMRequest {
 	}
 }
 
-func makeNonSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.LLMRequest {
-	return &schedulingtypes.LLMRequest{
+func makeNonSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.InferenceRequest {
+	return &schedulingtypes.InferenceRequest{
 		Headers: map[string]string{
 			ttftSLOHeaderKey: ttftSLO,
 			tpotSLOHeaderKey: tpotSLO,
@@ -63,7 +63,7 @@ func TestAdmitRequest(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		request   *schedulingtypes.LLMRequest
+		request   *schedulingtypes.InferenceRequest
 		endpoints []schedulingtypes.Endpoint
 		setupFn   func(endpoints []schedulingtypes.Endpoint) // set endpoint attributes
 		wantErr   bool

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/hashing.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/hashing.go
@@ -31,7 +31,7 @@ import (
 // hashPrompt divides the prompt into blocks and calculates a prefix cache hash for each block.
 // The first block hash includes the model name and cache salt (if provided).
 // For subsequent blocks, the hash is calculated as: hash(block i content, hash(i-1)).
-func hashPrompt(ctx context.Context, request *scheduling.LLMRequest, blockSizeTokens int, maxPrefixBlocks int) []blockHash {
+func hashPrompt(ctx context.Context, request *scheduling.InferenceRequest, blockSizeTokens int, maxPrefixBlocks int) []blockHash {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	if request == nil || request.Body == nil {
 		loggerDebug.Info("Request or request data is nil, skipping hashing")
@@ -93,7 +93,7 @@ func toBytes(i blockHash) []byte {
 	return bytes
 }
 
-func getUserInputBytes(request *scheduling.LLMRequest) ([]byte, error) {
+func getUserInputBytes(request *scheduling.InferenceRequest) ([]byte, error) {
 	switch {
 	case request.Body.Conversations != nil:
 		return json.Marshal(request.Body.Conversations.Items)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -137,7 +137,7 @@ func (p *prepareData) PluginState() *plugin.PluginState {
 }
 
 // PrepareRequestData is called by the director before scheduling requests.
-func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework.LLMRequest, pods []framework.Endpoint) error {
+func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework.InferenceRequest, pods []framework.Endpoint) error {
 	blockSize := p.GetBlockSize(pods)
 	maxBlocks := p.config.MaxPrefixBlocksToMatch
 	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
@@ -166,7 +166,7 @@ func (p *prepareData) PrepareRequestData(ctx context.Context, request *framework
 
 // PreRequest records in the shared indexer the result of the scheduling selection.
 // It updates the indexer with the prefix hashes for the selected endpoint(s).
-func (p *prepareData) PreRequest(ctx context.Context, request *framework.LLMRequest, schedulingResult *framework.SchedulingResult) {
+func (p *prepareData) PreRequest(ctx context.Context, request *framework.InferenceRequest, schedulingResult *framework.SchedulingResult) {
 	// Delete the state to avoid memory leak.
 	defer p.pluginState.Delete(request.RequestId)
 	primaryProfileResult := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -49,10 +49,10 @@ func TestPrepareRequestData(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2}
 
 	// First request to populate cache.
-	req1 := &fwksched.LLMRequest{
+	req1 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				Prompt: fwksched.Prompt{Raw: "aaaabbbb"},
 			},
@@ -89,10 +89,10 @@ func TestPreRequest(t *testing.T) {
 	p, _ := newPrepareData(context.Background(), config, nil)
 
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
-	req1 := &fwksched.LLMRequest{
+	req1 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				Prompt: fwksched.Prompt{Raw: "aaaabbbb"},
 			},
@@ -171,10 +171,10 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2, endpoint3}
 
 	// First request.
-	req1 := &fwksched.LLMRequest{
+	req1 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				Prompt: fwksched.Prompt{Raw: "aaaaaa"},
 			},
@@ -197,10 +197,10 @@ func TestPrefixPluginCompletion(t *testing.T) {
 	p.wg.Wait()
 
 	// Third request shares partial prefix with first one.
-	req3 := &fwksched.LLMRequest{
+	req3 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				Prompt: fwksched.Prompt{Raw: "aaaabbbb"},
 			},
@@ -238,10 +238,10 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1}
 
 	// First request with initial conversation
-	req1 := &fwksched.LLMRequest{
+	req1 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			ChatCompletions: &fwksched.ChatCompletionsRequest{
 				Messages: []fwksched.Message{
 					{Role: "system", Content: fwksched.Content{Raw: "You are a helpful assistant"}},
@@ -266,10 +266,10 @@ func TestPrefixPluginChatCompletionsGrowth(t *testing.T) {
 	p.wg.Wait()
 
 	// Second request adds assistant response and new user message
-	req2 := &fwksched.LLMRequest{
+	req2 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model1",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			ChatCompletions: &fwksched.ChatCompletionsRequest{
 				Messages: []fwksched.Message{
 					{Role: "system", Content: fwksched.Content{Raw: "You are a helpful assistant"}},
@@ -300,10 +300,10 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 		}, fwkdl.NewAttributes())
 	endpoints := []fwksched.Endpoint{endpoint}
 
-	req := &fwksched.LLMRequest{
+	req := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				// Length 128 chars.
 				// If block size is 64 chars: 2 blocks
@@ -356,10 +356,10 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	)
 
 	// Prompt is 16 chars = 4 blocks at blockSize 4 chars, but should be capped to 2.
-	req := &fwksched.LLMRequest{
+	req := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				Prompt: fwksched.Prompt{Raw: "aaaabbbbccccdddd"},
 			},
@@ -383,10 +383,10 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	p2, err := newPrepareData(context.Background(), cfg2, nil)
 	assert.NoError(t, err)
 
-	req2 := &fwksched.LLMRequest{
+	req2 := &fwksched.InferenceRequest{
 		RequestId:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwksched.LLMRequestBody{
+		Body: &fwksched.InferenceRequestBody{
 			Completions: &fwksched.CompletionsRequest{
 				Prompt: fwksched.Prompt{Raw: "aaaabbbbccccdddd"},
 			},
@@ -419,10 +419,10 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 				NamespacedName: k8stypes.NamespacedName{Name: "pod1"},
 			}, nil, fwkdl.NewAttributes())
 			endpoints := []fwksched.Endpoint{endpoint}
-			req := &fwksched.LLMRequest{
+			req := &fwksched.InferenceRequest{
 				RequestId:   uuid.NewString(),
 				TargetModel: "model-stress",
-				Body: &fwksched.LLMRequestBody{
+				Body: &fwksched.InferenceRequestBody{
 					Completions: &fwksched.CompletionsRequest{
 						Prompt: fwksched.Prompt{Raw: prompt},
 					},

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
@@ -150,7 +150,7 @@ func (c *Plugin) TypedName() plugin.TypedName {
 	return c.typedName
 }
 
-func (c *Plugin) ResponseBody(ctx context.Context, request *scheduling.LLMRequest, response *requestcontrol.Response,
+func (c *Plugin) ResponseBody(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response,
 	_ *datalayer.EndpointMetadata) {
 	// Convert the request usage Go struct into a protobuf struct so that it can be used as a CEL variable.
 	celData, err := c.getCelData(response)

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin_test.go
@@ -391,7 +391,7 @@ func TestValueReporting(t *testing.T) {
 				t.Fatalf("Failed to create plugin: %v", err)
 			}
 
-			plugin.ResponseBody(context.Background(), &scheduling.LLMRequest{}, currentResponse, &datalayer.EndpointMetadata{})
+			plugin.ResponseBody(context.Background(), &scheduling.InferenceRequest{}, currentResponse, &datalayer.EndpointMetadata{})
 
 			if diff := cmp.Diff(tt.wantResult, currentResponse.DynamicMetadata, protocmp.Transform()); diff != "" {
 				t.Errorf("ResponseComplete() DynamicMetadata mismatch (-want +got):\n%s", diff)

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
@@ -98,7 +98,7 @@ func (p *InFlightLoadProducer) ExtractNotification(ctx context.Context, event da
 	return nil
 }
 
-func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *framework.LLMRequest, endpoints []framework.Endpoint) error {
+func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *framework.InferenceRequest, endpoints []framework.Endpoint) error {
 	for _, e := range endpoints {
 		endpointID := e.GetMetadata().NamespacedName.String()
 		e.Put(attrconcurrency.InFlightLoadKey, &attrconcurrency.InFlightLoad{
@@ -109,7 +109,7 @@ func (p *InFlightLoadProducer) PrepareRequestData(_ context.Context, _ *framewor
 	return nil
 }
 
-func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.LLMRequest, result *framework.SchedulingResult) {
+func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.InferenceRequest, result *framework.SchedulingResult) {
 	if result == nil || len(result.ProfileResults) == 0 {
 		return
 	}
@@ -133,7 +133,7 @@ func (p *InFlightLoadProducer) PreRequest(_ context.Context, request *framework.
 
 func (p *InFlightLoadProducer) ResponseBody(
 	_ context.Context,
-	request *framework.LLMRequest,
+	request *framework.InferenceRequest,
 	resp *requestcontrol.Response,
 	targetEndpoint *datalayer.EndpointMetadata,
 ) {

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer_test.go
@@ -205,10 +205,10 @@ func (f *stubSchedulingEndpoint) Get(key string) (datalayer.Cloneable, bool) {
 }
 func (f *stubSchedulingEndpoint) Keys() []string { return f.attr.Keys() }
 
-func makeTokenRequest(requestID, prompt string) *schedulingtypes.LLMRequest {
-	return &schedulingtypes.LLMRequest{
+func makeTokenRequest(requestID, prompt string) *schedulingtypes.InferenceRequest {
+	return &schedulingtypes.InferenceRequest{
 		RequestId: requestID,
-		Body: &schedulingtypes.LLMRequestBody{
+		Body: &schedulingtypes.InferenceRequestBody{
 			Completions: &schedulingtypes.CompletionsRequest{Prompt: schedulingtypes.Prompt{Raw: prompt}},
 		},
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator.go
@@ -24,7 +24,7 @@ import (
 
 // TokenEstimator estimates the number of tokens for an LLM request.
 type TokenEstimator interface {
-	Estimate(request *framework.LLMRequest) int64
+	Estimate(request *framework.InferenceRequest) int64
 }
 
 // SimpleTokenEstimator estimates tokens from character count. tokens = characters / CharactersPerToken.
@@ -45,7 +45,7 @@ func NewSimpleTokenEstimator() TokenEstimator {
 // When RequestSizeBytes is set, input tokens are derived from request size (~4 bytes per token)
 // to avoid allocations. Otherwise, input tokens are estimated from prompt/message character count
 // using CharactersPerToken; output tokens are estimated as inputTokens * OutputRatio.
-func (e *SimpleTokenEstimator) Estimate(request *framework.LLMRequest) int64 {
+func (e *SimpleTokenEstimator) Estimate(request *framework.InferenceRequest) int64 {
 	if request == nil {
 		return 0
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/token_estimator_test.go
@@ -29,7 +29,7 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		request  *framework.LLMRequest
+		request  *framework.InferenceRequest
 		expected int64
 	}{
 		{
@@ -39,20 +39,20 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name:     "Empty request",
-			request:  &framework.LLMRequest{},
+			request:  &framework.InferenceRequest{},
 			expected: 0,
 		},
 		{
 			name: "Body nil",
-			request: &framework.LLMRequest{
+			request: &framework.InferenceRequest{
 				Body: nil,
 			},
 			expected: 0,
 		},
 		{
 			name: "Less than 4 characters",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{Raw: "123"},
 					},
@@ -62,8 +62,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Completions Request",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{Raw: "Hello, world!"},
 					},
@@ -73,8 +73,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Completions with empty prompt",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{},
 					},
@@ -84,8 +84,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Completions with exactly 4 characters",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{Raw: "1234"},
 					},
@@ -95,8 +95,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions Request with Structured content",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					ChatCompletions: &framework.ChatCompletionsRequest{
 						Messages: []framework.Message{
 							{
@@ -118,8 +118,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions with Raw content",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					ChatCompletions: &framework.ChatCompletionsRequest{
 						Messages: []framework.Message{
 							{
@@ -136,8 +136,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions with multiple messages",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					ChatCompletions: &framework.ChatCompletionsRequest{
 						Messages: []framework.Message{
 							{
@@ -166,8 +166,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Chat Completions with empty messages",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					ChatCompletions: &framework.ChatCompletionsRequest{
 						Messages: []framework.Message{},
 					},
@@ -177,8 +177,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Responses API with string input",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Responses: &framework.ResponsesRequest{
 						Input: "Tell me a story about a brave knight.",
 					},
@@ -188,8 +188,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Responses API with structured input",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Responses: &framework.ResponsesRequest{
 						Input: []any{
 							map[string]any{"role": "user", "content": "Hello"},
@@ -201,8 +201,8 @@ func TestSimpleTokenEstimator_Estimate(t *testing.T) {
 		},
 		{
 			name: "Conversations API",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Conversations: &framework.ConversationsRequest{
 						Items: []framework.ConversationItem{
 							{Type: "message", Role: "user", Content: "Hi there"},
@@ -230,13 +230,13 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		request  *framework.LLMRequest
+		request  *framework.InferenceRequest
 		expected int64
 	}{
 		{
 			name: "Empty prompt with custom config",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{},
 					},
@@ -246,8 +246,8 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 		},
 		{
 			name: "4 chars with custom config",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{Raw: "1234"},
 					},
@@ -257,8 +257,8 @@ func TestSimpleTokenEstimator_Estimate_CustomConfig(t *testing.T) {
 		},
 		{
 			name: "More than 4 chars with custom config",
-			request: &framework.LLMRequest{
-				Body: &framework.LLMRequestBody{
+			request: &framework.InferenceRequest{
+				Body: &framework.InferenceRequestBody{
 					Completions: &framework.CompletionsRequest{
 						Prompt: framework.Prompt{Raw: "This is a longer message."},
 					},

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/plugin.go
@@ -204,7 +204,7 @@ func (s *PredictedLatency) WithName(name string) *PredictedLatency {
 	return s
 }
 
-func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.LLMRequest) *predictedLatencyCtx {
+func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
 	sloCtx, err := t.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		sloCtx = newPredictedLatencyContext(request)
@@ -216,7 +216,7 @@ func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *f
 
 // predictedLatencyCtx holds per-request state for latency prediction and training.
 type predictedLatencyCtx struct {
-	schedulingRequest         framework.LLMRequest
+	schedulingRequest         framework.InferenceRequest
 	targetMetadata            *fwkdl.EndpointMetadata
 	prefillTargetMetadata     *fwkdl.EndpointMetadata
 	schedulingResult          *framework.SchedulingResult
@@ -248,7 +248,7 @@ type predictedLatencyCtx struct {
 	decodeTokensAtDispatch           int64
 }
 
-func newPredictedLatencyContext(request *framework.LLMRequest) *predictedLatencyCtx {
+func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedLatencyCtx {
 	var promptText string
 	if request.Body != nil {
 		promptText = request.Body.PromptText()
@@ -263,7 +263,7 @@ func newPredictedLatencyContext(request *framework.LLMRequest) *predictedLatency
 	}
 }
 
-func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.LLMRequest) (*predictedLatencyCtx, error) {
+func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.InferenceRequest) (*predictedLatencyCtx, error) {
 	id := request.Headers[reqcommon.RequestIdHeaderKey]
 	if item := s.sloContextStore.Get(id); item != nil {
 		return item.Value(), nil
@@ -271,12 +271,12 @@ func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framewo
 	return nil, fmt.Errorf("SLO context not found for request ID: %s", id)
 }
 
-func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.LLMRequest, ctx *predictedLatencyCtx) {
+func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.InferenceRequest, ctx *predictedLatencyCtx) {
 	id := request.Headers[reqcommon.RequestIdHeaderKey]
 	s.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
 }
 
-func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.LLMRequest) {
+func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.InferenceRequest) {
 	id := request.Headers[reqcommon.RequestIdHeaderKey]
 	s.sloContextStore.Delete(id)
 }
@@ -285,7 +285,7 @@ func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *fram
 
 // parseFloatHeader retrieves a header by name, parses it as a float64,
 // and returns the value or an error if the header is missing or invalid.
-func parseFloatHeader(request framework.LLMRequest, headerName string) (float64, error) {
+func parseFloatHeader(request framework.InferenceRequest, headerName string) (float64, error) {
 	headerValue, ok := request.Headers[headerName]
 	if !ok {
 		return 0, nil
@@ -300,7 +300,7 @@ func parseFloatHeader(request framework.LLMRequest, headerName string) (float64,
 	return parsedFloat, nil
 }
 
-func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framework.LLMRequest, predictedLatencyCtx *predictedLatencyCtx) {
+func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framework.InferenceRequest, predictedLatencyCtx *predictedLatencyCtx) {
 	logger := log.FromContext(ctx)
 	var err error
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/plugin_test.go
@@ -113,16 +113,16 @@ func createTestEndpoint(name string, kvCacheUsage float64, runningRequestsSize, 
 	)
 }
 
-func createTestLLMRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.LLMRequest {
-	return createTestLLMRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.LLMRequestBody{
+func createTestInferenceRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.InferenceRequest {
+	return createTestInferenceRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.InferenceRequestBody{
 		Completions: &fwksched.CompletionsRequest{
 			Prompt: fwksched.Prompt{Raw: "test prompt"},
 		},
 	})
 }
 
-func createTestChatCompletionsLLMRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.LLMRequest {
-	return createTestLLMRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.LLMRequestBody{
+func createTestChatCompletionsInferenceRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.InferenceRequest {
+	return createTestInferenceRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.InferenceRequestBody{
 		ChatCompletions: &fwksched.ChatCompletionsRequest{
 			Messages: []fwksched.Message{
 				{Role: "system", Content: fwksched.Content{Raw: "You are a helpful assistant."}},
@@ -132,7 +132,7 @@ func createTestChatCompletionsLLMRequest(reqID string, ttftSLO, tpotSLO float64)
 	})
 }
 
-func createTestLLMRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *fwksched.LLMRequestBody) *fwksched.LLMRequest {
+func createTestInferenceRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *fwksched.InferenceRequestBody) *fwksched.InferenceRequest {
 	headers := make(map[string]string)
 	headers[reqcommon.RequestIdHeaderKey] = reqID
 	if ttftSLO > 0 {
@@ -142,7 +142,7 @@ func createTestLLMRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *
 		headers["x-avg-tpot-slo"] = fmt.Sprintf("%f", tpotSLO)
 	}
 
-	return &fwksched.LLMRequest{
+	return &fwksched.InferenceRequest{
 		Headers: headers,
 		Body:    body,
 	}
@@ -382,7 +382,7 @@ func TestSloContextStoreEviction(t *testing.T) {
 	requestID := "test-req-id"
 	endpointName := types.NamespacedName{Name: "test-model", Namespace: "default"}
 
-	req := &fwksched.LLMRequest{
+	req := &fwksched.InferenceRequest{
 		Headers: map[string]string{
 			reqcommon.RequestIdHeaderKey: requestID,
 		},

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
@@ -33,7 +33,7 @@ var _ requestcontrol.PrepareDataPlugin = &PredictedLatency{}
 
 // PrepareRequestData prepares the SLO context for the request, including
 // parsing SLO headers, gathering prefix cache scores, and generating predictions.
-func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	logger := log.FromContext(ctx)
 	predictedLatencyCtx := s.getOrMakePredictedLatencyContextForRequest(request)
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks.go
@@ -40,7 +40,7 @@ var _ requestcontrol.ResponseBody = &PredictedLatency{}
 
 // --- RequestControl Hooks ---
 
-func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.LLMRequest, schedulingResult *schedulingtypes.SchedulingResult) {
+func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
@@ -110,7 +110,7 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
 }
 
-func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseReceived: request is nil, skipping")
@@ -119,7 +119,7 @@ func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *scheduli
 }
 
 // ResponseBody handles both per-chunk processing and request completion logic.
-func (t *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (t *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: request is nil, skipping")

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -73,7 +73,7 @@ func createTestRouter() *PredictedLatency {
 // Test cases
 
 func TestNewPredictedLatencyContext(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	ctx := newPredictedLatencyContext(request)
 
@@ -88,7 +88,7 @@ func TestNewPredictedLatencyContext(t *testing.T) {
 }
 
 func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
-	request := &schedulingtypes.LLMRequest{
+	request := &schedulingtypes.InferenceRequest{
 		Headers: map[string]string{reqcommon.RequestIdHeaderKey: "test-nil-body"},
 		Body:    nil,
 	}
@@ -99,7 +99,7 @@ func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
 }
 
 func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
-	request := createTestChatCompletionsLLMRequest("test-chat", 1.0, 0.05)
+	request := createTestChatCompletionsInferenceRequest("test-chat", 1.0, 0.05)
 	ctx := newPredictedLatencyContext(request)
 
 	assert.NotNil(t, ctx)
@@ -108,7 +108,7 @@ func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
 
 func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 
 	// Set context
@@ -123,7 +123,7 @@ func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
 
 func TestPredictedLatency_GetSLOContext_NotFound(t *testing.T) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	// Try to get context that doesn't exist
 	ctx, err := router.getPredictedLatencyContextForRequest(request)
@@ -135,7 +135,7 @@ func TestPredictedLatency_GetSLOContext_NotFound(t *testing.T) {
 
 func TestPredictedLatency_DeleteSLOContext(t *testing.T) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 
 	// Set and then delete context
@@ -151,7 +151,7 @@ func TestPredictedLatency_DeleteSLOContext(t *testing.T) {
 func TestPredictedLatency_PreRequest_NoSchedulingResult(t *testing.T) {
 	router := createTestRouter()
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	// Call PreRequest with nil scheduling result
 	router.PreRequest(ctx, request, nil)
@@ -164,7 +164,7 @@ func TestPredictedLatency_PreRequest_NoSchedulingResult(t *testing.T) {
 func TestPredictedLatency_PreRequest_EmptySchedulingResult(t *testing.T) {
 	router := createTestRouter()
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	schedulingResult := &schedulingtypes.SchedulingResult{
 		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{},
@@ -185,7 +185,7 @@ func TestPredictedLatency_PreRequest_Success(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set initial SLO context
@@ -218,7 +218,7 @@ func TestPredictedLatency_PreRequest_AddsToQueue(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set initial SLO context
@@ -244,8 +244,8 @@ func TestPredictedLatency_PreRequest_QueueAlreadyExists(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request1 := createTestLLMRequest("test-id-1", 100, 50)
-	request2 := createTestLLMRequest("test-id-2", 100, 50)
+	request1 := createTestInferenceRequest("test-id-1", 100, 50)
+	request2 := createTestInferenceRequest("test-id-2", 100, 50)
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set initial SLO contexts
@@ -274,7 +274,7 @@ func TestPredictedLatency_ResponseHeader_NilPredictor(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -294,7 +294,7 @@ func TestPredictedLatency_ResponseHeader_NoPod(t *testing.T) {
 	router.latencypredictor = mockPredictor
 
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -314,7 +314,7 @@ func TestPredictedLatency_ResponseHeader_NoContext(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	// Don't set SLO context
@@ -330,7 +330,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_NilPredictor(t *testing.T) 
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -350,7 +350,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FirstToken(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -407,7 +407,7 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FirstToken(t *testing.T)
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{} // EndOfStream is false
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -436,7 +436,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SubsequentTokens(t *testing
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -485,7 +485,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_QueueNotFound(t 
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -510,7 +510,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_NoContext(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	// Don't set SLO context - should handle gracefully
@@ -527,7 +527,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_Success(t *testi
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Create queue and add request
@@ -562,7 +562,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NilPredictor(t *
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -582,7 +582,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoPod(t *testing
 	router.latencypredictor = mockPredictor
 
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -603,7 +603,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoContext(t *tes
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Don't set SLO context - should handle gracefully
@@ -617,7 +617,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_WithMetrics(t *t
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Create queue
@@ -650,7 +650,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoSLOs(t *testin
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test-id", 0, 0) // No SLOs
+	request := createTestInferenceRequest("test-id", 0, 0) // No SLOs
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Create queue
@@ -680,7 +680,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true} // True
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -713,7 +713,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SingleChunk(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true} // True
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -746,7 +746,7 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FinalToken(t *testing.T)
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true} // True
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -804,7 +804,7 @@ func TestPredictedLatency_CheckPredictor_Success(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_Fields(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	// Test all field initialization
@@ -823,7 +823,7 @@ func TestPredictedLatencyContext_Fields(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	// Add some metrics
@@ -839,7 +839,7 @@ func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_PredictionData(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	ctx.predictionsForScheduling = make(map[string]endpointPredictionResult)
@@ -854,7 +854,7 @@ func TestPredictedLatencyContext_PredictionData(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_PrefixCacheScores(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	// Set prefix cache scores
@@ -878,7 +878,7 @@ func TestPredictedLatency_ConcurrentContextAccess(t *testing.T) {
 		wg.Go(func() {
 
 			requestID := uuid.New().String()
-			request := createTestLLMRequest(requestID, 100, 50)
+			request := createTestInferenceRequest(requestID, 100, 50)
 			predictedLatencyCtx := newPredictedLatencyContext(request)
 
 			// Set context
@@ -905,14 +905,14 @@ func TestPredictedLatency_MultipleRequests_SamePod(t *testing.T) {
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
 
-	request1 := createTestLLMRequest("test-id-1", 100, 50)
-	request2 := createTestLLMRequest("test-id-2", 100, 50)
-	request3 := createTestLLMRequest("test-id-3", 100, 50)
+	request1 := createTestInferenceRequest("test-id-1", 100, 50)
+	request2 := createTestInferenceRequest("test-id-2", 100, 50)
+	request3 := createTestInferenceRequest("test-id-3", 100, 50)
 
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set SLO contexts
-	for _, req := range []*schedulingtypes.LLMRequest{request1, request2, request3} {
+	for _, req := range []*schedulingtypes.InferenceRequest{request1, request2, request3} {
 		predictedLatencyCtx := newPredictedLatencyContext(req)
 		predictedLatencyCtx.avgTPOTSLO = 50
 		router.setPredictedLatencyContextForRequest(req, predictedLatencyCtx)
@@ -936,7 +936,7 @@ func TestPredictedLatency_RequestLifecycle_ResponseEndOfStream(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -989,8 +989,8 @@ func TestPredictedLatency_MultipleRequests_DifferentPods(t *testing.T) {
 	endpoint1 := createTestEndpoint("test-pod-1", 1, 1, 1)
 	endpoint2 := createTestEndpoint("test-pod-2", 1, 1, 1)
 
-	request1 := createTestLLMRequest("test-id-1", 100, 50)
-	request2 := createTestLLMRequest("test-id-2", 100, 50)
+	request1 := createTestInferenceRequest("test-id-1", 100, 50)
+	request2 := createTestInferenceRequest("test-id-2", 100, 50)
 
 	schedulingResult1 := createTestSchedulingResult(endpoint1.GetMetadata())
 	schedulingResult2 := createTestSchedulingResult(endpoint2.GetMetadata())
@@ -1055,7 +1055,7 @@ func TestPredictedLatencyContext_SLOValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := createTestLLMRequest("test-id", tt.ttftSLO, tt.tpotSLO)
+			request := createTestInferenceRequest("test-id", tt.ttftSLO, tt.tpotSLO)
 			ctx := newPredictedLatencyContext(request)
 			ctx.ttftSLO = tt.ttftSLO
 			ctx.avgTPOTSLO = tt.tpotSLO
@@ -1077,7 +1077,7 @@ func BenchmarkPredictedLatency_PreRequest(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		requestID := uuid.New().String()
-		request := createTestLLMRequest(requestID, 100, 50)
+		request := createTestInferenceRequest(requestID, 100, 50)
 		predictedLatencyCtx := newPredictedLatencyContext(request)
 		predictedLatencyCtx.avgTPOTSLO = 50
 		router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
@@ -1087,7 +1087,7 @@ func BenchmarkPredictedLatency_PreRequest(b *testing.B) {
 
 func BenchmarkPredictedLatency_ContextOperations(b *testing.B) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 
 	b.ResetTimer()
@@ -1099,7 +1099,7 @@ func BenchmarkPredictedLatency_ContextOperations(b *testing.B) {
 }
 
 func BenchmarkPredictedLatencyContext_Creation(b *testing.B) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/training_test.go
@@ -125,7 +125,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 	prefixCacheScores := []float64{0.0}
 
 	plCtx := &predictedLatencyCtx{
-		schedulingRequest: schedulingtypes.LLMRequest{
+		schedulingRequest: schedulingtypes.InferenceRequest{
 			TargetModel: "test-model",
 		},
 		incomingModelName: "incoming-model",
@@ -151,7 +151,7 @@ func TestBulkPredictWithMetrics_ChatCompletionsPrompt(t *testing.T) {
 		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
 	}
 
-	chatBody := &schedulingtypes.LLMRequestBody{
+	chatBody := &schedulingtypes.InferenceRequestBody{
 		ChatCompletions: &schedulingtypes.ChatCompletionsRequest{
 			Messages: []schedulingtypes.Message{
 				{Role: "user", Content: schedulingtypes.Content{Raw: "Hello world"}},

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -71,7 +71,7 @@ func NewDestinationEndpointServedVerifier() *DestinationEndpointServedVerifier {
 }
 
 // ResponseHeader is the handler for the ResponseHeader extension point.
-func (p *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
+func (p *DestinationEndpointServedVerifier) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, _ *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx).WithName(p.TypedName().String())
 	logger.V(logging.DEBUG).Info("Verifying destination endpoint served")
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -93,7 +93,7 @@ func (p *OpenAIParser) WithName(name string) *OpenAIParser {
 }
 
 // ParseRequest parses the request body and headers and returns a map representation.
-func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
+func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.InferenceRequestBody, error) {
 	bodyMap := make(map[string]any)
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
@@ -189,8 +189,8 @@ func determineAPITypeFromPath(path string) string {
 	return completionsAPI
 }
 
-// extractRequestBody extracts the LLMRequestBody from the given request body map using path-based detection.
-func extractRequestBody(rawBody []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
+// extractRequestBody extracts the InferenceRequestBody from the given request body map using path-based detection.
+func extractRequestBody(rawBody []byte, headers map[string]string) (*scheduling.InferenceRequestBody, error) {
 	// Determine API type from request path
 	path := getRequestPath(headers)
 	apiType := determineAPITypeFromPath(path)
@@ -199,14 +199,14 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*scheduling.
 	case conversationsAPI:
 		var conversations scheduling.ConversationsRequest
 		if err := json.Unmarshal(rawBody, &conversations); err == nil && len(conversations.Items) > 0 {
-			return &scheduling.LLMRequestBody{Conversations: &conversations}, nil
+			return &scheduling.InferenceRequestBody{Conversations: &conversations}, nil
 		}
 		return nil, errors.New("invalid conversations request: must have items field")
 
 	case responsesAPI:
 		var responses scheduling.ResponsesRequest
 		if err := json.Unmarshal(rawBody, &responses); err == nil && responses.Input != nil {
-			return &scheduling.LLMRequestBody{Responses: &responses}, nil
+			return &scheduling.InferenceRequestBody{Responses: &responses}, nil
 		}
 		return nil, errors.New("invalid responses request: must have input field")
 
@@ -214,7 +214,7 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*scheduling.
 		var chatCompletions scheduling.ChatCompletionsRequest
 		if err := json.Unmarshal(rawBody, &chatCompletions); err == nil {
 			if err = validateChatCompletionsMessages(chatCompletions.Messages); err == nil {
-				return &scheduling.LLMRequestBody{ChatCompletions: &chatCompletions}, nil
+				return &scheduling.InferenceRequestBody{ChatCompletions: &chatCompletions}, nil
 			}
 		}
 		return nil, errors.New("invalid chat completions request: must have valid messages field")
@@ -222,14 +222,14 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*scheduling.
 	case completionsAPI:
 		var completions scheduling.CompletionsRequest
 		if err := json.Unmarshal(rawBody, &completions); err == nil && !completions.Prompt.IsEmpty() {
-			return &scheduling.LLMRequestBody{Completions: &completions}, nil
+			return &scheduling.InferenceRequestBody{Completions: &completions}, nil
 		}
 		return nil, errors.New("invalid completions request: must have prompt field")
 
 	case embeddingsAPI:
 		var embeddings scheduling.EmbeddingsRequest
 		if err := json.Unmarshal(rawBody, &embeddings); err == nil && embeddings.Input != nil {
-			return &scheduling.LLMRequestBody{Embeddings: &embeddings}, nil
+			return &scheduling.InferenceRequestBody{Embeddings: &embeddings}, nil
 		}
 		return nil, errors.New("invalid embeddings request: must have input field")
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -50,7 +50,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 		name    string
 		headers map[string]string
 		body    map[string]any
-		want    *scheduling.LLMRequestBody
+		want    *scheduling.InferenceRequestBody
 		wantErr bool
 	}{
 		{
@@ -60,7 +60,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model":  "test",
 				"prompt": "test prompt",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Raw: "test prompt"},
 				},
@@ -77,7 +77,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model":  "test",
 				"prompt": []any{"Why is the sky blue?"},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Strings: []string{"Why is the sky blue?"}},
 				},
@@ -94,7 +94,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model":  "test",
 				"prompt": []any{"prompt1", "prompt2"},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Strings: []string{"prompt1", "prompt2"}},
 				},
@@ -127,7 +127,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					},
 				},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages: []scheduling.Message{
 						{Role: "system", Content: scheduling.Content{Raw: "this is a system message"}},
@@ -175,7 +175,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					},
 				},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages: []scheduling.Message{
 						{Role: "system", Content: scheduling.Content{
@@ -248,7 +248,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					},
 				},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages: []scheduling.Message{
 						{Role: "user", Content: scheduling.Content{
@@ -306,7 +306,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"add_generation_prompt":        true,
 				"chat_template_kwargs":         map[string]any{"key": "value"},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages:                  []scheduling.Message{{Role: "user", Content: scheduling.Content{Raw: "hello"}}},
 					Tools:                     []any{map[string]any{"type": "function"}},
@@ -487,7 +487,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"prompt":     "test prompt",
 				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt:    scheduling.Prompt{Raw: "test prompt"},
 					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
@@ -514,7 +514,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 				"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages: []scheduling.Message{
 						{Role: "system", Content: scheduling.Content{Raw: "this is a system message"}},
@@ -544,7 +544,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input":        "How do I check if a Python object is an instance of a class?",
 				"instructions": "You are a coding assistant that talks like a pirate.",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Responses: &scheduling.ResponsesRequest{
 					Input:        "How do I check if a Python object is an instance of a class?",
 					Instructions: "You are a coding assistant that talks like a pirate.",
@@ -564,7 +564,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input":      "test input",
 				"cache_salt": "abc123",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Responses: &scheduling.ResponsesRequest{
 					Input:     "test input",
 					CacheSalt: "abc123",
@@ -595,7 +595,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					{"type": "message", "role": "user", "content": "Hello"},
 				},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Conversations: &scheduling.ConversationsRequest{
 					Items: []scheduling.ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -616,7 +616,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					{"type": "message", "role": "user", "content": "Hello"},
 				},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Conversations: &scheduling.ConversationsRequest{
 					Items: []scheduling.ConversationItem{
 						{Type: "message", Role: "user", Content: "Hello"},
@@ -637,7 +637,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model":  "gpt-4o",
 				"prompt": "test prompt",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Raw: "test prompt"},
 				},
@@ -657,7 +657,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 				"stream": true,
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages: []scheduling.Message{{Role: "user", Content: scheduling.Content{Raw: "hello"}}},
 				},
@@ -679,7 +679,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model": "text-embedding-3-small",
 				"input": "The food was delicious and the waiter...",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: "The food was delicious and the waiter...",
 				},
@@ -696,7 +696,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model": "text-embedding-3-small",
 				"input": []any{"First document", "Second document"},
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: []any{"First document", "Second document"},
 				},
@@ -714,7 +714,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"input":      "embed this text",
 				"cache_salt": "embeddings-salt-123",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input:     "embed this text",
 					CacheSalt: "embeddings-salt-123",
@@ -733,7 +733,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				"model": "text-embedding-3-small",
 				"input": "text to embed",
 			},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: "text to embed",
 				},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -67,8 +67,8 @@ func (p *PassthroughParser) WithName(name string) *PassthroughParser {
 }
 
 // ParseRequest converts the request to RawPayload.
-func (p *PassthroughParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
-	return &scheduling.LLMRequestBody{
+func (p *PassthroughParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.InferenceRequestBody, error) {
+	return &scheduling.InferenceRequestBody{
 		Payload: scheduling.RawPayload(body),
 	}, nil
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
@@ -32,13 +32,13 @@ func TestPassthroughParser_ParseRequest(t *testing.T) {
 		name     string
 		body     []byte
 		headers  map[string]string
-		wantBody *scheduling.LLMRequestBody
+		wantBody *scheduling.InferenceRequestBody
 	}{
 		{
 			name:    "empty body",
 			body:    []byte{},
 			headers: map[string]string{},
-			wantBody: &scheduling.LLMRequestBody{
+			wantBody: &scheduling.InferenceRequestBody{
 				Payload: scheduling.RawPayload([]byte{}),
 			},
 		},
@@ -46,7 +46,7 @@ func TestPassthroughParser_ParseRequest(t *testing.T) {
 			name:    "non-empty body",
 			body:    []byte("hello world"),
 			headers: map[string]string{},
-			wantBody: &scheduling.LLMRequestBody{
+			wantBody: &scheduling.InferenceRequestBody{
 				Payload: scheduling.RawPayload([]byte("hello world")),
 			},
 		},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -80,21 +80,21 @@ func (p *VllmGRPCParser) SupportedAppProtocols() []v1.AppProtocol {
 	return []v1.AppProtocol{v1.AppProtocolH2C}
 }
 
-// ParseRequest parses the gRPC request body and headers and returns an LLMRequestBody.
-func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.LLMRequestBody, error) {
+// ParseRequest parses the gRPC request body and headers and returns an InferenceRequestBody.
+func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*scheduling.InferenceRequestBody, error) {
 	logger := log.FromContext(ctx)
 
 	path := headers[methodPathKey]
 	switch path {
 	case vllmEmbedPath:
-		extractedBody, err := convertEmbedToLLMRequestBody(body)
+		extractedBody, err := convertEmbedToInferenceRequestBody(body)
 		if err != nil {
 			return nil, fmt.Errorf("parsing gRPC payload for Embed: %w", err)
 		}
 		logger.V(logutil.TRACE).Info("parsed EmbedRequest")
 		return extractedBody, nil
 	case vllmGeneratePath:
-		extractedBody, err := convertToLLMRequestBody(body)
+		extractedBody, err := convertToInferenceRequestBody(body)
 		if err != nil {
 			return nil, fmt.Errorf("parsing gRPC payload for Generate: %w", err)
 		}
@@ -180,22 +180,22 @@ func toGenerateResponse(payload []byte, resp *pb.GenerateResponse) error {
 	return proto.Unmarshal(parsedPayload, resp)
 }
 
-func convertToLLMRequestBody(payload []byte) (*scheduling.LLMRequestBody, error) {
+func convertToInferenceRequestBody(payload []byte) (*scheduling.InferenceRequestBody, error) {
 	pbReq := &pb.GenerateRequest{}
 	if err := toGenerateRequest(payload, pbReq); err != nil {
 		return nil, err
 	}
-	var body *scheduling.LLMRequestBody
+	var body *scheduling.InferenceRequestBody
 	switch pbReq.Input.(type) {
 	case *pb.GenerateRequest_Text:
-		body = &scheduling.LLMRequestBody{
+		body = &scheduling.InferenceRequestBody{
 			Completions: &scheduling.CompletionsRequest{
 				Prompt: scheduling.Prompt{Raw: pbReq.GetText()},
 			},
 			Payload: scheduling.PayloadProto{Message: pbReq},
 		}
 	case *pb.GenerateRequest_Tokenized:
-		body = &scheduling.LLMRequestBody{
+		body = &scheduling.InferenceRequestBody{
 			Completions: &scheduling.CompletionsRequest{
 				Prompt: scheduling.Prompt{Raw: pbReq.GetTokenized().OriginalText},
 			},
@@ -240,14 +240,14 @@ func toGenerateRequest(payload []byte, req *pb.GenerateRequest) error {
 	return proto.Unmarshal(parsedPayload, req)
 }
 
-func convertEmbedToLLMRequestBody(payload []byte) (*scheduling.LLMRequestBody, error) {
+func convertEmbedToInferenceRequestBody(payload []byte) (*scheduling.InferenceRequestBody, error) {
 	pbReq := &pb.EmbedRequest{}
 	if err := toEmbedRequest(payload, pbReq); err != nil {
 		return nil, err
 	}
-	var body *scheduling.LLMRequestBody
+	var body *scheduling.InferenceRequestBody
 	if pbReq.Tokenized != nil {
-		body = &scheduling.LLMRequestBody{
+		body = &scheduling.InferenceRequestBody{
 			Embeddings: &scheduling.EmbeddingsRequest{
 				Input: pbReq.GetTokenized().OriginalText,
 			},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -91,7 +91,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 		headers       map[string]string
 		malformedData []byte
 		wantErr       bool
-		want          *scheduling.LLMRequestBody
+		want          *scheduling.InferenceRequestBody
 	}{
 		{
 			name: "Valid Text Request",
@@ -101,7 +101,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				},
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Raw: "Hello world"},
 				},
@@ -125,7 +125,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				},
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Raw: "Tokenized hello"},
 				},
@@ -164,7 +164,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				Stream: true,
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Stream: true,
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: scheduling.Prompt{Raw: "Hello world"},
@@ -186,7 +186,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				},
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Embed"},
-			want: &scheduling.LLMRequestBody{
+			want: &scheduling.InferenceRequestBody{
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: "Embed this",
 				},

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -102,7 +102,7 @@ func (p *Plugin) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) []framework.Endpoint {
 	logger := log.FromContext(ctx)
 
 	if len(endpoints) <= 1 || p.config.AffinityThreshold <= 0 {

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -81,7 +81,7 @@ func (p *Plugin) TypedName() fwkplugin.TypedName {
 // endpoints are kept. 1% of the time, only negative-tier endpoints are kept
 // (epsilon exploration for recovery). If only one tier has endpoints, that
 // tier is returned. If no endpoints have predictions, all are kept.
-func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) []framework.Endpoint {
 	logger := log.FromContext(ctx)
 
 	if len(endpoints) <= 1 {

--- a/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler.go
@@ -63,7 +63,7 @@ func (h *SingleProfileHandler) WithName(name string) *SingleProfileHandler {
 
 // Pick selects the SchedulingProfiles to run from the list of candidate profiles, while taking into consideration the request properties and the
 // previously executed cycles along with their results.
-func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, request *framework.LLMRequest, profiles map[string]framework.SchedulerProfile,
+func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest, profiles map[string]framework.SchedulerProfile,
 	profileResults map[string]*framework.ProfileRunResult) map[string]framework.SchedulerProfile {
 	if len(profiles) == len(profileResults) { // all profiles have been executed already in previous call
 		return map[string]framework.SchedulerProfile{}
@@ -76,7 +76,7 @@ func (h *SingleProfileHandler) Pick(_ context.Context, _ *framework.CycleState, 
 // It may aggregate results, log test profile outputs, or apply custom logic. It specifies in the SchedulingResult the
 // key of the primary profile that should be used to get the request selected destination.
 // When a profile run fails, its result in the profileResults map is nil.
-func (h *SingleProfileHandler) ProcessResults(_ context.Context, _ *framework.CycleState, _ *framework.LLMRequest,
+func (h *SingleProfileHandler) ProcessResults(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest,
 	profileResults map[string]*framework.ProfileRunResult) (*framework.SchedulingResult, error) {
 	if len(profileResults) != 1 {
 		return nil, errors.New("single profile handler is intended to be used with a single profile, failed to process multiple profiles")

--- a/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler_test.go
@@ -28,7 +28,7 @@ import (
 
 type fakeSchedulerProfile struct{}
 
-func (f *fakeSchedulerProfile) Run(_ context.Context, _ *framework.LLMRequest, _ *framework.CycleState, _ []framework.Endpoint) (*framework.ProfileRunResult, error) {
+func (f *fakeSchedulerProfile) Run(_ context.Context, _ *framework.InferenceRequest, _ *framework.CycleState, _ []framework.Endpoint) (*framework.ProfileRunResult, error) {
 	return &framework.ProfileRunResult{}, nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
@@ -73,7 +73,7 @@ func (s *KVCacheUtilizationScorer) WithName(name string) *KVCacheUtilizationScor
 }
 
 // Score returns the scoring result for the given list of endpoints based on context.
-func (s *KVCacheUtilizationScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *KVCacheUtilizationScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	scores := make(map[framework.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
 		scores[endpoint] = 1 - endpoint.GetMetrics().KVCacheUsagePercent

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization_test.go
@@ -82,7 +82,7 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scores := NewKVCacheUtilizationScorer().Score(context.Background(), fwksched.NewCycleState(), &fwksched.LLMRequest{}, test.endpoints)
+			scores := NewKVCacheUtilizationScorer().Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, test.endpoints)
 
 			for i, endpoint := range test.endpoints {
 				expectedScore := test.expectedScoresEndpoint[i]

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -141,7 +141,7 @@ type epData struct {
 }
 
 // Score returns a float64 score in [0,1] for each endpoint.
-func (s *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	logger := log.FromContext(ctx)
 	scores := make(map[framework.Endpoint]float64, len(endpoints))
 	for _, ep := range endpoints {

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -73,7 +73,7 @@ func (s *LoraAffinityScorer) WithName(name string) *LoraAffinityScorer {
 	return s
 }
 
-func (s *LoraAffinityScorer) Score(_ context.Context, _ *framework.CycleState, request *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *LoraAffinityScorer) Score(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	scores := make(map[framework.Endpoint]float64, len(endpoints))
 
 	// Assign a score to each endpoint for loading the target adapter.

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
@@ -30,13 +30,13 @@ import (
 func TestLoraAffinityScorer(t *testing.T) {
 	tests := []struct {
 		name                   string
-		request                *fwksched.LLMRequest
+		request                *fwksched.InferenceRequest
 		endpoints              []fwksched.Endpoint
 		expectedScoresEndpoint map[string]float64 // Map of endpoint name to expected score
 	}{
 		{
 			name:    "Target model is active",
-			request: &fwksched.LLMRequest{TargetModel: "active-model-1"},
+			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
 					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
@@ -52,7 +52,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 		},
 		{
 			name:    "Target model is waiting",
-			request: &fwksched.LLMRequest{TargetModel: "active-model-1"},
+			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
 					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
@@ -68,7 +68,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 		},
 		{
 			name:    "Endpoints have no space for new model",
-			request: &fwksched.LLMRequest{TargetModel: "active-model-1"},
+			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
 					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
@@ -92,7 +92,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 		},
 		{
 			name:    "Multipleendpoints with mixed active and waiting models",
-			request: &fwksched.LLMRequest{TargetModel: "active-model-1"},
+			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
 					&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
@@ -140,7 +140,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 		},
 		{
 			name:                   "Empty pods slice",
-			request:                &fwksched.LLMRequest{TargetModel: "modelA"},
+			request:                &fwksched.InferenceRequest{TargetModel: "modelA"},
 			endpoints:              []fwksched.Endpoint{},
 			expectedScoresEndpoint: map[string]float64{}, // No pods, no scores
 		},

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/headers.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/headers.go
@@ -26,7 +26,7 @@ import (
 
 // parseFloatHeader retrieves a header by name, parses it as a float64,
 // and returns the value or an error if the header is missing or invalid.
-func parseFloatHeader(request schedulingtypes.LLMRequest, headerName string) (float64, error) {
+func parseFloatHeader(request schedulingtypes.InferenceRequest, headerName string) (float64, error) {
 	// 1. Get header value from the map
 	headerValue, ok := request.Headers[headerName]
 	if !ok {

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/latencypredictor_helper_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/latencypredictor_helper_test.go
@@ -125,7 +125,7 @@ func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
 	prefixCacheScores := []float64{0.0}
 
 	plCtx := &predictedLatencyCtx{
-		schedulingRequest: schedulingtypes.LLMRequest{
+		schedulingRequest: schedulingtypes.InferenceRequest{
 			TargetModel: "test-model",
 		},
 		incomingModelName: "incoming-model",
@@ -151,7 +151,7 @@ func TestBulkPredictWithMetrics_ChatCompletionsPrompt(t *testing.T) {
 		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
 	}
 
-	chatBody := &schedulingtypes.LLMRequestBody{
+	chatBody := &schedulingtypes.InferenceRequestBody{
 		ChatCompletions: &schedulingtypes.ChatCompletionsRequest{
 			Messages: []schedulingtypes.Message{
 				{Role: "user", Content: schedulingtypes.Content{Raw: "Hello world"}},

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/prediction_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/prediction_test.go
@@ -267,7 +267,7 @@ func TestGeneratePredictions(t *testing.T) {
 			cfg.StreamingMode = true
 			s := NewPredictedLatency(cfg, tt.predictor)
 
-			request := createTestLLMRequest("test-gen-pred", tt.ttftSLO, tt.avgTPOTSLO)
+			request := createTestInferenceRequest("test-gen-pred", tt.ttftSLO, tt.avgTPOTSLO)
 			plCtx := newPredictedLatencyContext(request)
 			plCtx.ttftSLO = tt.ttftSLO
 			plCtx.avgTPOTSLO = tt.avgTPOTSLO
@@ -349,7 +349,7 @@ func TestUpdateRequestContextWithPredictions(t *testing.T) {
 			cfg := DefaultConfig
 			s := NewPredictedLatency(cfg, nil)
 
-			request := createTestLLMRequest("test-update-ctx", 1000, 50)
+			request := createTestInferenceRequest("test-update-ctx", 1000, 50)
 			plCtx := newPredictedLatencyContext(request)
 
 			s.updateRequestContextWithPredictions(plCtx, tt.predictions)
@@ -377,7 +377,7 @@ func TestGeneratePredictions_ValidityFlags(t *testing.T) {
 	cfg.SLOBufferFactor = 1.0
 	s := NewPredictedLatency(cfg, predictor)
 
-	request := createTestLLMRequest("test-validity", 1000, 50)
+	request := createTestInferenceRequest("test-validity", 1000, 50)
 	plCtx := newPredictedLatencyContext(request)
 	plCtx.ttftSLO = 1000
 	plCtx.avgTPOTSLO = 50

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/preparedata_hooks.go
@@ -29,7 +29,7 @@ import (
 )
 
 // PrepareRequestData prepares the SLO context for the request, including parsing SLO headers and gathering prefix cache scores abds generating predictions.
-func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	logger := log.FromContext(ctx)
 	predictedLatencyCtx := s.getOrMakePredictedLatencyContextForRequest(request)
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks.go
@@ -51,7 +51,7 @@ var _ requestcontrol.ResponseBody = &PredictedLatency{}
 var _ requestcontrol.AdmissionPlugin = &PredictedLatency{}
 
 type predictedLatencyCtx struct {
-	schedulingRequest         schedulingtypes.LLMRequest
+	schedulingRequest         schedulingtypes.InferenceRequest
 	targetMetadata            *fwkdl.EndpointMetadata
 	prefillTargetMetadata     *fwkdl.EndpointMetadata
 	schedulingResult          *schedulingtypes.SchedulingResult
@@ -92,7 +92,7 @@ type predictedLatencyCtx struct {
 	decodeTokensAtDispatch           int64
 }
 
-func newPredictedLatencyContext(request *schedulingtypes.LLMRequest) *predictedLatencyCtx {
+func newPredictedLatencyContext(request *schedulingtypes.InferenceRequest) *predictedLatencyCtx {
 	var promptText string
 	if request.Body != nil {
 		promptText = request.Body.PromptText()
@@ -108,7 +108,7 @@ func newPredictedLatencyContext(request *schedulingtypes.LLMRequest) *predictedL
 	}
 }
 
-func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *schedulingtypes.LLMRequest) (*predictedLatencyCtx, error) {
+func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *schedulingtypes.InferenceRequest) (*predictedLatencyCtx, error) {
 	id := request.Headers[reqcommon.RequestIdHeaderKey]
 	if item := s.sloContextStore.Get(id); item != nil {
 		return item.Value(), nil
@@ -116,18 +116,18 @@ func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *schedul
 	return nil, fmt.Errorf("SLO context not found for request ID: %s", id)
 }
 
-func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *schedulingtypes.LLMRequest, ctx *predictedLatencyCtx) {
+func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *schedulingtypes.InferenceRequest, ctx *predictedLatencyCtx) {
 	id := request.Headers[reqcommon.RequestIdHeaderKey]
 	s.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
 }
 
-func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *schedulingtypes.LLMRequest) {
+func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *schedulingtypes.InferenceRequest) {
 	id := request.Headers[reqcommon.RequestIdHeaderKey]
 	s.sloContextStore.Delete(id)
 }
 
 // --- RequestControl Hooks ---
-func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.LLMRequest, schedulingResult *schedulingtypes.SchedulingResult) {
+func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, schedulingResult *schedulingtypes.SchedulingResult) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
@@ -203,7 +203,7 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
 }
 
-func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseReceived: request is nil, skipping")
@@ -212,7 +212,7 @@ func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *scheduli
 }
 
 // ResponseBody now handles both per-chunk processing and request completion logic.
-func (t *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+func (t *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.InferenceRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: request is nil, skipping")
@@ -335,7 +335,7 @@ func (t *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.En
 	return true
 }
 
-func (t *PredictedLatency) AdmitRequest(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func (t *PredictedLatency) AdmitRequest(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	logger := log.FromContext(ctx)
 	if request == nil {
 		// This should not happen as the framework should not call AdmitRequest with a nil request, but we defensively check to avoid panics

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/requestcontrol_hooks_test.go
@@ -71,7 +71,7 @@ func createTestRouter() *PredictedLatency {
 // Test cases
 
 func TestNewPredictedLatencyContext(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	ctx := newPredictedLatencyContext(request)
 
@@ -86,7 +86,7 @@ func TestNewPredictedLatencyContext(t *testing.T) {
 }
 
 func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
-	request := &schedulingtypes.LLMRequest{
+	request := &schedulingtypes.InferenceRequest{
 		Headers: map[string]string{reqcommon.RequestIdHeaderKey: "test-nil-body"},
 		Body:    nil,
 	}
@@ -97,7 +97,7 @@ func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
 }
 
 func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
-	request := createTestChatCompletionsLLMRequest("test-chat", 1.0, 0.05)
+	request := createTestChatCompletionsInferenceRequest("test-chat", 1.0, 0.05)
 	ctx := newPredictedLatencyContext(request)
 
 	assert.NotNil(t, ctx)
@@ -106,7 +106,7 @@ func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
 
 func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 
 	// Set context
@@ -121,7 +121,7 @@ func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
 
 func TestPredictedLatency_GetSLOContext_NotFound(t *testing.T) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	// Try to get context that doesn't exist
 	ctx, err := router.getPredictedLatencyContextForRequest(request)
@@ -133,7 +133,7 @@ func TestPredictedLatency_GetSLOContext_NotFound(t *testing.T) {
 
 func TestPredictedLatency_DeleteSLOContext(t *testing.T) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 
 	// Set and then delete context
@@ -149,7 +149,7 @@ func TestPredictedLatency_DeleteSLOContext(t *testing.T) {
 func TestPredictedLatency_PreRequest_NoSchedulingResult(t *testing.T) {
 	router := createTestRouter()
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	// Call PreRequest with nil scheduling result
 	router.PreRequest(ctx, request, nil)
@@ -162,7 +162,7 @@ func TestPredictedLatency_PreRequest_NoSchedulingResult(t *testing.T) {
 func TestPredictedLatency_PreRequest_EmptySchedulingResult(t *testing.T) {
 	router := createTestRouter()
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	schedulingResult := &schedulingtypes.SchedulingResult{
 		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{},
@@ -183,7 +183,7 @@ func TestPredictedLatency_PreRequest_Success(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set initial SLO context
@@ -216,7 +216,7 @@ func TestPredictedLatency_PreRequest_AddsToQueue(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set initial SLO context
@@ -242,8 +242,8 @@ func TestPredictedLatency_PreRequest_QueueAlreadyExists(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request1 := createTestLLMRequest("test-id-1", 100, 50)
-	request2 := createTestLLMRequest("test-id-2", 100, 50)
+	request1 := createTestInferenceRequest("test-id-1", 100, 50)
+	request2 := createTestInferenceRequest("test-id-2", 100, 50)
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set initial SLO contexts
@@ -272,7 +272,7 @@ func TestPredictedLatency_ResponseHeader_NilPredictor(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -292,7 +292,7 @@ func TestPredictedLatency_ResponseHeader_NoPod(t *testing.T) {
 	router.latencypredictor = mockPredictor
 
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -312,7 +312,7 @@ func TestPredictedLatency_ResponseHeader_NoContext(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	// Don't set SLO context
@@ -328,7 +328,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_NilPredictor(t *testing.T) 
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -348,7 +348,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FirstToken(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -405,7 +405,7 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FirstToken(t *testing.T)
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{} // EndOfStream is false
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -434,7 +434,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SubsequentTokens(t *testing
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -483,7 +483,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_QueueNotFound(t 
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -508,7 +508,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_NoContext(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	// Don't set SLO context - should handle gracefully
@@ -525,7 +525,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_Success(t *testi
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Create queue and add request
@@ -560,7 +560,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NilPredictor(t *
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -580,7 +580,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoPod(t *testing
 	router.latencypredictor = mockPredictor
 
 	ctx := context.Background()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 
 	predictedLatencyCtx := newPredictedLatencyContext(request)
@@ -601,7 +601,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoContext(t *tes
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Don't set SLO context - should handle gracefully
@@ -615,7 +615,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_WithMetrics(t *t
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Create queue
@@ -648,7 +648,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoSLOs(t *testin
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test-id", 0, 0) // No SLOs
+	request := createTestInferenceRequest("test-id", 0, 0) // No SLOs
 	response := &requestcontrol.Response{EndOfStream: true}
 
 	// Create queue
@@ -678,7 +678,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true} // True
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -711,7 +711,7 @@ func TestPredictedLatency_StreamingMode_ResponseBody_SingleChunk(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true} // True
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -744,7 +744,7 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FinalToken(t *testing.T)
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{EndOfStream: true} // True
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -802,7 +802,7 @@ func TestPredictedLatency_CheckPredictor_Success(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_Fields(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	// Test all field initialization
@@ -821,7 +821,7 @@ func TestPredictedLatencyContext_Fields(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	// Add some metrics
@@ -837,7 +837,7 @@ func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_PredictionData(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	ctx.predictionsForScheduling = make(map[string]endpointPredictionResult)
@@ -852,7 +852,7 @@ func TestPredictedLatencyContext_PredictionData(t *testing.T) {
 }
 
 func TestPredictedLatencyContext_PrefixCacheScores(t *testing.T) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	ctx := newPredictedLatencyContext(request)
 
 	// Set prefix cache scores
@@ -876,7 +876,7 @@ func TestPredictedLatency_ConcurrentContextAccess(t *testing.T) {
 		wg.Go(func() {
 
 			requestID := uuid.New().String()
-			request := createTestLLMRequest(requestID, 100, 50)
+			request := createTestInferenceRequest(requestID, 100, 50)
 			predictedLatencyCtx := newPredictedLatencyContext(request)
 
 			// Set context
@@ -903,14 +903,14 @@ func TestPredictedLatency_MultipleRequests_SamePod(t *testing.T) {
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
 
-	request1 := createTestLLMRequest("test-id-1", 100, 50)
-	request2 := createTestLLMRequest("test-id-2", 100, 50)
-	request3 := createTestLLMRequest("test-id-3", 100, 50)
+	request1 := createTestInferenceRequest("test-id-1", 100, 50)
+	request2 := createTestInferenceRequest("test-id-2", 100, 50)
+	request3 := createTestInferenceRequest("test-id-3", 100, 50)
 
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
 	// Create and set SLO contexts
-	for _, req := range []*schedulingtypes.LLMRequest{request1, request2, request3} {
+	for _, req := range []*schedulingtypes.InferenceRequest{request1, request2, request3} {
 		predictedLatencyCtx := newPredictedLatencyContext(req)
 		predictedLatencyCtx.avgTPOTSLO = 50
 		router.setPredictedLatencyContextForRequest(req, predictedLatencyCtx)
@@ -934,7 +934,7 @@ func TestPredictedLatency_RequestLifecycle_ResponseEndOfStream(t *testing.T) {
 
 	ctx := context.Background()
 	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	response := &requestcontrol.Response{}
 	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
 
@@ -987,8 +987,8 @@ func TestPredictedLatency_MultipleRequests_DifferentPods(t *testing.T) {
 	endpoint1 := createTestEndpoint("test-pod-1", 1, 1, 1)
 	endpoint2 := createTestEndpoint("test-pod-2", 1, 1, 1)
 
-	request1 := createTestLLMRequest("test-id-1", 100, 50)
-	request2 := createTestLLMRequest("test-id-2", 100, 50)
+	request1 := createTestInferenceRequest("test-id-1", 100, 50)
+	request2 := createTestInferenceRequest("test-id-2", 100, 50)
 
 	schedulingResult1 := createTestSchedulingResult(endpoint1.GetMetadata())
 	schedulingResult2 := createTestSchedulingResult(endpoint2.GetMetadata())
@@ -1053,7 +1053,7 @@ func TestPredictedLatencyContext_SLOValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := createTestLLMRequest("test-id", tt.ttftSLO, tt.tpotSLO)
+			request := createTestInferenceRequest("test-id", tt.ttftSLO, tt.tpotSLO)
 			ctx := newPredictedLatencyContext(request)
 			ctx.ttftSLO = tt.ttftSLO
 			ctx.avgTPOTSLO = tt.tpotSLO
@@ -1075,7 +1075,7 @@ func BenchmarkPredictedLatency_PreRequest(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		requestID := uuid.New().String()
-		request := createTestLLMRequest(requestID, 100, 50)
+		request := createTestInferenceRequest(requestID, 100, 50)
 		predictedLatencyCtx := newPredictedLatencyContext(request)
 		predictedLatencyCtx.avgTPOTSLO = 50
 		router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
@@ -1085,7 +1085,7 @@ func BenchmarkPredictedLatency_PreRequest(b *testing.B) {
 
 func BenchmarkPredictedLatency_ContextOperations(b *testing.B) {
 	router := createTestRouter()
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 	predictedLatencyCtx := newPredictedLatencyContext(request)
 
 	b.ResetTimer()
@@ -1097,7 +1097,7 @@ func BenchmarkPredictedLatency_ContextOperations(b *testing.B) {
 }
 
 func BenchmarkPredictedLatencyContext_Creation(b *testing.B) {
-	request := createTestLLMRequest("test", 100, 50)
+	request := createTestInferenceRequest("test", 100, 50)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer.go
@@ -358,7 +358,7 @@ func (s *PredictedLatency) scoreWithoutPredictions(
 	return scores
 }
 
-func (s *PredictedLatency) Score(ctx context.Context, state *framework.CycleState, request *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *PredictedLatency) Score(ctx context.Context, state *framework.CycleState, request *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	logger := log.FromContext(ctx)
 	if s.latencypredictor == nil {
 		logger.V(logutil.DEBUG).Info("PredictedLatency: no predictor configured, returning nil scores")
@@ -414,7 +414,7 @@ func (s *PredictedLatency) Score(ctx context.Context, state *framework.CycleStat
 	return scores
 }
 
-func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.LLMRequest) *predictedLatencyCtx {
+func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.InferenceRequest) *predictedLatencyCtx {
 	sloCtx, err := t.getPredictedLatencyContextForRequest(request)
 	if err != nil {
 		sloCtx = newPredictedLatencyContext(request)

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_helpers.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_helpers.go
@@ -29,7 +29,7 @@ import (
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
-func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *schedulingtypes.LLMRequest, predictedLatencyCtx *predictedLatencyCtx) {
+func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *schedulingtypes.InferenceRequest, predictedLatencyCtx *predictedLatencyCtx) {
 	logger := log.FromContext(ctx)
 	var err error
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/predictedlatency/scorer_test.go
@@ -120,16 +120,16 @@ func createTestEndpoint(name string, kvCacheUsage float64, runningRequestsSize, 
 	)
 }
 
-func createTestLLMRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.LLMRequest {
-	return createTestLLMRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.LLMRequestBody{
+func createTestInferenceRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.InferenceRequest {
+	return createTestInferenceRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.InferenceRequestBody{
 		Completions: &fwksched.CompletionsRequest{
 			Prompt: fwksched.Prompt{Raw: "test prompt"},
 		},
 	})
 }
 
-func createTestChatCompletionsLLMRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.LLMRequest {
-	return createTestLLMRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.LLMRequestBody{
+func createTestChatCompletionsInferenceRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.InferenceRequest {
+	return createTestInferenceRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.InferenceRequestBody{
 		ChatCompletions: &fwksched.ChatCompletionsRequest{
 			Messages: []fwksched.Message{
 				{Role: "system", Content: fwksched.Content{Raw: "You are a helpful assistant."}},
@@ -139,7 +139,7 @@ func createTestChatCompletionsLLMRequest(reqID string, ttftSLO, tpotSLO float64)
 	})
 }
 
-func createTestLLMRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *fwksched.LLMRequestBody) *fwksched.LLMRequest {
+func createTestInferenceRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *fwksched.InferenceRequestBody) *fwksched.InferenceRequest {
 	headers := make(map[string]string)
 	headers[reqcommon.RequestIdHeaderKey] = reqID
 	if ttftSLO > 0 {
@@ -149,15 +149,15 @@ func createTestLLMRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *
 		headers["x-avg-tpot-slo"] = fmt.Sprintf("%f", tpotSLO)
 	}
 
-	return &fwksched.LLMRequest{
+	return &fwksched.InferenceRequest{
 		Headers: headers,
 		Body:    body,
 	}
 }
 
-// Add this helper function after the createTestLLMRequest function
+// Add this helper function after the createTestInferenceRequest function
 
-func setupPredictionContext(router *PredictedLatency, request *fwksched.LLMRequest, endpoints []fwksched.Endpoint, predictor *mockPredictor) {
+func setupPredictionContext(router *PredictedLatency, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint, predictor *mockPredictor) {
 	ctx := context.Background()
 
 	// Create prediction context
@@ -200,7 +200,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 		name           string
 		predictor      *mockPredictor
 		strategy       headroomStrategy
-		request        *fwksched.LLMRequest
+		request        *fwksched.InferenceRequest
 		endpoints      []fwksched.Endpoint
 		expectedScores map[string]float64 // Map of pod name to expected score
 		expectNil      bool
@@ -209,7 +209,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 			name:      "No predictor configured",
 			predictor: nil,
 			strategy:  headroomStrategyLeast,
-			request:   createTestLLMRequest("test", 1.0, 0.05),
+			request:   createTestInferenceRequest("test", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{
 				createTestEndpoint("pod1", 0.5, 2, 1),
 			},
@@ -225,7 +225,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 				},
 			},
 			strategy: headroomStrategyLeast,
-			request:  createTestLLMRequest("test", 1.0, 0.05),
+			request:  createTestInferenceRequest("test", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{
 				createTestEndpoint("pod1", 0.5, 2, 1), // 50% KV cache
 				createTestEndpoint("pod2", 0.6, 3, 2), // 60% KV cache
@@ -245,7 +245,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 				},
 			},
 			strategy: headroomStrategyLeast,
-			request:  createTestLLMRequest("test", 1.0, 0.05),
+			request:  createTestInferenceRequest("test", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{
 				createTestEndpoint("pod1", 0.8, 5, 3), // 80% KV cache, high load
 				createTestEndpoint("pod2", 0.9, 6, 4), // 90% KV cache, very high load
@@ -262,7 +262,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 				},
 			},
 			strategy: headroomStrategyLeast,
-			request:  createTestLLMRequest("test", 1.0, 0.05),
+			request:  createTestInferenceRequest("test", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{
 				createTestEndpoint("pod-positive", 0.3, 1, 0), // Low KV cache, positive headroom
 				createTestEndpoint("pod-negative", 0.9, 6, 4), // High KV cache, negative headroom
@@ -276,7 +276,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 				err: errors.New("prediction failed"),
 			},
 			strategy: headroomStrategyLeast,
-			request:  createTestLLMRequest("test", 1.0, 0.05),
+			request:  createTestInferenceRequest("test", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{
 				createTestEndpoint("pod1", 0.5, 2, 1),
 				createTestEndpoint("pod2", 0.6, 3, 2),
@@ -290,7 +290,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 			name:      "Empty pod list",
 			predictor: &mockPredictor{},
 			strategy:  headroomStrategyLeast,
-			request:   createTestLLMRequest("test", 1.0, 0.05),
+			request:   createTestInferenceRequest("test", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{},
 			// Should return empty scores map
 			expectedScores: map[string]float64{},
@@ -304,7 +304,7 @@ func TestPredictedLatency_Score(t *testing.T) {
 				},
 			},
 			strategy: headroomStrategyLeast,
-			request:  createTestChatCompletionsLLMRequest("test-chat", 1.0, 0.05),
+			request:  createTestChatCompletionsInferenceRequest("test-chat", 1.0, 0.05),
 			endpoints: []fwksched.Endpoint{
 				createTestEndpoint("pod1", 0.5, 2, 1),
 				createTestEndpoint("pod2", 0.6, 3, 2),
@@ -409,7 +409,7 @@ func TestPredictedLatency_Strategies(t *testing.T) {
 			cfg.HeadroomSelectionStrategy = string(tt.strategy)
 			router := NewPredictedLatency(cfg, predictor)
 
-			request := createTestLLMRequest("test", 1.0, 0.05)
+			request := createTestInferenceRequest("test", 1.0, 0.05)
 			endpoints := []fwksched.Endpoint{
 				createTestEndpoint("pod1", 0.5, 2, 1),
 				createTestEndpoint("pod2", 0.6, 3, 2),
@@ -771,7 +771,7 @@ func TestSloContextStoreEviction(t *testing.T) {
 	requestID := "test-req-id"
 	endpointName := types.NamespacedName{Name: "test-model", Namespace: "default"}
 
-	req := &fwksched.LLMRequest{
+	req := &fwksched.InferenceRequest{
 		Headers: map[string]string{
 			reqcommon.RequestIdHeaderKey: requestID,
 		},

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -92,7 +92,7 @@ func (p *Plugin) Consumes() map[string]any {
 }
 
 // Score returns the scoring result for the given list of pods based on prefix cache match info.
-func (p *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (p *Plugin) Score(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	scores := make(map[framework.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
@@ -75,7 +75,7 @@ func (s *QueueScorer) WithName(name string) *QueueScorer {
 }
 
 // Score returns the scoring result for the given list of endpoints based on context.
-func (s *QueueScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *QueueScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	minQueueSize := math.MaxInt
 	maxQueueSize := math.MinInt
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue_test.go
@@ -73,7 +73,7 @@ func TestQueueScorer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.LLMRequest{}, test.endpoints)
+			scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, test.endpoints)
 
 			for i, endpoint := range test.endpoints {
 				expectedScore := test.expectedScoresEndpoint[i]

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/running_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/running_test.go
@@ -73,7 +73,7 @@ func TestRunningRequestsSizeScorer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.LLMRequest{}, test.endpoints)
+			scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, test.endpoints)
 
 			for i, endpoint := range test.endpoints {
 				expectedScore := test.expectedScoresPod[i]

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
@@ -75,7 +75,7 @@ func (s *RunningRequestsSizeScorer) WithName(name string) *RunningRequestsSizeSc
 }
 
 // Score returns the scoring result for the given list of pods based on context.
-func (s *RunningRequestsSizeScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *RunningRequestsSizeScorer) Score(_ context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	minQueueSize := math.MaxInt
 	maxQueueSize := math.MinInt
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -80,7 +80,7 @@ func (s *TokenLoadScorer) Consumes() map[string]any {
 	}
 }
 
-func (s *TokenLoadScorer) Score(ctx context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
+func (s *TokenLoadScorer) Score(ctx context.Context, _ *framework.CycleState, _ *framework.InferenceRequest, endpoints []framework.Endpoint) map[framework.Endpoint]float64 {
 	scores := make(map[framework.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -53,7 +53,7 @@ func TestTokenLoadScorer(t *testing.T) {
 	// pod3: 1000 tokens
 	endpoints[2].Put(attrconcurrency.InFlightLoadKey, &attrconcurrency.InFlightLoad{Tokens: 1000})
 
-	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.LLMRequest{}, endpoints)
+	scores := scorer.Score(context.Background(), fwksched.NewCycleState(), &fwksched.InferenceRequest{}, endpoints)
 
 	assert.InDelta(t, 1.0, scores[endpoints[0]], 0.0001, "Pod1 (0 tokens) should have score 1.0")
 	assert.InDelta(t, 0.5, scores[endpoints[1]], 0.0001, "Pod2 (500 tokens) should have score 0.5")

--- a/pkg/epp/framework/plugins/scheduling/test/filter/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/test/filter/filter_test.go
@@ -30,13 +30,13 @@ import (
 func TestFilter(t *testing.T) {
 	tests := []struct {
 		name   string
-		req    *fwksched.LLMRequest
+		req    *fwksched.InferenceRequest
 		input  []fwksched.Endpoint
 		output []fwksched.Endpoint
 	}{
 		{
 			name: "header unset in request",
-			req:  &fwksched.LLMRequest{}, // Deliberately unset
+			req:  &fwksched.InferenceRequest{}, // Deliberately unset
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3000"}, nil, nil),
 			},
@@ -44,7 +44,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "header set but no IP match",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.99"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.99"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3000"}, nil, nil),
 			},
@@ -52,7 +52,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "IP-only header matches pod (port-agnostic)",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.1"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.1"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3002"}, nil, nil),
 			},
@@ -62,7 +62,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "IP:port header matches exact port",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.1:3002"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.1:3002"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3000"}, nil, nil),
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3002"}, nil, nil),
@@ -74,7 +74,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "IP:port header with non-matching port produces no match",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.1:9999"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.1:9999"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3002"}, nil, nil),
 			},
@@ -82,7 +82,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "multiple header values (IP and IP:port) produce multiple matches in order and deduped",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.3:3004, 10.0.0.2, 10.0.0.3"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "10.0.0.3:3004, 10.0.0.2, 10.0.0.3"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.1", Port: "3000"}, nil, nil),
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.2", Port: "3002"}, nil, nil),
@@ -95,7 +95,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "IPv6 with brackets and port",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "[fd00::1]:3002"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "[fd00::1]:3002"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "fd00::1", Port: "3002"}, nil, nil),
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "fd00::2", Port: "3002"}, nil, nil),
@@ -106,7 +106,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "IPv6 bare address (no port)",
-			req:  &fwksched.LLMRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "fd00::2"}},
+			req:  &fwksched.InferenceRequest{Headers: map[string]string{test.HeaderTestEppEndPointSelectionKey: "fd00::2"}},
 			input: []fwksched.Endpoint{
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "fd00::1", Port: "3002"}, nil, nil),
 				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{Address: "fd00::2", Port: "3004"}, nil, nil),

--- a/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
+++ b/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
@@ -67,7 +67,7 @@ func (f *HeaderBasedTestingFilter) WithName(name string) *HeaderBasedTestingFilt
 // Filter selects endpoints whose IP or IP:port matches any value in the
 // "test-epp-endpoint-selection" header. Values may be "IP" or "IP:port".
 // If a port is provided, only an exact IP:port match is accepted.
-func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *framework.CycleState, request *framework.LLMRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+func (f *HeaderBasedTestingFilter) Filter(_ context.Context, _ *framework.CycleState, request *framework.InferenceRequest, endpoints []framework.Endpoint) []framework.Endpoint {
 	hv, ok := request.Headers[test.HeaderTestEppEndPointSelectionKey]
 	if !ok || strings.TrimSpace(hv) == "" {
 		return []framework.Endpoint{}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -97,7 +97,7 @@ type RequestContext struct {
 	RequestRunning            bool
 	Request                   *Request
 
-	SchedulingRequest *schedulingtypes.LLMRequest
+	SchedulingRequest *schedulingtypes.InferenceRequest
 
 	RequestState         StreamRequestState
 	modelServerStreaming bool

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -177,7 +177,7 @@ type flowControlRequest struct {
 	fairnessID        string
 	priority          int
 	requestByteSize   uint64
-	inferenceRequest  *scheduling.LLMRequest
+	inferenceRequest  *scheduling.InferenceRequest
 	receivedTimestamp time.Time
 	reqMetadata       map[string]any
 	inferencePoolName string
@@ -192,13 +192,15 @@ func (r *flowControlRequest) ID() string {
 	}
 	return r.inferenceRequest.RequestId
 }
-func (r *flowControlRequest) InitialEffectiveTTL() time.Duration       { return 0 } // Use controller default.
-func (r *flowControlRequest) ByteSize() uint64                         { return r.requestByteSize }
-func (r *flowControlRequest) InferenceRequest() *scheduling.LLMRequest { return r.inferenceRequest }
-func (r *flowControlRequest) ReceivedTimestamp() time.Time             { return r.receivedTimestamp }
-func (r *flowControlRequest) GetMetadata() map[string]any              { return r.reqMetadata }
-func (r *flowControlRequest) InferencePoolName() string                { return r.inferencePoolName }
-func (r *flowControlRequest) ModelName() string                        { return r.modelName }
+func (r *flowControlRequest) InitialEffectiveTTL() time.Duration { return 0 } // Use controller default.
+func (r *flowControlRequest) ByteSize() uint64                   { return r.requestByteSize }
+func (r *flowControlRequest) InferenceRequest() *scheduling.InferenceRequest {
+	return r.inferenceRequest
+}
+func (r *flowControlRequest) ReceivedTimestamp() time.Time { return r.receivedTimestamp }
+func (r *flowControlRequest) GetMetadata() map[string]any  { return r.reqMetadata }
+func (r *flowControlRequest) InferencePoolName() string    { return r.inferencePoolName }
+func (r *flowControlRequest) ModelName() string            { return r.modelName }
 func (r *flowControlRequest) TargetModelName() string {
 	if r.inferenceRequest == nil {
 		return ""

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -69,7 +69,7 @@ func TestLegacyAdmissionController_Admit(t *testing.T) {
 	t.Parallel()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	reqCtx := &handlers.RequestContext{
-		SchedulingRequest: &schedulingtypes.LLMRequest{RequestId: "test-req"},
+		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestId: "test-req"},
 		Request: &handlers.Request{
 			Metadata: map[string]any{},
 		},
@@ -180,7 +180,7 @@ func TestFlowControlRequestAdapter(t *testing.T) {
 				fairnessID:       tc.fairnessID,
 				priority:         tc.priority,
 				requestByteSize:  tc.requestByteSize,
-				inferenceRequest: &schedulingtypes.LLMRequest{RequestId: tc.requestID},
+				inferenceRequest: &schedulingtypes.InferenceRequest{RequestId: tc.requestID},
 			}
 
 			assert.Equal(t, tc.requestID, fcReq.ID(), "ID() mismatch")
@@ -195,7 +195,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 	t.Parallel()
 	ctx := logutil.NewTestLoggerIntoContext(context.Background())
 	reqCtx := &handlers.RequestContext{
-		SchedulingRequest: &schedulingtypes.LLMRequest{RequestId: "test-req"},
+		SchedulingRequest: &schedulingtypes.InferenceRequest{RequestId: "test-req"},
 		Request: &handlers.Request{
 			Metadata: map[string]any{},
 		},

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -65,7 +65,7 @@ type Datastore interface {
 
 // Scheduler defines the interface required by the Director for scheduling.
 type Scheduler interface {
-	Schedule(ctx context.Context, request *fwksched.LLMRequest, candidateEndpoints []fwksched.Endpoint) (result *fwksched.SchedulingResult, err error)
+	Schedule(ctx context.Context, request *fwksched.InferenceRequest, candidateEndpoints []fwksched.Endpoint) (result *fwksched.SchedulingResult, err error)
 }
 
 // NewDirectorWithConfig creates a new Director instance with all dependencies.
@@ -151,8 +151,8 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 		attribute.Int("request_prio", *infObjective.Spec.Priority),
 	)
 
-	// Prepare LLMRequest (needed for both saturation detection and Scheduler)
-	reqCtx.SchedulingRequest = &fwksched.LLMRequest{
+	// Prepare InferenceRequest (needed for both saturation detection and Scheduler)
+	reqCtx.SchedulingRequest = &fwksched.InferenceRequest{
 		RequestId:        reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
 		TargetModel:      reqCtx.TargetModelName,
 		Body:             llmRequestBody,
@@ -206,7 +206,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	return reqCtx, nil
 }
 
-func (d *Director) processRequestBody(ctx context.Context, reqCtx *handlers.RequestContext, parser fwkrh.Parser) (*fwksched.LLMRequestBody, error) {
+func (d *Director) processRequestBody(ctx context.Context, reqCtx *handlers.RequestContext, parser fwkrh.Parser) (*fwksched.InferenceRequestBody, error) {
 	llmRequestBody, err := parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 	if err != nil {
 		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: err.Error()}
@@ -380,7 +380,7 @@ func (d *Director) GetRandomEndpoint() *fwkdl.EndpointMetadata {
 	return pod.GetMetadata()
 }
 
-func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.LLMRequest,
+func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.InferenceRequest,
 	schedulingResult *fwksched.SchedulingResult) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.preRequestPlugins {
@@ -393,7 +393,7 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.L
 }
 
 func (d *Director) runPrepareDataPlugins(ctx context.Context,
-	request *fwksched.LLMRequest, endpoints []fwksched.Endpoint) error {
+	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	if len(d.requestControlPlugins.prepareDataPlugins) == 0 {
 		return nil
 	}
@@ -401,7 +401,7 @@ func (d *Director) runPrepareDataPlugins(ctx context.Context,
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,
-	request *fwksched.LLMRequest, endpoints []fwksched.Endpoint) bool {
+	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) bool {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.admissionPlugins {
 		loggerDebug.Info("Running AdmitRequest plugin", "plugin", plugin.TypedName())
@@ -414,7 +414,7 @@ func (d *Director) runAdmissionPlugins(ctx context.Context,
 	return true
 }
 
-func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksched.LLMRequest, response *fwk.Response, targetEndpoint *fwkdl.EndpointMetadata) {
+func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwk.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
 	for _, plugin := range d.requestControlPlugins.responseReceivedPlugins {
 		loggerDebug.Info("Running ResponseReceived plugin", "plugin", plugin.TypedName())
@@ -425,7 +425,7 @@ func (d *Director) runResponseHeaderPlugins(ctx context.Context, request *fwksch
 	}
 }
 
-func (d *Director) runResponseBodyPlugins(ctx context.Context, request *fwksched.LLMRequest, response *fwk.Response, targetEndpoint *fwkdl.EndpointMetadata) {
+func (d *Director) runResponseBodyPlugins(ctx context.Context, request *fwksched.InferenceRequest, response *fwk.Response, targetEndpoint *fwkdl.EndpointMetadata) {
 	loggerTrace := log.FromContext(ctx).V(logutil.TRACE)
 	for _, plugin := range d.requestControlPlugins.responseStreamingPlugins {
 		loggerTrace.Info("Running ResponseStreaming plugin", "plugin", plugin.TypedName())

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -75,7 +75,7 @@ type mockScheduler struct {
 	dataProduced    bool // denotes whether data production is expected.
 }
 
-func (m *mockScheduler) Schedule(_ context.Context, _ *fwksched.LLMRequest, endpoints []fwksched.Endpoint) (*fwksched.SchedulingResult, error) {
+func (m *mockScheduler) Schedule(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) (*fwksched.SchedulingResult, error) {
 	if endpoints != nil && m.dataProduced {
 		data, ok := endpoints[0].Get(mockProducedDataKey)
 		if !ok || data.(mockProducedDataType).value != 42 {
@@ -125,7 +125,7 @@ func (m *mockPrepareDataPlugin) Consumes() map[string]any {
 	return m.consumes
 }
 
-func (m *mockPrepareDataPlugin) PrepareRequestData(ctx context.Context, request *fwksched.LLMRequest, endpoints []fwksched.Endpoint) error {
+func (m *mockPrepareDataPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, mockProducedDataType{value: 42})
 	return nil
 }
@@ -154,7 +154,7 @@ func (m *mockAdmissionPlugin) TypedName() fwkplugin.TypedName {
 	return m.typedName
 }
 
-func (m *mockAdmissionPlugin) AdmitRequest(ctx context.Context, request *fwksched.LLMRequest, endpoints []fwksched.Endpoint) error {
+func (m *mockAdmissionPlugin) AdmitRequest(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	return m.denialError
 }
 
@@ -1185,12 +1185,12 @@ func (p *testResponseStreaming) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *testResponseReceived) ResponseHeader(_ context.Context, _ *fwksched.LLMRequest, response *fwk.Response, targetPod *fwkdl.EndpointMetadata) {
+func (p *testResponseReceived) ResponseHeader(_ context.Context, _ *fwksched.InferenceRequest, response *fwk.Response, targetPod *fwkdl.EndpointMetadata) {
 	p.lastRespOnResponse = response
 	p.lastTargetPodOnResponse = targetPod.NamespacedName.String()
 }
 
-func (p *testResponseStreaming) ResponseBody(_ context.Context, _ *fwksched.LLMRequest, response *fwk.Response, targetPod *fwkdl.EndpointMetadata) {
+func (p *testResponseStreaming) ResponseBody(_ context.Context, _ *fwksched.InferenceRequest, response *fwk.Response, targetPod *fwkdl.EndpointMetadata) {
 	p.respsOnStreaming = append(p.respsOnStreaming, response)
 	p.targetPodsOnStreaming = append(p.targetPodsOnStreaming, targetPod.NamespacedName.String())
 

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -28,7 +28,7 @@ import (
 // executePluginsAsDAG executes PrepareData plugins as a DAG based on their dependencies asynchronously.
 // So, a plugin is executed only after all its dependencies have been executed.
 // If there is a cycle or any plugin fails with error, it returns an error.
-func executePluginsAsDAG(plugins []fwk.PrepareDataPlugin, ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func executePluginsAsDAG(plugins []fwk.PrepareDataPlugin, ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	for _, plugin := range plugins {
 		if err := plugin.PrepareRequestData(ctx, request, endpoints); err != nil {
 			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
@@ -39,7 +39,7 @@ func executePluginsAsDAG(plugins []fwk.PrepareDataPlugin, ctx context.Context, r
 
 // prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
 func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.PrepareDataPlugin,
-	ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+	ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- executePluginsAsDAG(plugins, ctx, request, endpoints)

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -42,7 +42,7 @@ func (m *mockPrepareRequestDataPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Type: "mock", Name: m.name}
 }
 
-func (m *mockPrepareRequestDataPlugin) PrepareRequestData(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func (m *mockPrepareRequestDataPlugin) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	m.executed = true
 	if m.delay > 0 {
 		select {
@@ -144,7 +144,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			ctx, cancel := tc.ctxFn()
 			defer cancel()
 
-			err := prepareDataPluginsWithTimeout(tc.timeout, tc.plugins, ctx, &schedulingtypes.LLMRequest{}, nil)
+			err := prepareDataPluginsWithTimeout(tc.timeout, tc.plugins, ctx, &schedulingtypes.InferenceRequest{}, nil)
 
 			if tc.expectSuccess {
 				assert.NoError(t, err)
@@ -168,7 +168,7 @@ type dagTestPlugin struct {
 	mu       sync.Mutex
 }
 
-func (p *dagTestPlugin) PrepareRequestData(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+func (p *dagTestPlugin) PrepareRequestData(ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.execTime = time.Now()
@@ -280,7 +280,7 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 				plugin.execTime = time.Time{}
 			}
 
-			err := executePluginsAsDAG(tc.plugins, context.Background(), &schedulingtypes.LLMRequest{}, nil)
+			err := executePluginsAsDAG(tc.plugins, context.Background(), &schedulingtypes.InferenceRequest{}, nil)
 
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -51,7 +51,7 @@ type Scheduler struct {
 }
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.
-func (s *Scheduler) Schedule(ctx context.Context, request *framework.LLMRequest, candidateEndpoints []framework.Endpoint) (result *framework.SchedulingResult, err error) {
+func (s *Scheduler) Schedule(ctx context.Context, request *framework.InferenceRequest, candidateEndpoints []framework.Endpoint) (result *framework.SchedulingResult, err error) {
 	loggerVerbose := log.FromContext(ctx).V(logutil.VERBOSE)
 
 	scheduleStart := time.Now()

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -114,7 +114,7 @@ func (p *SchedulerProfile) String() string {
 
 // Run runs a SchedulerProfile. It invokes all the SchedulerProfile plugins for the given request in this
 // order - Filters, Scorers, Picker. After completing all, it returns the result.
-func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.LLMRequest, cycleState *fwksched.CycleState, candidateEndpoints []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
+func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.InferenceRequest, cycleState *fwksched.CycleState, candidateEndpoints []fwksched.Endpoint) (*fwksched.ProfileRunResult, error) {
 	endpoints := p.runFilterPlugins(ctx, request, cycleState, candidateEndpoints)
 	if len(endpoints) == 0 {
 		return nil, errcommmon.Error{Code: errcommmon.Internal, Msg: "no endpoints available for the given request"}
@@ -127,7 +127,7 @@ func (p *SchedulerProfile) Run(ctx context.Context, request *fwksched.LLMRequest
 	return result, nil
 }
 
-func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksched.LLMRequest, cycleState *fwksched.CycleState, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksched.InferenceRequest, cycleState *fwksched.CycleState, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	logger := log.FromContext(ctx)
 	filteredEndpoints := endpoints
 	logger.V(logutil.DEBUG).Info("Before running filter plugins", "endpoints", filteredEndpoints)
@@ -148,7 +148,7 @@ func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksch
 	return filteredEndpoints
 }
 
-func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksched.LLMRequest, cycleState *fwksched.CycleState, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksched.InferenceRequest, cycleState *fwksched.CycleState, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	logger := log.FromContext(ctx)
 	logger.V(logutil.DEBUG).Info("Before running scorer plugins", "endpoints", endpoints)
 

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -120,7 +120,7 @@ func TestSchedulePlugins(t *testing.T) {
 			test.profile.picker.(*testPlugin).reset()
 
 			// Initialize the scheduling context
-			request := &fwksched.LLMRequest{
+			request := &fwksched.InferenceRequest{
 				TargetModel: "test-model",
 				RequestId:   uuid.NewString(),
 			}
@@ -204,13 +204,13 @@ func (tp *testPlugin) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-func (tp *testPlugin) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.LLMRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func (tp *testPlugin) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	tp.FilterCallCount++
 	return findEndpoints(endpoints, tp.FilterRes...)
 
 }
 
-func (tp *testPlugin) Score(_ context.Context, _ *fwksched.CycleState, _ *fwksched.LLMRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+func (tp *testPlugin) Score(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	tp.ScoreCallCount++
 	scoredEndpoints := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
@@ -396,7 +396,7 @@ func TestRunWithOutOfRangeScores(t *testing.T) {
 		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
 	}
 
-	request := &fwksched.LLMRequest{
+	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
 		RequestId:   uuid.NewString(),
 	}
@@ -448,7 +448,7 @@ func TestFilterExecutionOrder(t *testing.T) {
 		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil),
 	}
 
-	request := &fwksched.LLMRequest{
+	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
 		RequestId:   uuid.NewString(),
 	}
@@ -492,7 +492,7 @@ func TestFilterExecutionOrderViaAddPlugins(t *testing.T) {
 		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil),
 	}
 
-	request := &fwksched.LLMRequest{
+	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
 		RequestId:   uuid.NewString(),
 	}
@@ -544,7 +544,7 @@ func TestFilterChainReceivesPreviousOutput(t *testing.T) {
 		fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, nil, nil),
 	}
 
-	request := &fwksched.LLMRequest{
+	request := &fwksched.InferenceRequest{
 		TargetModel: "test-model",
 		RequestId:   uuid.NewString(),
 	}
@@ -570,7 +570,7 @@ func (f *orderTrackingFilter) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: f.name, Type: f.name}
 }
 
-func (f *orderTrackingFilter) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.LLMRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func (f *orderTrackingFilter) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	*f.executionOrder = append(*f.executionOrder, f.name)
 	return endpoints // pass-through
 }
@@ -585,7 +585,7 @@ func (f *countingFilter) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: f.name, Type: f.name}
 }
 
-func (f *countingFilter) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.LLMRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func (f *countingFilter) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	*f.receivedCount = len(endpoints)
 	return endpoints // pass-through
 }
@@ -599,7 +599,7 @@ func (p *filterOnlyPlugin) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *filterOnlyPlugin) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.LLMRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func (p *filterOnlyPlugin) Filter(_ context.Context, _ *fwksched.CycleState, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	return endpoints
 }
 

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -60,14 +60,14 @@ func TestSchedule(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		req     *fwksched.LLMRequest
+		req     *fwksched.InferenceRequest
 		input   []fwksched.Endpoint
 		wantRes *fwksched.SchedulingResult
 		err     bool
 	}{
 		{
 			name: "no candidate endpoints",
-			req: &fwksched.LLMRequest{
+			req: &fwksched.InferenceRequest{
 				RequestId:   uuid.NewString(),
 				TargetModel: "any-model",
 			},
@@ -77,7 +77,7 @@ func TestSchedule(t *testing.T) {
 		},
 		{
 			name: "finds optimal endpoint",
-			req: &fwksched.LLMRequest{
+			req: &fwksched.InferenceRequest{
 				RequestId:   uuid.NewString(),
 				TargetModel: "critical",
 			},

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -357,8 +357,8 @@ func (ts *testDirector) HandleRequest(ctx context.Context, reqCtx *handlers.Requ
 	reqCtx.TargetEndpoint = fmt.Sprintf("%s:%d", podAddress, poolPort)
 
 	// Populate SchedulingRequest for testing request-based streaming detection.
-	reqCtx.SchedulingRequest = &scheduling.LLMRequest{
-		Body: &scheduling.LLMRequestBody{},
+	reqCtx.SchedulingRequest = &scheduling.InferenceRequest{
+		Body: &scheduling.InferenceRequestBody{},
 	}
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		reqCtx.SchedulingRequest.Body.Stream = true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Enables direct application across various GenAI models, not only OpenAI format, without rewriting the core admission, mutation, or scheduling flows. Pluggable parsers can now intercept raw request bytes and construct a generic InferenceRequest upfront, giving the EPP the flexibility to route, process, and score payloads transparently regardless of the original protocol.

**Which issue(s) this PR fixes**:
Related to #2447 

**Does this PR introduce a user-facing change?**:

```release-note
Enables the user to use protocols other than OpenAI via the generic InferenceRequest interface.
```

This is a series of 3 PRs.

(1) This PR simply renames LLMRequest to InferenceRequest
(2) The second PR moves RequestBody from scheduling to requesthandling (2808)
(3) The third PR separates the parser from the directory (2810)
