### PR TITLE
docs: update release process for sub-modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
 
-1. Update `version/version.go` with the new semver tag
+1. Update `version/version.go` with the new semver tag. You can do this manually, or run the automated release target: `MAJOR=X MINOR=Y PATCH=Z make release` (this will also update Helm chart values and run tests).
 1. An issue is proposing a new release with a changelog since the last release
 1. All [OWNERS](OWNERS) must LGTM this release
 1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push origin $VERSION`


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR updates `RELEASE.md` to:
1. Address Issue #2691 by adding explicit instructions for maintainers to tag sub-modules (e.g., `conformance/go.mod`) to support Go module pinning and downstream usage.
2. Document the usage of `MAJOR=X MINOR=Y PATCH=Z make release` to automate updating versions and Helm values across the repo.

**Which issue(s) this PR fixes**:

See #2691

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```