### PR TITLE
refactor(bbr): move ConfigMap label filter into the plugin

### DIFF
--- a/cmd/bbr/runner/runner.go
+++ b/cmd/bbr/runner/runner.go
@@ -26,13 +26,10 @@ import (
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	healthPb "google.golang.org/grpc/health/grpc_health_v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -147,17 +144,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			return nil
 		}(),
 	}
-	// label "inference.networking.k8s.io/bbr-managed" = "true" is used for server-side filtering of configmaps.
-	// only the configmap objects with this label will be tracked by bbr.
-	cacheOptions := cache.Options{
-		ByObject: map[client.Object]cache.ByObject{
-			&corev1.ConfigMap{}: {
-				Label: labels.SelectorFromSet(labels.Set{
-					"inference.networking.k8s.io/bbr-managed": "true",
-				}),
-			},
-		},
-	}
+	cacheOptions := cache.Options{}
 	// Apply namespace filtering only if env var is set.
 	namespace := os.Getenv("NAMESPACE")
 	if namespace != "" {

--- a/pkg/bbr/plugins/basemodelextractor/base_model_to_header.go
+++ b/pkg/bbr/plugins/basemodelextractor/base_model_to_header.go
@@ -58,14 +58,13 @@ func BaseModelToHeaderPluginFactory(name string, _ json.RawMessage, handle frame
 
 // NewBaseModelToHeaderPlugin returns a *BaseModelToHeaderPlugin with an initialized AdaptersStore.
 func NewBaseModelToHeaderPlugin(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*BaseModelToHeaderPlugin, error) {
-	reconcilerBuidler := reconcilerBuilder()
 	adaptersStore := NewAdaptersStore()
 	configMapReconciler := &ConfigMapReconciler{
 		Reader:        clientReader,
 		AdaptersStore: adaptersStore,
 	}
 
-	if err := reconcilerBuidler.For(&corev1.ConfigMap{}).Complete(configMapReconciler); err != nil {
+	if err := reconcilerBuilder().For(&corev1.ConfigMap{}).WithEventFilter(bbrManagedPredicate()).Complete(configMapReconciler); err != nil {
 		return nil, fmt.Errorf("failed to register configmap reconciler for plugin '%s' - %w", BaseModelToHeaderPluginType, err)
 	}
 

--- a/pkg/bbr/plugins/basemodelextractor/configmap_reconciler.go
+++ b/pkg/bbr/plugins/basemodelextractor/configmap_reconciler.go
@@ -24,8 +24,29 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+const bbrManagedLabel = "inference.networking.k8s.io/bbr-managed"
+
+func hasBbrManagedLabel(object client.Object) bool {
+	return object.GetLabels()[bbrManagedLabel] == "true"
+}
+
+// bbrManagedPredicate filters events to only ConfigMaps labeled with
+// "inference.networking.k8s.io/bbr-managed" = "true".
+func bbrManagedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return hasBbrManagedLabel(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return hasBbrManagedLabel(e.ObjectOld) || hasBbrManagedLabel(e.ObjectNew)
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasBbrManagedLabel(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return hasBbrManagedLabel(e.Object) },
+	}
+}
 
 // ConfigMapReconciler watches ConfigMap objects and updates the AdaptersStore
 // with adapter-to-base-model mappings parsed from each ConfigMap's data.
@@ -44,7 +65,7 @@ func (c *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("unable to get ConfigMap - %w", err)
 	}
 
-	if errors.IsNotFound(err) || !configmap.DeletionTimestamp.IsZero() {
+	if errors.IsNotFound(err) || !configmap.DeletionTimestamp.IsZero() || !hasBbrManagedLabel(configmap) {
 		// ConfigMap object got deleted or is marked for deletion.
 		c.AdaptersStore.configMapDelete(configmap)
 		return ctrl.Result{}, nil


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `runner.go` had a server-side label filter on ConfigMaps (`inference.networking.k8s.io/bbr-managed=true`) set in the cache options. This is specific to the `base-model-to-header` plugin, but it was sitting in the framework — meaning the framework knew about plugin details.


This PR moves the filter into the plugin itself using a client-side predicate:
- Remove `ByObject` label selector from `runner.go` cache options
- Add `bbrManagedPredicate()` in `configmap_reconciler.go`
- Wire it via `WithEventFilter` in `base_model_to_header.go`

Now the framework stays clean and the plugin owns its own filtering.

**Which issue(s) this PR fixes**:

Fixes #2678

**Does this PR introduce a user-facing change?**:

```
NONE
```