### PR TITLE
fix: expose pool-level average running requests metric and fix integer truncation

### DIFF
--- a/pkg/epp/backend/metrics/logger.go
+++ b/pkg/epp/backend/metrics/logger.go
@@ -85,6 +85,7 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 
 	var kvCacheTotal float64
 	var queueTotal int
+	var runningRequestsTotal int
 
 	podMetrics := datastore.PodList(PodsWithFreshMetrics(metricsStalenessThreshold))
 	logger.V(logutil.TRACE).Info("Refreshing Prometheus Metrics", "ReadyPods", len(podMetrics))
@@ -98,8 +99,10 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 	for _, pod := range podMetrics {
 		kvCacheTotal += pod.GetMetrics().KVCacheUsagePercent
 		queueTotal += pod.GetMetrics().WaitingQueueSize
+		runningRequestsTotal += pod.GetMetrics().RunningRequestsSize
 	}
 
 	metrics.RecordInferencePoolAvgKVCache(pool.Name, kvCacheTotal/float64(podTotalCount))
-	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(queueTotal/podTotalCount))
+	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(queueTotal)/float64(podTotalCount))
+	metrics.RecordInferencePoolAvgRunningRequests(pool.Name, float64(runningRequestsTotal)/float64(podTotalCount))
 }

--- a/pkg/epp/backend/metrics/logger_test.go
+++ b/pkg/epp/backend/metrics/logger_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	eppmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
+	poolutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/pool"
+)
+
+func TestRefreshPrometheusMetricsAvgValues(t *testing.T) {
+	eppmetrics.Register()
+	eppmetrics.Reset()
+
+	logger := logr.Discard()
+
+	// Pod1: RunningRequests=0, Queue=1
+	// Pod2: RunningRequests=1, Queue=2
+	// Correct avg: RunningRequests=0.5, Queue=1.5
+	// Integer truncation would give: RunningRequests=0, Queue=1
+	ds := &fakeOddMetricsDataStore{}
+
+	refreshPrometheusMetrics(logger, ds, 100*time.Millisecond)
+
+	families, err := ctrlmetrics.Registry.Gather()
+	assert.NoError(t, err)
+
+	findGauge := func(name string) float64 {
+		for _, f := range families {
+			if f.GetName() == name {
+				for _, m := range f.GetMetric() {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+		t.Fatalf("metric %s not found", name)
+		return 0
+	}
+
+	avgRunning := findGauge("inference_pool_average_running_requests")
+	avgQueue := findGauge("inference_pool_average_queue_size")
+
+	assert.InDelta(t, 0.5, avgRunning, 0.001, "average running requests should be 0.5, not truncated to 0")
+	assert.InDelta(t, 1.5, avgQueue, 0.001, "average queue size should be 1.5, not truncated to 1")
+}
+
+type fakeOddMetricsDataStore struct{}
+
+func (f *fakeOddMetricsDataStore) PoolGet() (*datalayer.EndpointPool, error) {
+	pool := &v1.InferencePool{Spec: v1.InferencePoolSpec{TargetPorts: []v1.Port{{Number: 8000}}}}
+	return poolutil.InferencePoolToEndpointPool(pool), nil
+}
+
+func (f *fakeOddMetricsDataStore) PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.Endpoint {
+	pod1 := &fwkdl.EndpointMetadata{
+		NamespacedName: types.NamespacedName{Name: "pod1", Namespace: "default"},
+		Address:        "1.2.3.4:5678",
+	}
+	pod2 := &fwkdl.EndpointMetadata{
+		NamespacedName: types.NamespacedName{Name: "pod2", Namespace: "default"},
+		Address:        "1.2.3.4:5679",
+	}
+	m1 := &fwkdl.Metrics{
+		RunningRequestsSize: 0,
+		WaitingQueueSize:    1,
+		KVCacheUsagePercent: 10.0,
+		UpdateTime:          time.Now(),
+	}
+	m2 := &fwkdl.Metrics{
+		RunningRequestsSize: 1,
+		WaitingQueueSize:    2,
+		KVCacheUsagePercent: 20.0,
+		UpdateTime:          time.Now(),
+	}
+	ep1 := fwkdl.NewEndpoint(pod1, m1)
+	ep2 := fwkdl.NewEndpoint(pod2, m2)
+	pods := []fwkdl.Endpoint{ep1, ep2}
+	res := []fwkdl.Endpoint{}
+	for _, pod := range pods {
+		if predicate(pod) {
+			res = append(res, pod)
+		}
+	}
+	return res
+}

--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -120,13 +120,15 @@ func refreshPrometheusMetrics(logger logr.Logger, datastore datalayer.PoolInfo, 
 	totals := calculateTotals(podMetrics)
 
 	metrics.RecordInferencePoolAvgKVCache(pool.Name, totals.kvCache/float64(podCount))
-	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(totals.queueSize/podCount))
+	metrics.RecordInferencePoolAvgQueueSize(pool.Name, float64(totals.queueSize)/float64(podCount))
+	metrics.RecordInferencePoolAvgRunningRequests(pool.Name, float64(totals.runningRequests)/float64(podCount))
 }
 
 // totals holds aggregated metric values
 type totals struct {
-	kvCache   float64
-	queueSize int
+	kvCache         float64
+	queueSize       int
+	runningRequests int
 }
 
 func calculateTotals(endpoints []fwkdl.Endpoint) totals {
@@ -135,6 +137,7 @@ func calculateTotals(endpoints []fwkdl.Endpoint) totals {
 		metrics := pod.GetMetrics()
 		result.kvCache += metrics.KVCacheUsagePercent
 		result.queueSize += metrics.WaitingQueueSize
+		result.runningRequests += metrics.RunningRequestsSize
 	}
 	return result
 }

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -29,10 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metrics"
 	poolutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/pool"
 )
 
@@ -79,6 +81,127 @@ func TestLogger(t *testing.T) {
 	assert.Contains(t, logOutput, "RunningRequestsSize:3 WaitingQueueSize:7 KVCacheUsagePercent:42.5 KvCacheMaxTokenCapacity:2048")
 	assert.Contains(t, logOutput, "Metadata: {NamespacedName:default/pod2 PodName: Address:1.2.3.4:5679")
 	assert.Contains(t, logOutput, "\"Stale metrics\": \"[]\"")
+}
+
+func TestCalculateTotals(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints []fwkdl.Endpoint
+		want      totals
+	}{
+		{
+			name:      "empty list",
+			endpoints: []fwkdl.Endpoint{},
+			want:      totals{},
+		},
+		{
+			name: "single endpoint",
+			endpoints: []fwkdl.Endpoint{
+				fwkdl.NewEndpoint(pod1, &fwkdl.Metrics{
+					KVCacheUsagePercent: 50.0,
+					WaitingQueueSize:    3,
+					RunningRequestsSize: 5,
+					UpdateTime:          time.Now(),
+				}),
+			},
+			want: totals{kvCache: 50.0, queueSize: 3, runningRequests: 5},
+		},
+		{
+			name: "multiple endpoints aggregated",
+			endpoints: []fwkdl.Endpoint{
+				fwkdl.NewEndpoint(pod1, &fwkdl.Metrics{
+					KVCacheUsagePercent: 30.0,
+					WaitingQueueSize:    2,
+					RunningRequestsSize: 1,
+					UpdateTime:          time.Now(),
+				}),
+				fwkdl.NewEndpoint(pod2, &fwkdl.Metrics{
+					KVCacheUsagePercent: 70.0,
+					WaitingQueueSize:    5,
+					RunningRequestsSize: 3,
+					UpdateTime:          time.Now(),
+				}),
+			},
+			want: totals{kvCache: 100.0, queueSize: 7, runningRequests: 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateTotals(tt.endpoints)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRefreshPrometheusMetricsAvgValues(t *testing.T) {
+	metrics.Register()
+	metrics.Reset()
+
+	logger := logr.Discard()
+
+	// Use a datastore where pods have odd-sum metrics so that
+	// integer division would truncate incorrectly.
+	// Pod1: RunningRequests=0, Queue=1
+	// Pod2: RunningRequests=1, Queue=2
+	// Correct avg: RunningRequests=0.5, Queue=1.5
+	// Integer truncation would give: RunningRequests=0, Queue=1
+	ds := &FakeOddMetricsDataStore{}
+
+	refreshPrometheusMetrics(logger, ds, 100*time.Millisecond)
+
+	families, err := ctrlmetrics.Registry.Gather()
+	assert.NoError(t, err)
+
+	findGauge := func(name string) float64 {
+		for _, f := range families {
+			if f.GetName() == name {
+				for _, m := range f.GetMetric() {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+		t.Fatalf("metric %s not found", name)
+		return 0
+	}
+
+	avgRunning := findGauge("inference_pool_average_running_requests")
+	avgQueue := findGauge("inference_pool_average_queue_size")
+
+	assert.InDelta(t, 0.5, avgRunning, 0.001, "average running requests should be 0.5, not truncated to 0")
+	assert.InDelta(t, 1.5, avgQueue, 0.001, "average queue size should be 1.5, not truncated to 1")
+}
+
+type FakeOddMetricsDataStore struct{}
+
+func (f *FakeOddMetricsDataStore) PoolGet() (*datalayer.EndpointPool, error) {
+	pool := &v1.InferencePool{Spec: v1.InferencePoolSpec{TargetPorts: []v1.Port{{Number: 8000}}}}
+	return poolutil.InferencePoolToEndpointPool(pool), nil
+}
+
+func (f *FakeOddMetricsDataStore) PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.Endpoint {
+	m1 := &fwkdl.Metrics{
+		RunningRequestsSize: 0,
+		WaitingQueueSize:    1,
+		KVCacheUsagePercent: 10.0,
+		UpdateTime:          time.Now(),
+	}
+	m2 := &fwkdl.Metrics{
+		RunningRequestsSize: 1,
+		WaitingQueueSize:    2,
+		KVCacheUsagePercent: 20.0,
+		UpdateTime:          time.Now(),
+	}
+	ep1 := fwkdl.NewEndpoint(pod1, m1)
+	ep2 := fwkdl.NewEndpoint(pod2, m2)
+	pods := []fwkdl.Endpoint{ep1, ep2}
+	res := []fwkdl.Endpoint{}
+	for _, pod := range pods {
+		if predicate(pod) {
+			res = append(res, pod)
+		}
+	}
+	return res
 }
 
 var pod1 = &fwkdl.EndpointMetadata{

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -292,6 +292,15 @@ var (
 		poolLabels,
 	)
 
+	inferencePoolAvgRunningRequests = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: inferencePoolComponent,
+			Name:      "average_running_requests",
+			Help:      metricsutil.HelpMsgWithStability("The average number of running requests across model servers in the pool.", compbasemetrics.ALPHA),
+		},
+		poolLabels,
+	)
+
 	inferencePoolReadyPods = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: inferencePoolComponent,
@@ -486,6 +495,7 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(normalizedTimePerOutputToken)
 		metrics.Registry.MustRegister(inferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(inferencePoolAvgQueueSize)
+		metrics.Registry.MustRegister(inferencePoolAvgRunningRequests)
 		metrics.Registry.MustRegister(inferencePoolReadyPods)
 		metrics.Registry.MustRegister(schedulerE2ELatency)
 		metrics.Registry.MustRegister(schedulerAttemptsTotal)
@@ -536,6 +546,7 @@ func Reset() {
 	normalizedTimePerOutputToken.Reset()
 	inferencePoolAvgKVCache.Reset()
 	inferencePoolAvgQueueSize.Reset()
+	inferencePoolAvgRunningRequests.Reset()
 	inferencePoolReadyPods.Reset()
 	schedulerE2ELatency.Reset()
 	schedulerAttemptsTotal.Reset()
@@ -761,6 +772,10 @@ func RecordInferencePoolAvgKVCache(name string, utilization float64) {
 
 func RecordInferencePoolAvgQueueSize(name string, queueSize float64) {
 	inferencePoolAvgQueueSize.WithLabelValues(name).Set(queueSize)
+}
+
+func RecordInferencePoolAvgRunningRequests(name string, runningRequests float64) {
+	inferencePoolAvgRunningRequests.WithLabelValues(name).Set(runningRequests)
 }
 
 func RecordInferencePoolReadyPods(name string, runningPods float64) {

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -48,6 +48,7 @@ const (
 	runningRequestsMetric              = inferenceObjectiveComponent + "_running_requests"
 	kvCacheAvgUsageMetric              = inferencePoolComponent + "_average_kv_cache_utilization"
 	queueAvgSizeMetric                 = inferencePoolComponent + "_average_queue_size"
+	runningRequestsAvgMetric           = inferencePoolComponent + "_average_running_requests"
 )
 
 func TestMain(m *testing.M) {
@@ -531,22 +532,25 @@ func TestRunningRequestsMetrics(t *testing.T) {
 func TestInferencePoolMetrics(t *testing.T) {
 	Reset()
 	scenarios := []struct {
-		name         string
-		poolName     string
-		kvCacheAvg   float64
-		queueSizeAvg float64
+		name               string
+		poolName           string
+		kvCacheAvg         float64
+		queueSizeAvg       float64
+		runningRequestsAvg float64
 	}{
 		{
-			name:         "basic test",
-			poolName:     "p1",
-			kvCacheAvg:   0.3,
-			queueSizeAvg: 0.4,
+			name:               "basic test",
+			poolName:           "p1",
+			kvCacheAvg:         0.3,
+			queueSizeAvg:       0.4,
+			runningRequestsAvg: 0.5,
 		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			RecordInferencePoolAvgKVCache(scenario.poolName, scenario.kvCacheAvg)
 			RecordInferencePoolAvgQueueSize(scenario.poolName, scenario.queueSizeAvg)
+			RecordInferencePoolAvgRunningRequests(scenario.poolName, scenario.runningRequestsAvg)
 
 			wantKVCache, err := os.Open("testdata/kv_cache_avg_metrics")
 			defer func() {
@@ -571,6 +575,19 @@ func TestInferencePoolMetrics(t *testing.T) {
 				t.Fatal(err)
 			}
 			if err := testutil.GatherAndCompare(metrics.Registry, wantQueueSize, queueAvgSizeMetric); err != nil {
+				t.Error(err)
+			}
+
+			wantRunningRequests, err := os.Open("testdata/running_requests_avg_metrics")
+			defer func() {
+				if err := wantRunningRequests.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := testutil.GatherAndCompare(metrics.Registry, wantRunningRequests, runningRequestsAvgMetric); err != nil {
 				t.Error(err)
 			}
 		})

--- a/pkg/epp/metrics/testdata/running_requests_avg_metrics
+++ b/pkg/epp/metrics/testdata/running_requests_avg_metrics
@@ -1,0 +1,3 @@
+# HELP inference_pool_average_running_requests [ALPHA] The average number of running requests across model servers in the pool.
+# TYPE inference_pool_average_running_requests gauge
+inference_pool_average_running_requests{name="p1"} 0.5


### PR DESCRIPTION
## What this PR does

1. **Exposes `inference_pool_average_running_requests` as a new Prometheus gauge.** `RunningRequestsSize` was already collected from model server pods and used internally by scorer plugins, but was never exported as a pool-level Prometheus metric (unlike `average_kv_cache_utilization` and `average_queue_size`).

2. **Fixes an existing integer-division truncation bug in `average_queue_size`.** The old code used `float64(int/int)` which silently floors the result -- e.g. a pool with per-pod queue sizes `[1, 2]` reported `1` instead of `1.5`. Both the new and existing averages now use `float64(total)/float64(count)`.

Both the new datalayer logger and the legacy backend logger are updated.

## Changes

| File | Change |
|------|--------|
| `pkg/epp/metrics/metrics.go` | New gauge definition, registration, reset, and recorder function |
| `pkg/epp/datalayer/logger/logger.go` | Aggregate `RunningRequestsSize` in `calculateTotals`; fix int division |
| `pkg/epp/backend/metrics/logger.go` | Same fix applied to legacy logger |
| `pkg/epp/datalayer/logger/logger_test.go` | `TestCalculateTotals` + `TestRefreshPrometheusMetricsAvgValues` |
| `pkg/epp/backend/metrics/logger_test.go` | `TestRefreshPrometheusMetricsAvgValues` for legacy path |
| `pkg/epp/metrics/metrics_test.go` | Updated `TestInferencePoolMetrics` with new gauge assertion |
| `pkg/epp/metrics/testdata/running_requests_avg_metrics` | Golden file |

## How to verify

```bash
make test-unit   # all pass
make lint        # 0 issues
```

The `TestRefreshPrometheusMetricsAvgValues` tests use pods with odd-sum metrics (e.g. `[0, 1]`) so integer truncation would produce `0` instead of the correct `0.5`, catching the bug path directly.

Fixes #2689