### PR TITLE
fix: add read lock to AllOrderedPriorityLevels to prevent data race

### DIFF
--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -250,10 +250,15 @@ func (s *registryShard) PriorityBandAccessor(priority int) (flowcontrol.Priority
 	return &priorityBandAccessor{shard: s, band: band}, nil
 }
 
-// AllOrderedPriorityLevels returns a cached, sorted slice of all configured priority levels for this shard.
-// This is a lock-free read.
+// AllOrderedPriorityLevels returns a snapshot of all configured priority levels for this shard,
+// sorted in descending order. The returned slice is a copy, safe for the caller to iterate
+// without holding any lock.
 func (s *registryShard) AllOrderedPriorityLevels() []int {
-	return s.orderedPriorityLevels
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]int, len(s.orderedPriorityLevels))
+	copy(result, s.orderedPriorityLevels)
+	return result
 }
 
 // Stats returns a snapshot of the aggregated statistics for this specific shard.

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -514,3 +514,69 @@ func TestShard_Concurrency_MixedWorkload(t *testing.T) {
 	assert.Zero(t, finalStats.TotalLen, "After all paired add/remove operations, the total length should be zero")
 	assert.Zero(t, finalStats.TotalByteSize, "After all paired add/remove operations, the total byte size should be zero")
 }
+
+// TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety verifies that AllOrderedPriorityLevels() is safe to call
+// concurrently with addPriorityBand() and deletePriorityBand(). This test is designed to trigger the Go race detector
+// if the implementation returns the internal slice without proper synchronization.
+func TestShard_Concurrency_AllOrderedPriorityLevels_RaceSafety(t *testing.T) {
+	t.Parallel()
+	const (
+		numReaders = 5
+		iterations = 200
+	)
+
+	h := newShardTestHarness(t)
+
+	dynamicPrio := 15
+	newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio)
+	require.NoError(t, err)
+	h.shard.config.PriorityBands[dynamicPrio] = newBandCfg
+
+	stopCh := make(chan struct{})
+	var readersWg, writerWg sync.WaitGroup
+
+	// Readers: continuously call AllOrderedPriorityLevels() and iterate
+	readersWg.Add(numReaders)
+	for range numReaders {
+		go func() {
+			defer readersWg.Done()
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+					levels := h.shard.AllOrderedPriorityLevels()
+					// Force iteration over the returned slice to surface races on the backing array.
+					sum := 0
+					for _, p := range levels {
+						sum += p
+					}
+				}
+			}
+		}()
+	}
+
+	// Writer: repeatedly add and delete a priority band, modifying orderedPriorityLevels.
+	// deletePriorityBand also removes the config entry, so we must restore it before each add.
+	writerWg.Add(1)
+	go func() {
+		defer writerWg.Done()
+		for range iterations {
+			h.shard.addPriorityBand(dynamicPrio)
+			h.shard.deletePriorityBand(dynamicPrio)
+
+			h.shard.mu.Lock()
+			h.shard.config.PriorityBands[dynamicPrio] = newBandCfg
+			h.shard.mu.Unlock()
+		}
+	}()
+
+	writerWg.Wait()
+	close(stopCh)
+	readersWg.Wait()
+
+	// If we reach here without the race detector firing, the implementation is safe.
+	// Final sanity: dynamic band should be removed, only the original two remain.
+	assert.Equal(t, []int{highPriority, lowPriority}, h.shard.AllOrderedPriorityLevels(),
+		"After all add/delete cycles, only original priority levels should remain")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

Fix a data race in `registryShard.AllOrderedPriorityLevels()` where it returned the internal `orderedPriorityLevels` slice without holding a lock. Concurrent calls to `addPriorityBand()` or `deletePriorityBand()` (which modify the slice under `mu.Lock()`) could cause torn reads or iteration over a mutating backing array.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
/kind bug

