### PR TITLE
fix: lora-syncer gracefully handles adapter load failures without blocking

### DIFF
--- a/tools/dynamic-lora-sidecar/sidecar/sidecar.py
+++ b/tools/dynamic-lora-sidecar/sidecar/sidecar.py
@@ -236,13 +236,13 @@ class LoraReconciler:
             time.sleep(self.health_check_interval.seconds)
         return False
 
-    def load_adapter(self, adapter: LoraAdapter) -> None | str:
+    def load_adapter(self, adapter: LoraAdapter, registered: set) -> None | str:
         """Sends a request to load the specified model."""
-        if adapter in self.registered_adapters:
+        if adapter in registered:
             logging.info(
                 f"{adapter.id} already present on model server {self.model_server}"
             )
-            return
+            return None
         url = f"http://{self.model_server}/v1/load_lora_adapter"
         payload = {
             "lora_name": adapter.id,
@@ -258,13 +258,13 @@ class LoraReconciler:
             logging.error(f"error loading model {adapter.id}: {e}")
             return f"error loading model {adapter.id}: {e}"
 
-    def unload_adapter(self, adapter: LoraAdapter) -> None | str:
+    def unload_adapter(self, adapter: LoraAdapter, registered: set) -> None | str:
         """Sends a request to unload the specified model."""
-        if adapter not in self.registered_adapters:
+        if adapter not in registered:
             logging.info(
                 f"{adapter.id} already doesn't exist on model server {self.model_server}"
             )
-            return
+            return None
         url = f"http://{self.model_server}/v1/unload_lora_adapter"
         payload = {"lora_name": adapter.id}
         try:
@@ -281,31 +281,40 @@ class LoraReconciler:
         logging.info(
             f"reconciling model server {self.model_server} with config stored at {self.config_file}"
         )
-        
+
         if not self.is_server_healthy:
             logging.error(f"vllm server at {self.model_server} not healthy")
             return
-        invalid_adapters = ", ".join(
-            str(a.id)
-            for a in self.ensure_exist_adapters & self.ensure_not_exist_adapters
-        )
-        logging.warning(
-            f"skipped adapters found in both `ensureExist` and `ensureNotExist` {invalid_adapters}"
-        )
+
+        # Fetch registered adapters once to avoid redundant API calls per adapter.
+        registered = self.registered_adapters
+
+        conflicting = self.ensure_exist_adapters & self.ensure_not_exist_adapters
+        if conflicting:
+            invalid_adapters = ", ".join(str(a.id) for a in conflicting)
+            logging.warning(
+                f"skipped adapters found in both `ensureExist` and `ensureNotExist`: {invalid_adapters}"
+            )
+
         adapters_to_load = self.ensure_exist_adapters - self.ensure_not_exist_adapters
         adapters_to_load_id = ", ".join(str(a.id) for a in adapters_to_load)
-        logging.info(f"adapter to load {adapters_to_load_id}")
+        logging.info(f"adapters to load: {adapters_to_load_id}")
         for adapter in adapters_to_load:
-            err = self.load_adapter(adapter)
-            if err is None:
-                self.update_adapter_status_metrics(adapter.id, is_loaded=True)
+            err = self.load_adapter(adapter, registered)
+            if err is not None:
+                logging.error(f"skipping adapter {adapter.id} due to load failure, will retry next reconcile")
+                continue
+            self.update_adapter_status_metrics(adapter.id, is_loaded=True)
+
         adapters_to_unload = self.ensure_not_exist_adapters - self.ensure_exist_adapters
         adapters_to_unload_id = ", ".join(str(a.id) for a in adapters_to_unload)
-        logging.info(f"adapters to unload {adapters_to_unload_id}")
+        logging.info(f"adapters to unload: {adapters_to_unload_id}")
         for adapter in adapters_to_unload:
-            err = self.unload_adapter(adapter)
-            if err is None:
-                self.update_adapter_status_metrics(adapter.id, is_loaded=False)
+            err = self.unload_adapter(adapter, registered)
+            if err is not None:
+                logging.error(f"skipping adapter {adapter.id} due to unload failure, will retry next reconcile")
+                continue
+            self.update_adapter_status_metrics(adapter.id, is_loaded=False)
 
     def update_adapter_status_metrics(self, adapter_id: str, is_loaded: bool):
         """Update adapter status metrics"""

--- a/tools/dynamic-lora-sidecar/sidecar/test_sidecar.py
+++ b/tools/dynamic-lora-sidecar/sidecar/test_sidecar.py
@@ -139,6 +139,7 @@ class LoraReconcilerTest(unittest.TestCase):
         with patch("builtins.open", mock_file):
             with patch.object(LoraReconciler, "is_server_healthy", return_value=True):
                 mock_post.return_value = getMockResponse()
+                registered = self.reconciler.registered_adapters
                 # loading a new adapter
                 adapter = EXIST_ADAPTERS[0]
                 url = "http://localhost:8000/v1/load_lora_adapter"
@@ -147,10 +148,10 @@ class LoraReconcilerTest(unittest.TestCase):
                     "lora_path": adapter.source,
                     "base_model_name": adapter.base_model,
                 }
-                self.reconciler.load_adapter(adapter)
+                self.reconciler.load_adapter(adapter, registered)
                 # adapter 2 already exists `id:already_exists`
                 already_exists = EXIST_ADAPTERS[2]
-                self.reconciler.load_adapter(already_exists)
+                self.reconciler.load_adapter(already_exists, registered)
                 mock_post.assert_called_once_with(url, json=payload)
 
     @patch("sidecar.requests.get")
@@ -163,12 +164,13 @@ class LoraReconcilerTest(unittest.TestCase):
         with patch("builtins.open", mock_file):
             with patch.object(LoraReconciler, "is_server_healthy", return_value=True):
                 mock_post.return_value = getMockResponse()
+                registered = self.reconciler.registered_adapters
                 # unloading an existing adapter `id:to_remove`
                 adapter = NOT_EXIST_ADAPTERS[2]
-                self.reconciler.unload_adapter(adapter)
+                self.reconciler.unload_adapter(adapter, registered)
                 payload = {"lora_name": adapter.id}
                 adapter = NOT_EXIST_ADAPTERS[0]
-                self.reconciler.unload_adapter(adapter)
+                self.reconciler.unload_adapter(adapter, registered)
                 mock_post.assert_called_once_with(
                     "http://localhost:8000/v1/unload_lora_adapter",
                     json=payload,
@@ -208,14 +210,20 @@ class LoraReconcilerTest(unittest.TestCase):
                         self.assertEqual(mock_unload.call_count, 2, "Expected 2 unload adapter calls")
                         
                         # Check that the adapters with the correct IDs were loaded
-                        loaded_ids = [call.args[0].id for call in mock_load.call_args_list]
+                        loaded_ids = [c.args[0].id for c in mock_load.call_args_list]
                         self.assertIn("sql-lora-v1", loaded_ids, "sql-lora-v1 should have been loaded")
                         self.assertIn("already_exists", loaded_ids, "already_exists should have been loaded")
-                        
+                        # Verify registered set was passed
+                        for c in mock_load.call_args_list:
+                            self.assertIsInstance(c.args[1], set, "registered set should be passed to load_adapter")
+
                         # Check that the adapters with the correct IDs were unloaded
-                        unloaded_ids = [call.args[0].id for call in mock_unload.call_args_list]
+                        unloaded_ids = [c.args[0].id for c in mock_unload.call_args_list]
                         self.assertIn("sql-lora-v2", unloaded_ids, "sql-lora-v2 should have been unloaded")
                         self.assertIn("to_remove", unloaded_ids, "to_remove should have been unloaded")
+                        # Verify registered set was passed
+                        for c in mock_unload.call_args_list:
+                            self.assertIsInstance(c.args[1], set, "registered set should be passed to unload_adapter")
 
     def test_health_check_settings(self):
         """Test that health check settings are properly initialized from command line args"""


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

Fixes lora-syncer error handling so that a single adapter load/unload failure does not block processing of remaining adapters. Previously, a permanently invalid adapter (e.g., LoRA rank exceeding vLLM's max) would cause misleading
error logs and prevent other valid adapters from being loaded on every reconcile cycle.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #584 

/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
