### PR TITLE
cleanup: remove PriorityName field from PriorityBandConfig

### DIFF
--- a/pkg/epp/flowcontrol/benchmark/benchmark.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark.go
@@ -206,7 +206,7 @@ func setupRegistry(
 
 	for i := 0; i < int(p); i++ {
 		band, err := registry.NewPriorityBandConfig(
-			handle, i, fmt.Sprintf("band-%d", i),
+			handle, i,
 			registry.WithBandMaxBytes(10_000_000_000), // Prevent capacity-based rejections.
 		)
 		if err != nil {

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -211,9 +211,6 @@ type ShardStats struct {
 type PriorityBandStats struct {
 	// Priority is the numerical priority level this struct describes.
 	Priority int
-	// PriorityName is a human-readable name for the priority band (e.g., "Critical", "Sheddable").
-	// The registry configuration requires this field, so it is guaranteed to be non-empty.
-	PriorityName string
 	// CapacityBytes is the configured maximum total byte size for this priority band.
 	// When viewed via `AggregateStats`, this is the global limit. When viewed via `ShardStats`, this is the partitioned
 	// value for that specific shard.

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -248,7 +248,7 @@ func (sp *ShardProcessor) enqueue(item *FlowItem) {
 		return
 	}
 
-	band, err := sp.shard.PriorityBandAccessor(key.Priority)
+	_, err = sp.shard.PriorityBandAccessor(key.Priority)
 	if err != nil {
 		finalErr := fmt.Errorf("configuration error: failed to get priority band for priority %d: %w", key.Priority, err)
 		sp.logger.Error(finalErr, "Rejecting item.", "flowKey", key, "reqID", req.ID())
@@ -260,7 +260,7 @@ func (sp *ShardProcessor) enqueue(item *FlowItem) {
 	// This check is safe because it is performed by the single-writer Run goroutine.
 	if !sp.hasCapacity(key.Priority, req.ByteSize()) {
 		sp.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity",
-			"flowKey", key, "reqID", req.ID(), "priorityName", band.PriorityName(), "reqByteSize", req.ByteSize())
+			"flowKey", key, "reqID", req.ID(), "reqByteSize", req.ByteSize())
 		item.FinalizeWithOutcome(types.QueueOutcomeRejectedCapacity, fmt.Errorf("%w: %w",
 			types.ErrRejected, types.ErrQueueAtCapacity))
 		return
@@ -271,12 +271,12 @@ func (sp *ShardProcessor) enqueue(item *FlowItem) {
 	if err := managedQ.Add(item); err != nil {
 		finalErr := fmt.Errorf("failed to add item to queue for flow key %s: %w", key, err)
 		sp.logger.Error(finalErr, "Rejecting item post-admission.",
-			"flowKey", key, "reqID", req.ID(), "priorityName", band.PriorityName())
+			"flowKey", key, "reqID", req.ID())
 		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
 	sp.logger.V(logutil.TRACE).Info("Item enqueued.",
-		"flowKey", key, "reqID", req.ID(), "priorityName", band.PriorityName())
+		"flowKey", key, "reqID", req.ID())
 }
 
 // hasCapacity checks if the shard and the specific priority band have enough capacity.
@@ -338,7 +338,7 @@ func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
 		item, err := sp.selectItem(ctx, originalBand)
 		if err != nil {
 			sp.logger.Error(err, "Failed to select item, skipping priority band for this cycle",
-				"priority", priority, "priorityName", originalBand.PriorityName())
+				"priority", priority)
 			continue // Continue to the next band to maximize work conservation.
 		}
 		if item == nil {
@@ -350,7 +350,7 @@ func (sp *ShardProcessor) dispatchCycle(ctx context.Context) bool {
 		// --- Dispatch ---
 		if err := sp.dispatchItem(item); err != nil {
 			sp.logger.Error(err, "Failed to dispatch item, skipping priority band for this cycle",
-				"flowKey", req.FlowKey(), "reqID", req.ID(), "priorityName", originalBand.PriorityName())
+				"flowKey", req.FlowKey(), "reqID", req.ID())
 			continue // Continue to the next band to maximize work conservation.
 		}
 		return true

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	configapi "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
@@ -57,8 +56,6 @@ const (
 	// defaultPriorityBandGCTimeout is the default duration of inactivity after which a dynamically provisioned
 	// priority band is garbage collected. Set to 2x flow GC timeout to ensure flows are cleaned up first.
 	defaultPriorityBandGCTimeout time.Duration = 2 * defaultFlowGCTimeout
-	// dynamicDefaultPriorityBandName is the reserved name for the template band used for dynamic provisioning.
-	dynamicDefaultPriorityBandName = "Dynamic-Default"
 )
 
 // --- Capability Checking ---
@@ -151,11 +148,6 @@ type PriorityBandConfig struct {
 	// Convention: Highest numeric value corresponds to highest priority (centered on 0).
 	// Required.
 	Priority int
-
-	// PriorityName is a human-readable name for this priority band (e.g., "Critical", "Standard").
-	// It must be unique across all priority bands in the configuration.
-	// Required.
-	PriorityName string
 
 	// OrderingPolicy is the hydrated singleton instance of the policy.
 	// This policy governs which request *within this flow's queue* to select next (e.g., "fcfs").
@@ -416,7 +408,7 @@ func buildDefaultPriorityBandTemplate(
 	}
 
 	// We pass priority 0 as placeholder since it's a template.
-	templateBand, err := NewPriorityBandConfig(handle, 0, dynamicDefaultPriorityBandName, bandOpts...)
+	templateBand, err := NewPriorityBandConfig(handle, 0, bandOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default priority band template: %w", err)
 	}
@@ -439,7 +431,7 @@ func buildPriorityBand(handle plugin.Handle, band configapi.PriorityBandConfig) 
 		bandOpts = append(bandOpts, WithFairnessPolicy(band.FairnessPolicyRef, handle))
 	}
 
-	pb, err := NewPriorityBandConfig(handle, band.Priority, "", bandOpts...)
+	pb, err := NewPriorityBandConfig(handle, band.Priority, bandOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create priority band config for priority %d: %w", band.Priority, err)
 	}
@@ -473,7 +465,7 @@ func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
 	// Initialize DefaultPriorityBand if missing.
 	// This ensures we always have a template for dynamic provisioning.
 	if builder.config.DefaultPriorityBand == nil {
-		template, err := NewPriorityBandConfig(handle, 0, dynamicDefaultPriorityBandName)
+		template, err := NewPriorityBandConfig(handle, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create default priority band: %w", err)
 		}
@@ -502,12 +494,10 @@ func NewConfig(handle plugin.Handle, opts ...ConfigOption) (*Config, error) {
 func NewPriorityBandConfig(
 	handle plugin.Handle,
 	priority int,
-	name string,
 	opts ...PriorityBandConfigOption,
 ) (*PriorityBandConfig, error) {
 	pb := &PriorityBandConfig{
-		Priority:     priority,
-		PriorityName: name,
+		Priority: priority,
 	}
 
 	for _, opt := range opts {
@@ -526,9 +516,6 @@ func NewPriorityBandConfig(
 // --- Validation, Defaults & Hydration ---
 
 func (p *PriorityBandConfig) applyDefaults(handle plugin.Handle) error {
-	if p.PriorityName == "" {
-		p.PriorityName = fmt.Sprintf("priority-%d", p.Priority)
-	}
 	if p.OrderingPolicy == nil {
 		policy, err := orderingPolicy(DefaultOrderingPolicyRef, handle)
 		if err != nil {
@@ -559,9 +546,6 @@ func (p *PriorityBandConfig) applyDefaults(handle plugin.Handle) error {
 
 // validate checks the integrity of a single band's configuration.
 func (p *PriorityBandConfig) validate(checker capabilityChecker) error {
-	if p.PriorityName == "" {
-		return fmt.Errorf("PriorityName is required for priority band %d", p.Priority)
-	}
 	if p.OrderingPolicy == nil {
 		return fmt.Errorf("OrderingPolicy instance is missing for priority band %d", p.Priority)
 	}
@@ -573,8 +557,8 @@ func (p *PriorityBandConfig) validate(checker capabilityChecker) error {
 	}
 	if checker != nil {
 		if err := checker.CheckCompatibility(p.OrderingPolicy, p.Queue); err != nil {
-			return fmt.Errorf("priority band %d (%s) configuration error: %w",
-				p.Priority, p.PriorityName, err)
+			return fmt.Errorf("priority band %d configuration error: %w",
+				p.Priority, err)
 		}
 	}
 	return nil
@@ -604,13 +588,7 @@ func (c *Config) validate(checker capabilityChecker) error {
 	}
 
 	// Validate statically configured bands.
-	names := sets.New[string]()
 	for _, band := range c.PriorityBands {
-		if names.Has(band.PriorityName) {
-			return fmt.Errorf("duplicate priority name %q found", band.PriorityName)
-		}
-		names.Insert(band.PriorityName)
-
 		if err := band.validate(checker); err != nil {
 			return err
 		}
@@ -638,7 +616,6 @@ func (c *Config) partition(shardIndex, totalShards int) *ShardConfig {
 	for _, template := range c.PriorityBands {
 		shardBand := &PriorityBandConfig{
 			Priority:       template.Priority,
-			PriorityName:   template.PriorityName,
 			OrderingPolicy: template.OrderingPolicy,
 			FairnessPolicy: template.FairnessPolicy,
 			Queue:          template.Queue,

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -81,9 +81,9 @@ func (m *mockCapabilityChecker) CheckCompatibility(p flowcontrol.OrderingPolicy,
 
 // mustBand is a helper to simplify test table setup.
 // It panics if the band config creation fails, which should not happen with valid static inputs.
-func mustBand(t *testing.T, priority int, name string, opts ...PriorityBandConfigOption) *PriorityBandConfig {
+func mustBand(t *testing.T, priority int, opts ...PriorityBandConfigOption) *PriorityBandConfig {
 	handle := newTestPluginsHandle(t)
-	pb, err := NewPriorityBandConfig(handle, priority, name, opts...)
+	pb, err := NewPriorityBandConfig(handle, priority, opts...)
 	require.NoError(t, err, "failed to create test band")
 	return pb
 }
@@ -103,7 +103,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "ShouldApplySystemDefaults_WhenNoOptionsProvided",
 			opts: []ConfigOption{
-				WithPriorityBand(mustBand(t, 1, "Default")),
+				WithPriorityBand(mustBand(t, 1)),
 			},
 			handle: newTestPluginsHandle(t),
 			assertion: func(t *testing.T, cfg *Config) {
@@ -128,7 +128,7 @@ func TestNewConfig(t *testing.T) {
 				WithMaxBytes(5000),
 				WithFlowGCTimeout(1 * time.Hour),
 				WithPriorityBandGCTimeout(2 * time.Hour),
-				WithPriorityBand(mustBand(t, 1, "High")),
+				WithPriorityBand(mustBand(t, 1)),
 			},
 			handle: newTestPluginsHandle(t),
 			assertion: func(t *testing.T, cfg *Config) {
@@ -141,8 +141,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "ShouldApplyBandDefaults_WithRawStructLiterals",
 			opts: []ConfigOption{
-				// Simulate a user passing a manually constructed struct (bypassing NewPriorityBandConfig).
-				WithPriorityBand(&PriorityBandConfig{Priority: 1, PriorityName: "Raw"}),
+				WithPriorityBand(&PriorityBandConfig{Priority: 1}),
 			},
 			handle: newTestPluginsHandle(t),
 			assertion: func(t *testing.T, cfg *Config) {
@@ -164,7 +163,6 @@ func TestNewConfig(t *testing.T) {
 			assertion: func(t *testing.T, cfg *Config) {
 				assert.Empty(t, cfg.PriorityBands, "PriorityBands map should be empty")
 				require.NotNil(t, cfg.DefaultPriorityBand, "DefaultPriorityBand template must be initialized")
-				assert.Equal(t, "Dynamic-Default", cfg.DefaultPriorityBand.PriorityName)
 				assert.Equal(t, defaultQueue, cfg.DefaultPriorityBand.Queue)
 				assert.NotNil(t, cfg.DefaultPriorityBand.FairnessPolicy)
 				assert.Equal(t, DefaultFairnessPolicyRef, cfg.DefaultPriorityBand.FairnessPolicy.TypedName().Name)
@@ -174,8 +172,7 @@ func TestNewConfig(t *testing.T) {
 			name: "ShouldRespectCustomDefaultPriorityBand",
 			opts: []ConfigOption{
 				WithDefaultPriorityBand(&PriorityBandConfig{
-					PriorityName: "My-Custom-Template",
-					Queue:        "CustomQueue",
+					Queue: "CustomQueue",
 				}),
 				withCapabilityChecker(&mockCapabilityChecker{
 					checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error { return nil },
@@ -184,7 +181,6 @@ func TestNewConfig(t *testing.T) {
 			handle: newTestPluginsHandle(t),
 			assertion: func(t *testing.T, cfg *Config) {
 				require.NotNil(t, cfg.DefaultPriorityBand)
-				assert.Equal(t, "My-Custom-Template", cfg.DefaultPriorityBand.PriorityName)
 				assert.Equal(t, queue.RegisteredQueueName("CustomQueue"), cfg.DefaultPriorityBand.Queue)
 				assert.NotNil(t, cfg.DefaultPriorityBand.FairnessPolicy)
 				assert.Equal(t, DefaultFairnessPolicyRef, cfg.DefaultPriorityBand.FairnessPolicy.TypedName().Name)
@@ -247,17 +243,8 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "ShouldError_WhenDuplicatePriorityLevelAdded",
 			opts: []ConfigOption{
-				WithPriorityBand(mustBand(t, 1, "A")),
-				WithPriorityBand(mustBand(t, 1, "B")), // Same priority level
-			},
-			handle:    newTestPluginsHandle(t),
-			expectErr: true,
-		},
-		{
-			name: "ShouldError_WhenDuplicatePriorityNameAdded",
-			opts: []ConfigOption{
-				WithPriorityBand(mustBand(t, 1, "High")),
-				WithPriorityBand(mustBand(t, 2, "High")), // Same name
+				WithPriorityBand(mustBand(t, 1)),
+				WithPriorityBand(mustBand(t, 1)), // Same priority level
 			},
 			handle:    newTestPluginsHandle(t),
 			expectErr: true,
@@ -268,24 +255,11 @@ func TestNewConfig(t *testing.T) {
 			handle:    newTestPluginsHandle(t),
 			expectErr: true,
 		},
-		{
-			name: "ShouldSynthesizeName_WhenBandNameMissing",
-			opts: []ConfigOption{
-				// Use raw struct to bypass NewPriorityBandConfig validation which forces a name argument.
-				WithPriorityBand(&PriorityBandConfig{Priority: 1}),
-			},
-			handle: newTestPluginsHandle(t),
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1, "Priority bands should contain the configured band")
-				assert.Equal(t, "priority-1", cfg.PriorityBands[1].PriorityName,
-					"PriorityName should be synthesized from priority level")
-			},
-		},
 
 		// --- Hydration Failures ---
 		{
 			name:      "ShouldError_WhenDefaultPolicyMissingFromHandle",
-			opts:      []ConfigOption{WithPriorityBand(&PriorityBandConfig{Priority: 1, PriorityName: "A"})},
+			opts:      []ConfigOption{WithPriorityBand(&PriorityBandConfig{Priority: 1})},
 			handle:    utils.NewTestHandle(t.Context()), // Handle has no plugin.
 			expectErr: true,
 		},
@@ -294,7 +268,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "ShouldError_WhenCapabilityCheckerFails",
 			opts: []ConfigOption{
-				WithPriorityBand(mustBand(t, 1, "High")),
+				WithPriorityBand(mustBand(t, 1)),
 				withCapabilityChecker(&mockCapabilityChecker{
 					checkCompatibilityFunc: func(flowcontrol.OrderingPolicy, queue.RegisteredQueueName) error {
 						return contracts.ErrPolicyQueueIncompatible
@@ -308,7 +282,7 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "ShouldError_WhenDefaultRuntimeCheckerDetectsUnknownQueue",
 			opts: []ConfigOption{
-				WithPriorityBand(mustBand(t, 1, "BadBand", WithQueue("non-existent-queue"))),
+				WithPriorityBand(mustBand(t, 1, WithQueue("non-existent-queue"))),
 			},
 			handle:    newTestPluginsHandle(t),
 			expectErr: true,
@@ -344,7 +318,7 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 	t.Run("ShouldApplyUserOverrides", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 1, "Custom",
+		pb, err := NewPriorityBandConfig(handle, 1,
 			WithQueue(queue.RegisteredQueueName("CustomQueue")),
 			WithBandMaxBytes(999),
 			WithOrderingPolicy(ordering.EDFOrderingPolicyType, handle),
@@ -361,14 +335,14 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 	t.Run("ShouldError_OnInvalidOptions", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 1, "Bad", WithQueue(""))
+		pb, err := NewPriorityBandConfig(handle, 1, WithQueue(""))
 		assert.Error(t, err, "Should error when setting empty queue")
 		assert.Nil(t, pb)
 	})
 
 	t.Run("ShouldError_WhenPolicyRefUnknown", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 1, "Bad",
+		pb, err := NewPriorityBandConfig(handle, 1,
 			WithFairnessPolicy("UnknownPolicy", handle),
 		)
 		assert.Error(t, err)
@@ -378,7 +352,7 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 	t.Run("ShouldDefaultToHeap_WhenPolicyRequiresIt", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 10, "EDF-Band",
+		pb, err := NewPriorityBandConfig(handle, 10,
 			WithOrderingPolicy(ordering.EDFOrderingPolicyType, handle),
 			WithFairnessPolicy(fairness.GlobalStrictFairnessPolicyType, handle),
 		)
@@ -389,7 +363,7 @@ func TestNewPriorityBandConfig(t *testing.T) {
 
 	t.Run("ShouldDefaultToList_WhenPolicyDoesNotRequirePriority", func(t *testing.T) {
 		t.Parallel()
-		pb, err := NewPriorityBandConfig(handle, 20, "FCFS-Band",
+		pb, err := NewPriorityBandConfig(handle, 20,
 			WithOrderingPolicy(ordering.FCFSOrderingPolicyType, handle),
 			WithFairnessPolicy(fairness.GlobalStrictFairnessPolicyType, handle),
 		)
@@ -411,9 +385,9 @@ func TestConfig_Partition(t *testing.T) {
 	cfg, err := NewConfig(
 		handle,
 		WithMaxBytes(103),
-		WithPriorityBand(mustBand(t, 1, "Band1", WithBandMaxBytes(55))),
-		WithPriorityBand(mustBand(t, 2, "Band2", WithBandMaxBytes(0))), // Explicit 0 implies default behavior via logic.
-		WithPriorityBand(mustBand(t, 3, "Band3", WithBandMaxBytes(20))),
+		WithPriorityBand(mustBand(t, 1, WithBandMaxBytes(55))),
+		WithPriorityBand(mustBand(t, 2, WithBandMaxBytes(0))), // Explicit 0 implies default behavior via logic.
+		WithPriorityBand(mustBand(t, 3, WithBandMaxBytes(20))),
 	)
 	require.NoError(t, err)
 
@@ -465,8 +439,8 @@ func TestConfig_Clone(t *testing.T) {
 	original, err := NewConfig(
 		handle,
 		WithMaxBytes(1000),
-		WithPriorityBand(mustBand(t, 1, "A")),
-		WithPriorityBand(mustBand(t, 2, "B")),
+		WithPriorityBand(mustBand(t, 1)),
+		WithPriorityBand(mustBand(t, 2)),
 	)
 	require.NoError(t, err, "Setup failed")
 
@@ -482,7 +456,6 @@ func TestConfig_Clone(t *testing.T) {
 		require.NotSame(t, original.PriorityBands[1], clone.PriorityBands[1],
 			"Map values (pointers to bands) should differ")
 		assert.Equal(t, original.MaxBytes, clone.MaxBytes)
-		assert.Equal(t, original.PriorityBands[1].PriorityName, clone.PriorityBands[1].PriorityName)
 	})
 
 	t.Run("ShouldIsolateModifications", func(t *testing.T) {
@@ -490,12 +463,9 @@ func TestConfig_Clone(t *testing.T) {
 
 		// Modify the clone's map entry.
 		clone.PriorityBands[1].MaxBytes = 99999
-		clone.PriorityBands[1].PriorityName = "Modified"
 
 		assert.Equal(t, defaultPriorityBandMaxBytes, original.PriorityBands[1].MaxBytes)
-		assert.Equal(t, "A", original.PriorityBands[1].PriorityName)
 		assert.Equal(t, uint64(99999), clone.PriorityBands[1].MaxBytes)
-		assert.Equal(t, "Modified", clone.PriorityBands[1].PriorityName)
 	})
 
 	t.Run("ShouldDeepCopyDefaultPriorityBand", func(t *testing.T) {
@@ -507,12 +477,6 @@ func TestConfig_Clone(t *testing.T) {
 
 		require.NotSame(t, original.DefaultPriorityBand, clone.DefaultPriorityBand,
 			"Clone should have a distinct pointer for DefaultPriorityBand")
-		assert.Equal(t, original.DefaultPriorityBand.PriorityName, clone.DefaultPriorityBand.PriorityName)
-
-		// Modify Clone.
-		clone.DefaultPriorityBand.PriorityName = "Hacked"
-		assert.Equal(t, "Dynamic-Default", original.DefaultPriorityBand.PriorityName,
-			"Modifying clone template should not affect original")
 	})
 }
 
@@ -547,8 +511,7 @@ func TestNewConfigFromAPI(t *testing.T) {
 				// Verify Explicit Band
 				require.Contains(t, cfg.PriorityBands, 1, "Configured priority band should be present")
 				assert.Equal(t, uint64(50), cfg.PriorityBands[1].MaxBytes, "Band MaxBytes should be correctly translated")
-				assert.Equal(t, "priority-1", cfg.PriorityBands[1].PriorityName,
-					"PriorityName should be defaulted if not provided")
+				assert.Equal(t, uint64(50), cfg.PriorityBands[1].MaxBytes, "Band MaxBytes should be correctly translated")
 
 				// Verify Default Template
 				require.NotNil(t, cfg.DefaultPriorityBand, "DefaultPriorityBand should be configured")
@@ -604,22 +567,6 @@ func TestNewConfigFromAPI(t *testing.T) {
 					"Default priority band template should be initialized automatically")
 				assert.Equal(t, defaultPriorityBandMaxBytes, cfg.DefaultPriorityBand.MaxBytes,
 					"Default template should use system default capacity")
-			},
-		},
-		{
-			name: "ShouldSynthesizePriorityName_WhenMissing",
-			apiConfig: &configapi.FlowControlConfig{
-				PriorityBands: []configapi.PriorityBandConfig{
-					{
-						Priority: 1,
-						// No PriorityName provided
-					},
-				},
-			},
-			assertion: func(t *testing.T, cfg *Config) {
-				require.Contains(t, cfg.PriorityBands, 1, "Priority band should be present")
-				assert.Equal(t, "priority-1", cfg.PriorityBands[1].PriorityName,
-					"PriorityName should be synthesized from priority index")
 			},
 		},
 

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -288,7 +288,6 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 
 	newBand := *fr.config.DefaultPriorityBand
 	newBand.Priority = priority
-	newBand.PriorityName = fmt.Sprintf("Dynamic-%d", priority)
 	fr.config.PriorityBands[priority] = &newBand
 
 	fr.perPriorityBandStats.LoadOrStore(priority, &bandStats{})
@@ -334,7 +333,6 @@ func (fr *FlowRegistry) Stats() contracts.AggregateStats {
 		bandCfg := fr.config.PriorityBands[priority]
 		stats.PerPriorityBandStats[priority] = contracts.PriorityBandStats{
 			Priority:      priority,
-			PriorityName:  bandCfg.PriorityName,
 			CapacityBytes: bandCfg.MaxBytes,
 			ByteSize:      uint64(bandStats.byteSize.Load()),
 			Len:           uint64(bandStats.len.Load()),

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -74,8 +74,8 @@ func newRegistryTestHarness(t *testing.T, opts harnessOptions) *registryTestHarn
 			newTestPluginsHandle(t),
 			WithInitialShardCount(shardCount),
 			WithFlowGCTimeout(5*time.Minute),
-			WithPriorityBand(&PriorityBandConfig{Priority: highPriority, PriorityName: "High"}),
-			WithPriorityBand(&PriorityBandConfig{Priority: lowPriority, PriorityName: "Low"}),
+			WithPriorityBand(&PriorityBandConfig{Priority: highPriority}),
+			WithPriorityBand(&PriorityBandConfig{Priority: lowPriority}),
 		)
 		require.NoError(t, err, "Test setup: failed to create default config")
 	}
@@ -177,7 +177,7 @@ func TestFlowRegistry_WithConnection_AndHandle(t *testing.T) {
 
 		handle := newTestPluginsHandle(t)
 		badQueueName := queue.RegisteredQueueName("non-existent-queue")
-		badBand, err := NewPriorityBandConfig(handle, highPriority, "High", WithQueue(badQueueName))
+		badBand, err := NewPriorityBandConfig(handle, highPriority, WithQueue(badQueueName))
 		require.NoError(t, err)
 
 		// Create a Config that uses a mock checker to bypass the strict validation.
@@ -465,7 +465,7 @@ func TestFlowRegistry_UpdateShardCount(t *testing.T) {
 			t.Parallel()
 
 			handle := newTestPluginsHandle(t)
-			band, err := NewPriorityBandConfig(handle, highPriority, "A", WithBandMaxBytes(bandCapacity))
+			band, err := NewPriorityBandConfig(handle, highPriority, WithBandMaxBytes(bandCapacity))
 			require.NoError(t, err)
 
 			config, err := NewConfig(
@@ -1397,7 +1397,7 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 
 	// We create a custom band config that uses this failing queue.
 	// We set it as the default band so that dynamic provisioning is used.
-	failingBand, err := NewPriorityBandConfig(handle, 0, "FailingBand", WithQueue(failQueueName))
+	failingBand, err := NewPriorityBandConfig(handle, 0, WithQueue(failQueueName))
 	require.NoError(t, err)
 
 	cfg, err := NewConfig(handle, withCapabilityChecker(mockChecker), WithDefaultPriorityBand(failingBand))

--- a/pkg/epp/flowcontrol/registry/shard.go
+++ b/pkg/epp/flowcontrol/registry/shard.go
@@ -280,7 +280,6 @@ func (s *registryShard) Stats() contracts.ShardStats {
 
 		stats.PerPriorityBandStats[priority] = contracts.PriorityBandStats{
 			Priority:      priority,
-			PriorityName:  band.config.PriorityName,
 			CapacityBytes: band.config.MaxBytes, // This is the partitioned capacity.
 			ByteSize:      uint64(band.byteSize.Load()),
 			Len:           uint64(band.len.Load()),
@@ -389,13 +388,6 @@ func (a *priorityBandAccessor) Priority() int {
 	a.shard.mu.RLock()
 	defer a.shard.mu.RUnlock()
 	return a.band.config.Priority
-}
-
-// PriorityName returns the human-readable name of this priority band.
-func (a *priorityBandAccessor) PriorityName() string {
-	a.shard.mu.RLock()
-	defer a.shard.mu.RUnlock()
-	return a.band.config.PriorityName
 }
 
 // PolicyState returns the opaque, mutable state for the fairness policy scoped to this band.

--- a/pkg/epp/flowcontrol/registry/shard_test.go
+++ b/pkg/epp/flowcontrol/registry/shard_test.go
@@ -58,8 +58,8 @@ func newShardTestHarness(t *testing.T) *shardTestHarness {
 
 	globalConfig, err := NewConfig(
 		newTestPluginsHandle(t),
-		WithPriorityBand(&PriorityBandConfig{Priority: highPriority, PriorityName: "High"}),
-		WithPriorityBand(&PriorityBandConfig{Priority: lowPriority, PriorityName: "Low"}),
+		WithPriorityBand(&PriorityBandConfig{Priority: highPriority}),
+		WithPriorityBand(&PriorityBandConfig{Priority: lowPriority}),
 	)
 	require.NoError(t, err, "Test setup: validating and defaulting config should not fail")
 
@@ -127,7 +127,6 @@ func TestShard_New(t *testing.T) {
 		val, ok := h.shard.priorityBands.Load(highPriority)
 		bandHigh := val.(*priorityBand)
 		require.True(t, ok, "Priority band %d (High) must be initialized", highPriority)
-		assert.Equal(t, "High", bandHigh.config.PriorityName, "Priority band name must match the configuration")
 		require.NotNil(t, bandHigh.fairnessPolicy, "Fairness policy must be instantiated during construction")
 		assert.Equal(t, DefaultFairnessPolicyRef, bandHigh.fairnessPolicy.TypedName().Name,
 			"Must match the configured fairness policy implementation")
@@ -247,7 +246,6 @@ func TestShard_PriorityBandAccessor(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, h.highPriorityKey1.Priority, accessor.Priority(),
 				"Accessor Priority() must match the configured numerical priority")
-			assert.Equal(t, "High", accessor.PriorityName(), "Accessor PriorityName() must match the configured name")
 		})
 
 		t.Run("FlowKeys_ShouldReturnAllKeysInBand", func(t *testing.T) {
@@ -401,7 +399,7 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 
 		// Update the config definition first (simulating the Registry's job).
 		dynamicPrio := 15
-		newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio, "Dynamic-15")
+		newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio)
 		require.NoError(t, err)
 		h.shard.config.PriorityBands[dynamicPrio] = newBandCfg
 
@@ -411,9 +409,8 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 		assert.Equal(t, expectedLevels, h.shard.AllOrderedPriorityLevels(),
 			"New priority must be inserted into the sorted order correctly")
 
-		accessor, err := h.shard.PriorityBandAccessor(dynamicPrio)
+		_, err = h.shard.PriorityBandAccessor(dynamicPrio)
 		require.NoError(t, err, "Accessor should be available for the new band")
-		assert.Equal(t, "Dynamic-15", accessor.PriorityName())
 	})
 
 	t.Run("ShouldBeIdempotent", func(t *testing.T) {
@@ -422,7 +419,7 @@ func TestShard_DynamicProvisioning(t *testing.T) {
 
 		// Prepare config.
 		dynamicPrio := 15
-		newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio, "Dynamic-15")
+		newBandCfg, err := NewPriorityBandConfig(newTestPluginsHandle(t), dynamicPrio)
 		require.NoError(t, err)
 		h.shard.config.PriorityBands[dynamicPrio] = newBandCfg
 

--- a/pkg/epp/framework/interface/flowcontrol/accessors.go
+++ b/pkg/epp/framework/interface/flowcontrol/accessors.go
@@ -54,9 +54,6 @@ type PriorityBandAccessor interface {
 	// Priority returns the numerical priority level of this group.
 	Priority() int
 
-	// PriorityName returns the human-readable name of this priority band.
-	PriorityName() string
-
 	// FlowKeys returns the list of identities for every flow currently active within this group.
 	// The caller can use the ID field from each key to look up a specific queue via the Queue(id) method.
 	// The order of keys is not guaranteed unless specified by the implementation.

--- a/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
+++ b/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
@@ -194,16 +194,14 @@ var _ flowcontrol.FlowQueueAccessor = &MockFlowQueueAccessor{}
 // This avoids collision with the interface method of the same name.
 type MockPriorityBandAccessor struct {
 	PriorityV         int
-	PriorityNameV     string
 	PolicyStateV      any
 	FlowKeysFunc      func() []flowcontrol.FlowKey
 	QueueFunc         func(flowID string) flowcontrol.FlowQueueAccessor
 	IterateQueuesFunc func(callback func(flow flowcontrol.FlowQueueAccessor) (keepIterating bool))
 }
 
-func (m *MockPriorityBandAccessor) Priority() int        { return m.PriorityV }
-func (m *MockPriorityBandAccessor) PriorityName() string { return m.PriorityNameV }
-func (m *MockPriorityBandAccessor) PolicyState() any     { return m.PolicyStateV }
+func (m *MockPriorityBandAccessor) Priority() int    { return m.PriorityV }
+func (m *MockPriorityBandAccessor) PolicyState() any { return m.PolicyStateV }
 
 func (m *MockPriorityBandAccessor) FlowKeys() []flowcontrol.FlowKey {
 	if m.FlowKeysFunc != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind cleanup

**What this PR does / why we need it**:

Re-opening #2042

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2013 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
