### PR TITLE
feat: extend  with multimodal features for MM-aware prefix-cache scoring

### DIFF
--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -29,6 +29,12 @@ import (
 
 const nilString = "<nil>"
 
+// Modality identifies the type of multimodal content in a prompt.
+type Modality string
+
+// ModalityImage is the only currently supported modality.
+const ModalityImage Modality = "image"
+
 // RequestObjectives represents the scheduling objectives parsed from the InferenceObjectiveSpec, to be used in scheduling decisions.
 type RequestObjectives struct {
 	Priority int
@@ -59,8 +65,25 @@ type LLMRequest struct {
 // and consumed by scheduling plugins that benefit from actual token data
 // (e.g., prefix cache scoring, latency prediction).
 type TokenizedPrompt struct {
-	// TokenIDs are the token IDs for the prompt.
+	// TokenIDs are the token IDs for the prompt, including multimodal placeholder tokens.
 	TokenIDs []uint32
+	// MultiModalFeatures holds one entry per multimodal item in prompt order.
+	// Nil if the prompt contains no multimodal content.
+	MultiModalFeatures []MultiModalFeature
+}
+
+// MultiModalFeature holds all data needed for precise prefix-cache scoring of a single
+// multimodal item. Items are ordered by token position within the prompt.
+// Currently only ModalityImage is supported.
+type MultiModalFeature struct {
+	// Modality identifies the type of content.
+	Modality Modality
+	// Hash is the content hash of the item, used for KV-cache reuse across requests.
+	Hash string
+	// Offset is the index of the first placeholder token for this item in TokenIDs.
+	Offset int
+	// Length is the number of placeholder tokens this item occupies in TokenIDs.
+	Length int
 }
 
 func (r *LLMRequest) String() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**Problem**

`TokenizedPrompt` ([introduced in kubernetes-sigs/gateway-api-inference-extension#2542](https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2542)) carries only `TokenIDs`. This is sufficient for text-only prefix-cache scoring, but breaks for multimodal requests: two requests sharing identical token IDs but containing different images map to the same KV-cache block hashes, causing the scorer to route them to pods holding the wrong image's cached data.

**Solution**

Extend `TokenizedPrompt` with `MultiModalFeatures []MultiModalFeature` — a flat, prompt-ordered slice of per-item MM metadata, following the same per-item aggregated design vLLM uses in `MultiModalFeatureSpec` / `EngineCoreRequest.mm_features`.

Each `MultiModalFeature` carries everything needed for block-level prefix-cache scoring:
- **`Modality`** — typed string (`ModalityImage`); extends naturally when audio/video land
- **`Hash`** — content hash of the item, used to taint block hashes and detect KV-cache reuse across requests (mirrors `mm_identifier` in [llm-d/llm-d-kv-cache#444](https://github.com/llm-d/llm-d-kv-cache/pull/444))
- **`Offset` / `Length`** — placeholder token span in `TokenIDs`, used to map the item onto the correct KV-cache blocks (mirrors `PlaceholderRange` in vLLM and llm-d-kv-cache)

`MultiModalFeatures` is `nil` for text-only prompts — no overhead on the common path.

**Related**
- llm-d/llm-d-kv-cache#444 — MM `extra_keys` support, defines the block-hash tainting algorithm this feeds into
- llm-d/llm-d-inference-scheduler#772 — wires `MMFeatures` through `TokenizedPromptState` and scorer
- kubernetes-sigs/gateway-api-inference-extension#2542 — original `TokenizedPrompt` introduction
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->

