### PR TITLE
feat: configurable EnvoyFilter op in BBR chart

### DIFF
--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -19,7 +19,7 @@ spec:
           filter:
             name: "envoy.filters.network.http_connection_manager"
     patch:
-      operation: INSERT_FIRST
+      operation: {{ .Values.provider.istio.envoyFilter.operation }}
       value:
         name: envoy.filters.http.ext_proc.bbr
         typed_config:

--- a/config/charts/body-based-routing/values.yaml
+++ b/config/charts/body-based-routing/values.yaml
@@ -38,5 +38,12 @@ bbr:
 provider:
   name: none
 
+  # Istio-specific configuration.
+  # This block is only used if name is "istio".
+  istio:
+    envoyFilter:
+      # Operation for inserting the ext_proc filter into the Envoy filter chain.
+      operation: INSERT_FIRST
+
 inferenceGateway:
   name: inference-gateway


### PR DESCRIPTION
## Problem

The BBR Helm chart hardcodes `operation: INSERT_FIRST` in the Istio
EnvoyFilter template. When BBR is used with auth middleware (e.g.,
Kuadrant Wasm plugin) that validates the `Authorization` header, BBR
runs before auth and strips the header — causing 401 errors.

## Solution

Make the operation configurable via `provider.istio.envoyFilter.operation`
in `values.yaml` (default: `INSERT_FIRST`, preserving current behavior).

Users can override to `INSERT_BEFORE` when auth middleware needs to see
the original `Authorization` header before BBR transforms it.

## Changes

- `config/charts/body-based-routing/templates/istio.yaml`: Use
  `{{ .Values.provider.istio.envoyFilter.operation }}`
- `config/charts/body-based-routing/values.yaml`: Add
  `provider.istio.envoyFilter.operation: INSERT_FIRST`

```release-note
NONE
```