### PR TITLE
Add latency admission sub-plugin for SLO-based request shedding

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/OWNERS
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kaushikmitr

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/README.md
@@ -1,0 +1,35 @@
+# Latency SLO Admitter (`latency-slo-admitter`)
+
+Rejects sheddable requests when no endpoint can meet latency SLO constraints.
+
+## Interface
+
+AdmissionPlugin
+
+## Behavior
+
+Non-sheddable requests (priority >= 0) always bypass admission.
+
+For sheddable requests (priority < 0), the plugin admits if **any** of these conditions
+are met:
+
+| Condition | What it checks |
+|-----------|---------------|
+| **hasValid** | At least one endpoint has valid predictions meeting SLOs |
+| **hasIdle** | At least one endpoint has zero dispatched requests |
+| **hasCold** | At least one endpoint has <2% KV cache (predictions unreliable) |
+
+If none are met, the request is rejected.
+
+## Config
+
+None. The plugin reads prediction validity directly from `LatencyPredictionInfo` endpoint
+attributes set by the `predicted-latency-producer` plugin. No `StreamingMode` config needed
+because the predictor already neutralizes TPOT for non-streaming mode and prefill endpoints.
+
+## Dependencies
+
+- Requires `predicted-latency-producer` to run first (in PrepareRequestData) to populate
+  `LatencyPredictionInfo` attributes on endpoints.
+- Reads `DispatchedRequestCount` from the same attributes for idle detection.
+- Reads `KVCacheUsagePercent` from endpoint metrics for cold detection.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencyslo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requestcontrol"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
+)
+
+const (
+	LatencyAdmissionPluginType = "latency-slo-admitter"
+
+	ttftSLOHeaderKey = "x-slo-ttft-ms"
+	tpotSLOHeaderKey = "x-slo-tpot-ms"
+)
+
+// compile-time validation
+var _ requestcontrol.AdmissionPlugin = &LatencyAdmission{}
+
+// LatencyAdmissionConfig holds configuration for the latency admission plugin.
+type LatencyAdmissionConfig struct{}
+
+var LatencyAdmissionDefaultConfig = LatencyAdmissionConfig{}
+
+// LatencyAdmission rejects sheddable requests when no endpoint can meet SLO constraints.
+// It reads latency predictions from endpoint attributes (published by the data provider)
+// and makes an independent admission decision.
+type LatencyAdmission struct {
+	typedName fwkplugin.TypedName
+	config    LatencyAdmissionConfig
+}
+
+// LatencyAdmissionFactory creates a new LatencyAdmission plugin instance.
+func LatencyAdmissionFactory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	config := LatencyAdmissionDefaultConfig
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config for LatencyAdmission: %w", err)
+		}
+	}
+	return NewLatencyAdmission(config).WithName(name), nil
+}
+
+// NewLatencyAdmission creates a new LatencyAdmission plugin.
+func NewLatencyAdmission(config LatencyAdmissionConfig) *LatencyAdmission {
+	return &LatencyAdmission{
+		typedName: fwkplugin.TypedName{Type: LatencyAdmissionPluginType, Name: LatencyAdmissionPluginType},
+		config:    config,
+	}
+}
+
+func (p *LatencyAdmission) WithName(name string) *LatencyAdmission {
+	p.typedName.Name = name
+	return p
+}
+
+func (p *LatencyAdmission) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// Consumes declares that this plugin reads latency prediction data from endpoints.
+func (p *LatencyAdmission) Consumes() map[string]any {
+	return map[string]any{
+		attrlatency.LatencyPredictionInfoKey: attrlatency.LatencyPredictionInfo{},
+	}
+}
+
+// AdmitRequest rejects sheddable requests if no endpoint can serve them within SLO.
+//
+// Reject only when ALL of:
+//   - No endpoint has a valid prediction (all violate SLO)
+//   - No endpoint is idle (all have running requests)
+//   - No cold pod exists (predictions are reliable)
+func (p *LatencyAdmission) AdmitRequest(ctx context.Context, request *schedulingtypes.LLMRequest, endpoints []schedulingtypes.Endpoint) error {
+	logger := log.FromContext(ctx)
+	if request == nil {
+		return nil
+	}
+
+	// Only reject sheddable requests (negative priority).
+	if request.Objectives.Priority >= 0 {
+		return nil
+	}
+
+	// Check if SLOs are set — if not, we can't determine validity, so admit.
+	ttftSLO := parseFloatHeaderValue(request.Headers[ttftSLOHeaderKey])
+	tpotSLO := parseFloatHeaderValue(request.Headers[tpotSLOHeaderKey])
+	hasSLO := ttftSLO > 0 || tpotSLO > 0
+	if !hasSLO {
+		return nil
+	}
+
+	hasValid := false
+	hasCold := false
+	hasIdle := false
+	hasPredictions := false
+
+	for _, endpoint := range endpoints {
+		metrics := endpoint.GetMetrics()
+
+		// Cold pod: KV cache < 2% — predictions may be unreliable, don't reject.
+		if metrics.KVCacheUsagePercent < 0.02 {
+			hasCold = true
+		}
+
+		// Idle pod: no running requests — likely can serve the request.
+		if metrics.RunningRequestsSize == 0 {
+			hasIdle = true
+		}
+
+		// Valid prediction: both TTFT and TPOT within SLO.
+		if latencyInfoRaw, ok := endpoint.Get(attrlatency.LatencyPredictionInfoKey); ok {
+			hasPredictions = true
+			latencyInfo := latencyInfoRaw.(*attrlatency.LatencyPredictionInfo)
+			if latencyInfo.IsValid() {
+				hasValid = true
+			}
+		}
+	}
+
+	// If no predictions are available, fail-open.
+	if !hasPredictions {
+		return nil
+	}
+
+	if !hasValid && !hasIdle && !hasCold {
+		logger.V(logutil.DEBUG).Info("LatencyAdmission: rejecting sheddable request, no valid endpoint available",
+			"endpoints", len(endpoints))
+		return errors.New("no valid endpoint available to serve the request")
+	}
+
+	return nil
+}
+
+func parseFloatHeaderValue(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latencyslo
+
+import (
+	"context"
+	"testing"
+
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
+)
+
+func makeLatencyAdmissionEndpoint(name string, kvCache float64, runningRequests int) schedulingtypes.Endpoint {
+	return schedulingtypes.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+		&fwkdl.Metrics{
+			KVCacheUsagePercent: kvCache,
+			RunningRequestsSize: runningRequests,
+		},
+		nil,
+	)
+}
+
+func makeSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.LLMRequest {
+	return &schedulingtypes.LLMRequest{
+		Headers: map[string]string{
+			ttftSLOHeaderKey: ttftSLO,
+			tpotSLOHeaderKey: tpotSLO,
+		},
+		Objectives: schedulingtypes.RequestObjectives{Priority: -1},
+	}
+}
+
+func makeNonSheddableRequest(ttftSLO, tpotSLO string) *schedulingtypes.LLMRequest {
+	return &schedulingtypes.LLMRequest{
+		Headers: map[string]string{
+			ttftSLOHeaderKey: ttftSLO,
+			tpotSLOHeaderKey: tpotSLO,
+		},
+		Objectives: schedulingtypes.RequestObjectives{Priority: 1},
+	}
+}
+
+func TestAdmitRequest(t *testing.T) {
+	plugin := NewLatencyAdmission(LatencyAdmissionDefaultConfig)
+
+	tests := []struct {
+		name      string
+		request   *schedulingtypes.LLMRequest
+		endpoints []schedulingtypes.Endpoint
+		setupFn   func(endpoints []schedulingtypes.Endpoint) // set endpoint attributes
+		wantErr   bool
+	}{
+		{
+			name:    "nil request — admit",
+			request: nil,
+			wantErr: false,
+		},
+		{
+			name:    "non-sheddable request — always admit",
+			request: makeNonSheddableRequest("100", "30"),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+			},
+			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+				// All invalid predictions
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40))
+			},
+			wantErr: false,
+		},
+		{
+			name:    "no SLO headers — admit",
+			request: makeSheddableRequest("", ""),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "sheddable, all invalid, all busy, no cold — reject",
+			request: makeSheddableRequest("100", "30"),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+				makeLatencyAdmissionEndpoint("pod2", 0.4, 3),
+			},
+			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40))
+				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -30, -5, 130, 35))
+			},
+			wantErr: true,
+		},
+		{
+			name:    "sheddable, all invalid, but one pod idle — admit",
+			request: makeSheddableRequest("100", "30"),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+				makeLatencyAdmissionEndpoint("pod2", 0.4, 0), // idle
+			},
+			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40))
+				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -30, -5, 130, 35))
+			},
+			wantErr: false,
+		},
+		{
+			name:    "sheddable, all invalid, but cold pod exists — admit",
+			request: makeSheddableRequest("100", "30"),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+				makeLatencyAdmissionEndpoint("pod2", 0.01, 3), // cold
+			},
+			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40))
+				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -30, -5, 130, 35))
+			},
+			wantErr: false,
+		},
+		{
+			name:    "sheddable, one valid endpoint — admit",
+			request: makeSheddableRequest("100", "30"),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+				makeLatencyAdmissionEndpoint("pod2", 0.4, 3),
+			},
+			setupFn: func(endpoints []schedulingtypes.Endpoint) {
+				endpoints[0].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(false, false, -50, -10, 150, 40))
+				endpoints[1].Put(attrlatency.LatencyPredictionInfoKey,
+					attrlatency.NewLatencyPredictionInfo(true, true, 20, 5, 80, 25)) // valid
+			},
+			wantErr: false,
+		},
+		{
+			name:    "sheddable, no prediction data on endpoints — admit (fail-open)",
+			request: makeSheddableRequest("100", "30"),
+			endpoints: []schedulingtypes.Endpoint{
+				makeLatencyAdmissionEndpoint("pod1", 0.5, 5),
+			},
+			// no setupFn — no latency attributes set
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupFn != nil {
+				tt.setupFn(tt.endpoints)
+			}
+			err := plugin.AdmitRequest(context.Background(), tt.request, tt.endpoints)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AdmitRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a standalone admission/ sub-package that rejects sheddable requests (priority < 0) when no endpoint can meet SLO constraints.

Admission checks:
- hasValid: at least one endpoint has valid predictions meeting SLOs
- hasIdle: at least one endpoint has zero dispatched requests
- hasCold: at least one endpoint has <2% KV cache (unreliable predictions)

If none of these conditions are met, sheddable requests are rejected. Non-sheddable requests (priority >= 0) always bypass admission.

Reads prediction validity directly from LatencyPredictionInfo endpoint attributes — no StreamingMode config needed since the predictor already neutralizes TPOT for non-streaming mode.

This is an additive change — the existing monolithic plugin is untouched. The new admission/ package is not wired up yet.
