### PR TITLE
Add predictor sub-plugin for latency prediction pipeline

### DIFF
--- a/hack/verify-framework-imports.go
+++ b/hack/verify-framework-imports.go
@@ -47,6 +47,8 @@ var (
 // These are utility packages that the framework is permitted to import.
 var globalExceptions = []string{
 	"pkg/common/observability/logging",
+	"pkg/common/error",
+	"pkg/common/request",
 }
 
 // currentCodeExceptionMap maps existing violation in files to their allowed import exceptions.
@@ -95,6 +97,30 @@ var currentCodeExceptionMap = map[string][]string{
 	},
 	"pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go": {
 		"pkg/epp/metrics",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/plugin.go": {
+		"sidecars/latencypredictorasync",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/plugin_test.go": {
+		"sidecars/latencypredictorasync",
+		"test/utils",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/prediction.go": {
+		"sidecars/latencypredictorasync",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/prediction_test.go": {
+		"sidecars/latencypredictorasync",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/requestcontrol_hooks.go": {
+		"pkg/epp/metrics",
+		"sidecars/latencypredictorasync",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/training.go": {
+		"pkg/epp/metrics",
+		"sidecars/latencypredictorasync",
+	},
+	"pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/training_test.go": {
+		"sidecars/latencypredictorasync",
 	},
 }
 

--- a/pkg/epp/framework/plugins/datalayer/attribute/latency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/latency/data_types.go
@@ -24,6 +24,14 @@ const (
 	LatencyPredictionInfoKey = "LatencyPredictionInfoKey"
 )
 
+// TODO: Split LatencyPredictionInfo into two attribute keys:
+//
+//   - LatencyPredictionInfo — pure ML output: ttftValid, tpotValid, ttftHeadroom,
+//     tpotHeadroom, ttft, tpot.
+//   - EndpointRoutingContext — operational state the predictor passes to downstream
+//     plugins: dispatchedRequestCount, prefillTokensInFlight, minRunningTPOTSLO,
+//     endpointRole. Scales cleanly for disaggregated serving additions.
+
 // LatencyPredictionInfo contains latency predictions for an endpoint
 type LatencyPredictionInfo struct {
 	// Individual validity checks
@@ -37,6 +45,11 @@ type LatencyPredictionInfo struct {
 	// Raw prediction values
 	ttft float64 // Predicted time to first token (ms)
 	tpot float64 // Predicted time per output token (ms)
+
+	// Dispatched request count from EPP's internal tracking.
+	// More accurate than model server's RunningRequestsSize for routing,
+	// as it reflects requests dispatched by this EPP instance.
+	dispatchedRequestCount int
 }
 
 func NewLatencyPredictionInfo(
@@ -54,14 +67,32 @@ func NewLatencyPredictionInfo(
 	}
 }
 
+func NewLatencyPredictionInfoWithDispatch(
+	ttftValid, tpotValid bool,
+	ttftHeadroom, tpotHeadroom float64,
+	ttft, tpot float64,
+	dispatchedRequestCount int,
+) *LatencyPredictionInfo {
+	return &LatencyPredictionInfo{
+		ttftValid:              ttftValid,
+		tpotValid:              tpotValid,
+		ttftHeadroom:           ttftHeadroom,
+		tpotHeadroom:           tpotHeadroom,
+		ttft:                   ttft,
+		tpot:                   tpot,
+		dispatchedRequestCount: dispatchedRequestCount,
+	}
+}
+
 // Getters
-func (l *LatencyPredictionInfo) TTFTValid() bool       { return l.ttftValid }
-func (l *LatencyPredictionInfo) TPOTValid() bool       { return l.tpotValid }
-func (l *LatencyPredictionInfo) IsValid() bool         { return l.ttftValid && l.tpotValid }
-func (l *LatencyPredictionInfo) TTFTHeadroom() float64 { return l.ttftHeadroom }
-func (l *LatencyPredictionInfo) TPOTHeadroom() float64 { return l.tpotHeadroom }
-func (l *LatencyPredictionInfo) TTFT() float64         { return l.ttft }
-func (l *LatencyPredictionInfo) TPOT() float64         { return l.tpot }
+func (l *LatencyPredictionInfo) TTFTValid() bool             { return l.ttftValid }
+func (l *LatencyPredictionInfo) TPOTValid() bool             { return l.tpotValid }
+func (l *LatencyPredictionInfo) IsValid() bool               { return l.ttftValid && l.tpotValid }
+func (l *LatencyPredictionInfo) TTFTHeadroom() float64       { return l.ttftHeadroom }
+func (l *LatencyPredictionInfo) TPOTHeadroom() float64       { return l.tpotHeadroom }
+func (l *LatencyPredictionInfo) TTFT() float64               { return l.ttft }
+func (l *LatencyPredictionInfo) TPOT() float64               { return l.tpot }
+func (l *LatencyPredictionInfo) DispatchedRequestCount() int { return l.dispatchedRequestCount }
 
 // Clone implements fwkdl.Cloneable
 func (l *LatencyPredictionInfo) Clone() fwkdl.Cloneable {
@@ -69,11 +100,12 @@ func (l *LatencyPredictionInfo) Clone() fwkdl.Cloneable {
 		return nil
 	}
 	return &LatencyPredictionInfo{
-		ttftValid:    l.ttftValid,
-		tpotValid:    l.tpotValid,
-		ttftHeadroom: l.ttftHeadroom,
-		tpotHeadroom: l.tpotHeadroom,
-		ttft:         l.ttft,
-		tpot:         l.tpot,
+		ttftValid:              l.ttftValid,
+		tpotValid:              l.tpotValid,
+		ttftHeadroom:           l.ttftHeadroom,
+		tpotHeadroom:           l.tpotHeadroom,
+		ttft:                   l.ttft,
+		tpot:                   l.tpot,
+		dispatchedRequestCount: l.dispatchedRequestCount,
 	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/OWNERS
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kaushikmitr

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/README.md
@@ -1,0 +1,60 @@
+# Latency Predictor Plugin (`latency-predictor`)
+
+Trains XGBoost models via a sidecar and generates per-endpoint TTFT/TPOT predictions.
+
+## Interfaces
+
+PrepareDataPlugin, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
+
+## Responsibilities
+
+- Bulk predictions during `PrepareRequestData` (writes `LatencyPredictionInfo` to endpoint attributes)
+- TTFT training data collection on first token / EOS
+- TPOT training data collection at EOS (streaming mode)
+- Per-endpoint running request queue tracking
+- Prefix cache score forwarding from `PrefixCacheMatchInfo` attributes
+- E2E latency metrics when `streamingMode=false`
+
+## Config
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `samplingMean` | 1000 | Mean interval for decode token sampling |
+| `maxDecodeTokenSamplesForPrediction` | 0 | Max tokens to sample for TPOT prediction (0 = disabled) |
+| `sloBufferFactor` | 1.0 | Multiplier for SLO headroom calculation |
+| `contextTTL` | 5m | TTL for per-request context in the cache |
+| `streamingMode` | false | Record TTFT on first chunk (true) vs EOS (false) |
+| `endpointRoleLabel` | "" | Label key for disaggregated serving roles |
+| `predictInPrepareData` | true | Enable/disable bulk predictions. Set false for training-only mode |
+
+## Default Behavior (`streamingMode: false`)
+
+By default, the system assumes no SLO headers and trains for end-to-end request latency.
+TTFT is recorded at EOS and represents the full e2e latency (reported as
+`request_e2e_latency_seconds` in metrics). TPOT is not trained because there is no
+per-token streaming. The scorer routes based on e2e latency predictions only, with TPOT
+automatically neutralized.
+
+## Streaming Mode (`streamingMode: true`)
+
+Set this when clients send `"stream": true` and you want to train separate TTFT (time to
+first token) and TPOT (time per output token) models. TTFT is recorded on the first
+streaming chunk, and TPOT is sampled across subsequent tokens.
+
+## Disaggregated Serving
+
+Set `endpointRoleLabel` to the label distinguishing prefill from decode pods. TPOT is
+automatically neutralized for prefill endpoints (`TPOTValid=true`, `TPOTHeadroom=0`),
+ensuring TPOT doesn't affect scoring, admission, or tier classification for prefill pods.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `plugin.go` | Struct, factory, config, per-request context, queue helpers |
+| `requestcontrol_hooks.go` | PreRequest, ResponseHeader, ResponseBody hooks |
+| `preparedata_hooks.go` | PrepareRequestData, Produces, Consumes |
+| `training.go` | buildTrainingEntry, buildPredictionRequest, bulkPredict |
+| `prediction.go` | generatePredictions, validatePrediction, TPOT neutralization |
+| `decode_token_sampler.go` | Poisson-distributed token sampling for TPOT |
+| `running_request_queue.go` | Per-pod request priority queue |

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/decode_token_sampler.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/decode_token_sampler.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// decodeTokenSampler handles Poisson-distributed sampling for predictions only
+// Training happens on every token regardless of sampling
+type decodeTokenSampler struct {
+	rng                                *rand.Rand
+	nextSampleToken                    int
+	samplingMean                       float64
+	maxDecodeTokenSamplesForPrediction int
+	sampleCount                        int
+}
+
+func newDecodeTokenSampler(requestID string, samplingMean float64, maxDecodeTokenSamplesForPrediction int) *decodeTokenSampler {
+	// Use request ID hash as seed for reproducibility
+	seed := int64(0)
+	if requestID != "" {
+		hash := fnv.New64a()
+		hash.Write([]byte(requestID))
+		seed = int64(hash.Sum64())
+	}
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+
+	sampler := &decodeTokenSampler{
+		rng:                                rand.New(rand.NewSource(seed)),
+		samplingMean:                       samplingMean,
+		maxDecodeTokenSamplesForPrediction: maxDecodeTokenSamplesForPrediction,
+	}
+
+	// Set first sample token (skip token 1 since that's TTFT)
+	sampler.nextSampleToken = 2 + sampler.poissonNext()
+
+	return sampler
+}
+
+// poissonNext generates the next interval using Poisson distribution
+func (ts *decodeTokenSampler) poissonNext() int {
+	lambda := ts.samplingMean
+	if lambda <= 0 {
+		return 1
+	}
+
+	// For small lambda, use Knuth's algorithm
+	if lambda < 30 {
+		l := math.Exp(-lambda)
+		k := 0
+		p := 1.0
+
+		for p > l {
+			k++
+			p *= ts.rng.Float64()
+		}
+		return k - 1
+	}
+
+	// For larger lambda, use normal approximation
+	normal := ts.rng.NormFloat64()
+	interval := int(math.Round(lambda + math.Sqrt(lambda)*normal))
+	if interval < 1 {
+		return 1
+	}
+	return interval
+}
+
+// shouldPredict determines if we should make a prediction for the current token
+func (ts *decodeTokenSampler) shouldPredict(currentToken int) bool {
+	return currentToken == ts.nextSampleToken && ts.sampleCount < ts.maxDecodeTokenSamplesForPrediction
+}
+
+// recordPrediction records that a prediction was made and calculates the next sample token
+func (ts *decodeTokenSampler) recordPrediction(currentToken int) {
+	if ts.sampleCount >= ts.maxDecodeTokenSamplesForPrediction {
+		return
+	}
+
+	ts.sampleCount++
+
+	if ts.sampleCount < ts.maxDecodeTokenSamplesForPrediction {
+		interval := ts.poissonNext()
+		ts.nextSampleToken = currentToken + interval
+	}
+}
+
+// getNextSampleToken returns the next token to predict for
+func (ts *decodeTokenSampler) getNextSampleToken() int {
+	return ts.nextSampleToken
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/decode_token_sampler_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/decode_token_sampler_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"testing"
+)
+
+func TestNewTokenSampler(t *testing.T) {
+	s := newDecodeTokenSampler("req-123", 100, 5)
+	if s == nil {
+		t.Fatal("sampler should not be nil")
+	}
+	if s.samplingMean != 100 {
+		t.Errorf("samplingMean = %f, want 100", s.samplingMean)
+	}
+	if s.maxDecodeTokenSamplesForPrediction != 5 {
+		t.Errorf("maxSamples = %d, want 5", s.maxDecodeTokenSamplesForPrediction)
+	}
+	// First sample should be >= 2 (skips token 1 = TTFT)
+	if s.nextSampleToken < 2 {
+		t.Errorf("nextSampleToken = %d, want >= 2", s.nextSampleToken)
+	}
+}
+
+func TestTokenSamplerDeterministic(t *testing.T) {
+	// Same request ID → same seed → same sequence
+	s1 := newDecodeTokenSampler("req-abc", 50, 10)
+	s2 := newDecodeTokenSampler("req-abc", 50, 10)
+
+	if s1.nextSampleToken != s2.nextSampleToken {
+		t.Errorf("same request ID should produce same first sample: %d vs %d",
+			s1.nextSampleToken, s2.nextSampleToken)
+	}
+}
+
+func TestTokenSamplerShouldPredict(t *testing.T) {
+	s := newDecodeTokenSampler("req-1", 10, 3)
+	nextToken := s.getNextSampleToken()
+
+	// Before the sample token — should not predict
+	if s.shouldPredict(nextToken - 1) {
+		t.Error("should not predict before nextSampleToken")
+	}
+
+	// At the sample token — should predict
+	if !s.shouldPredict(nextToken) {
+		t.Error("should predict at nextSampleToken")
+	}
+}
+
+func TestTokenSamplerMaxSamples(t *testing.T) {
+	s := newDecodeTokenSampler("req-2", 1, 2) // mean=1, max=2 samples
+
+	// Record 2 predictions
+	token := s.getNextSampleToken()
+	s.recordPrediction(token)
+	token = s.getNextSampleToken()
+	s.recordPrediction(token)
+
+	// After max samples, shouldPredict should return false
+	if s.shouldPredict(token + 1) {
+		t.Error("should not predict after max samples reached")
+	}
+}
+
+func TestTokenSamplerZeroMean(t *testing.T) {
+	// samplingMean=0 → poissonNext returns 1
+	s := newDecodeTokenSampler("req-3", 0, 10)
+	if s.nextSampleToken < 2 {
+		t.Errorf("nextSampleToken = %d, want >= 2", s.nextSampleToken)
+	}
+}
+
+func TestTokenSamplerLargeLambda(t *testing.T) {
+	// Large lambda uses normal approximation path
+	s := newDecodeTokenSampler("req-4", 1000, 5)
+	if s.nextSampleToken < 2 {
+		t.Errorf("nextSampleToken = %d, want >= 2", s.nextSampleToken)
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/plugin.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+)
+
+const (
+	// LatencyDataProviderPluginType is the plugin type for the latency predictor.
+	// It trains XGBoost models via the sidecar and generates predictions for scoring.
+	LatencyDataProviderPluginType = "latency-predictor-producer"
+
+	// TTFTSLOHeaderKey is the header key for the TTFT SLO.
+	TTFTSLOHeaderKey = "x-slo-ttft-ms"
+	// TPOTSLOHeaderKey is the header key for the TPOT SLO.
+	TPOTSLOHeaderKey = "x-slo-tpot-ms"
+
+	// Experimental_DefaultPrefillProfile is the default profile name for prefill pods in disaggregated serving.
+	Experimental_DefaultPrefillProfile = "prefill"
+)
+
+// PredictedLatency is the latency data provider plugin. It handles:
+//   - PrepareRequestData: bulk predictions via the latency predictor sidecar
+//   - PreRequest: dispatch-time bookkeeping (token counters, request queues)
+//   - ResponseHeader/ResponseBody: training data collection (TTFT/TPOT)
+//   - Produces/Consumes: endpoint attribute declarations
+//
+// Scoring, picking, and admission are handled by separate sub-plugins:
+// LatencyScorer, AffinityWeightedPicker, and LatencyAdmission.
+type PredictedLatency struct {
+	typedName             plugin.TypedName
+	latencypredictor      latencypredictor.PredictorInterface
+	runningRequestLists   sync.Map                                      // Key: types.NamespacedName, Value: *requestPriorityQueue
+	sloContextStore       *ttlcache.Cache[string, *predictedLatencyCtx] // TTL cache for request contexts
+	config                Config
+	prefillTokensInFlight sync.Map // Key: pod NamespacedName.String(), Value: *atomic.Int64
+}
+
+// podCounter returns the atomic counter for the given pod key, creating it if necessary.
+func (t *PredictedLatency) podCounter(m *sync.Map, key string) *atomic.Int64 {
+	v, _ := m.LoadOrStore(key, new(atomic.Int64))
+	return v.(*atomic.Int64)
+}
+
+type Config struct {
+	SamplingMean                       float64       `json:"samplingMean,omitempty"`
+	MaxDecodeTokenSamplesForPrediction int           `json:"maxDecodeTokenSamplesForPrediction,omitempty"`
+	SLOBufferFactor                    float64       `json:"sloBufferFactor,omitempty"`
+	ContextTTL                         time.Duration `json:"contextTTL,omitempty"`
+	StreamingMode                      bool          `json:"streamingMode,omitempty"`
+	EndpointRoleLabel                  string        `json:"endpointRoleLabel,omitempty"`
+	// PredictInPrepareData controls whether bulk predictions are generated during
+	// PrepareRequestData. Set to false to disable predictions (training-only mode).
+	// When false, the predictor still collects training data but does not call the
+	// sidecar for predictions. Default: true.
+	PredictInPrepareData bool `json:"predictInPrepareData,omitempty"`
+}
+
+var DefaultConfig = Config{
+	SamplingMean:                       1000,
+	MaxDecodeTokenSamplesForPrediction: 0,
+	SLOBufferFactor:                    1,
+	ContextTTL:                         5 * time.Minute,
+	StreamingMode:                      false,
+	PredictInPrepareData:               true,
+}
+
+func PredictedLatencyFactory(name string, rawParameters json.RawMessage, handle plugin.Handle) (plugin.Plugin, error) {
+	parameters := DefaultConfig
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config for PredictedLatency: %w", err)
+		}
+	}
+
+	if err := parameters.validate(); err != nil {
+		return nil, fmt.Errorf("invalid PredictedLatency config: %w", err)
+	}
+
+	predictor, err := startPredictor(handle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start latency predictor: %w", err)
+	}
+
+	return NewPredictedLatency(parameters, predictor).WithName(name), nil
+}
+
+func (c *Config) validate() error {
+	var errs []error
+
+	if c.SamplingMean <= 0 {
+		errs = append(errs, fmt.Errorf("samplingMean must be > 0, got %f", c.SamplingMean))
+	}
+
+	if c.MaxDecodeTokenSamplesForPrediction < 0 {
+		errs = append(errs, fmt.Errorf("maxDecodeTokenSamplesForPrediction must be >= 0, got %d", c.MaxDecodeTokenSamplesForPrediction))
+	}
+
+	if c.SLOBufferFactor <= 0 {
+		errs = append(errs, fmt.Errorf("sloBufferFactor must be > 0, got %f", c.SLOBufferFactor))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func NewPredictedLatency(config Config, predictor latencypredictor.PredictorInterface) *PredictedLatency {
+	predictedLatency := &PredictedLatency{
+		typedName:        plugin.TypedName{Type: LatencyDataProviderPluginType, Name: LatencyDataProviderPluginType},
+		latencypredictor: predictor,
+		config:           config,
+	}
+
+	predictedLatency.sloContextStore = ttlcache.New(
+		ttlcache.WithTTL[string, *predictedLatencyCtx](config.ContextTTL),
+	)
+
+	predictedLatency.sloContextStore.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[string, *predictedLatencyCtx]) {
+		if reason != ttlcache.EvictionReasonExpired {
+			return
+		}
+		plCtx := item.Value()
+		predictedLatency.removeRequestFromQueue(item.Key(), plCtx)
+		if plCtx.prefillTokensAtDispatch > 0 || plCtx.prefillTokensAtDispatchOnPrefill > 0 {
+			if plCtx.prefillTargetMetadata != nil && plCtx.ttft == 0 {
+				prefillPodKey := plCtx.prefillTargetMetadata.NamespacedName.String()
+				if predictedLatency.podCounter(&predictedLatency.prefillTokensInFlight, prefillPodKey).Add(-int64(plCtx.inputTokenCount)) == 0 {
+					predictedLatency.prefillTokensInFlight.Delete(prefillPodKey)
+				}
+			}
+			if plCtx.targetMetadata != nil {
+				decodePodKey := plCtx.targetMetadata.NamespacedName.String()
+				if predictedLatency.podCounter(&predictedLatency.prefillTokensInFlight, decodePodKey).Add(-int64(plCtx.inputTokenCount)) == 0 {
+					predictedLatency.prefillTokensInFlight.Delete(decodePodKey)
+				}
+			}
+		}
+	})
+
+	go predictedLatency.sloContextStore.Start()
+	return predictedLatency
+}
+
+func startPredictor(handle plugin.Handle) (latencypredictor.PredictorInterface, error) {
+	predictor := latencypredictor.New(latencypredictor.ConfigFromEnv(), ctrl.Log.WithName("latency-predictor-producer"))
+	if err := predictor.Start(handle.Context()); err != nil {
+		return nil, fmt.Errorf("failed to start latency predictor: %w", err)
+	}
+
+	go func() {
+		<-handle.Context().Done()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		predictor.Stop(stopCtx)
+	}()
+	return predictor, nil
+}
+
+func (s *PredictedLatency) TypedName() plugin.TypedName {
+	return s.typedName
+}
+
+func (s *PredictedLatency) WithName(name string) *PredictedLatency {
+	s.typedName.Name = name
+	return s
+}
+
+func (t *PredictedLatency) getOrMakePredictedLatencyContextForRequest(request *framework.LLMRequest) *predictedLatencyCtx {
+	sloCtx, err := t.getPredictedLatencyContextForRequest(request)
+	if err != nil {
+		sloCtx = newPredictedLatencyContext(request)
+	}
+	return sloCtx
+}
+
+// --- Per-request context ---
+
+// predictedLatencyCtx holds per-request state for latency prediction and training.
+type predictedLatencyCtx struct {
+	schedulingRequest         framework.LLMRequest
+	targetMetadata            *fwkdl.EndpointMetadata
+	prefillTargetMetadata     *fwkdl.EndpointMetadata
+	schedulingResult          *framework.SchedulingResult
+	lastSeenMetrics           map[string]*fwkdl.Metrics
+	lastTokenTimestamp        time.Time
+	requestReceivedTimestamp  time.Time
+	generatedTokenCount       int
+	incomingModelName         string
+	ttft                      float64
+	predictedTTFT             float64
+	avgTPOT                   float64
+	avgPredictedTPOT          float64
+	decodeTokenSampler        *decodeTokenSampler
+	tpotObservations          []float64
+	predictedTPOTObservations []float64
+
+	promptText      string
+	inputTokenCount int
+
+	prefixCacheScoresForEndpoints map[string]float64
+
+	ttftSLO    float64
+	avgTPOTSLO float64
+
+	predictionsForScheduling map[string]endpointPredictionResult
+
+	prefillTokensAtDispatch          int64
+	prefillTokensAtDispatchOnPrefill int64
+	decodeTokensAtDispatch           int64
+}
+
+func newPredictedLatencyContext(request *framework.LLMRequest) *predictedLatencyCtx {
+	var promptText string
+	if request.Body != nil {
+		promptText = request.Body.PromptText()
+	}
+	return &predictedLatencyCtx{
+		schedulingRequest:             *request,
+		promptText:                    promptText,
+		inputTokenCount:               len(strings.Fields(promptText)),
+		lastSeenMetrics:               make(map[string]*fwkdl.Metrics),
+		prefixCacheScoresForEndpoints: make(map[string]float64),
+		predictionsForScheduling:      make(map[string]endpointPredictionResult),
+	}
+}
+
+func (s *PredictedLatency) getPredictedLatencyContextForRequest(request *framework.LLMRequest) (*predictedLatencyCtx, error) {
+	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	if item := s.sloContextStore.Get(id); item != nil {
+		return item.Value(), nil
+	}
+	return nil, fmt.Errorf("SLO context not found for request ID: %s", id)
+}
+
+func (s *PredictedLatency) setPredictedLatencyContextForRequest(request *framework.LLMRequest, ctx *predictedLatencyCtx) {
+	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	s.sloContextStore.Set(id, ctx, ttlcache.DefaultTTL)
+}
+
+func (s *PredictedLatency) deletePredictedLatencyContextForRequest(request *framework.LLMRequest) {
+	id := request.Headers[reqcommon.RequestIdHeaderKey]
+	s.sloContextStore.Delete(id)
+}
+
+// --- Header parsing ---
+
+// parseFloatHeader retrieves a header by name, parses it as a float64,
+// and returns the value or an error if the header is missing or invalid.
+func parseFloatHeader(request framework.LLMRequest, headerName string) (float64, error) {
+	headerValue, ok := request.Headers[headerName]
+	if !ok {
+		return 0, nil
+	}
+	parsedFloat, err := strconv.ParseFloat(headerValue, 64)
+	if err != nil {
+		return 0, errcommon.Error{
+			Code: errcommon.BadRequest,
+			Msg:  headerName + " must be a float",
+		}
+	}
+	return parsedFloat, nil
+}
+
+func (s *PredictedLatency) parseSLOHeaders(ctx context.Context, request *framework.LLMRequest, predictedLatencyCtx *predictedLatencyCtx) {
+	logger := log.FromContext(ctx)
+	var err error
+
+	predictedLatencyCtx.ttftSLO, err = parseFloatHeader(*request, TTFTSLOHeaderKey)
+	if err != nil {
+		logger.V(logutil.DEBUG).Error(errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("%v must be a float: %v", TTFTSLOHeaderKey, err)}, "PredictedLatency: Error parsing TTFT SLO from header")
+	}
+
+	predictedLatencyCtx.avgTPOTSLO, err = parseFloatHeader(*request, TPOTSLOHeaderKey)
+	if err != nil {
+		logger.V(logutil.DEBUG).Error(errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("%v must be a float: %v", TPOTSLOHeaderKey, err)}, "PredictedLatency: Error parsing TPOT SLO from header")
+	}
+}
+
+// --- Running request queue helpers ---
+
+func (s *PredictedLatency) getEndpointMinTPOTSLO(endpoint framework.Endpoint) float64 {
+	endpointName := endpoint.GetMetadata().NamespacedName
+	if runningReqs := s.getRunningRequestList(endpointName); runningReqs != nil && runningReqs.GetSize() > 0 {
+		if min := runningReqs.Peek(); min != nil {
+			return min.tpot
+		}
+	}
+	return 0
+}
+
+func (s *PredictedLatency) getEndpointRunningRequestCount(endpoint framework.Endpoint) int {
+	endpointName := endpoint.GetMetadata().NamespacedName
+	if runningReqs := s.getRunningRequestList(endpointName); runningReqs != nil {
+		return runningReqs.GetSize()
+	}
+	return 0
+}
+
+func (s *PredictedLatency) getRunningRequestList(endpointName types.NamespacedName) *requestPriorityQueue {
+	if value, ok := s.runningRequestLists.Load(endpointName); ok {
+		return value.(*requestPriorityQueue)
+	}
+	return nil
+}
+
+func (s *PredictedLatency) removeRequestFromEndpoint(endpointName types.NamespacedName, requestID string) {
+	if queue := s.getRunningRequestList(endpointName); queue != nil {
+		queue.Remove(requestID)
+		if queue.GetSize() == 0 {
+			s.runningRequestLists.Delete(endpointName)
+		}
+	}
+}
+
+func (s *PredictedLatency) removeRequestFromQueue(requestID string, ctx *predictedLatencyCtx) {
+	if ctx == nil || ctx.targetMetadata == nil {
+		return
+	}
+	endpointName := types.NamespacedName{
+		Name:      ctx.targetMetadata.NamespacedName.Name,
+		Namespace: ctx.targetMetadata.NamespacedName.Namespace,
+	}
+	s.removeRequestFromEndpoint(endpointName, requestID)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/plugin_test.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+	"sigs.k8s.io/gateway-api-inference-extension/test/utils"
+)
+
+// mockPredictor implements PredictorInterface for testing
+type mockPredictor struct {
+	predictions map[string]*latencypredictor.PredictionResponse
+	err         error
+}
+
+func (m *mockPredictor) Predict(ctx context.Context, request latencypredictor.PredictionRequest) (*latencypredictor.PredictionResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := fmt.Sprintf("%.1f", request.KVCachePercentage)
+	if pred, ok := m.predictions[key]; ok {
+		return pred, nil
+	}
+	return &latencypredictor.PredictionResponse{TTFT: 0.5, TPOT: 0.03}, nil
+}
+
+func (m *mockPredictor) PredictBulk(ctx context.Context, requests []latencypredictor.PredictionRequest) (*latencypredictor.BulkPredictionResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	responses := make([]latencypredictor.PredictionResponse, 0, len(requests))
+	for _, request := range requests {
+		key := fmt.Sprintf("%.1f", request.KVCachePercentage)
+		if pred, ok := m.predictions[key]; ok {
+			responses = append(responses, *pred)
+		} else {
+			return nil, fmt.Errorf("no prediction for key %s", key)
+		}
+	}
+	return &latencypredictor.BulkPredictionResponse{Predictions: responses}, nil
+}
+
+func (m *mockPredictor) PredictBulkStrict(ctx context.Context, requests []latencypredictor.PredictionRequest) (*latencypredictor.BulkPredictionResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	responses := make([]latencypredictor.PredictionResponse, 0, len(requests))
+	for _, request := range requests {
+		key := fmt.Sprintf("%.1f", request.KVCachePercentage)
+		if pred, ok := m.predictions[key]; ok {
+			responses = append(responses, *pred)
+		} else {
+			return nil, fmt.Errorf("no prediction for key %s", key)
+		}
+	}
+	return &latencypredictor.BulkPredictionResponse{Predictions: responses}, nil
+}
+
+func (m *mockPredictor) AddTrainingDataBulk(data []latencypredictor.TrainingEntry) error {
+	return nil
+}
+
+func (m *mockPredictor) AddTrainingData(data latencypredictor.TrainingEntry) error {
+	return nil
+}
+
+func (m *mockPredictor) HealthCheck() error {
+	return nil
+}
+
+func (m *mockPredictor) GetServerStatus(ctx context.Context) (*latencypredictor.ServerStatusResponse, error) {
+	return &latencypredictor.ServerStatusResponse{}, nil
+}
+
+func createTestEndpoint(name string, kvCacheUsage float64, runningRequestsSize, waitingQueueSize int) fwksched.Endpoint {
+	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: "default",
+		}},
+		&fwkdl.Metrics{
+			KVCacheUsagePercent: kvCacheUsage,
+			RunningRequestsSize: runningRequestsSize,
+			WaitingQueueSize:    waitingQueueSize,
+		},
+		nil,
+	)
+}
+
+func createTestLLMRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.LLMRequest {
+	return createTestLLMRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.LLMRequestBody{
+		Completions: &fwksched.CompletionsRequest{
+			Prompt: "test prompt",
+		},
+	})
+}
+
+func createTestChatCompletionsLLMRequest(reqID string, ttftSLO, tpotSLO float64) *fwksched.LLMRequest {
+	return createTestLLMRequestWithBody(reqID, ttftSLO, tpotSLO, &fwksched.LLMRequestBody{
+		ChatCompletions: &fwksched.ChatCompletionsRequest{
+			Messages: []fwksched.Message{
+				{Role: "system", Content: fwksched.Content{Raw: "You are a helpful assistant."}},
+				{Role: "user", Content: fwksched.Content{Raw: "Tell me a joke."}},
+			},
+		},
+	})
+}
+
+func createTestLLMRequestWithBody(reqID string, ttftSLO, tpotSLO float64, body *fwksched.LLMRequestBody) *fwksched.LLMRequest {
+	headers := make(map[string]string)
+	headers[reqcommon.RequestIdHeaderKey] = reqID
+	if ttftSLO > 0 {
+		headers["x-ttft-slo"] = fmt.Sprintf("%f", ttftSLO)
+	}
+	if tpotSLO > 0 {
+		headers["x-avg-tpot-slo"] = fmt.Sprintf("%f", tpotSLO)
+	}
+
+	return &fwksched.LLMRequest{
+		Headers: headers,
+		Body:    body,
+	}
+}
+
+func TestPredictedLatency_TypedName(t *testing.T) {
+	predictor := &mockPredictor{}
+	cfg := DefaultConfig
+	router := NewPredictedLatency(cfg, predictor)
+
+	tn := router.TypedName()
+	assert.Equal(t, "latency-predictor-producer", tn.Type, "Type should be latency-predictor")
+	assert.Equal(t, "latency-predictor-producer", tn.Name, "Default name should be latency-predictor")
+}
+
+func TestPredictedLatency_WithName(t *testing.T) {
+	predictor := &mockPredictor{}
+	cfg := DefaultConfig
+	router := NewPredictedLatency(cfg, predictor)
+
+	customName := "custom-router"
+	router = router.WithName(customName)
+
+	tn := router.TypedName()
+	assert.Equal(t, "latency-predictor-producer", tn.Type, "Type should remain latency-predictor")
+	assert.Equal(t, customName, tn.Name, "Name should be updated to custom name")
+}
+
+func TestPredictedLatency_GetPodRunningRequestCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupRequests func(*PredictedLatency, fwksched.Endpoint)
+		expectedCount int
+	}{
+		{
+			name:          "No running requests",
+			setupRequests: func(r *PredictedLatency, p fwksched.Endpoint) {},
+			expectedCount: 0,
+		},
+		{
+			name: "One running request",
+			setupRequests: func(r *PredictedLatency, p fwksched.Endpoint) {
+				podName := types.NamespacedName{
+					Name:      p.GetMetadata().NamespacedName.Name,
+					Namespace: p.GetMetadata().NamespacedName.Namespace,
+				}
+				queue := newRequestPriorityQueue()
+				queue.Add("req1", 0.04)
+				r.runningRequestLists.Store(podName, queue)
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Multiple running requests",
+			setupRequests: func(r *PredictedLatency, p fwksched.Endpoint) {
+				endpointName := types.NamespacedName{
+					Name:      p.GetMetadata().NamespacedName.Name,
+					Namespace: p.GetMetadata().NamespacedName.Namespace,
+				}
+				queue := newRequestPriorityQueue()
+				queue.Add("req1", 0.04)
+				queue.Add("req2", 0.03)
+				queue.Add("req3", 0.05)
+				r.runningRequestLists.Store(endpointName, queue)
+			},
+			expectedCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predictor := &mockPredictor{}
+			cfg := DefaultConfig
+			router := NewPredictedLatency(cfg, predictor)
+			pod := createTestEndpoint("test-pod", 0.5, 2, 1)
+
+			tt.setupRequests(router, pod)
+
+			count := router.getEndpointRunningRequestCount(pod)
+			assert.Equal(t, tt.expectedCount, count, "Running request count should match expected")
+		})
+	}
+}
+
+func TestPredictedLatency_GetPodMinTPOTSLO(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupRequests func(*PredictedLatency, fwksched.Endpoint)
+		expectedSLO   float64
+	}{
+		{
+			name:          "No running requests",
+			setupRequests: func(r *PredictedLatency, p fwksched.Endpoint) {},
+			expectedSLO:   0.0,
+		},
+		{
+			name: "One running request",
+			setupRequests: func(r *PredictedLatency, e fwksched.Endpoint) {
+				endpointName := types.NamespacedName{
+					Name:      e.GetMetadata().NamespacedName.Name,
+					Namespace: e.GetMetadata().NamespacedName.Namespace,
+				}
+				queue := newRequestPriorityQueue()
+				queue.Add("req1", 0.04)
+				r.runningRequestLists.Store(endpointName, queue)
+			},
+			expectedSLO: 0.04,
+		},
+		{
+			name: "Multiple running requests - should return minimum",
+			setupRequests: func(r *PredictedLatency, e fwksched.Endpoint) {
+				endpointName := types.NamespacedName{
+					Name:      e.GetMetadata().NamespacedName.Name,
+					Namespace: e.GetMetadata().NamespacedName.Namespace,
+				}
+				queue := newRequestPriorityQueue()
+				queue.Add("req1", 0.05)
+				queue.Add("req2", 0.03) // This is the minimum
+				queue.Add("req3", 0.04)
+				r.runningRequestLists.Store(endpointName, queue)
+			},
+			expectedSLO: 0.03,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predictor := &mockPredictor{}
+			cfg := DefaultConfig
+			router := NewPredictedLatency(cfg, predictor)
+			pod := createTestEndpoint("test-pod", 0.5, 2, 1)
+
+			tt.setupRequests(router, pod)
+
+			minSLO := router.getEndpointMinTPOTSLO(pod)
+			assert.InDelta(t, tt.expectedSLO, minSLO, 0.0001, "Min TPOT SLO should match expected")
+		})
+	}
+}
+
+func TestPredictedLatencyFactory(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginName string
+		jsonParams string
+		expectErr  bool
+	}{
+		{
+			name:       "valid config with all fields",
+			pluginName: "full-config",
+			jsonParams: `{
+				"samplingMean": 150.0,
+				"maxDecodeTokenSamplesForPrediction": 30,
+				"sloBufferFactor": 1.2
+			}`,
+			expectErr: false,
+		},
+		{
+			name:       "valid config with minimal override (uses defaults)",
+			pluginName: "minimal",
+			jsonParams: `{}`,
+			expectErr:  false,
+		},
+		{
+			name:       "invalid samplingMean <= 0",
+			pluginName: "bad-sampling-mean",
+			jsonParams: `{"samplingMean": -1.0}`,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid maxSampledTokens < 0",
+			pluginName: "bad-max-tokens",
+			jsonParams: `{"maxDecodeTokenSamplesForPrediction": -1}`,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid sloBufferFactor <= 0",
+			pluginName: "bad-buffer",
+			jsonParams: `{"sloBufferFactor": 0}`,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handle := utils.NewTestHandle(context.Background())
+			rawParams := json.RawMessage(tt.jsonParams)
+			plugin, err := PredictedLatencyFactory(tt.pluginName, rawParams, handle)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, plugin)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, plugin)
+			}
+		})
+	}
+}
+
+func TestPredictedLatencyFactoryInvalidJSON(t *testing.T) {
+	invalidTests := []struct {
+		name       string
+		jsonParams string
+	}{
+		{
+			name:       "malformed JSON",
+			jsonParams: `{"samplingMean": 100.0, "maxDecodeTokenSamplesForPrediction":`, // incomplete
+		},
+		{
+			name:       "samplingMean as string",
+			jsonParams: `{"samplingMean": "100"}`,
+		},
+		{
+			name:       "maxSampledTokens as float",
+			jsonParams: `{"maxDecodeTokenSamplesForPrediction": 20.5}`,
+		},
+	}
+
+	for _, tt := range invalidTests {
+		t.Run(tt.name, func(t *testing.T) {
+			handle := utils.NewTestHandle(context.Background())
+			rawParams := json.RawMessage(tt.jsonParams)
+			plugin, err := PredictedLatencyFactory("test", rawParams, handle)
+
+			assert.Error(t, err)
+			assert.Nil(t, plugin)
+		})
+	}
+}
+
+func TestSloContextStoreEviction(t *testing.T) {
+	config := DefaultConfig
+	config.ContextTTL = 100 * time.Millisecond
+	pl := NewPredictedLatency(config, nil)
+
+	requestID := "test-req-id"
+	endpointName := types.NamespacedName{Name: "test-model", Namespace: "default"}
+
+	req := &fwksched.LLMRequest{
+		Headers: map[string]string{
+			reqcommon.RequestIdHeaderKey: requestID,
+		},
+	}
+
+	metadata := &fwkdl.EndpointMetadata{
+		NamespacedName: endpointName,
+	}
+
+	sloCtx := newPredictedLatencyContext(req)
+	sloCtx.targetMetadata = metadata
+	sloCtx.avgTPOTSLO = 0.05
+
+	pl.setPredictedLatencyContextForRequest(req, sloCtx)
+
+	queue := newRequestPriorityQueue()
+	queue.Add(requestID, sloCtx.avgTPOTSLO)
+	pl.runningRequestLists.Store(endpointName, queue)
+
+	assert.True(t, queue.Contains(requestID), "Request should be in queue initially")
+	item := pl.sloContextStore.Get(requestID)
+	assert.NotNil(t, item, "Item should be in cache initially")
+
+	time.Sleep(300 * time.Millisecond)
+	item = pl.sloContextStore.Get(requestID)
+	assert.Nil(t, item, "Item should have been evicted from cache")
+	assert.False(t, queue.Contains(requestID), "Request should be removed from queue via OnEviction")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/prediction.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package requestcontrol contains helpers to decouple latency-predictor logic.
+package latencypredictor
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+)
+
+type endpointPredictionResult struct {
+	Endpoint         schedulingtypes.Endpoint
+	TTFT             float64
+	TPOT             float64
+	TTFTValid        bool
+	TPOTValid        bool
+	IsValid          bool
+	Error            error
+	Headroom         float64 // Headroom for the pod, if applicable
+	TTFTHeadroom     float64 // TTFT headroom for the pod
+	PrefixCacheScore float64 // Prefix cache score for the pod
+}
+
+// generatePredictions creates prediction results for all candidate pods
+func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, candidateEndpoints []schedulingtypes.Endpoint) ([]endpointPredictionResult, error) {
+	logger := log.FromContext(ctx)
+	predictions := make([]endpointPredictionResult, 0, len(candidateEndpoints))
+
+	// Prepare inputs for bulk prediction
+	metricsStates := make([]*fwkdl.Metrics, len(candidateEndpoints))
+	targetEndpointsMetadatas := make([]*fwkdl.EndpointMetadata, len(candidateEndpoints))
+	prompts := make([]string, len(candidateEndpoints))
+	generatedTokenCounts := make([]int, len(candidateEndpoints))
+	prefixCacheScores := make([]float64, len(candidateEndpoints))
+	prefillTokensInFlights := make([]int64, len(candidateEndpoints))
+
+	for i, endpoint := range candidateEndpoints {
+		logger.V(logutil.TRACE).Info("Candidate pod for scheduling", "endpoint", endpoint.GetMetadata().String(), "metrics", endpoint.GetMetrics().String())
+
+		// Get prefix cache score for the pod
+		prefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name]
+
+		logger.V(logutil.DEBUG).Info("Prefix cache score for pod", "pod", endpoint.GetMetadata().String(), "prefixCacheScore", prefixCacheScore)
+
+		metricsStates[i] = endpoint.GetMetrics()
+		targetEndpointsMetadatas[i] = endpoint.GetMetadata()
+		prompts[i] = predictedLatencyCtx.promptText
+		generatedTokenCounts[i] = 1
+		prefixCacheScores[i] = prefixCacheScore
+
+		podKey := endpoint.GetMetadata().NamespacedName.String()
+		prefillTokensInFlights[i] = s.podCounter(&s.prefillTokensInFlight, podKey).Load()
+	}
+
+	// Bulk predict
+	bulkPredictions, err := bulkPredictWithMetrics(ctx, predictedLatencyCtx, s.latencypredictor, metricsStates, s.config.EndpointRoleLabel, targetEndpointsMetadatas, prompts, generatedTokenCounts, prefixCacheScores, prefillTokensInFlights)
+	if err != nil {
+		logger.V(logutil.DEBUG).Error(err, "Bulk prediction failed")
+		return nil, err
+	}
+
+	// Process results
+	for i, endpoint := range candidateEndpoints {
+		prediction := bulkPredictions[i]
+		predResult := endpointPredictionResult{Endpoint: endpoint}
+
+		predResult.PrefixCacheScore = prefixCacheScores[i]
+		predResult.TTFT = prediction.TTFT
+		predResult.TPOT = prediction.TPOT
+
+		podMinTPOTSLO := s.getEndpointMinTPOTSLO(endpoint)
+		predResult.TTFTValid, predResult.TPOTValid, predResult.IsValid, predResult.Headroom, predResult.TTFTHeadroom = s.validatePrediction(prediction, predictedLatencyCtx, podMinTPOTSLO)
+
+		// Neutralize TPOT when it's not meaningful:
+		// - Non-streaming mode: TPOT is never trained (no per-token observations)
+		// - Disaggregated prefill: prefill pods don't generate tokens
+		// Setting TPOTValid=true and Headroom=0 prevents untrained TPOT
+		// predictions from polluting scoring, tier classification, or admission.
+		if !s.config.StreamingMode || hasPrefillRole(s.config.EndpointRoleLabel, endpoint) {
+			predResult.TPOTValid = true
+			predResult.Headroom = 0
+			predResult.IsValid = predResult.TTFTValid
+		}
+
+		logger.V(logutil.DEBUG).Info("Prediction for scheduling",
+			"endpoint", endpoint.GetMetadata().String(),
+			"prefixCacheScore", predResult.PrefixCacheScore,
+			"TTFT", prediction.TTFT,
+			"TPOT", prediction.TPOT,
+			"buffer", s.config.SLOBufferFactor,
+			"podMinTPOTSLO", podMinTPOTSLO,
+			"ttftSLO", predictedLatencyCtx.ttftSLO,
+			"requestTPOTSLO", predictedLatencyCtx.avgTPOTSLO,
+			"tpotHeadroom", predResult.Headroom,
+			"ttftHeadroom", predResult.TTFTHeadroom,
+			"tpotValid", predResult.TPOTValid,
+			"ttftValid", predResult.TTFTValid,
+		)
+
+		predictions = append(predictions, predResult)
+	}
+
+	return predictions, nil
+}
+
+// updateRequestContextWithPredictions updates the request context with prediction data
+func (s *PredictedLatency) updateRequestContextWithPredictions(predictedLatencyCtx *predictedLatencyCtx, predictions []endpointPredictionResult) {
+	predMap := make(map[string]endpointPredictionResult, len(predictions))
+	for _, pred := range predictions {
+		if pred.Endpoint != nil && pred.Endpoint.GetMetadata() != nil {
+			predMap[pred.Endpoint.GetMetadata().NamespacedName.Name] = pred
+		}
+	}
+	predictedLatencyCtx.predictionsForScheduling = predMap
+}
+
+func (s *PredictedLatency) validatePrediction(
+	pred *latencypredictor.PredictionResponse,
+	predictedLatencyCtx *predictedLatencyCtx,
+	podMinTPOTSLO float64,
+) (ttftOk, tpotOk, isValid bool, headroom float64, ttftHeadroom float64) {
+
+	ttftOk = pred.TTFT < predictedLatencyCtx.ttftSLO
+	ttftHeadroom = predictedLatencyCtx.ttftSLO - pred.TTFT
+
+	tpotOk = true
+	headroom = 0.0
+
+	if s.config.StreamingMode {
+		bufferedTPOT := predictedLatencyCtx.avgTPOTSLO * s.config.SLOBufferFactor
+		// a podMinTPOTSLO of 0 means no either no requests, or no TPOT SLOs specified on running requests
+		if podMinTPOTSLO > 0 {
+			if podMinTPOTSLO < predictedLatencyCtx.avgTPOTSLO {
+				log.FromContext(context.Background()).V(logutil.DEBUG).Info("Pod min TPOT SLO is less than the req SLO, adjusting", "podMinTPOTSLO", podMinTPOTSLO, "bufferedTPOT", predictedLatencyCtx.avgTPOTSLO)
+			}
+			bufferedTPOT = min(bufferedTPOT, podMinTPOTSLO*s.config.SLOBufferFactor)
+		}
+
+		tpotOk = pred.TPOT < bufferedTPOT
+		headroom = bufferedTPOT - pred.TPOT
+	}
+
+	isValid = ttftOk && tpotOk
+
+	return
+}
+
+// hasPrefillRole returns true if the endpoint has the prefill role label set.
+func hasPrefillRole(roleLabel string, endpoint schedulingtypes.Endpoint) bool {
+	if roleLabel == "" {
+		return false
+	}
+	labels := endpoint.GetMetadata().Labels
+	return labels != nil && labels[roleLabel] == "prefill"
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/prediction_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+)
+
+func createTestEndpointWithLabels(name string, kvCacheUsage float64, runningRequestsSize, waitingQueueSize int, labels map[string]string) fwksched.Endpoint {
+	return fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+		Labels:         labels,
+	}, &fwkdl.Metrics{
+		KVCacheUsagePercent: kvCacheUsage,
+		RunningRequestsSize: runningRequestsSize,
+		WaitingQueueSize:    waitingQueueSize,
+	}, nil)
+}
+
+func TestValidatePrediction_StreamingMode(t *testing.T) {
+	cfg := DefaultConfig
+	cfg.StreamingMode = true
+	pl := NewPredictedLatency(cfg, nil)
+
+	tests := []struct {
+		name            string
+		pred            *latencypredictor.PredictionResponse
+		ttftSLO         float64
+		tpotSLO         float64
+		podMinTPOTSLO   float64
+		wantTTFTOk      bool
+		wantTPOTOk      bool
+		wantValid       bool
+		wantHeadroomPos bool // headroom > 0
+	}{
+		{
+			name:            "both within SLO",
+			pred:            &latencypredictor.PredictionResponse{TTFT: 50, TPOT: 20},
+			ttftSLO:         100,
+			tpotSLO:         30,
+			wantTTFTOk:      true,
+			wantTPOTOk:      true,
+			wantValid:       true,
+			wantHeadroomPos: true,
+		},
+		{
+			name:       "TTFT exceeds SLO",
+			pred:       &latencypredictor.PredictionResponse{TTFT: 150, TPOT: 20},
+			ttftSLO:    100,
+			tpotSLO:    30,
+			wantTTFTOk: false,
+			wantTPOTOk: true,
+			wantValid:  false,
+		},
+		{
+			name:       "TPOT exceeds SLO",
+			pred:       &latencypredictor.PredictionResponse{TTFT: 50, TPOT: 40},
+			ttftSLO:    100,
+			tpotSLO:    30,
+			wantTTFTOk: true,
+			wantTPOTOk: false,
+			wantValid:  false,
+		},
+		{
+			name:            "podMinTPOTSLO tightens threshold",
+			pred:            &latencypredictor.PredictionResponse{TTFT: 50, TPOT: 25},
+			ttftSLO:         100,
+			tpotSLO:         30,
+			podMinTPOTSLO:   20, // tighter than request SLO
+			wantTTFTOk:      true,
+			wantTPOTOk:      false, // 25 > 20*1.0
+			wantValid:       false,
+			wantHeadroomPos: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &predictedLatencyCtx{
+				ttftSLO:    tt.ttftSLO,
+				avgTPOTSLO: tt.tpotSLO,
+			}
+			ttftOk, tpotOk, valid, headroom, ttftHeadroom := pl.validatePrediction(tt.pred, ctx, tt.podMinTPOTSLO)
+			assert.Equal(t, tt.wantTTFTOk, ttftOk, "ttftOk")
+			assert.Equal(t, tt.wantTPOTOk, tpotOk, "tpotOk")
+			assert.Equal(t, tt.wantValid, valid, "isValid")
+			if tt.wantTTFTOk {
+				assert.Greater(t, ttftHeadroom, 0.0, "ttftHeadroom should be positive when TTFT valid")
+			}
+			if tt.wantHeadroomPos {
+				assert.Greater(t, headroom, 0.0, "headroom should be positive")
+			}
+		})
+	}
+}
+
+func TestValidatePrediction_NonStreamingMode(t *testing.T) {
+	config := DefaultConfig
+	config.StreamingMode = false
+	pl := NewPredictedLatency(config, nil)
+
+	ctx := &predictedLatencyCtx{
+		ttftSLO:    100,
+		avgTPOTSLO: 30,
+	}
+
+	// In non-streaming mode, TPOT is always valid regardless of prediction
+	pred := &latencypredictor.PredictionResponse{TTFT: 50, TPOT: 999}
+	ttftOk, tpotOk, valid, headroom, _ := pl.validatePrediction(pred, ctx, 0)
+
+	assert.True(t, ttftOk, "TTFT should be valid")
+	assert.True(t, tpotOk, "TPOT should always be valid in non-streaming mode")
+	assert.True(t, valid, "overall should be valid")
+	assert.Equal(t, 0.0, headroom, "headroom should be 0 in non-streaming mode")
+}
+
+func TestValidatePrediction_PrefillEndpointNeutralizeTPOT(t *testing.T) {
+	// In disaggregated serving, prefill endpoints should have TPOT neutralized.
+	// Even if TPOT prediction violates SLO, prefill should be valid if TTFT is OK.
+	config := DefaultConfig
+	config.EndpointRoleLabel = "role"
+	config.StreamingMode = true
+	pl := NewPredictedLatency(config, nil)
+
+	prefillEp := createTestEndpointWithLabels("prefill-pod", 0.3, 0, 0, map[string]string{"role": "prefill"})
+	decodeEp := createTestEndpointWithLabels("decode-pod", 0.3, 0, 0, map[string]string{"role": "decode"})
+
+	plCtx := &predictedLatencyCtx{
+		ttftSLO:                       100,
+		avgTPOTSLO:                    30,
+		promptText:                    "test",
+		prefixCacheScoresForEndpoints: map[string]float64{"prefill-pod": 0, "decode-pod": 0, "unlabeled-pod": 0},
+		predictionsForScheduling:      make(map[string]endpointPredictionResult),
+	}
+
+	// Mock predictor that returns TTFT=50 (within SLO) but TPOT=999 (violates SLO)
+	mockPred := &latencypredictor.PredictionResponse{TTFT: 50, TPOT: 999}
+
+	// Prefill: TPOT should be neutralized → valid
+	ttftOk, tpotOk, valid, _, _ := pl.validatePrediction(mockPred, plCtx, 0)
+	// validatePrediction itself doesn't know about roles — it fails TPOT
+	assert.True(t, ttftOk, "prefill TTFT should be valid")
+	assert.False(t, tpotOk, "validatePrediction itself doesn't know about roles")
+	assert.False(t, valid, "validatePrediction itself doesn't know about roles")
+
+	// But generatePredictions applies the override for prefill endpoints.
+	// Test the override logic directly:
+	predResult := endpointPredictionResult{
+		Endpoint:  prefillEp,
+		TTFT:      50,
+		TPOT:      999,
+		TTFTValid: true,
+		TPOTValid: false,
+		IsValid:   false,
+		Headroom:  -969, // 30 - 999
+	}
+
+	// Simulate the fix logic from generatePredictions
+	if config.EndpointRoleLabel != "" && prefillEp.GetMetadata().Labels != nil {
+		if prefillEp.GetMetadata().Labels[config.EndpointRoleLabel] == Experimental_DefaultPrefillProfile {
+			predResult.TPOTValid = true
+			predResult.Headroom = 0
+			predResult.IsValid = predResult.TTFTValid
+		}
+	}
+
+	assert.True(t, predResult.TPOTValid, "prefill TPOT should be neutralized to true")
+	assert.True(t, predResult.IsValid, "prefill should be valid (TTFT OK, TPOT neutralized)")
+	assert.Equal(t, 0.0, predResult.Headroom, "prefill TPOT headroom should be 0")
+
+	// Decode endpoint should NOT be neutralized
+	decodeResult := endpointPredictionResult{
+		Endpoint:  decodeEp,
+		TTFTValid: true,
+		TPOTValid: false,
+		IsValid:   false,
+		Headroom:  -969,
+	}
+	if config.EndpointRoleLabel != "" && decodeEp.GetMetadata().Labels != nil {
+		if decodeEp.GetMetadata().Labels[config.EndpointRoleLabel] == Experimental_DefaultPrefillProfile {
+			decodeResult.TPOTValid = true
+			decodeResult.Headroom = 0
+			decodeResult.IsValid = decodeResult.TTFTValid
+		}
+	}
+	assert.False(t, decodeResult.TPOTValid, "decode TPOT should NOT be neutralized")
+	assert.False(t, decodeResult.IsValid, "decode should remain invalid")
+
+}
+
+func TestUpdateRequestContextWithPredictions(t *testing.T) {
+	pl := NewPredictedLatency(DefaultConfig, nil)
+	ctx := &predictedLatencyCtx{
+		predictionsForScheduling: make(map[string]endpointPredictionResult),
+	}
+
+	ep1 := createTestEndpoint("pod1", 0.5, 5, 0)
+	ep2 := createTestEndpoint("pod2", 0.3, 3, 0)
+
+	predictions := []endpointPredictionResult{
+		{Endpoint: ep1, TTFT: 50, TPOT: 20, IsValid: true},
+		{Endpoint: ep2, TTFT: 80, TPOT: 30, IsValid: false},
+	}
+
+	pl.updateRequestContextWithPredictions(ctx, predictions)
+
+	assert.Len(t, ctx.predictionsForScheduling, 2)
+	assert.Equal(t, 50.0, ctx.predictionsForScheduling["pod1"].TTFT)
+	assert.Equal(t, 80.0, ctx.predictionsForScheduling["pod2"].TTFT)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/preparedata_hooks.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"math"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
+	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+)
+
+var _ requestcontrol.PrepareDataPlugin = &PredictedLatency{}
+
+// PrepareRequestData prepares the SLO context for the request, including
+// parsing SLO headers, gathering prefix cache scores, and generating predictions.
+func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+	logger := log.FromContext(ctx)
+	predictedLatencyCtx := s.getOrMakePredictedLatencyContextForRequest(request)
+
+	s.parseSLOHeaders(ctx, request, predictedLatencyCtx)
+	var prefixCacheScore float64
+	for _, endpoint := range endpoints {
+
+		if prefixCacheInfoRaw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoKey); ok {
+			prefixCacheInfo := prefixCacheInfoRaw.(*attrprefix.PrefixCacheMatchInfo)
+			prefixCacheScore = float64(prefixCacheInfo.MatchBlocks()) / float64(prefixCacheInfo.TotalBlocks())
+			if !math.IsNaN(prefixCacheScore) {
+				logger.V(logutil.DEBUG).Info("Found prefix cache score in pod attribute", "pod", endpoint.GetMetadata().NamespacedName.Name, "score", prefixCacheScore)
+			} else {
+				prefixCacheScore = 0.0
+				logger.V(logutil.DEBUG).Info("Prefix cache score is NaN, defaulting to 0", "pod", endpoint.GetMetadata().NamespacedName.Name)
+			}
+		} else {
+			logger.V(logutil.DEBUG).Info("No prefix cache score found in pod attribute, defaulting to 0", "pod", endpoint.GetMetadata().NamespacedName.Name)
+			prefixCacheScore = 0.0
+		}
+		predictedLatencyCtx.prefixCacheScoresForEndpoints[endpoint.GetMetadata().NamespacedName.Name] = prefixCacheScore
+	}
+	if !s.config.PredictInPrepareData {
+		logger.V(logutil.DEBUG).Info("PredictInPrepareData disabled, skipping predictions")
+		s.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+		return nil
+	}
+
+	predictions, err := s.generatePredictions(ctx, predictedLatencyCtx, endpoints)
+	if err == nil && len(predictions) == len(endpoints) {
+		s.updateRequestContextWithPredictions(predictedLatencyCtx, predictions)
+
+		// Store predictions in endpoint attributes
+		for _, pred := range predictions {
+			if pred.Endpoint != nil {
+				latencyInfo := attrlatency.NewLatencyPredictionInfoWithDispatch(
+					pred.TTFTValid,
+					pred.TPOTValid,
+					pred.TTFTHeadroom,
+					pred.Headroom, // Maps to TPOTHeadroom
+					pred.TTFT,
+					pred.TPOT,
+					s.getEndpointRunningRequestCount(pred.Endpoint),
+				)
+				pred.Endpoint.Put(attrlatency.LatencyPredictionInfoKey, latencyInfo)
+				logger.V(logutil.DEBUG).Info("Stored latency prediction in endpoint",
+					"pod", pred.Endpoint.GetMetadata().NamespacedName.Name,
+					"ttft", pred.TTFT,
+					"tpot", pred.TPOT,
+					"ttftValid", pred.TTFTValid,
+					"tpotValid", pred.TPOTValid,
+					"ttftHeadroom", pred.TTFTHeadroom,
+					"tpotHeadroom", pred.Headroom)
+			}
+		}
+	}
+
+	s.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+	return nil
+}
+
+func (p *PredictedLatency) Produces() map[string]any {
+	return map[string]any{
+		attrlatency.LatencyPredictionInfoKey: attrlatency.LatencyPredictionInfo{},
+	}
+}
+
+func (p *PredictedLatency) Consumes() map[string]any {
+	return map[string]any{attrprefix.PrefixCacheMatchInfoKey: attrprefix.PrefixCacheMatchInfo{}}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/preparedata_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/preparedata_hooks_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
+	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+)
+
+func TestProducesConsumes(t *testing.T) {
+	pl := NewPredictedLatency(DefaultConfig, nil)
+
+	produces := pl.Produces()
+	assert.Contains(t, produces, attrlatency.LatencyPredictionInfoKey)
+
+	consumes := pl.Consumes()
+	assert.Contains(t, consumes, attrprefix.PrefixCacheMatchInfoKey)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/requestcontrol_hooks.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+)
+
+var _ requestcontrol.PreRequest = &PredictedLatency{}
+var _ requestcontrol.ResponseHeader = &PredictedLatency{}
+var _ requestcontrol.ResponseBody = &PredictedLatency{}
+
+// --- RequestControl Hooks ---
+
+func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingtypes.LLMRequest, schedulingResult *schedulingtypes.SchedulingResult) {
+	logger := log.FromContext(ctx)
+	if request == nil {
+		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: request is nil, skipping")
+		return
+	}
+
+	if schedulingResult == nil || len(schedulingResult.ProfileResults) == 0 {
+		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping PreRequest because no scheduling result was provided.")
+		return
+	}
+
+	targetMetadata := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName].TargetEndpoints[0].GetMetadata()
+	if !t.checkPredictor(logger, targetMetadata) {
+		return
+	}
+
+	endpointName := types.NamespacedName{
+		Name:      targetMetadata.NamespacedName.Name,
+		Namespace: targetMetadata.NamespacedName.Namespace,
+	}
+
+	logger.V(logutil.TRACE).Info("request ID for SLO tracking", "requestID", request.Headers[reqcommon.RequestIdHeaderKey], "endpointName", endpointName)
+	if request.Headers[reqcommon.RequestIdHeaderKey] == "" {
+		logger.V(logutil.DEBUG).Error(errors.New("missing request ID"), "PredictedLatency.PreRequest: Request is missing request ID header")
+		return
+	}
+
+	id := request.Headers[reqcommon.RequestIdHeaderKey]
+
+	actual, _ := t.runningRequestLists.LoadOrStore(endpointName, newRequestPriorityQueue())
+	endpointRequestList := actual.(*requestPriorityQueue)
+
+	predictedLatencyCtx, err := t.getPredictedLatencyContextForRequest(request)
+	if err != nil {
+		id := request.Headers[reqcommon.RequestIdHeaderKey]
+		logger.V(logutil.DEBUG).Info("PredictedLatency.PreRequest: Failed to get SLO context for request", "error", err, "requestID", id)
+		return
+	}
+
+	added := endpointRequestList.Add(id, predictedLatencyCtx.avgTPOTSLO)
+	if !added {
+		logger.V(logutil.TRACE).Info("PredictedLatency: Item already exists in queue", "endpointName", endpointName, "requestID", id)
+	}
+
+	predictedLatencyCtx.targetMetadata = targetMetadata
+	if prefillResult, exists := schedulingResult.ProfileResults[Experimental_DefaultPrefillProfile]; exists && prefillResult != nil && len(prefillResult.TargetEndpoints) > 0 {
+		prefillMetadata := prefillResult.TargetEndpoints[0].GetMetadata()
+		predictedLatencyCtx.prefillTargetMetadata = prefillMetadata
+		logger.V(logutil.DEBUG).Info("Prefill target identified for request", "requestID", id, "prefillEndpoint", prefillMetadata.NamespacedName.String())
+	} else {
+		logger.V(logutil.DEBUG).Info("No prefill target identified for request", "requestID", id)
+	}
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now()
+	refreshLastSeenMetrics(ctx, predictedLatencyCtx)
+
+	decodePodKey := endpointName.String()
+	if predictedLatencyCtx.prefillTargetMetadata != nil {
+		prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
+		t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Load()
+	}
+	t.podCounter(&t.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+	predictedLatencyCtx.prefillTokensAtDispatch = t.podCounter(&t.prefillTokensInFlight, decodePodKey).Load()
+	predictedLatencyCtx.decodeTokensAtDispatch = 0
+
+	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
+}
+
+func (t *PredictedLatency) ResponseHeader(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+	logger := log.FromContext(ctx)
+	if request == nil {
+		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseReceived: request is nil, skipping")
+		return
+	}
+}
+
+// ResponseBody handles both per-chunk processing and request completion logic.
+func (t *PredictedLatency) ResponseBody(ctx context.Context, request *schedulingtypes.LLMRequest, response *requestcontrol.Response, targetMetadata *fwkdl.EndpointMetadata) {
+	logger := log.FromContext(ctx)
+	if request == nil {
+		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: request is nil, skipping")
+		return
+	}
+	if !t.checkPredictor(logger, targetMetadata) {
+		return
+	}
+
+	now := time.Now()
+	predictedLatencyCtx, err := t.getPredictedLatencyContextForRequest(request)
+	if err != nil {
+		id := request.Headers[reqcommon.RequestIdHeaderKey]
+		logger.V(logutil.DEBUG).Info("PredictedLatency.ResponseBody: Failed to get SLO context", "error", err, "requestID", id)
+		return
+	}
+
+	if predictedLatencyCtx.ttft == 0 {
+		if t.config.StreamingMode && !response.EndOfStream {
+			processFirstTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.StreamingMode, t.config.EndpointRoleLabel, predictedLatencyCtx, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
+
+			if predictedLatencyCtx.prefillTargetMetadata != nil {
+				prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
+				if t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Add(-int64(predictedLatencyCtx.inputTokenCount)) == 0 {
+					t.prefillTokensInFlight.Delete(prefillPodKey)
+				}
+			}
+		}
+	} else {
+		processTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.EndpointRoleLabel, predictedLatencyCtx, targetMetadata, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
+	}
+
+	if response.EndOfStream {
+		ttftNotYetRecorded := predictedLatencyCtx.ttft == 0
+		if !t.config.StreamingMode {
+			processFirstTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.StreamingMode, t.config.EndpointRoleLabel, predictedLatencyCtx, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
+		}
+
+		if predictedLatencyCtx.ttft > 0 {
+			// In non-streaming mode, TTFT represents full e2e latency.
+			logger.V(logutil.TRACE).Info("Averages calculated", "avgActualTTFT", predictedLatencyCtx.ttft, "avgPredictedTTFT", predictedLatencyCtx.predictedTTFT)
+			metrics.RecordRequestTTFT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.ttft/1000)
+			metrics.RecordRequestPredictedTTFT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.predictedTTFT/1000)
+			if predictedLatencyCtx.ttftSLO > 0 {
+				metrics.RecordRequestTTFTWithSLO(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.ttft, predictedLatencyCtx.ttftSLO)
+			}
+		}
+
+		if predictedLatencyCtx.ttft > 0 && predictedLatencyCtx.generatedTokenCount > 1 {
+			e2eMs := float64(now.Sub(predictedLatencyCtx.requestReceivedTimestamp).Milliseconds())
+			predictedLatencyCtx.avgTPOT = (e2eMs - predictedLatencyCtx.ttft) / float64(predictedLatencyCtx.generatedTokenCount-1)
+		}
+
+		if predictedLatencyCtx.avgTPOT > 0 {
+			logger.V(logutil.TRACE).Info("Averages calculated", "avgActualTPOT", predictedLatencyCtx.avgTPOT, "avgPredictedTPOT", predictedLatencyCtx.avgPredictedTPOT)
+			metrics.RecordRequestTPOT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgTPOT/1000)
+			metrics.RecordRequestPredictedTPOT(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgPredictedTPOT/1000)
+			if predictedLatencyCtx.avgTPOTSLO > 0 {
+				metrics.RecordRequestTPOTWithSLO(ctx, predictedLatencyCtx.incomingModelName, request.TargetModel, predictedLatencyCtx.avgTPOT, predictedLatencyCtx.avgTPOTSLO)
+			}
+
+			if m, err := getLatestMetricsForProfile(predictedLatencyCtx, ""); err == nil {
+				entry := buildTrainingEntry(
+					t.config.EndpointRoleLabel,
+					targetMetadata,
+					m,
+					predictedLatencyCtx.promptText,
+					0,
+					predictedLatencyCtx.avgTPOT,
+					now,
+					0,
+					0,
+				)
+				entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatch
+				entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
+				if err := t.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
+					logger.V(logutil.DEBUG).Error(err, "record TPOT training failed")
+				}
+			}
+		}
+
+		decodePodKey := targetMetadata.NamespacedName.String()
+		if ttftNotYetRecorded && predictedLatencyCtx.prefillTargetMetadata != nil {
+			prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
+			if t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Add(-int64(predictedLatencyCtx.inputTokenCount)) == 0 {
+				t.prefillTokensInFlight.Delete(prefillPodKey)
+			}
+		}
+		if t.podCounter(&t.prefillTokensInFlight, decodePodKey).Add(-int64(predictedLatencyCtx.inputTokenCount)) == 0 {
+			t.prefillTokensInFlight.Delete(decodePodKey)
+		}
+
+		id := request.Headers[reqcommon.RequestIdHeaderKey]
+		t.removeRequestFromQueue(id, predictedLatencyCtx)
+		t.deletePredictedLatencyContextForRequest(request)
+	}
+}
+
+func (t *PredictedLatency) checkPredictor(logger logr.Logger, metadata *fwkdl.EndpointMetadata) bool {
+	if metadata == nil {
+		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping hook because no target metadata was provided.")
+		return false
+	}
+	if t.latencypredictor == nil {
+		logger.V(logutil.TRACE).Info("PredictedLatency: Skipping hook because predictor missing")
+		return false
+	}
+	return true
+}
+
+// processPreRequestForLatencyPrediction looks up the stored prediction for the target endpoint.
+func processPreRequestForLatencyPrediction(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx) {
+	logger := log.FromContext(ctx)
+	targetName := predictedLatencyCtx.targetMetadata.NamespacedName.Name
+	if m := predictedLatencyCtx.prefillTargetMetadata; m != nil {
+		targetName = m.NamespacedName.Name
+	}
+	if storedPred, ok := predictedLatencyCtx.predictionsForScheduling[targetName]; ok {
+		logger.V(logutil.DEBUG).Info("PreRequest TTFT from stored prediction", "value_ms", storedPred.TTFT, "endpoint", targetName)
+		predictedLatencyCtx.predictedTTFT = storedPred.TTFT
+	} else {
+		logger.V(logutil.DEBUG).Info("PreRequest: no stored prediction found for target endpoint", "endpoint", targetName)
+		predictedLatencyCtx.predictedTTFT = 0
+	}
+	predictedLatencyCtx.lastTokenTimestamp = time.Now()
+}
+
+// processFirstTokenForLatencyPrediction records actual TTFT, trains, predicts first TPOT.
+func processFirstTokenForLatencyPrediction(
+	ctx context.Context,
+	predictor latencypredictor.PredictorInterface,
+	streamingMode bool,
+	endpointRoleLabel string,
+	predictedLatencyCtx *predictedLatencyCtx,
+	now time.Time,
+	samplingMean float64,
+	maxDecodeTokenSamplesForPrediction int,
+) {
+	logger := log.FromContext(ctx)
+
+	initializeSampler(ctx, predictedLatencyCtx, samplingMean, maxDecodeTokenSamplesForPrediction)
+	predictedLatencyCtx.ttft = float64(now.Sub(predictedLatencyCtx.requestReceivedTimestamp).Milliseconds())
+	predictedLatencyCtx.generatedTokenCount = 1
+
+	if prefillTargetMetadata := predictedLatencyCtx.prefillTargetMetadata; prefillTargetMetadata != nil {
+		prefillMetrics, err := getLatestMetricsForProfile(predictedLatencyCtx, Experimental_DefaultPrefillProfile)
+		if err == nil {
+			prefillPrefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[prefillTargetMetadata.NamespacedName.Name]
+			logger.V(logutil.DEBUG).Info("Recording prefill TTFT training data",
+				"ttft_ms", predictedLatencyCtx.ttft,
+				"prefillPod", prefillTargetMetadata.NamespacedName.Name,
+				"prefixCacheScore", prefillPrefixCacheScore)
+			recordTTFTTrainingData(ctx, predictor, endpointRoleLabel, predictedLatencyCtx, prefillMetrics, prefillTargetMetadata, now, prefillPrefixCacheScore)
+		}
+	} else {
+		m, err := getLatestMetricsForProfile(predictedLatencyCtx, "")
+		if err != nil {
+			logger.V(logutil.DEBUG).Info("Skipping TTFT training due to missing metrics or schedulingResult", "error", err)
+			return
+		}
+		targetEndpointMetadata := predictedLatencyCtx.targetMetadata
+		prefixCacheScore := predictedLatencyCtx.prefixCacheScoresForEndpoints[targetEndpointMetadata.NamespacedName.Name]
+		logger.V(logutil.DEBUG).Info("Recording TTFT training data", "ttft_ms", predictedLatencyCtx.ttft, "predicted_ttft_ms", predictedLatencyCtx.predictedTTFT, "prefixCacheScore", prefixCacheScore)
+		recordTTFTTrainingData(ctx, predictor, endpointRoleLabel, predictedLatencyCtx, m, targetEndpointMetadata, now, prefixCacheScore)
+	}
+
+	if streamingMode {
+		predictFirstTPOT(ctx, predictedLatencyCtx)
+	}
+
+	predictedLatencyCtx.lastTokenTimestamp = now
+	refreshLastSeenMetrics(ctx, predictedLatencyCtx)
+}
+
+func initializeSampler(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx, samplingMean float64, maxDecodeTokenSamplesForPrediction int) {
+	if predictedLatencyCtx.decodeTokenSampler == nil {
+		logger := log.FromContext(ctx)
+		requestID := predictedLatencyCtx.schedulingRequest.Headers[reqcommon.RequestIdHeaderKey]
+		predictedLatencyCtx.decodeTokenSampler = newDecodeTokenSampler(requestID, samplingMean, maxDecodeTokenSamplesForPrediction)
+		logger.V(logutil.DEBUG).Info("Initialized token sampler for first token", "request_id", requestID, "next_prediction_token", predictedLatencyCtx.decodeTokenSampler.getNextSampleToken())
+	}
+}
+
+func predictFirstTPOT(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx) {
+	logger := log.FromContext(ctx)
+	targetName := predictedLatencyCtx.targetMetadata.NamespacedName.Name
+	if storedPred, ok := predictedLatencyCtx.predictionsForScheduling[targetName]; ok {
+		logger.V(logutil.DEBUG).Info("first TPOT from stored prediction", "value_ms", storedPred.TPOT)
+		predictedLatencyCtx.predictedTPOTObservations = append(predictedLatencyCtx.predictedTPOTObservations, storedPred.TPOT)
+		predictedLatencyCtx.avgPredictedTPOT = calculateRunningAverage(predictedLatencyCtx.avgPredictedTPOT, storedPred.TPOT, len(predictedLatencyCtx.predictedTPOTObservations))
+	} else {
+		logger.V(logutil.DEBUG).Info("first TPOT: no stored prediction found for target endpoint", "endpoint", targetName)
+		predictedLatencyCtx.predictedTPOTObservations = append(predictedLatencyCtx.predictedTPOTObservations, 0)
+		predictedLatencyCtx.avgPredictedTPOT = calculateRunningAverage(predictedLatencyCtx.avgPredictedTPOT, 0, len(predictedLatencyCtx.predictedTPOTObservations))
+	}
+}
+
+// processTokenForLatencyPrediction records actual inter-token latency, sampled predictions, and advances timestamp.
+func processTokenForLatencyPrediction(
+	ctx context.Context,
+	predictor latencypredictor.PredictorInterface,
+	endpointRoleLabel string,
+	predictedLatencyCtx *predictedLatencyCtx,
+	targetEndpointMetadata *fwkdl.EndpointMetadata,
+	now time.Time,
+	samplingMean float64,
+	maxDecodeTokenSamplesForPrediction int,
+) {
+	logger := log.FromContext(ctx)
+
+	if predictedLatencyCtx.decodeTokenSampler == nil {
+		requestID := predictedLatencyCtx.schedulingRequest.Headers[reqcommon.RequestIdHeaderKey]
+		predictedLatencyCtx.decodeTokenSampler = newDecodeTokenSampler(requestID, samplingMean, maxDecodeTokenSamplesForPrediction)
+		logger.V(logutil.DEBUG).Info("Initialized token sampler for subsequent tokens", "request_id", requestID, "next_prediction_token", predictedLatencyCtx.decodeTokenSampler.getNextSampleToken())
+	}
+
+	latencyMs := float64(now.Sub(predictedLatencyCtx.lastTokenTimestamp).Milliseconds())
+	predictedLatencyCtx.generatedTokenCount++
+
+	if predictedLatencyCtx.generatedTokenCount == 2 || predictedLatencyCtx.decodeTokenSampler.shouldPredict(predictedLatencyCtx.generatedTokenCount) {
+		predictedLatencyCtx.tpotObservations = append(predictedLatencyCtx.tpotObservations, latencyMs)
+	}
+	if predictedLatencyCtx.generatedTokenCount == 2 {
+		logger.V(logutil.DEBUG).Info("First inter-token latency observed",
+			"actual_tpot_ms", latencyMs,
+			"predicted_tpot_ms", predictedLatencyCtx.avgPredictedTPOT)
+	}
+
+	m, err := getLatestMetricsForProfile(predictedLatencyCtx, "")
+	if err != nil {
+		logger.V(logutil.DEBUG).Info("Skipping TPOT prediction due to missing metrics or schedulingResult", "error", err)
+		return
+	}
+
+	if predictedLatencyCtx.decodeTokenSampler.shouldPredict(predictedLatencyCtx.generatedTokenCount) {
+		in := buildPredictionRequest(
+			endpointRoleLabel,
+			targetEndpointMetadata,
+			m,
+			predictedLatencyCtx.promptText,
+			predictedLatencyCtx.generatedTokenCount,
+			0,
+		)
+		start := time.Now()
+		p, err := predictor.Predict(ctx, in)
+		dur := time.Since(start)
+		if err != nil || p == nil {
+			logger.V(logutil.DEBUG).Error(err, "TPOT predict failed", "duration_ms", dur.Milliseconds())
+			predictedLatencyCtx.predictedTPOTObservations = append(predictedLatencyCtx.predictedTPOTObservations, 0)
+			predictedLatencyCtx.avgPredictedTPOT = calculateRunningAverage(predictedLatencyCtx.avgPredictedTPOT, 0, len(predictedLatencyCtx.predictedTPOTObservations))
+		} else {
+			logger.V(logutil.DEBUG).Info("TPOT predict succeeded", "value_ms", p.TPOT, "duration_ms", dur.Milliseconds())
+			predictedLatencyCtx.predictedTPOTObservations = append(predictedLatencyCtx.predictedTPOTObservations, p.TPOT)
+			predictedLatencyCtx.avgPredictedTPOT = calculateRunningAverage(predictedLatencyCtx.avgPredictedTPOT, p.TPOT, len(predictedLatencyCtx.predictedTPOTObservations))
+		}
+		metrics.RecordRequestTPOTPredictionDuration(ctx, predictedLatencyCtx.schedulingRequest.TargetModel, predictedLatencyCtx.incomingModelName, dur.Seconds())
+		predictedLatencyCtx.decodeTokenSampler.recordPrediction(predictedLatencyCtx.generatedTokenCount)
+	}
+
+	predictedLatencyCtx.lastTokenTimestamp = now
+	refreshLastSeenMetrics(ctx, predictedLatencyCtx)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/requestcontrol_hooks_test.go
@@ -1,0 +1,1110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	testModelName   = "test-model"
+	kvUsage         = 1
+	runningRequests = 1
+	waitingQueue    = 1
+)
+
+// Helper functions
+
+func createTestSchedulingResult(metadata *fwkdl.EndpointMetadata) *schedulingtypes.SchedulingResult {
+
+	mockPod := createTestEndpoint(metadata.NamespacedName.Name, kvUsage, runningRequests, waitingQueue)
+
+	return &schedulingtypes.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{
+			"default": {
+				TargetEndpoints: []schedulingtypes.Endpoint{mockPod},
+			},
+		},
+	}
+}
+
+func createTestRouter() *PredictedLatency {
+	cfg := DefaultConfig
+	cfg.StreamingMode = true
+	return &PredictedLatency{
+		sloContextStore: ttlcache.New(
+			ttlcache.WithTTL[string, *predictedLatencyCtx](cfg.ContextTTL),
+		),
+		// runningRequestLists is a sync.Map and needs no initialization
+		latencypredictor: nil,
+		config:           cfg,
+	}
+}
+
+// Test cases
+
+func TestNewPredictedLatencyContext(t *testing.T) {
+	request := createTestLLMRequest("test", 100, 50)
+
+	ctx := newPredictedLatencyContext(request)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, *request, ctx.schedulingRequest)
+	assert.Equal(t, "test prompt", ctx.promptText)
+	assert.NotNil(t, ctx.lastSeenMetrics)
+	assert.NotNil(t, ctx.prefixCacheScoresForEndpoints)
+	assert.NotNil(t, ctx.predictionsForScheduling)
+	assert.Empty(t, ctx.lastSeenMetrics)
+	assert.Empty(t, ctx.prefixCacheScoresForEndpoints)
+}
+
+func TestNewPredictedLatencyContext_NilBody(t *testing.T) {
+	request := &schedulingtypes.LLMRequest{
+		Headers: map[string]string{reqcommon.RequestIdHeaderKey: "test-nil-body"},
+		Body:    nil,
+	}
+	ctx := newPredictedLatencyContext(request)
+
+	assert.NotNil(t, ctx)
+	assert.Empty(t, ctx.promptText)
+}
+
+func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
+	request := createTestChatCompletionsLLMRequest("test-chat", 1.0, 0.05)
+	ctx := newPredictedLatencyContext(request)
+
+	assert.NotNil(t, ctx)
+	assert.Equal(t, "You are a helpful assistant. Tell me a joke. ", ctx.promptText)
+}
+
+func TestPredictedLatency_SetAndGetSLOContext(t *testing.T) {
+	router := createTestRouter()
+	request := createTestLLMRequest("test", 100, 50)
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+
+	// Set context
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Get context
+	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+
+	require.NoError(t, err)
+	assert.Equal(t, predictedLatencyCtx, retrievedCtx)
+}
+
+func TestPredictedLatency_GetSLOContext_NotFound(t *testing.T) {
+	router := createTestRouter()
+	request := createTestLLMRequest("test", 100, 50)
+
+	// Try to get context that doesn't exist
+	ctx, err := router.getPredictedLatencyContextForRequest(request)
+
+	assert.Error(t, err)
+	assert.Nil(t, ctx)
+	assert.Contains(t, err.Error(), "SLO context not found")
+}
+
+func TestPredictedLatency_DeleteSLOContext(t *testing.T) {
+	router := createTestRouter()
+	request := createTestLLMRequest("test", 100, 50)
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+
+	// Set and then delete context
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+	router.deletePredictedLatencyContextForRequest(request)
+
+	// Verify it's deleted
+	ctx, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+	assert.Nil(t, ctx)
+}
+
+func TestPredictedLatency_PreRequest_NoSchedulingResult(t *testing.T) {
+	router := createTestRouter()
+	ctx := context.Background()
+	request := createTestLLMRequest("test", 100, 50)
+
+	// Call PreRequest with nil scheduling result
+	router.PreRequest(ctx, request, nil)
+
+	// Should not create SLO context
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_PreRequest_EmptySchedulingResult(t *testing.T) {
+	router := createTestRouter()
+	ctx := context.Background()
+	request := createTestLLMRequest("test", 100, 50)
+
+	schedulingResult := &schedulingtypes.SchedulingResult{
+		ProfileResults: map[string]*schedulingtypes.ProfileRunResult{},
+	}
+
+	// Call PreRequest with empty scheduling result
+	router.PreRequest(ctx, request, schedulingResult)
+
+	// Should not create SLO context
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_PreRequest_Success(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	// Create and set initial SLO context
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.avgTPOTSLO = 50
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Initialize the request priority queue
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, newRequestPriorityQueue())
+
+	beforeTime := time.Now()
+	router.PreRequest(ctx, request, schedulingResult)
+	afterTime := time.Now()
+
+	// Verify SLO context was updated
+	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+	require.NoError(t, err)
+	assert.Equal(t, endpoint.GetMetadata(), retrievedCtx.targetMetadata)
+	assert.Equal(t, schedulingResult, retrievedCtx.schedulingResult)
+	assert.True(t, retrievedCtx.requestReceivedTimestamp.After(beforeTime) ||
+		retrievedCtx.requestReceivedTimestamp.Equal(beforeTime))
+	assert.True(t, retrievedCtx.requestReceivedTimestamp.Before(afterTime) ||
+		retrievedCtx.requestReceivedTimestamp.Equal(afterTime))
+}
+
+func TestPredictedLatency_PreRequest_AddsToQueue(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	// Create and set initial SLO context
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.avgTPOTSLO = 50
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// PreRequest should create the queue
+	router.PreRequest(ctx, request, schedulingResult)
+
+	// Verify queue was created and request was added
+	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().NamespacedName)
+	assert.True(t, exists, "Queue should be created for endpoint")
+	assert.NotNil(t, value)
+	queue := value.(*requestPriorityQueue)
+	assert.NotNil(t, queue)
+}
+
+func TestPredictedLatency_PreRequest_QueueAlreadyExists(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request1 := createTestLLMRequest("test-id-1", 100, 50)
+	request2 := createTestLLMRequest("test-id-2", 100, 50)
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	// Create and set initial SLO contexts
+	predictedLatencyCtx1 := newPredictedLatencyContext(request1)
+	predictedLatencyCtx1.avgTPOTSLO = 50
+	router.setPredictedLatencyContextForRequest(request1, predictedLatencyCtx1)
+
+	predictedLatencyCtx2 := newPredictedLatencyContext(request2)
+	predictedLatencyCtx2.avgTPOTSLO = 50
+	router.setPredictedLatencyContextForRequest(request2, predictedLatencyCtx2)
+	// Add first request
+	router.PreRequest(ctx, request1, schedulingResult)
+
+	// Add second request to same pod
+	router.PreRequest(ctx, request2, schedulingResult)
+
+	// Verify both are in the same queue
+	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().NamespacedName)
+	assert.True(t, exists)
+	assert.NotNil(t, value)
+}
+
+func TestPredictedLatency_ResponseHeader_NilPredictor(t *testing.T) {
+	router := createTestRouter()
+	router.latencypredictor = nil
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should not panic and should return early
+	router.ResponseHeader(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should still exist
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.NoError(t, err)
+}
+
+func TestPredictedLatency_ResponseHeader_NoPod(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should not panic with nil pod
+	router.ResponseHeader(ctx, request, response, nil)
+
+	// Predictor should not be called
+
+}
+
+func TestPredictedLatency_ResponseHeader_NoContext(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+
+	// Don't set SLO context
+	router.ResponseHeader(ctx, request, response, endpoint.GetMetadata())
+
+	// Should handle missing context gracefully
+
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_NilPredictor(t *testing.T) {
+	router := createTestRouter()
+	router.latencypredictor = nil
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should not panic and should return early
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should still exist
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.NoError(t, err)
+}
+func TestPredictedLatency_StreamingMode_ResponseBody_FirstToken(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now().Add(-100 * time.Millisecond)
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+	predictedLatencyCtx.ttftSLO = 100
+	predictedLatencyCtx.avgTPOTSLO = 50
+	predictedLatencyCtx.incomingModelName = testModelName
+	predictedLatencyCtx.predictedTTFT = 80.0
+	predictedLatencyCtx.avgPredictedTPOT = 30.0
+
+	predictedLatencyCtx.lastSeenMetrics["prefill"] = &fwkdl.Metrics{
+		KVCacheUsagePercent: 0.5,
+		WaitingQueueSize:    1,
+		RunningRequestsSize: 1,
+	}
+	predictedLatencyCtx.lastSeenMetrics["default"] = &fwkdl.Metrics{
+		KVCacheUsagePercent: 0.5,
+		WaitingQueueSize:    1,
+		RunningRequestsSize: 1,
+	}
+
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Initialize the queue and add the request
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+
+	beforeTime := time.Now()
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+	afterTime := time.Now()
+
+	// Verify first token timestamp was set
+	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, retrievedCtx.ttft, float64(100), "ttft should be set to >= 100ms")
+
+	assert.True(t, retrievedCtx.lastTokenTimestamp.After(beforeTime) ||
+		retrievedCtx.lastTokenTimestamp.Equal(beforeTime))
+	assert.True(t, retrievedCtx.lastTokenTimestamp.Before(afterTime) ||
+		retrievedCtx.lastTokenTimestamp.Equal(afterTime))
+}
+
+func TestPredictedLatency_NonStreamingMode_ResponseBody_FirstToken(t *testing.T) {
+	router := createTestRouter()
+	router.config.StreamingMode = false // Non-streaming mode
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{} // EndOfStream is false
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now().Add(-100 * time.Millisecond)
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Verify that in non-streaming mode it returns early and does NOT set ttft or lastTokenTimestamp
+	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+	require.NoError(t, err)
+
+	assert.Zero(t, retrievedCtx.ttft, "ttft should not be set because it should early return in non-streaming mode")
+	assert.True(t, retrievedCtx.lastTokenTimestamp.IsZero(), "lastTokenTimestamp should not be set")
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_SubsequentTokens(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now()
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+	predictedLatencyCtx.ttftSLO = 100
+	predictedLatencyCtx.avgTPOTSLO = 50
+	predictedLatencyCtx.incomingModelName = testModelName
+	predictedLatencyCtx.predictedTTFT = 80.0
+	predictedLatencyCtx.avgPredictedTPOT = 30.0
+	// ADD THIS - populate metrics
+	predictedLatencyCtx.lastSeenMetrics["prefill"] = &fwkdl.Metrics{
+		KVCacheUsagePercent: 0.5,
+		WaitingQueueSize:    1,
+		RunningRequestsSize: 1,
+	}
+	predictedLatencyCtx.lastSeenMetrics["default"] = &fwkdl.Metrics{
+		KVCacheUsagePercent: 0.5,
+		WaitingQueueSize:    1,
+		RunningRequestsSize: 1,
+	}
+	firstTokenTime := time.Now().Add(-100 * time.Millisecond)
+
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Initialize the queue and add the request
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Verify token timestamp was updated
+	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+	require.NoError(t, err)
+	assert.True(t, retrievedCtx.lastTokenTimestamp.After(firstTokenTime))
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_QueueNotFound(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.incomingModelName = testModelName
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata() // ADD THIS to avoid other issues
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Create an EMPTY queue (not nil, but empty) to test queue.Remove behavior
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, newRequestPriorityQueue())
+
+	// Should handle gracefully when request is not in queue
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should be deleted
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+func TestPredictedLatency_StreamingMode_ResponseBody_NoContext(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+
+	// Don't set SLO context - should handle gracefully
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Should not panic
+
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_Success(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	// Create queue and add request
+	queue := newRequestPriorityQueue()
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.ttft = 80
+	predictedLatencyCtx.avgTPOT = 30
+	predictedLatencyCtx.predictedTTFT = 85
+	predictedLatencyCtx.avgPredictedTPOT = 32
+	predictedLatencyCtx.ttftSLO = 100
+	predictedLatencyCtx.avgTPOTSLO = 50
+	predictedLatencyCtx.incomingModelName = "incoming-model"
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Verify context was deleted
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+
+	// Verify request was removed from queue
+	assert.Equal(t, 0, queue.Len())
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NilPredictor(t *testing.T) {
+	router := createTestRouter()
+	router.latencypredictor = nil
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should not panic
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should still exist (deletion happens only with predictor)
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.NoError(t, err)
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoPod(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should not panic with nil pod
+	router.ResponseBody(ctx, request, response, nil)
+
+	// Context should still exist (deletion happens only with validpod.GetPod())
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.NoError(t, err)
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoContext(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	// Don't set SLO context - should handle gracefully
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_WithMetrics(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	// Create queue
+	queue := newRequestPriorityQueue()
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.ttft = 80
+	predictedLatencyCtx.avgTPOT = 30
+	predictedLatencyCtx.predictedTTFT = 85
+	predictedLatencyCtx.avgPredictedTPOT = 32
+	predictedLatencyCtx.ttftSLO = 100
+	predictedLatencyCtx.avgTPOTSLO = 50
+	predictedLatencyCtx.incomingModelName = "incoming-model"
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should record metrics without panicking
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Verify cleanup
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken_NoSLOs(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test-id", 0, 0) // No SLOs
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	// Create queue
+	queue := newRequestPriorityQueue()
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 0)
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.ttft = 80
+	predictedLatencyCtx.avgTPOT = 30
+	predictedLatencyCtx.incomingModelName = testModelName
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Should handle missing SLOs gracefully
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Verify cleanup
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_FinalToken(t *testing.T) {
+	router := createTestRouter()
+	router.config.StreamingMode = true
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true} // True
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now().Add(-200 * time.Millisecond)
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+	predictedLatencyCtx.ttft = 100 // TTFT > 0: means first token already arrived (False for FirstChunk)
+
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Initialize the queue and add the request
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should be deleted when EndOfStream is reached
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_StreamingMode_ResponseBody_SingleChunk(t *testing.T) {
+	router := createTestRouter()
+	router.config.StreamingMode = true
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true} // True
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now().Add(-150 * time.Millisecond)
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+	// ttft == 0: First chunk and Final chunk at the same time
+
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Initialize the queue and add the request
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should be deleted when EndOfStream is reached
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_NonStreamingMode_ResponseBody_FinalToken(t *testing.T) {
+	router := createTestRouter()
+	router.config.StreamingMode = false
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true} // True
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now().Add(-300 * time.Millisecond)
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+	// ttft == 0: For non-streaming, TTFT happens when EndOfStream is true
+
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// Initialize the queue and add the request
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Context should be deleted when EndOfStream is reached
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_CheckPredictor_NilPod(t *testing.T) {
+	router := createTestRouter()
+	logger := logr.Discard()
+
+	result := router.checkPredictor(logger, nil)
+
+	assert.False(t, result)
+}
+
+func TestPredictedLatency_CheckPredictor_NilPredictor(t *testing.T) {
+	router := createTestRouter()
+	router.latencypredictor = nil
+	logger := logr.Discard()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+
+	result := router.checkPredictor(logger, endpoint.GetMetadata())
+
+	assert.False(t, result)
+}
+
+func TestPredictedLatency_CheckPredictor_Success(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+	logger := logr.Discard()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+
+	result := router.checkPredictor(logger, endpoint.GetMetadata())
+
+	assert.True(t, result)
+}
+
+func TestPredictedLatencyContext_Fields(t *testing.T) {
+	request := createTestLLMRequest("test", 100, 50)
+	ctx := newPredictedLatencyContext(request)
+
+	// Test all field initialization
+	assert.NotNil(t, ctx.lastSeenMetrics)
+	assert.NotNil(t, ctx.prefixCacheScoresForEndpoints)
+	assert.NotNil(t, ctx.predictionsForScheduling)
+	assert.Empty(t, ctx.tpotObservations)
+	assert.Empty(t, ctx.predictedTPOTObservations)
+	assert.Zero(t, ctx.generatedTokenCount)
+	assert.Zero(t, ctx.ttft)
+	assert.Zero(t, ctx.avgTPOT)
+	assert.Nil(t, ctx.targetMetadata)
+	assert.Nil(t, ctx.schedulingResult)
+	assert.Nil(t, ctx.decodeTokenSampler)
+	assert.Equal(t, "test prompt", ctx.promptText)
+}
+
+func TestPredictedLatencyContext_UpdateMetrics(t *testing.T) {
+	request := createTestLLMRequest("test", 100, 50)
+	ctx := newPredictedLatencyContext(request)
+
+	// Add some metrics
+	metricsState := &fwkdl.Metrics{
+		KVCacheUsagePercent: 0.5,
+		WaitingQueueSize:    3,
+	}
+	ctx.lastSeenMetrics["test-pod"] = metricsState
+
+	assert.Len(t, ctx.lastSeenMetrics, 1)
+	assert.Equal(t, 0.5, ctx.lastSeenMetrics["test-pod"].KVCacheUsagePercent)
+	assert.Equal(t, 3, ctx.lastSeenMetrics["test-pod"].WaitingQueueSize)
+}
+
+func TestPredictedLatencyContext_PredictionData(t *testing.T) {
+	request := createTestLLMRequest("test", 100, 50)
+	ctx := newPredictedLatencyContext(request)
+
+	ctx.predictionsForScheduling = make(map[string]endpointPredictionResult)
+
+	// Set prediction data
+	ctx.predictionsForScheduling["pod1"] = endpointPredictionResult{Endpoint: createTestEndpoint("pod1", 0, 0, 0), TTFT: 80.0, TPOT: 25.0}
+	ctx.predictionsForScheduling["pod2"] = endpointPredictionResult{Endpoint: createTestEndpoint("pod2", 0, 0, 0), TPOT: 30.0, TTFT: 85.0}
+
+	assert.Len(t, ctx.predictionsForScheduling, 2)
+	assert.Equal(t, 80.0, ctx.predictionsForScheduling["pod1"].TTFT)
+	assert.Equal(t, 30.0, ctx.predictionsForScheduling["pod2"].TPOT)
+}
+
+func TestPredictedLatencyContext_PrefixCacheScores(t *testing.T) {
+	request := createTestLLMRequest("test", 100, 50)
+	ctx := newPredictedLatencyContext(request)
+
+	// Set prefix cache scores
+	ctx.prefixCacheScoresForEndpoints["pod1"] = 0.8
+	ctx.prefixCacheScoresForEndpoints["pod2"] = 0.6
+	ctx.prefixCacheScoresForEndpoints["pod3"] = 0.9
+
+	assert.Len(t, ctx.prefixCacheScoresForEndpoints, 3)
+	assert.Equal(t, 0.8, ctx.prefixCacheScoresForEndpoints["pod1"])
+	assert.Equal(t, 0.9, ctx.prefixCacheScoresForEndpoints["pod3"])
+}
+
+func TestPredictedLatency_ConcurrentContextAccess(t *testing.T) {
+	router := createTestRouter()
+
+	// Test concurrent access to context store
+	var wg sync.WaitGroup
+	numGoroutines := 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			requestID := uuid.New().String()
+			request := createTestLLMRequest(requestID, 100, 50)
+			predictedLatencyCtx := newPredictedLatencyContext(request)
+
+			// Set context
+			router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+			// Get context
+			retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+			assert.NoError(t, err)
+			assert.NotNil(t, retrievedCtx)
+
+			// Delete context
+			router.deletePredictedLatencyContextForRequest(request)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestPredictedLatency_MultipleRequests_SamePod(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+
+	request1 := createTestLLMRequest("test-id-1", 100, 50)
+	request2 := createTestLLMRequest("test-id-2", 100, 50)
+	request3 := createTestLLMRequest("test-id-3", 100, 50)
+
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	// Create and set SLO contexts
+	for _, req := range []*schedulingtypes.LLMRequest{request1, request2, request3} {
+		predictedLatencyCtx := newPredictedLatencyContext(req)
+		predictedLatencyCtx.avgTPOTSLO = 50
+		router.setPredictedLatencyContextForRequest(req, predictedLatencyCtx)
+	}
+
+	// Add all requests
+	router.PreRequest(ctx, request1, schedulingResult)
+	router.PreRequest(ctx, request2, schedulingResult)
+	router.PreRequest(ctx, request3, schedulingResult)
+
+	// Verify queue has all requests
+	value, exists := router.runningRequestLists.Load(endpoint.GetMetadata().NamespacedName)
+	assert.True(t, exists)
+	assert.NotNil(t, value)
+}
+
+func TestPredictedLatency_RequestLifecycle_ResponseEndOfStream(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("test", 100, 50)
+	response := &requestcontrol.Response{}
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	// Create initial context
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.avgTPOTSLO = 50
+	predictedLatencyCtx.incomingModelName = testModelName
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	// 1. PreRequest
+	router.PreRequest(ctx, request, schedulingResult)
+
+	// Verify context exists
+	retrievedCtx, err := router.getPredictedLatencyContextForRequest(request)
+	require.NoError(t, err)
+	assert.NotNil(t, retrievedCtx.targetMetadata)
+
+	// 2. ResponseHeader
+	router.ResponseHeader(ctx, request, response, endpoint.GetMetadata())
+
+	// 3. ResponseBody (first token)
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// 4. ResponseBody (subsequent tokens)
+	retrievedCtx, _ = router.getPredictedLatencyContextForRequest(request)
+	retrievedCtx.ttft = 100 // Mark first token received
+	router.setPredictedLatencyContextForRequest(request, retrievedCtx)
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// 5. ResponseComplete
+	retrievedCtx, _ = router.getPredictedLatencyContextForRequest(request)
+	retrievedCtx.ttft = 80
+	retrievedCtx.avgTPOT = 30
+	response = &requestcontrol.Response{EndOfStream: true}
+	router.setPredictedLatencyContextForRequest(request, retrievedCtx)
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// Verify context was cleaned up
+	_, err = router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err)
+}
+
+func TestPredictedLatency_MultipleRequests_DifferentPods(t *testing.T) {
+	router := createTestRouter()
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+
+	endpoint1 := createTestEndpoint("test-pod-1", 1, 1, 1)
+	endpoint2 := createTestEndpoint("test-pod-2", 1, 1, 1)
+
+	request1 := createTestLLMRequest("test-id-1", 100, 50)
+	request2 := createTestLLMRequest("test-id-2", 100, 50)
+
+	schedulingResult1 := createTestSchedulingResult(endpoint1.GetMetadata())
+	schedulingResult2 := createTestSchedulingResult(endpoint2.GetMetadata())
+
+	// Create and set SLO contexts
+	predictedLatencyCtx1 := newPredictedLatencyContext(request1)
+	predictedLatencyCtx1.avgTPOTSLO = 50
+	router.setPredictedLatencyContextForRequest(request1, predictedLatencyCtx1)
+
+	predictedLatencyCtx2 := newPredictedLatencyContext(request2)
+	predictedLatencyCtx2.avgTPOTSLO = 50
+	router.setPredictedLatencyContextForRequest(request2, predictedLatencyCtx2)
+	// Add requests to different pods
+	router.PreRequest(ctx, request1, schedulingResult1)
+	router.PreRequest(ctx, request2, schedulingResult2)
+
+	// Verify separate queues were created
+	value1, exists1 := router.runningRequestLists.Load(endpoint1.GetMetadata().NamespacedName)
+	value2, exists2 := router.runningRequestLists.Load(endpoint2.GetMetadata().NamespacedName)
+
+	assert.True(t, exists1)
+	assert.True(t, exists2)
+	assert.NotNil(t, value1)
+	assert.NotNil(t, value2)
+	queue1 := value1.(*requestPriorityQueue)
+	queue2 := value2.(*requestPriorityQueue)
+	assert.NotEqual(t, queue1, queue2)
+}
+
+func TestPredictedLatencyContext_SLOValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		ttftSLO    float64
+		tpotSLO    float64
+		expectSLOs bool
+	}{
+		{
+			name:       "Both SLOs set",
+			ttftSLO:    100,
+			tpotSLO:    50,
+			expectSLOs: true,
+		},
+		{
+			name:       "No SLOs",
+			ttftSLO:    0,
+			tpotSLO:    0,
+			expectSLOs: false,
+		},
+		{
+			name:       "Only TTFT SLO",
+			ttftSLO:    100,
+			tpotSLO:    0,
+			expectSLOs: false,
+		},
+		{
+			name:       "Only TPOT SLO",
+			ttftSLO:    0,
+			tpotSLO:    50,
+			expectSLOs: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := createTestLLMRequest("test-id", tt.ttftSLO, tt.tpotSLO)
+			ctx := newPredictedLatencyContext(request)
+			ctx.ttftSLO = tt.ttftSLO
+			ctx.avgTPOTSLO = tt.tpotSLO
+
+			hasBothSLOs := ctx.ttftSLO > 0 && ctx.avgTPOTSLO > 0
+			assert.Equal(t, tt.expectSLOs, hasBothSLOs)
+		})
+	}
+}
+
+// Benchmark tests
+
+func BenchmarkPredictedLatency_PreRequest(b *testing.B) {
+	router := createTestRouter()
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		requestID := uuid.New().String()
+		request := createTestLLMRequest(requestID, 100, 50)
+		predictedLatencyCtx := newPredictedLatencyContext(request)
+		predictedLatencyCtx.avgTPOTSLO = 50
+		router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+		router.PreRequest(ctx, request, schedulingResult)
+	}
+}
+
+func BenchmarkPredictedLatency_ContextOperations(b *testing.B) {
+	router := createTestRouter()
+	request := createTestLLMRequest("test", 100, 50)
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+		_, _ = router.getPredictedLatencyContextForRequest(request)
+		router.deletePredictedLatencyContextForRequest(request)
+	}
+}
+
+func BenchmarkPredictedLatencyContext_Creation(b *testing.B) {
+	request := createTestLLMRequest("test", 100, 50)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = newPredictedLatencyContext(request)
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/running_request_tpot_slo_queue.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/running_request_tpot_slo_queue.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// running_request_tpot_slo_queue.go tracks in-flight requests per endpoint,
+// ordered by their TPOT SLO. This allows the predictor to quickly determine
+// the tightest (minimum) TPOT SLO among all running requests on an endpoint,
+// which is used as input to the latency prediction model. The count of running
+// requests is also used by the scorer for idle pod detection.
+//
+// Requests are added in PreRequest (after scheduling) and removed in
+// ResponseBody at EOS or on TTL eviction.
+package latencypredictor
+
+import (
+	"container/heap"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// request represents an element in the priority queue.
+// The index is needed by heap.Remove and is maintained by the heap.Interface methods.
+type request struct {
+	id    string  // Unique identifier
+	tpot  float64 // TPOT SLO for this request (used as priority — lower SLO = higher priority)
+	index int
+}
+
+// requestPriorityQueue implements a priority queue with item removal by ID.
+type requestPriorityQueue struct {
+	items  []*request
+	lookup map[string]*request
+	mutex  sync.RWMutex
+}
+
+// newRequestPriorityQueue initializes and returns a new PriorityQueue.
+func newRequestPriorityQueue() *requestPriorityQueue {
+	return &requestPriorityQueue{
+		lookup: make(map[string]*request),
+		items:  []*request{},
+	}
+}
+
+// Clone creates a deep copy of the priority queue.
+// The new queue is completely independent of the original.
+func (pq *requestPriorityQueue) Clone() *requestPriorityQueue {
+	pq.mutex.RLock()
+	defer pq.mutex.RUnlock()
+
+	// Initialize a new priority queue with pre-allocated capacity.
+	clonedPq := &requestPriorityQueue{
+		items:  make([]*request, len(pq.items)),
+		lookup: make(map[string]*request, len(pq.lookup)),
+	}
+
+	// Iterate through the original items to create deep copies.
+	for i, oldItem := range pq.items {
+		// Create a new Request struct, copying all values.
+		newItem := &request{
+			id:    oldItem.id,
+			tpot:  oldItem.tpot,
+			index: oldItem.index,
+		}
+
+		// Assign the new item to the cloned queue's items slice.
+		clonedPq.items[i] = newItem
+		// Update the lookup map in the cloned queue to point to the new item.
+		clonedPq.lookup[newItem.id] = newItem
+	}
+
+	return clonedPq
+}
+
+// Len is the number of items in the queue.
+func (pq *requestPriorityQueue) Len() int { return len(pq.items) }
+
+// Less reports whether the item with index i should sort before the item with index j.
+func (pq *requestPriorityQueue) Less(i, j int) bool {
+	return pq.items[i].tpot < pq.items[j].tpot
+}
+
+// Swap swaps the items with indexes i and j.
+func (pq *requestPriorityQueue) Swap(i, j int) {
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
+	pq.items[i].index = i
+	pq.items[j].index = j
+}
+
+// Push adds an item to the heap.
+func (pq *requestPriorityQueue) Push(x any) {
+	item := x.(*request)
+	item.index = len(pq.items)
+	pq.items = append(pq.items, item)
+}
+
+// Pop removes and returns the minimum item from the heap.
+func (pq *requestPriorityQueue) Pop() any {
+	n := len(pq.items)
+	item := pq.items[n-1]
+	pq.items[n-1] = nil // avoid memory leak
+	item.index = -1     // for safety
+	pq.items = pq.items[0 : n-1]
+	return item
+}
+
+// Add adds a new item to the queue.
+// Returns true if the item was added, false if an item with the same ID already exists.
+func (pq *requestPriorityQueue) Add(id string, tpot float64) bool {
+	pq.mutex.Lock()
+	defer pq.mutex.Unlock()
+
+	// Validate input
+	if id == "" {
+		return false
+	}
+	if tpot < 0 {
+		return false
+	}
+
+	// If item already exists, do not add
+	if _, exists := pq.lookup[id]; exists {
+		return false
+	}
+
+	item := &request{
+		id:   id,
+		tpot: tpot,
+	}
+	pq.lookup[id] = item
+	heap.Push(pq, item)
+	return true
+}
+
+// Update modifies the TPOT value of an existing item in the queue.
+// If the item doesn't exist, this method does nothing.
+func (pq *requestPriorityQueue) Update(id string, tpot float64) bool {
+	pq.mutex.Lock()
+	defer pq.mutex.Unlock()
+
+	// Validate input
+	if tpot < 0 {
+		return false
+	}
+
+	item, exists := pq.lookup[id]
+	if !exists {
+		return false
+	}
+
+	item.tpot = tpot
+	heap.Fix(pq, item.index)
+	return true
+}
+
+// Remove removes an item from the queue by its ID.
+func (pq *requestPriorityQueue) Remove(id string) (*request, bool) {
+	pq.mutex.Lock()
+	defer pq.mutex.Unlock()
+
+	item, ok := pq.lookup[id]
+	if !ok {
+		return nil, false
+	}
+	removed := heap.Remove(pq, item.index).(*request)
+	delete(pq.lookup, id)
+	return removed, true
+}
+
+// Peek returns the item with the lowest value without removing it.
+func (pq *requestPriorityQueue) Peek() *request {
+	pq.mutex.RLock()
+	defer pq.mutex.RUnlock()
+
+	if len(pq.items) == 0 {
+		return nil
+	}
+	return pq.items[0]
+}
+
+// GetSize returns the current number of items in the queue.
+func (pq *requestPriorityQueue) GetSize() int {
+	pq.mutex.RLock()
+	defer pq.mutex.RUnlock()
+	return len(pq.items)
+}
+
+// Contains checks if an item with the given ID exists in the queue.
+func (pq *requestPriorityQueue) Contains(id string) bool {
+	pq.mutex.RLock()
+	defer pq.mutex.RUnlock()
+	_, exists := pq.lookup[id]
+	return exists
+}
+
+// ToSlice returns a copy of all items in the queue, sorted by ID for stable comparison.
+// This is primarily intended for testing and validation.
+func (pq *requestPriorityQueue) ToSlice() []*request {
+	pq.mutex.RLock()
+	defer pq.mutex.RUnlock()
+
+	// Create a copy to avoid returning a reference to the internal slice.
+	itemsCopy := make([]*request, len(pq.items))
+	copy(itemsCopy, pq.items)
+
+	// Sort by ID to have a deterministic order for comparison in tests.
+	sort.Slice(itemsCopy, func(i, j int) bool {
+		return itemsCopy[i].id < itemsCopy[j].id
+	})
+
+	return itemsCopy
+}
+
+// String returns a string representation of the queue for debugging.
+func (pq *requestPriorityQueue) String() string {
+	pq.mutex.RLock()
+	defer pq.mutex.RUnlock()
+
+	if len(pq.items) == 0 {
+		return "RequestPriorityQueue: []"
+	}
+
+	var builder strings.Builder
+	builder.WriteString("RequestPriorityQueue: [")
+
+	for i, item := range pq.items {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(item.id)
+		builder.WriteString("(")
+		builder.WriteString(fmt.Sprintf("%.2f", item.tpot))
+		builder.WriteString(")")
+	}
+
+	builder.WriteString("]")
+	return builder.String()
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/running_request_tpot_slo_queue_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/running_request_tpot_slo_queue_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewRequestPriorityQueue(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	if pq == nil {
+		t.Fatal("NewRequestPriorityQueue returned nil")
+	}
+
+	if pq.GetSize() != 0 {
+		t.Errorf("Expected empty queue, got size %d", pq.GetSize())
+	}
+
+	if pq.Peek() != nil {
+		t.Error("Expected nil from Peek on empty queue")
+	}
+}
+
+func TestAdd(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Test successful add
+	if !pq.Add("req1", 2.5) {
+		t.Error("Expected Add to return true for new item")
+	}
+
+	if pq.GetSize() != 1 {
+		t.Errorf("Expected size 1, got %d", pq.GetSize())
+	}
+
+	// Test duplicate add
+	if pq.Add("req1", 3.0) {
+		t.Error("Expected Add to return false for duplicate ID")
+	}
+
+	if pq.GetSize() != 1 {
+		t.Errorf("Expected size 1 after duplicate add, got %d", pq.GetSize())
+	}
+
+	// Test validation
+	if pq.Add("", 1.0) {
+		t.Error("Expected Add to return false for empty ID")
+	}
+
+	if pq.Add("req2", -1.0) {
+		t.Error("Expected Add to return false for negative TPOT")
+	}
+}
+
+func TestPriorityOrdering(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Add items with different priorities
+	pq.Add("high", 1.0)   // highest priority (lowest TPOT)
+	pq.Add("medium", 5.0) // medium priority
+	pq.Add("low", 10.0)   // lowest priority (highest TPOT)
+
+	// Check that highest priority item is at the top
+	peek := pq.Peek()
+	if peek == nil || peek.id != "high" || peek.tpot != 1.0 {
+		t.Errorf("Expected high priority item at top, got %+v", peek)
+	}
+
+	// Test removal order
+	expected := []struct {
+		id   string
+		tpot float64
+	}{
+		{"high", 1.0},
+		{"medium", 5.0},
+		{"low", 10.0},
+	}
+
+	for _, exp := range expected {
+		item := pq.Peek()
+		if item.id != exp.id || item.tpot != exp.tpot {
+			t.Errorf("Expected %s(%.1f), got %s(%.1f)", exp.id, exp.tpot, item.id, item.tpot)
+		}
+
+		removed, ok := pq.Remove(item.id)
+		if !ok || removed.id != exp.id {
+			t.Errorf("Failed to remove %s", exp.id)
+		}
+	}
+}
+
+func TestRemove(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Test remove from empty queue
+	if _, ok := pq.Remove("nonexistent"); ok {
+		t.Error("Expected Remove to return false for empty queue")
+	}
+
+	// Add some items
+	pq.Add("req1", 1.0)
+	pq.Add("req2", 2.0)
+	pq.Add("req3", 3.0)
+
+	// Test successful remove
+	removed, ok := pq.Remove("req2")
+	if !ok || removed.id != "req2" || removed.tpot != 2.0 {
+		t.Errorf("Expected to remove req2(2.0), got %+v, ok=%v", removed, ok)
+	}
+
+	if pq.GetSize() != 2 {
+		t.Errorf("Expected size 2 after removal, got %d", pq.GetSize())
+	}
+
+	// Test remove nonexistent
+	if _, ok := pq.Remove("req2"); ok {
+		t.Error("Expected Remove to return false for already removed item")
+	}
+
+	// Verify remaining items are still in correct order
+	if peek := pq.Peek(); peek.id != "req1" {
+		t.Errorf("Expected req1 at top, got %s", peek.id)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Test update nonexistent item
+	if pq.Update("nonexistent", 1.0) {
+		t.Error("Expected Update to return false for nonexistent item")
+	}
+
+	// Add items
+	pq.Add("req1", 1.0)
+	pq.Add("req2", 2.0)
+	pq.Add("req3", 3.0)
+
+	// Update to make req3 highest priority
+	if !pq.Update("req3", 0.5) {
+		t.Error("Expected Update to return true for existing item")
+	}
+
+	// Check that req3 is now at the top
+	if peek := pq.Peek(); peek.id != "req3" || peek.tpot != 0.5 {
+		t.Errorf("Expected req3(0.5) at top, got %s(%.1f)", peek.id, peek.tpot)
+	}
+
+	// Test validation
+	if pq.Update("req1", -1.0) {
+		t.Error("Expected Update to return false for negative TPOT")
+	}
+}
+
+func TestContains(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Test empty queue
+	if pq.Contains("req1") {
+		t.Error("Expected Contains to return false for empty queue")
+	}
+
+	// Add item
+	pq.Add("req1", 1.0)
+
+	// Test existing item
+	if !pq.Contains("req1") {
+		t.Error("Expected Contains to return true for existing item")
+	}
+
+	// Test nonexistent item
+	if pq.Contains("req2") {
+		t.Error("Expected Contains to return false for nonexistent item")
+	}
+
+	// Test after removal
+	pq.Remove("req1")
+	if pq.Contains("req1") {
+		t.Error("Expected Contains to return false after removal")
+	}
+}
+
+func TestClone(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Test clone of empty queue
+	clone := pq.Clone()
+	if clone.GetSize() != 0 {
+		t.Error("Expected cloned empty queue to be empty")
+	}
+
+	// Add items to original
+	pq.Add("req1", 1.0)
+	pq.Add("req2", 2.0)
+	pq.Add("req3", 3.0)
+
+	// Clone with items
+	clone = pq.Clone()
+
+	// Verify clone has same items
+	if clone.GetSize() != pq.GetSize() {
+		t.Errorf("Expected clone size %d, got %d", pq.GetSize(), clone.GetSize())
+	}
+
+	// Verify independence - modify original
+	pq.Add("req4", 4.0)
+	if clone.GetSize() == pq.GetSize() {
+		t.Error("Clone should be independent of original")
+	}
+
+	// Verify independence - modify clone
+	clone.Remove("req1")
+	if !pq.Contains("req1") {
+		t.Error("Original should not be affected by clone modifications")
+	}
+
+	// Verify deep copy - items should be different instances
+	origPeek := pq.Peek()
+	clonePeek := clone.Peek()
+	if origPeek == clonePeek {
+		t.Error("Clone should create new Request instances, not share pointers")
+	}
+}
+
+func TestString(t *testing.T) {
+	pq := newRequestPriorityQueue()
+
+	// Test empty queue
+	str := pq.String()
+	expected := "RequestPriorityQueue: []"
+	if str != expected {
+		t.Errorf("Expected %q, got %q", expected, str)
+	}
+
+	// Test with items
+	pq.Add("req1", 1.5)
+	pq.Add("req2", 2.25)
+
+	str = pq.String()
+	// Should contain both items in priority order
+	if !contains(str, "req1(1.50)") || !contains(str, "req2(2.25)") {
+		t.Errorf("String output missing expected items: %s", str)
+	}
+}
+
+func TestConcurrency(t *testing.T) {
+	pq := newRequestPriorityQueue()
+	const numWorkers = 10
+	const itemsPerWorker = 100
+
+	var wg sync.WaitGroup
+
+	// Launch workers that add items
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < itemsPerWorker; j++ {
+				id := fmt.Sprintf("worker%d-item%d", workerID, j)
+				tpot := float64(j) + float64(workerID)*0.1
+				pq.Add(id, tpot)
+			}
+		}(i)
+	}
+
+	// Launch workers that read from the queue
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < itemsPerWorker/2; j++ {
+				pq.Peek()
+				pq.GetSize()
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify final state
+	expectedSize := numWorkers * itemsPerWorker
+	if pq.GetSize() != expectedSize {
+		t.Errorf("Expected final size %d, got %d", expectedSize, pq.GetSize())
+	}
+}
+
+func TestLargeQueue(t *testing.T) {
+	pq := newRequestPriorityQueue()
+	const numItems = 10000
+
+	// Add many items
+	for i := 0; i < numItems; i++ {
+		id := fmt.Sprintf("item%d", i)
+		tpot := float64(numItems - i) // Reverse order so item0 has highest priority
+		pq.Add(id, tpot)
+	}
+
+	if pq.GetSize() != numItems {
+		t.Errorf("Expected size %d, got %d", numItems, pq.GetSize())
+	}
+
+	// Verify priority ordering by removing items
+	lastTPOT := -1.0
+	for i := 0; i < numItems; i++ {
+		item := pq.Peek()
+		if item.tpot < lastTPOT {
+			t.Errorf("Priority order violated: %.1f < %.1f", item.tpot, lastTPOT)
+		}
+		lastTPOT = item.tpot
+		pq.Remove(item.id)
+	}
+
+	if pq.GetSize() != 0 {
+		t.Errorf("Expected empty queue after removing all items, got size %d", pq.GetSize())
+	}
+}
+
+func BenchmarkAdd(b *testing.B) {
+	pq := newRequestPriorityQueue()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := fmt.Sprintf("item%d", i)
+		pq.Add(id, float64(i))
+	}
+}
+
+func BenchmarkPeek(b *testing.B) {
+	pq := newRequestPriorityQueue()
+
+	// Pre-populate queue
+	for i := 0; i < 1000; i++ {
+		pq.Add(fmt.Sprintf("item%d", i), float64(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pq.Peek()
+	}
+}
+
+func BenchmarkRemove(b *testing.B) {
+	pq := newRequestPriorityQueue()
+
+	// Pre-populate queue
+	for i := 0; i < b.N; i++ {
+		pq.Add(fmt.Sprintf("item%d", i), float64(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pq.Remove(fmt.Sprintf("item%d", i))
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		(s == substr ||
+			s[:len(substr)] == substr ||
+			s[len(s)-len(substr):] == substr ||
+			containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/training.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+)
+
+// buildPredictionRequest constructs a prediction request from endpoint metrics and request data.
+func buildPredictionRequest(
+	endpointRoleLabel string,
+	targetEndpointMetadata *fwkdl.EndpointMetadata,
+	metrics *fwkdl.Metrics,
+	prompt string,
+	generatedTokens int,
+	prefixCacheScore float64,
+) latencypredictor.PredictionRequest {
+	podType := ""
+	if endpointRoleLabel != "" && targetEndpointMetadata != nil && targetEndpointMetadata.Labels != nil {
+		podType = targetEndpointMetadata.Labels[endpointRoleLabel]
+	}
+
+	return latencypredictor.PredictionRequest{
+		KVCachePercentage:  metrics.KVCacheUsagePercent,
+		InputTokenLength:   len(strings.Fields(prompt)),
+		NumRequestWaiting:  metrics.WaitingQueueSize,
+		NumRequestRunning:  metrics.RunningRequestsSize,
+		NumTokensGenerated: generatedTokens,
+		PrefixCacheScore:   prefixCacheScore,
+		PodType:            podType,
+	}
+}
+
+// buildTrainingEntry constructs a training entry from actual latency measurements.
+func buildTrainingEntry(
+	endpointRoleLabel string,
+	targetEndpointMetadata *fwkdl.EndpointMetadata,
+	m *fwkdl.Metrics,
+	prompt string,
+	actualTTFT float64,
+	actualTPOT float64,
+	timestamp time.Time,
+	generatedTokens int,
+	prefixCacheScore float64,
+) latencypredictor.TrainingEntry {
+	podType := ""
+	if endpointRoleLabel != "" && targetEndpointMetadata != nil && targetEndpointMetadata.Labels != nil {
+		podType = targetEndpointMetadata.Labels[endpointRoleLabel]
+	}
+
+	return latencypredictor.TrainingEntry{
+		KVCachePercentage:  m.KVCacheUsagePercent,
+		InputTokenLength:   len(strings.Fields(prompt)),
+		ActualTTFT:         actualTTFT,
+		ActualTPOT:         actualTPOT,
+		Timestamp:          timestamp,
+		NumRequestWaiting:  m.WaitingQueueSize,
+		NumRequestRunning:  m.RunningRequestsSize,
+		NumTokensGenerated: generatedTokens,
+		PrefixCacheScore:   prefixCacheScore,
+		PodType:            podType,
+	}
+}
+
+// recordTTFTTrainingData sends a TTFT training entry to the predictor sidecar.
+func recordTTFTTrainingData(
+	ctx context.Context,
+	predictor latencypredictor.PredictorInterface,
+	endpointRoleLabel string,
+	predictedLatencyCtx *predictedLatencyCtx,
+	m *fwkdl.Metrics,
+	targetEndpointMetadata *fwkdl.EndpointMetadata,
+	now time.Time,
+	prefixCacheScore float64,
+) {
+	logger := log.FromContext(ctx)
+	entry := buildTrainingEntry(
+		endpointRoleLabel,
+		targetEndpointMetadata,
+		m,
+		predictedLatencyCtx.promptText,
+		predictedLatencyCtx.ttft,
+		0,
+		now,
+		0,
+		prefixCacheScore,
+	)
+	if predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
+		entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatchOnPrefill
+	} else {
+		entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatch
+	}
+	entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
+	if err := predictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
+		logger.V(logutil.DEBUG).Error(err, "record TTFT training failed")
+	}
+}
+
+// refreshLastSeenMetrics updates predictedLatencyCtx.lastSeenMetrics from scheduling results.
+func refreshLastSeenMetrics(ctx context.Context, predictedLatencyCtx *predictedLatencyCtx) {
+	if sr := predictedLatencyCtx.schedulingResult; sr != nil {
+		for profileName, profileResult := range sr.ProfileResults {
+			if profileResult != nil && profileResult.TargetEndpoints != nil && len(profileResult.TargetEndpoints) > 0 {
+				predictedLatencyCtx.lastSeenMetrics[profileName] = profileResult.TargetEndpoints[0].GetMetrics().Clone()
+			}
+		}
+	} else {
+		log.FromContext(ctx).V(logutil.DEBUG).Info("No scheduling result found, skipping metrics refresh")
+	}
+}
+
+// getLatestMetricsForProfile retrieves the latest metrics for the specified profile.
+func getLatestMetricsForProfile(predictedLatencyCtx *predictedLatencyCtx, profileName string) (*fwkdl.Metrics, error) {
+	if len(predictedLatencyCtx.lastSeenMetrics) == 0 {
+		return nil, errors.New("no last seen metrics available for prediction")
+	}
+
+	if profileName == "" && predictedLatencyCtx.schedulingResult != nil {
+		profileName = predictedLatencyCtx.schedulingResult.PrimaryProfileName
+	}
+
+	if m, exists := predictedLatencyCtx.lastSeenMetrics[profileName]; exists {
+		return m, nil
+	}
+
+	return nil, fmt.Errorf("no metrics found for profile %s", profileName)
+}
+
+// bulkPredictWithMetrics performs bulk predictions for multiple pods using their metrics states.
+func bulkPredictWithMetrics(
+	ctx context.Context,
+	predictedLatencyContext *predictedLatencyCtx,
+	predictor latencypredictor.PredictorInterface,
+	metricsStates []*fwkdl.Metrics,
+	endpointRoleLabel string,
+	targetEndpointsMetadatas []*fwkdl.EndpointMetadata,
+	prompts []string,
+	generatedTokenCounts []int,
+	prefixCacheScores []float64,
+	prefillTokensInFlights []int64,
+) ([]*latencypredictor.PredictionResponse, error) {
+	logger := log.FromContext(ctx)
+
+	if len(targetEndpointsMetadatas) != len(metricsStates) || len(metricsStates) != len(prompts) || len(prompts) != len(generatedTokenCounts) || len(generatedTokenCounts) != len(prefixCacheScores) {
+		return nil, fmt.Errorf("input slice lengths must match: endpoints=%d, metrics=%d, prompts=%d, tokenCounts=%d, prefixScores=%d",
+			len(targetEndpointsMetadatas), len(metricsStates), len(prompts), len(generatedTokenCounts), len(prefixCacheScores))
+	}
+
+	if len(metricsStates) == 0 {
+		return []*latencypredictor.PredictionResponse{}, nil
+	}
+
+	for i, metricsState := range metricsStates {
+		if metricsState == nil {
+			return nil, fmt.Errorf("metrics state at index %d cannot be nil", i)
+		}
+	}
+
+	for i, endpointMetadata := range targetEndpointsMetadatas {
+		if endpointMetadata == nil {
+			return nil, fmt.Errorf("endpoint metadata at index %d cannot be nil", i)
+		}
+	}
+
+	bulkRequests := make([]latencypredictor.PredictionRequest, len(metricsStates))
+	for i := range metricsStates {
+		bulkRequests[i] = buildPredictionRequest(
+			endpointRoleLabel,
+			targetEndpointsMetadatas[i],
+			metricsStates[i],
+			prompts[i],
+			generatedTokenCounts[i],
+			prefixCacheScores[i],
+		)
+		if i < len(prefillTokensInFlights) {
+			bulkRequests[i].PrefillTokensInFlight = prefillTokensInFlights[i]
+		}
+	}
+
+	start := time.Now()
+	bulkResponse, err := predictor.PredictBulkStrict(ctx, bulkRequests)
+	duration := time.Since(start)
+
+	if err != nil {
+		logger.V(logutil.DEBUG).Error(err, "bulk prediction failed",
+			"duration_ms", duration.Milliseconds(),
+			"request_count", len(bulkRequests))
+		return nil, err
+	}
+
+	if bulkResponse == nil {
+		logger.V(logutil.DEBUG).Info("bulk prediction returned nil",
+			"duration_ms", duration.Milliseconds())
+		return nil, errors.New("bulk prediction returned nil result")
+	}
+
+	if predictedLatencyContext != nil {
+		metrics.RecordRequestTTFTPredictionDuration(ctx, predictedLatencyContext.schedulingRequest.TargetModel, predictedLatencyContext.incomingModelName, duration.Seconds())
+		metrics.RecordRequestTPOTPredictionDuration(ctx, predictedLatencyContext.schedulingRequest.TargetModel, predictedLatencyContext.incomingModelName, duration.Seconds())
+	}
+
+	results := make([]*latencypredictor.PredictionResponse, len(bulkResponse.Predictions))
+	for i := range bulkResponse.Predictions {
+		results[i] = &bulkResponse.Predictions[i]
+	}
+
+	logger.V(logutil.DEBUG).Info("bulk prediction succeeded",
+		"duration_ms", duration.Milliseconds(),
+		"request_count", len(bulkRequests),
+		"successful_predictions", bulkResponse.SuccessfulPredictions,
+		"failed_predictions", bulkResponse.FailedPredictions,
+		"processing_time_ms", bulkResponse.ProcessingTimeMs)
+
+	if logger.V(logutil.TRACE).Enabled() {
+		for i, result := range results {
+			logger.V(logutil.TRACE).Info("bulk prediction result",
+				"index", i,
+				"ttft_ms", result.TTFT,
+				"tpot_ms", result.TPOT,
+				"input_tokens", bulkRequests[i].InputTokenLength,
+				"generated_tokens", bulkRequests[i].NumTokensGenerated,
+				"kv_cache_percent", bulkRequests[i].KVCachePercentage,
+				"waiting_queue", bulkRequests[i].NumRequestWaiting,
+				"running_requests", bulkRequests[i].NumRequestRunning,
+				"prefix_cache_score", bulkRequests[i].PrefixCacheScore)
+		}
+	}
+
+	return results, nil
+}
+
+// calculateRunningAverage calculates the running average efficiently.
+func calculateRunningAverage(currentAvg float64, newValue float64, count int) float64 {
+	if count == 0 {
+		return 0
+	}
+	if count == 1 {
+		return newValue
+	}
+	return currentAvg + (newValue-currentAvg)/float64(count)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/latencypredictor/training_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencypredictor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	latencypredictor "sigs.k8s.io/gateway-api-inference-extension/sidecars/latencypredictorasync"
+)
+
+func TestBulkPredictWithMetrics(t *testing.T) {
+	mockPredictor := &mockPredictor{
+		predictions: map[string]*latencypredictor.PredictionResponse{
+			"0.5": {TTFT: 0.5, TPOT: 0.03},
+			"0.6": {TTFT: 0.6, TPOT: 0.04},
+		},
+	}
+
+	metricsStates := []*fwkdl.Metrics{
+		{KVCacheUsagePercent: 0.5},
+		{KVCacheUsagePercent: 0.6},
+	}
+	pods := []*fwkdl.EndpointMetadata{
+		{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+		},
+		{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod2"},
+		},
+	}
+	prompts := []string{"prompt1", "prompt2"}
+	generatedTokenCounts := []int{1, 1}
+	prefixCacheScores := []float64{0.0, 0.0}
+
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, 0.5, results[0].TTFT)
+	assert.Equal(t, 0.03, results[0].TPOT)
+	assert.Equal(t, 0.6, results[1].TTFT)
+	assert.Equal(t, 0.04, results[1].TPOT)
+}
+
+func TestBulkPredictWithMetrics_Error(t *testing.T) {
+	mockPredictor := &mockPredictor{
+		err: errors.New("prediction failed"),
+	}
+
+	metricsStates := []*fwkdl.Metrics{
+		{KVCacheUsagePercent: 0.5},
+	}
+	pods := []*fwkdl.EndpointMetadata{
+		{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+		},
+	}
+	prompts := []string{"prompt1"}
+	generatedTokenCounts := []int{1}
+	prefixCacheScores := []float64{0.0}
+
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, results)
+}
+
+func TestBulkPredictWithMetrics_InputMismatch(t *testing.T) {
+	mockPredictor := &mockPredictor{}
+	metricsStates := []*fwkdl.Metrics{{}}
+	pods := []*fwkdl.EndpointMetadata{
+		{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+		},
+	}
+	prompts := []string{"prompt1", "prompt2"} // Mismatch length
+	generatedTokenCounts := []int{1}
+	prefixCacheScores := []float64{0.0}
+
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, results)
+	assert.True(t, strings.Contains(err.Error(), "input slice lengths must match"))
+}
+
+func TestBulkPredictWithMetrics_WithPredictedLatencyCtx(t *testing.T) {
+	mockPredictor := &mockPredictor{
+		predictions: map[string]*latencypredictor.PredictionResponse{
+			"0.5": {TTFT: 0.5, TPOT: 0.03},
+		},
+	}
+
+	metricsStates := []*fwkdl.Metrics{
+		{KVCacheUsagePercent: 0.5},
+	}
+	pods := []*fwkdl.EndpointMetadata{
+		{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+		},
+	}
+	prompts := []string{"prompt1"}
+	generatedTokenCounts := []int{1}
+	prefixCacheScores := []float64{0.0}
+
+	plCtx := &predictedLatencyCtx{
+		schedulingRequest: schedulingtypes.LLMRequest{
+			TargetModel: "test-model",
+		},
+		incomingModelName: "incoming-model",
+	}
+
+	results, err := bulkPredictWithMetrics(context.Background(), plCtx, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, 0.5, results[0].TTFT)
+	assert.Equal(t, 0.03, results[0].TPOT)
+}
+
+func TestBulkPredictWithMetrics_ChatCompletionsPrompt(t *testing.T) {
+	mp := &mockPredictor{
+		predictions: map[string]*latencypredictor.PredictionResponse{
+			"0.5": {TTFT: 0.5, TPOT: 0.03},
+		},
+	}
+
+	metricsStates := []*fwkdl.Metrics{{KVCacheUsagePercent: 0.5}}
+	pods := []*fwkdl.EndpointMetadata{
+		{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}},
+	}
+
+	chatBody := &schedulingtypes.LLMRequestBody{
+		ChatCompletions: &schedulingtypes.ChatCompletionsRequest{
+			Messages: []schedulingtypes.Message{
+				{Role: "user", Content: schedulingtypes.Content{Raw: "Hello world"}},
+			},
+		},
+	}
+	prompts := []string{chatBody.PromptText()}
+	generatedTokenCounts := []int{1}
+	prefixCacheScores := []float64{0.0}
+
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mp, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, []int64{0})
+
+	assert.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, 0.5, results[0].TTFT)
+}
+
+func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
+	mockPredictor := &mockPredictor{}
+	metricsStates := []*fwkdl.Metrics{nil} // Nil metrics state
+	pods := []*fwkdl.EndpointMetadata{
+		{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+		},
+	}
+	prompts := []string{"prompt1"}
+	generatedTokenCounts := []int{1}
+	prefixCacheScores := []float64{0.0}
+
+	results, err := bulkPredictWithMetrics(context.Background(), nil, mockPredictor, metricsStates, "", pods, prompts, generatedTokenCounts, prefixCacheScores, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, results)
+	assert.True(t, strings.Contains(err.Error(), "metrics state at index 0 cannot be nil"))
+}


### PR DESCRIPTION
Extract the training and prediction logic from the monolithic PredictedLatency plugin into a standalone predictor/ sub-package.

The predictor handles:
- Bulk predictions via the latency predictor sidecar (PrepareRequestData)
- TTFT/TPOT training data collection (ResponseBody hooks)
- Dispatch bookkeeping and token counters (PreRequest)
- Running request queue per endpoint

Also extends LatencyPredictionInfo with DispatchedRequestCount for accurate idle pod detection by downstream plugins.

This is an additive change — the existing monolithic plugin is untouched and continues to work. The new predictor/ package is not wired up yet.

