### PR TITLE
[pluggable parser] refactor: replace ParsedBody 'any' with strongly-typed RequestPayload interface

### DIFF
--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 )
 
@@ -72,6 +73,32 @@ func (r *LLMRequest) String() string {
 		r.RequestId, r.TargetModel, r.Body, r.Headers)
 }
 
+// RequestPayload represents a strongly-typed unmarshaled request payload or raw bytes.
+type RequestPayload interface {
+	isRequestPayload()
+	IsParsed() bool
+}
+
+// PayloadMap represents a JSON request body unmarshaled into a map.
+type PayloadMap map[string]any
+
+func (PayloadMap) isRequestPayload() {}
+func (PayloadMap) IsParsed() bool    { return true }
+
+// PayloadProto represents a gRPC request body unmarshaled into a proto.Message.
+type PayloadProto struct {
+	proto.Message
+}
+
+func (PayloadProto) isRequestPayload() {}
+func (PayloadProto) IsParsed() bool    { return true }
+
+// RawPayload represents an unparsed request body kept as raw bytes.
+type RawPayload []byte
+
+func (RawPayload) isRequestPayload() {}
+func (RawPayload) IsParsed() bool    { return false }
+
 // LLMRequestBody contains the request-body fields that we parse out as user input,
 // to be used in forming scheduling decisions.
 // An LLMRequestBody must contain exactly one of CompletionsRequest, ChatCompletionsRequest, ResponsesRequest, ConversationsRequest, or EmbeddingsRequest.
@@ -86,10 +113,10 @@ type LLMRequestBody struct {
 	Conversations *ConversationsRequest `json:"conversations,omitempty"`
 	// EmbeddingsRequest is the representation of the OpenAI /v1/embeddings request body.
 	Embeddings *EmbeddingsRequest `json:"embeddings,omitempty"`
-	// ParsedBody contains the unmarshaled request payload.
-	// Note: Because this handles multiple protocols, this field is strictly expected
-	// to be either a map[string]any (for HTTP/JSON) or a proto.Message (for gRPC).
-	ParsedBody any `json:"-"`
+	// Payload contains the unmarshaled request payload or raw bytes.
+	// If the payload is unmarshaled, we can perform advanced processing (like prefix cache aware routing).
+	// If it remains as raw bytes, such processing may not be supported.
+	Payload RequestPayload `json:"-"`
 
 	// Stream indicates whether the request specifies a streaming response (e.g., via a stream field).
 	// This typically implies the model server's response will be streamed.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -96,7 +96,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if err != nil {
 		return nil, err
 	}
-	extractedBody.ParsedBody = bodyMap
+	extractedBody.Payload = scheduling.PayloadMap(bodyMap)
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true
 	}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -63,7 +63,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: "test prompt",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model":  "test",
 					"prompt": "test prompt",
 				},
@@ -90,7 +90,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						{Role: "user", Content: scheduling.Content{Raw: "hello"}},
 					},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "test",
 					"messages": []any{
 						map[string]any{
@@ -152,7 +152,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						}},
 					},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "test",
 					"messages": []any{
 						map[string]any{
@@ -221,7 +221,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						}},
 					},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "test",
 					"messages": []any{
 						map[string]any{
@@ -273,7 +273,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					AddGenerationPrompt:       true,
 					ChatTemplateKWArgs:        map[string]any{"key": "value"},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "test",
 					"messages": []any{
 						map[string]any{"role": "user", "content": "hello"},
@@ -448,7 +448,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					Prompt:    "test prompt",
 					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model":      "test",
 					"prompt":     "test prompt",
 					"cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
@@ -478,7 +478,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					},
 					CacheSalt: "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "test",
 					"messages": []any{
 						map[string]any{
@@ -505,7 +505,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					Input:        "How do I check if a Python object is an instance of a class?",
 					Instructions: "You are a coding assistant that talks like a pirate.",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model":        "gpt-4o",
 					"input":        "How do I check if a Python object is an instance of a class?",
 					"instructions": "You are a coding assistant that talks like a pirate.",
@@ -525,7 +525,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					Input:     "test input",
 					CacheSalt: "abc123",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model":      "gpt-4o",
 					"input":      "test input",
 					"cache_salt": "abc123",
@@ -557,7 +557,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						{Type: "message", Role: "user", Content: "Hello"},
 					},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "gpt-4o",
 					"items": []any{map[string]any{"type": "message", "role": "user", "content": "Hello"}},
 				},
@@ -578,7 +578,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 						{Type: "message", Role: "user", Content: "Hello"},
 					},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "gpt-4o",
 					"items": []any{
 						map[string]any{"type": "message", "role": "user", "content": "Hello"},
@@ -597,7 +597,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: "test prompt",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model":  "gpt-4o",
 					"prompt": "test prompt",
 				},
@@ -617,7 +617,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				ChatCompletions: &scheduling.ChatCompletionsRequest{
 					Messages: []scheduling.Message{{Role: "user", Content: scheduling.Content{Raw: "hello"}}},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "test",
 					"messages": []any{
 						map[string]any{"role": "user", "content": "hello"},
@@ -639,7 +639,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: "The food was delicious and the waiter...",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "text-embedding-3-small",
 					"input": "The food was delicious and the waiter...",
 				},
@@ -656,7 +656,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: []any{"First document", "Second document"},
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "text-embedding-3-small",
 					"input": []any{"First document", "Second document"},
 				},
@@ -675,7 +675,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 					Input:     "embed this text",
 					CacheSalt: "embeddings-salt-123",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model":      "text-embedding-3-small",
 					"input":      "embed this text",
 					"cache_salt": "embeddings-salt-123",
@@ -693,7 +693,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				Embeddings: &scheduling.EmbeddingsRequest{
 					Input: "text to embed",
 				},
-				ParsedBody: map[string]any{
+				Payload: scheduling.PayloadMap{
 					"model": "text-embedding-3-small",
 					"input": "text to embed",
 				},

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -158,14 +158,14 @@ func convertToLLMRequestBody(payload []byte) (*scheduling.LLMRequestBody, error)
 			Completions: &scheduling.CompletionsRequest{
 				Prompt: pbReq.GetText(),
 			},
-			ParsedBody: pbReq,
+			Payload: scheduling.PayloadProto{Message: pbReq},
 		}
 	case *pb.GenerateRequest_Tokenized:
 		body = &scheduling.LLMRequestBody{
 			Completions: &scheduling.CompletionsRequest{
 				Prompt: pbReq.GetTokenized().OriginalText,
 			},
-			ParsedBody: pbReq,
+			Payload: scheduling.PayloadProto{Message: pbReq},
 		}
 	default:
 		return nil, errors.New("not supported request inputType")

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -102,11 +102,12 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: "Hello world",
 				},
-				ParsedBody: &pb.GenerateRequest{
-					Input: &pb.GenerateRequest_Text{
-						Text: "Hello world",
-					},
-				},
+				Payload: scheduling.PayloadProto{
+					Message: &pb.GenerateRequest{
+						Input: &pb.GenerateRequest_Text{
+							Text: "Hello world",
+						},
+					}},
 			},
 		},
 		{
@@ -122,13 +123,14 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: "Tokenized hello",
 				},
-				ParsedBody: &pb.GenerateRequest{
-					Input: &pb.GenerateRequest_Tokenized{
-						Tokenized: &pb.TokenizedInput{
-							OriginalText: "Tokenized hello",
+				Payload: scheduling.PayloadProto{
+					Message: &pb.GenerateRequest{
+						Input: &pb.GenerateRequest_Tokenized{
+							Tokenized: &pb.TokenizedInput{
+								OriginalText: "Tokenized hello",
+							},
 						},
-					},
-				},
+					}},
 			},
 		},
 		{
@@ -158,12 +160,13 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				Completions: &scheduling.CompletionsRequest{
 					Prompt: "Hello world",
 				},
-				ParsedBody: &pb.GenerateRequest{
-					Input: &pb.GenerateRequest_Text{
-						Text: "Hello world",
-					},
-					Stream: true,
-				},
+				Payload: scheduling.PayloadProto{
+					Message: &pb.GenerateRequest{
+						Input: &pb.GenerateRequest_Text{
+							Text: "Hello world",
+						},
+						Stream: true,
+					}},
 				Stream: true,
 			},
 		},

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
@@ -214,14 +213,16 @@ func (d *Director) processRequestBody(ctx context.Context, reqCtx *handlers.Requ
 		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: err.Error()}
 	}
 
-	switch v := llmRequestBody.ParsedBody.(type) {
-	case proto.Message:
+	switch v := llmRequestBody.Payload.(type) {
+	case fwksched.PayloadProto:
 		// Protos are not currently mutated, return as-is.
 		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
-	case map[string]any:
+	case fwksched.PayloadMap:
 		if err := d.mutateAndRepackage(ctx, reqCtx, v); err != nil {
 			return nil, err
 		}
+	case fwksched.RawPayload:
+		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
 	default:
 		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

This PR refactors the `ParsedBody` field in `LLMRequestBody` from an empty interface (any) to a sealed `RequestPayload` interface. 
* Introduced concrete types implementing RequestPayload:
   * PayloadMap (wraps map[string]any for JSON)
   * PayloadProto (wraps proto.Message for gRPC)
   * RawPayload (wraps []byte for unparsed data, this will be further used for no-op parser #2698 )
   
Note: currently all the definition is within the scheduling pkg, it will be moeved to requesthandling pkg in #2673

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially #2698

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
