### PR TITLE
[LatencyPredictor Decomposition] Add SLO headroom tier filter for latency-based routing

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/OWNERS
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kaushikmitr

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/README.md
@@ -1,0 +1,32 @@
+# SLO Headroom Tier Filter (`slo-headroom-tier-filter`)
+
+Probabilistic filter that selects endpoints based on predicted latency headroom
+(SLO - predicted). Splits endpoints into positive (meets SLO) and negative (violates SLO)
+tiers and probabilistically selects one tier.
+
+This filter is only needed when SLO headers are configured. When no SLO is set,
+headroom = 0 - predicted, which is always negative. All endpoints pass through in
+the negative tier (the filter is effectively a no-op).
+
+## Behavior
+
+- Positive tier: `TTFTHeadroom >= 0 AND TPOTHeadroom >= 0`
+- Negative tier: at least one headroom is negative
+- When both tiers exist: 99% keep positive only, 1% keep negative only (epsilon exploration)
+- When only one tier exists: keep that tier
+- When no predictions: keep all endpoints
+- Endpoints without predictions are placed in the negative tier
+
+The 1% exploration ensures endpoints recovering from overload receive occasional traffic
+so their state is re-evaluated.
+
+## Config
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `epsilonExploreNeg` | 0.01 | Probability of selecting negative tier when both exist |
+
+## Inputs
+
+- `LatencyPredictionInfo` endpoint attribute:
+  - `TTFTHeadroom` / `TPOTHeadroom` for tier classification

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package headroomtier provides a probabilistic filter that selects endpoints
+// based on predicted latency headroom (SLO - predicted). It splits endpoints
+// into positive (meets SLO) and negative (violates SLO) tiers, and
+// probabilistically selects one tier to pass through.
+package sloheadroomtier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
+)
+
+const (
+	PluginType = "slo-headroom-tier-filter"
+)
+
+var _ framework.Filter = &Plugin{}
+
+type Config struct {
+	// EpsilonExploreNeg is the probability of selecting the negative tier
+	// when both tiers have endpoints. This ensures overloaded endpoints get
+	// occasional traffic for recovery. Range: [0, 1]. Default: 0.01 (1%).
+	EpsilonExploreNeg float64 `json:"epsilonExploreNeg,omitempty"`
+}
+
+var DefaultConfig = Config{
+	EpsilonExploreNeg: 0.01,
+}
+
+type Plugin struct {
+	typedName fwkplugin.TypedName
+	config    Config
+}
+
+func Factory(name string, rawParameters json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	config := DefaultConfig
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		}
+	}
+	if config.EpsilonExploreNeg < 0 || config.EpsilonExploreNeg > 1.0 {
+		return nil, fmt.Errorf("epsilonExploreNeg must be in [0, 1], got %f", config.EpsilonExploreNeg)
+	}
+	return &Plugin{
+		typedName: fwkplugin.TypedName{Type: PluginType, Name: name},
+		config:    config,
+	}, nil
+}
+
+func (p *Plugin) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// Filter splits endpoints into positive headroom (meets SLO) and negative
+// headroom (violates SLO) tiers. 99% of the time, only positive-tier
+// endpoints are kept. 1% of the time, only negative-tier endpoints are kept
+// (epsilon exploration for recovery). If only one tier has endpoints, that
+// tier is returned. If no endpoints have predictions, all are kept.
+func (p *Plugin) Filter(ctx context.Context, _ *framework.CycleState, _ *framework.LLMRequest, endpoints []framework.Endpoint) []framework.Endpoint {
+	logger := log.FromContext(ctx)
+
+	if len(endpoints) <= 1 {
+		return endpoints
+	}
+
+	var positive, negative, noPrediction []framework.Endpoint
+	for _, ep := range endpoints {
+		raw, ok := ep.Get(attrlatency.LatencyPredictionInfoKey)
+		if !ok {
+			noPrediction = append(noPrediction, ep)
+			continue
+		}
+		info := raw.(*attrlatency.LatencyPredictionInfo)
+		// Validity flags are not checked; invalid predictions are expected to
+		// have negative headroom by convention (the predictor sets headroom =
+		// SLO - predicted, which is negative when the prediction exceeds SLO).
+		if info.TTFTHeadroom() >= 0 && info.TPOTHeadroom() >= 0 {
+			positive = append(positive, ep)
+		} else {
+			negative = append(negative, ep)
+		}
+	}
+
+	// No predictions available, keep all.
+	if len(positive) == 0 && len(negative) == 0 {
+		logger.V(logutil.DEBUG).Info("SLOHeadroomTierFilter: no predictions, keeping all",
+			"total", len(endpoints))
+		return endpoints
+	}
+
+	// Endpoints without predictions go to negative tier (can't confirm SLO).
+	negative = append(negative, noPrediction...)
+
+	switch {
+	case len(positive) > 0 && len(negative) > 0:
+		if rand.Float64() < p.config.EpsilonExploreNeg {
+			logger.V(logutil.DEBUG).Info("SLOHeadroomTierFilter: epsilon explore, selecting negative tier",
+				"positive", len(positive), "negative", len(negative))
+			return negative
+		}
+		logger.V(logutil.DEBUG).Info("SLOHeadroomTierFilter: selecting positive tier",
+			"positive", len(positive), "negative", len(negative))
+		return positive
+	case len(positive) > 0:
+		logger.V(logutil.DEBUG).Info("SLOHeadroomTierFilter: only positive tier",
+			"positive", len(positive))
+		return positive
+	default:
+		logger.V(logutil.DEBUG).Info("SLOHeadroomTierFilter: only negative tier",
+			"negative", len(negative))
+		return negative
+	}
+}
+
+func (p *Plugin) Consumes() map[string]any {
+	return map[string]any{
+		attrlatency.LatencyPredictionInfoKey: attrlatency.LatencyPredictionInfo{},
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sloheadroomtier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	framework "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
+)
+
+func makeEndpoint(name string, ttftHeadroom, tpotHeadroom float64, hasPrediction bool) framework.Endpoint {
+	meta := &fwkdl.EndpointMetadata{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+	}
+	ep := framework.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	if hasPrediction {
+		ep.Put(attrlatency.LatencyPredictionInfoKey, attrlatency.NewLatencyPredictionInfo(
+			ttftHeadroom >= 0, tpotHeadroom >= 0, ttftHeadroom, tpotHeadroom, 100, 10))
+	}
+	return ep
+}
+
+func TestFilter_SingleEndpoint(t *testing.T) {
+	p := &Plugin{config: DefaultConfig}
+	endpoints := []framework.Endpoint{makeEndpoint("a", 10, 5, true)}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 1, len(result))
+}
+
+func TestFilter_NoPredictions(t *testing.T) {
+	p := &Plugin{config: DefaultConfig}
+	endpoints := []framework.Endpoint{
+		makeEndpoint("a", 0, 0, false),
+		makeEndpoint("b", 0, 0, false),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 2, len(result), "no predictions should keep all")
+}
+
+func TestFilter_AllPositive(t *testing.T) {
+	p := &Plugin{config: Config{EpsilonExploreNeg: 0}}
+	endpoints := []framework.Endpoint{
+		makeEndpoint("a", 100, 50, true),
+		makeEndpoint("b", 200, 80, true),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 2, len(result), "only positive tier, keep all")
+}
+
+func TestFilter_AllNegative(t *testing.T) {
+	p := &Plugin{config: Config{EpsilonExploreNeg: 0}}
+	endpoints := []framework.Endpoint{
+		makeEndpoint("a", -100, -50, true),
+		makeEndpoint("b", -200, -80, true),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 2, len(result), "only negative tier, keep all")
+}
+
+func TestFilter_BothTiers_SelectPositive(t *testing.T) {
+	p := &Plugin{config: Config{EpsilonExploreNeg: 0}} // never explore
+	endpoints := []framework.Endpoint{
+		makeEndpoint("pos1", 100, 50, true),
+		makeEndpoint("pos2", 200, 80, true),
+		makeEndpoint("neg1", -100, -50, true),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 2, len(result), "should select positive tier")
+	assert.Equal(t, "pos1", result[0].GetMetadata().NamespacedName.Name)
+}
+
+func TestFilter_BothTiers_EpsilonExploreNeg(t *testing.T) {
+	p := &Plugin{config: Config{EpsilonExploreNeg: 1.0}} // always explore
+	endpoints := []framework.Endpoint{
+		makeEndpoint("pos1", 100, 50, true),
+		makeEndpoint("neg1", -100, -50, true),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	assert.Equal(t, 1, len(result), "should select negative tier")
+	assert.Equal(t, "neg1", result[0].GetMetadata().NamespacedName.Name)
+}
+
+func TestFilter_NoPredictionGoesToNegative(t *testing.T) {
+	p := &Plugin{config: Config{EpsilonExploreNeg: 1.0}} // always explore neg
+	endpoints := []framework.Endpoint{
+		makeEndpoint("pos1", 100, 50, true),
+		makeEndpoint("nopred", 0, 0, false),
+	}
+	result := p.Filter(context.Background(), nil, nil, endpoints)
+	// nopred goes to negative, epsilon selects negative
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, "nopred", result[0].GetMetadata().NamespacedName.Name)
+}
+
+// Note: Deficit bucketing tests are in the slo-deficit-bucket-filter package.
+
+func TestFactory_ValidConfig(t *testing.T) {
+	plugin, err := Factory("test", nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, plugin)
+}
+
+func TestFactory_InvalidEpsilon(t *testing.T) {
+	_, err := Factory("test", []byte(`{"epsilonExploreNeg": 1.5}`), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "epsilonExploreNeg must be in [0, 1]")
+}


### PR DESCRIPTION
Add a probabilistic filter that splits endpoints into positive (meets SLO) and negative (violates SLO) tiers based on predicted latency headroom, and selects one tier per request.

- 99% of requests: keep positive tier only
- 1% (epsilon exploration): keep negative tier for recovery
- No-op when no predictions available or only one tier exists
- When no SLO is set (headroom always negative), all endpoints pass

This is an additive change. The filter is not wired up yet.

