### PR TITLE
[flake] ignore metrics update after endpoint is released

### DIFF
--- a/pkg/epp/backend/metrics/pod_metrics_test.go
+++ b/pkg/epp/backend/metrics/pod_metrics_test.go
@@ -47,16 +47,6 @@ var (
 		},
 		WaitingModels: map[string]int{},
 	}
-	updated = &MetricsState{
-		WaitingQueueSize:    9999,
-		KVCacheUsagePercent: 0.99,
-		MaxActiveModels:     99,
-		ActiveModels: map[string]int{
-			"foo": 1,
-			"bar": 1,
-		},
-		WaitingModels: map[string]int{},
-	}
 )
 
 func TestMetricsRefresh(t *testing.T) {
@@ -75,13 +65,8 @@ func TestMetricsRefresh(t *testing.T) {
 	}
 	assert.EventuallyWithT(t, condition, time.Second, time.Millisecond)
 
-	// Stop the loop, and simulate metric update again, this time the PodMetrics won't get the
-	// new update.
+	// Stop the loop.
 	pmf.ReleaseEndpoint(pm)
-	time.Sleep(pmf.refreshMetricsInterval * 2 /* small buffer for robustness */)
-	pmc.SetRes(map[types.NamespacedName]*MetricsState{pod1Info.NamespacedName: updated})
-	// Still expect the same condition (no metrics update).
-	assert.EventuallyWithT(t, condition, time.Second, time.Millisecond)
 }
 
 type FakeRefresherDataStore struct{}


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/kind flake

**What this PR does / why we need it**:
The test was asserting that after ReleaseEndpoint, the refresh loop stops updating pod metrics.
While correct in principle, this is inherently racy: `ReleaseEndpoint` signals the goroutine to stop
(by closing a channel) but doesn't wait for it to exit. Under load, the goroutine can fire one final
refresh after the test sets new values in the fake client, causing a spurious failure.

In production this behavior is intentional and `ReleaseEndpoint` is fire-and-forget.
When a pod is released from the pool, its metrics are no longer consulted and there's no need
to synchronize on goroutine exit.

The test still validates that the refresh loop starts and correctly updates metrics. 
The racy flake ("no updates after stop") is dropped.

**Which issue(s) this PR fixes**:
Fixes #2730

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
