### PR TITLE
fix: accumulate ResponseSize in HandleResponseBody so response_sizes metric is recorded

### DIFF
--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -45,6 +45,8 @@ func (s *StreamingServer) HandleResponseBody(ctx context.Context, reqCtx *Reques
 	logger := log.FromContext(ctx)
 	logger.V(logutil.DEBUG).Info("HandleResponseBody is triggered", "len(responseBytes)", len(responseBytes), "endOfStream", endOfStream)
 
+	reqCtx.ResponseSize += len(responseBytes)
+
 	parsedResp, err := s.parser.ParseResponse(ctx, responseBytes, reqCtx.Response.Headers, endOfStream)
 	if err != nil {
 		logger.Error(err, "parsing response")

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -362,3 +362,53 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	assert.NotContains(t, gotHeaders, metadata.DestinationEndpointKey)
 	assert.NotContains(t, gotHeaders, "content-length")
 }
+
+func TestResponseSizeAccumulation(t *testing.T) {
+	ctx := logutil.NewTestLoggerIntoContext(context.Background())
+
+	tests := []struct {
+		name             string
+		chunks           [][]byte
+		wantResponseSize int
+	}{
+		{
+			name:             "single chunk",
+			chunks:           [][]byte{[]byte("hello world")},
+			wantResponseSize: 11,
+		},
+		{
+			name:             "multiple chunks",
+			chunks:           [][]byte{[]byte("chunk1"), []byte("chunk2"), []byte("chunk3")},
+			wantResponseSize: 18,
+		},
+		{
+			name:             "empty chunk",
+			chunks:           [][]byte{[]byte("")},
+			wantResponseSize: 0,
+		},
+		{
+			name:             "mixed chunks with empty",
+			chunks:           [][]byte{[]byte("data"), []byte(""), []byte("more")},
+			wantResponseSize: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &StreamingServer{
+				parser:   openai.NewOpenAIParser(),
+				director: &mockDirector{},
+			}
+			reqCtx := &RequestContext{
+				Response: &Response{
+					Headers: map[string]string{},
+				},
+			}
+			for i, chunk := range tt.chunks {
+				endOfStream := i == len(tt.chunks)-1
+				server.HandleResponseBody(ctx, reqCtx, chunk, endOfStream)
+			}
+			assert.Equal(t, tt.wantResponseSize, reqCtx.ResponseSize)
+		})
+	}
+}


### PR DESCRIPTION
ResponseSize was never incremented, causing RecordResponseSizes to always report 0. Move the accumulation into HandleResponseBody where every chunk (streaming and non-streaming) passes through, and add tests that exercise the real code path.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`reqCtx.ResponseSize` was never incremented anywhere in the codebase, so `RecordResponseSizes` always recorded 0. This PR moves the accumulation into `HandleResponseBody` (response.go), which is the single function every response chunk passes through for both streaming and non-streaming paths. It also removes the need for callers (like `Process()` in server.go) to track size separately.

A new `TestResponseSizeAccumulation` test covers single chunk, multiple chunks, empty chunks, and mixed scenarios by calling the real `HandleResponseBody` code path.

**Which issue(s) this PR fixes**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```