### PR TITLE
fix(logging): map negative Zap levels to custom verbosity constants

### DIFF
--- a/pkg/common/observability/logging/logger.go
+++ b/pkg/common/observability/logging/logger.go
@@ -31,8 +31,35 @@ import (
 // level can be adjusted after the controller-runtime delegation is fulfilled.
 var atomicLevel = uberzap.NewAtomicLevelAt(zapcore.InfoLevel)
 
+func customLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+	if l >= 0 {
+		zapcore.LowercaseLevelEncoder(l, enc)
+		return
+	}
+
+	switch l {
+	case zapcore.Level(-1 * DEBUG): // -4
+		enc.AppendString("debug")
+	case zapcore.Level(-1 * TRACE): // -5
+		enc.AppendString("trace")
+	default:
+		if l >= zapcore.Level(-1*VERBOSE) { // >= -3 (i.e. V(1)-V(3))
+			enc.AppendString("info")
+		} else {
+			enc.AppendString("trace")
+		}
+	}
+}
+
 func InitSetupLogging() {
-	logger := zap.New(zap.Level(atomicLevel), zap.RawZapOpts(uberzap.AddCaller()))
+	config := uberzap.NewProductionEncoderConfig()
+	config.EncodeLevel = customLevelEncoder
+
+	logger := zap.New(
+		zap.Level(atomicLevel),
+		zap.RawZapOpts(uberzap.AddCaller()),
+		zap.Encoder(zapcore.NewJSONEncoder(config)),
+	)
 	ctrl.SetLogger(logger)
 }
 

--- a/pkg/common/observability/logging/logger_test.go
+++ b/pkg/common/observability/logging/logger_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+)
+
+type mockArrayEncoder struct {
+	zapcore.PrimitiveArrayEncoder
+	strings []string
+}
+
+func (m *mockArrayEncoder) AppendString(s string) {
+	m.strings = append(m.strings, s)
+}
+
+func TestCustomLevelEncoder(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    zapcore.Level
+		expected string
+	}{
+		{
+			name:     "Standard Info (0)",
+			level:    zapcore.InfoLevel, // 0
+			expected: "info",
+		},
+		{
+			name:     "Standard Warn (1)",
+			level:    zapcore.WarnLevel, // 1
+			expected: "warn",
+		},
+		{
+			name:     "Standard Error (2)",
+			level:    zapcore.ErrorLevel, // 2
+			expected: "error",
+		},
+		{
+			name:     "V(1) (-1)",
+			level:    zapcore.Level(-1),
+			expected: "info",
+		},
+		{
+			name:     "V(2) Default (-2)",
+			level:    zapcore.Level(-2),
+			expected: "info",
+		},
+		{
+			name:     "Verbose (-3)",
+			level:    zapcore.Level(-3),
+			expected: "info",
+		},
+		{
+			name:     "Debug (-4)",
+			level:    zapcore.Level(-4),
+			expected: "debug",
+		},
+		{
+			name:     "Trace (-5)",
+			level:    zapcore.Level(-5),
+			expected: "trace",
+		},
+		{
+			name:     "Extremely Verbose (-6)",
+			level:    zapcore.Level(-6),
+			expected: "trace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc := &mockArrayEncoder{}
+			customLevelEncoder(tt.level, enc)
+			if len(enc.strings) != 1 {
+				t.Fatalf("Expected 1 string appended, got %d", len(enc.strings))
+			}
+			if enc.strings[0] != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, enc.strings[0])
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

We define custom log level constants (`VERBOSE=3`, `DEBUG=4`, `TRACE=5`). However, `controller-runtime/pkg/log/zap` maps `V(n)` verbosity to Zap's internal levels using `zap_level = -1 * n`. 

By default, Zap's JSON encoder prints any negative level as `"debug"`. Consequently, any verbosity call like `logger.V(1).Info(...)` was being outputted as `{"level":"debug"}` in JSON output, confusing users who expected only `V(4)` to be interpreted as Debug.

This PR introduces a custom `LevelEncoder` for Zap that correctly maps negative levels to the project's semantic intent:
- `V(4)` (-4) outputs as `"debug"`
- `V(5)` (-5) outputs as `"trace"`
- `V(1)`-`V(3)` (-1 to -3) outputs as `"info"` (verbose informational logs)
- Standard Info (0), Warn (1), and Error (2) remain unchanged.

I considered standard alignment with k8s logging which would involve removing our custom constants and using standard lower numbers for debug (e.g., `V(1)` as standard debug); however, I decided against this approach because it would shift the behavioral meaning of the `-v` flag (forcing breaking config changes for deployments already relying on `--v=4` or `--v=5`).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2636

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
