### PR TITLE
fix bbr: skip gracefully when body field is missing

### DIFF
--- a/pkg/bbr/handlers/request_test.go
+++ b/pkg/bbr/handlers/request_test.go
@@ -208,20 +208,99 @@ func TestHandleRequestBody(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:    "model not found",
-			body:    map[string]any{"prompt": "Tell me a joke"},
-			wantErr: true,
+			name: "model not found - skips gracefully",
+			body: map[string]any{"prompt": "Tell me a joke"},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								ClearRouteCache: true,
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*basepb.HeaderValueOption{
+										{
+											Header: &basepb.HeaderValue{
+												Key: basemodelextractor.BaseModelHeader,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
-			name:      "model not found with streaming",
+			name:      "model not found with streaming - skips gracefully",
 			body:      map[string]any{"prompt": "Tell me a joke"},
 			streaming: true,
-			wantErr:   true,
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								ClearRouteCache: true,
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*basepb.HeaderValueOption{
+										{
+											Header: &basepb.HeaderValue{
+												Key:      "Content-Length",
+												RawValue: []byte("27"),
+											},
+										},
+										{
+											Header: &basepb.HeaderValue{
+												Key: basemodelextractor.BaseModelHeader,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								BodyMutation: &extProcPb.BodyMutation{
+									Mutation: &extProcPb.BodyMutation_StreamedResponse{
+										StreamedResponse: &extProcPb.StreamedBodyResponse{
+											Body:        []byte(`{"prompt":"Tell me a joke"}`),
+											EndOfStream: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
-			name:    "model in body but empty",
-			body:    map[string]any{"model": "", "prompt": "Tell me a joke"},
-			wantErr: true,
+			name: "model in body but empty - skips gracefully",
+			body: map[string]any{"model": "", "prompt": "Tell me a joke"},
+			want: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{
+								ClearRouteCache: true,
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*basepb.HeaderValueOption{
+										{
+											Header: &basepb.HeaderValue{
+												Key: basemodelextractor.BaseModelHeader,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "model is not string, success after it's being auto converted to string",
@@ -473,7 +552,7 @@ func TestHandleRequestBody(t *testing.T) {
 	bbr_body_field_not_found_total{field="model"} 2
 	# HELP bbr_success_total [ALPHA] Count of time the request was processed successfully.
 	# TYPE bbr_success_total counter
-	bbr_success_total{} 4
+	bbr_success_total{} 7
 	`
 
 	if err := metricsutils.GatherAndCompare(crmetrics.Registry, strings.NewReader(wantMetrics),

--- a/pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header.go
+++ b/pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header.go
@@ -26,7 +26,6 @@ import (
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/metrics"
-	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
@@ -113,13 +112,15 @@ func (p *BodyFieldToHeaderPlugin) ProcessRequest(ctx context.Context, _ *framewo
 	rawFieldValue, exists := request.Body[p.fieldName]
 	if !exists {
 		metrics.RecordBodyFieldNotFound(p.fieldName)
-		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("field '%s' not found in request body", p.fieldName)}
+		log.FromContext(ctx).V(logutil.VERBOSE).Info("field not found in request body, skipping", "field", p.fieldName)
+		return nil
 	}
 
 	fieldStr := fmt.Sprintf("%v", rawFieldValue) // convert any type to string
 	if fieldStr == "" {
 		metrics.RecordBodyFieldEmpty(p.fieldName)
-		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("field '%s' is empty and couldn't be processed", p.fieldName)}
+		log.FromContext(ctx).V(logutil.VERBOSE).Info("field is empty in request body, skipping", "field", p.fieldName)
+		return nil
 	}
 
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("parsed field from body", "field", p.fieldName, "value", fieldStr)

--- a/pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header_test.go
+++ b/pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header_test.go
@@ -228,7 +228,7 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 			wantHeader: "true",
 		},
 		{
-			name:       "field not found",
+			name:       "field not found - skips gracefully",
 			fieldName:  "missing",
 			headerName: "X-Gateway-Missing",
 			request: func() *framework.InferenceRequest {
@@ -236,10 +236,9 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 				r.Body["other"] = "value"
 				return r
 			}(),
-			wantErr: true,
 		},
 		{
-			name:       "field is empty string",
+			name:       "field is empty string - skips gracefully",
 			fieldName:  "model",
 			headerName: "X-Gateway-Model",
 			request: func() *framework.InferenceRequest {
@@ -247,7 +246,6 @@ func TestBodyFieldToHeaderPlugin_ProcessRequest(t *testing.T) {
 				r.Body["model"] = ""
 				return r
 			}(),
-			wantErr: true,
 		},
 		{
 			name:       "nil field value",

--- a/test/integration/bbr/hermetic_test.go
+++ b/test/integration/bbr/hermetic_test.go
@@ -56,10 +56,26 @@ func TestBodyBasedRouting(t *testing.T) {
 			wantResponse: ExpectBBRUnaryResponse("llama", "llama", "test"),
 		},
 		{
-			name:             "immediate response: no model parameter in body",
-			req:              integration.ReqLLMUnary(logger, "test1", ""),
-			wantStatusCode:   envoyTypePb.StatusCode_BadRequest,
-			wantBodyContains: "model",
+			name: "no model parameter in body - skips gracefully",
+			req:  integration.ReqLLMUnary(logger, "test1", ""),
+			wantResponse: &extProcPb.ProcessingResponse{
+				Response: &extProcPb.ProcessingResponse_RequestBody{
+					RequestBody: &extProcPb.BodyResponse{
+						Response: &extProcPb.CommonResponse{
+							ClearRouteCache: true,
+							HeaderMutation: &extProcPb.HeaderMutation{
+								SetHeaders: []*envoyCorev3.HeaderValueOption{
+									{
+										Header: &envoyCorev3.HeaderValue{
+											Key: "X-Gateway-Base-Model-Name",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -231,10 +247,35 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 			},
 		},
 		{
-			name:             "immediate response: handles missing model field",
-			reqs:             integration.ReqLLM(logger, "test", "", ""),
-			wantStatusCode:   envoyTypePb.StatusCode_BadRequest,
-			wantBodyContains: "model",
+			name: "missing model field - skips gracefully",
+			reqs: integration.ReqLLM(logger, "test", "", ""),
+			wantResponses: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								ClearRouteCache: true,
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*envoyCorev3.HeaderValueOption{
+										{
+											Header: &envoyCorev3.HeaderValue{
+												Key:      "Content-Length",
+												RawValue: []byte("50"),
+											},
+										},
+										{
+											Header: &envoyCorev3.HeaderValue{
+												Key: "X-Gateway-Base-Model-Name",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ExpectBBRBodyPassThrough("test", ""),
+			},
 		},
 	}
 


### PR DESCRIPTION
## Problem

The `body-field-to-header` plugin returns a `BadRequest` error when
the configured field (e.g., `model`) is not found or empty in the
request body. This causes ext_proc to send an `ImmediateResponse`
error for any request that doesn't contain the expected field.

When the gateway handles multiple types of requests (not just
inference), non-matching requests fail unnecessarily. In `BUFFERED`
processing mode, this results in a 504 timeout.

## Solution

Log and skip instead of returning an error when the field is missing
or empty. The metrics (`RecordBodyFieldNotFound`, `RecordBodyFieldEmpty`)
are still recorded for observability.

This makes the plugin safe to use on gateways that serve mixed
traffic — requests without the configured field pass through
unmodified.

## Changes

- `pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header.go`: Replace
  error returns with log + `return nil` for missing/empty field cases
- `pkg/bbr/plugins/bodyfieldtoheader/body_field_to_header_test.go`:
  Update test expectations to match skip behavior

```release-note
NONE
```