### PR TITLE
optimize httproute rendering

### DIFF
--- a/config/charts/epplib/templates/_helpers.tpl
+++ b/config/charts/epplib/templates/_helpers.tpl
@@ -49,3 +49,15 @@ inference.networking.k8s.io/igw-mode: standalone
 inference.networking.k8s.io/igw-mode: inferencepool
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Create a default fully qualified app name for inferenceGateway.
+*/}}
+{{- define "gateway-api-inference-extension.gateway.fullname" -}}
+  {{- if .Values.experimentalHttpRoute.inferenceGatewayName -}}
+    {{- .Values.experimentalHttpRoute.inferenceGatewayName | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- printf "%s-inference-gateway" .Release.Name| trunc 63 | trimSuffix "-" -}}
+  {{- end -}}
+{{- end -}}

--- a/config/charts/inferencepool/templates/httproute.yaml
+++ b/config/charts/inferencepool/templates/httproute.yaml
@@ -8,7 +8,7 @@ spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: {{ .Values.experimentalHttpRoute.inferenceGatewayName }}
+    name: {{ include "gateway-api-inference-extension.gateway.fullname" . }}
   rules:
   - backendRefs:
     - group: inference.networking.k8s.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

In most cases, the inference pool is installed as a sub-chart or managed via Helmfile (see the llm-d guides). The gateway, on the other hand, is deployed separately using the llm-d-infra chart.

To avoid hard-coding the gateway name in HTTPRoute, it's better to derive it from the Helm release name. This way, users don’t need to manually update the gateway name on every install or upgrade.

This makes the setup more flexible and improves the overall installation experience, especially when deploying across different environments.

###  Without Gateway Name Specified
```bash
% helm -n public template epp config/charts/inferencepool --set experimentalHttpRoute.enabled=true  --set experimentalHttpRoute.inferenceGatewayName="" --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b|grep HTTPRoute -A 20
kind: HTTPRoute
metadata:
  name: epp
  namespace: public
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: epp-inference-gateway 
  rules:
  - backendRefs:
    - group: inference.networking.k8s.io
      kind: InferencePool
      name: epp
    matches:
    - path:
        type: PathPrefix
        value: /
    timeouts:
      request: 300s

```


### With Gateway Name Specified
```bash
% helm -n public template epp config/charts/inferencepool --set experimentalHttpRoute.enabled=true  --set experimentalHttpRoute.inferenceGatewayName="inference-gateway" --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b|grep HTTPRoute -A 20
kind: HTTPRoute
metadata:
  name: epp
  namespace: public
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: inference-gateway 
  rules:
  - backendRefs:
    - group: inference.networking.k8s.io
      kind: InferencePool
      name: epp
    matches:
    - path:
        type: PathPrefix
        value: /
    timeouts:
      request: 300s
```






**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
