### PR TITLE
fix: add subFilter anchor for INSERT_BEFORE

### DIFF
--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -18,6 +18,10 @@ spec:
         filterChain:
           filter:
             name: "envoy.filters.network.http_connection_manager"
+            {{- if .Values.provider.istio.envoyFilter.anchorSubFilter }}
+            subFilter:
+              name: {{ .Values.provider.istio.envoyFilter.anchorSubFilter }}
+            {{- end }}
     patch:
       operation: {{ .Values.provider.istio.envoyFilter.operation }}
       value:

--- a/config/charts/body-based-routing/values.yaml
+++ b/config/charts/body-based-routing/values.yaml
@@ -44,6 +44,8 @@ provider:
     envoyFilter:
       # Operation for inserting the ext_proc filter into the Envoy filter chain.
       operation: INSERT_FIRST
+      # Anchor filter for INSERT_BEFORE/INSERT_AFTER (empty = no anchor).
+      anchorSubFilter: ""
 
 inferenceGateway:
   name: inference-gateway


### PR DESCRIPTION
## Problem

#2727 made the EnvoyFilter operation configurable, but
`INSERT_BEFORE` / `INSERT_AFTER` require a `subFilter` match to
specify the anchor point in the filter chain. Without it, the
filter is inserted at the same position as `INSERT_FIRST`.

## Solution

Add an optional `provider.istio.envoyFilter.anchorSubFilter` field.
When set, the template includes a `subFilter` match so the operation
has a reference point in the chain. When empty (default), no
`subFilter` is added — preserving current `INSERT_FIRST` behavior.

This allows users to anchor against any filter in the chain
(e.g., `envoy.filters.http.router`, `envoy.filters.http.ext_authz`).

## Changes

- `config/charts/body-based-routing/templates/istio.yaml`: Conditionally
  add `subFilter` match when `anchorSubFilter` is set
- `config/charts/body-based-routing/values.yaml`: Add
  `provider.istio.envoyFilter.anchorSubFilter: ""` (empty default)

```release-note
NONE
```