### PR TITLE
release: align conformance module tagging

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -71,7 +71,7 @@ This document defines the process for releasing Gateway API Inference Extension.
      git checkout -b release-${MAJOR}.${MINOR} ${REMOTE}/release-${MAJOR}.${MINOR}
      ```
 
-4. Update release-specific content, generate release artifacts, and stage the changes.
+4. Update release-specific content, generate release artifacts, pin the `conformance` module to the matching root-module version, and stage the changes.
 
    ```shell
    make release
@@ -97,38 +97,20 @@ This document defines the process for releasing Gateway API Inference Extension.
     git push ${REMOTE} release-${MAJOR}.${MINOR}
     ```
 
-7. Tag the head of your release branch with the number.
+7. Create and push signed tags for the repo and the `conformance` module.
 
-   For a release candidate:
+   ```shell
+   make release-tags
+   ```
 
-    ```shell
-    git tag -s -a v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} Release Candidate'
-    ```
-
-   For a major, minor or patch release:
-
-    ```shell
-    git tag -s -a v${MAJOR}.${MINOR}.${PATCH} -m 'Gateway API Inference Extension v${MAJOR}.${MINOR}.${PATCH} Release'
-    ```
+   This creates and pushes the following tags together:
+   - `v${MAJOR}.${MINOR}.${PATCH}` or `v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}`
+   - `conformance/v${MAJOR}.${MINOR}.${PATCH}` or `conformance/v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}`
 
    **Note:** A PGP key must be [registered] to your GitHub account.
 
-8. Push the tag to the Gateway API Inference Extension repo.
-
-   For a release candidate:
-
-    ```shell
-    git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}
-    ```
-
-   For a major, minor or patch release:
-
-    ```shell
-    git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}
-    ```
-
-9. Pushing the tag triggers Prow to build and publish the container image to the [staging registry][].
-10. Submit a PR against [k8s.io][] to add the staging image tag and SHA to [`k8s-staging-gateway-api-inference-extension/images.yaml`][yaml]. This will
+8. Pushing the root tag triggers Prow to build and publish the container image to the [staging registry][].
+9. Submit a PR against [k8s.io][] to add the staging image tag and SHA to [`k8s-staging-gateway-api-inference-extension/images.yaml`][yaml]. This will
     promote the image to the production registry, e.g. `registry.k8s.io/gateway-api-inference-extension/epp:v${MAJOR}.${MINOR}.${PATCH}`.
     1. Collect release digests from Artifact Registry:
        ```shell
@@ -144,14 +126,14 @@ This document defines the process for releasing Gateway API Inference Extension.
        - `latency-training-server`
     3. If an artifact does not yet have a section in `images.yaml` (for example a newly added chart), add a new section before adding the digest mapping.
     **Note:** Add a link to this issue when the PR is merged.
-11. Test the steps in the tagged quickstart guide after the PR merges, for example: `https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v0.1.0-rc.1/pkg/README.md`.
-12. Create a [new release][]:
-    1. Choose the tag that you created for the release.
+10. Test the steps in the tagged quickstart guide after the PR merges, for example: `https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v0.1.0-rc.1/pkg/README.md`.
+11. Create a [new release][]:
+    1. Choose the root tag that you created for the release, for example `v1.5.0`.
     2. Use the tag as the release title, i.e. `v0.1.0` refer to previous release for the content of the release body.
     3. Click "Generate release notes" and preview the release body.
     4. Click "Attach binaries by dropping them here or selecting them." and add the contents of the `artifacts` directory generated from `make release`.
     5. If this is a release candidate, select the "This is a pre-release" checkbox.
-13. If you find any bugs in this process, create an [issue][].
+12. If you find any bugs in this process, create an [issue][].
 
 ## Announce the Release
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 GIT_COMMIT_SHA ?= "$(shell git rev-parse HEAD 2>/dev/null)"
-GIT_TAG ?= $(shell git describe --tags --dirty --always)
+# Keep root-module build metadata anchored to top-level release tags so
+# submodule tags such as conformance/v1.5.0 do not leak into image versions.
+ROOT_RELEASE_TAG_MATCH ?= v[0-9]*
+GIT_TAG ?= $(shell git describe --tags --match '$(ROOT_RELEASE_TAG_MATCH)' --dirty --always)
 TARGETARCH ?= $(shell go env GOARCH)
 PLATFORMS ?= linux/$(TARGETARCH)
 DOCKER_BUILDX_CMD ?= docker buildx
@@ -71,7 +74,7 @@ ifdef GO_VERSION
 BUILDER_IMAGE = golang:$(GO_VERSION)
 endif
 
-BUILD_REF ?= $(shell git describe --abbrev=0 2>/dev/null)
+BUILD_REF ?= $(shell git describe --tags --match '$(ROOT_RELEASE_TAG_MATCH)' --abbrev=0 2>/dev/null)
 ifdef EXTRA_TAG
 IMAGE_EXTRA_TAG ?= $(IMAGE_REPO):$(EXTRA_TAG)
 BBR_IMAGE_EXTRA_TAG ?= $(BBR_IMAGE_REPO):$(EXTRA_TAG)
@@ -489,6 +492,10 @@ standalone-helm-chart-push: yq helm-install
 .PHONY: release-quickstart
 release-quickstart: ## Update the quickstart guide for a release.
 	./hack/release-quickstart.sh
+
+.PHONY: release-tags
+release-tags: ## Create and push signed tags for the root and conformance modules.
+	./hack/release-tags.sh
 
 .PHONY: artifacts
 artifacts: kustomize yq

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,16 @@
 # Release Process
 
-The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
+Use [.github/ISSUE_TEMPLATE/new-release.md](.github/ISSUE_TEMPLATE/new-release.md)
+as the source of truth when cutting a release.
 
-1. Update `version/version.go` with the new semver tag. You can do this manually, or run the automated release target: `MAJOR=X MINOR=Y PATCH=Z make release` (this will also update Helm chart values and run tests).
-1. An issue is proposing a new release with a changelog since the last release
-1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push origin $VERSION`
-1. For sub-modules (e.g., `conformance/go.mod`), the OWNER should create and push a prefixed tag: `git tag -s conformance/$VERSION` followed by `git push origin conformance/$VERSION`
-1. The release issue is closed
-1. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+In short:
+
+1. Open a New Release issue.
+1. Run `MAJOR=X MINOR=Y PATCH=Z make release` on the release branch. This
+   updates the release artifacts and pins the `conformance` module to the
+   matching root-module version.
+1. Commit and push the release branch.
+1. Run `MAJOR=X MINOR=Y PATCH=Z make release-tags` to create and push both
+   signed tags: `$VERSION` and `conformance/$VERSION`.
+1. Create the GitHub Release from the root tag only, then follow the remaining
+   publication and announcement steps from the issue template.

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -27,7 +27,7 @@ PATCH="${PATCH:-0}"
 if [[ -z "${RC-}" ]]; then
   RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}"
 else
-  RELEASE_TAG="v${MAJOR}.${MINOR}.0-rc.${RC}"
+  RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}"
 fi
 
 # The vLLM image versions
@@ -65,12 +65,22 @@ README="pkg/README.md"
 echo "Updating ${README} ..."
 
 # Replace URLs that refer to a tag (whether via refs/tags or releases/download)
-# This regex matches any version in the form v<MAJOR>.<MINOR>.0-rc[.]?<number>
-sed -i.bak -E "s|(refs/tags/)v[0-9]+\.[0-9]+\.0-rc\.?[0-9]+|\1${RELEASE_TAG}|g" "$README"
-sed -i.bak -E "s|(releases/download/)v[0-9]+\.[0-9]+\.0-rc\.?[0-9]+|\1${RELEASE_TAG}|g" "$README"
+# This regex matches any version in the form v<MAJOR>.<MINOR>.<PATCH>-rc[.]?<number>
+sed -i.bak -E "s|(refs/tags/)v[0-9]+\.[0-9]+\.[0-9]+-rc\.?[0-9]+|\1${RELEASE_TAG}|g" "$README"
+sed -i.bak -E "s|(releases/download/)v[0-9]+\.[0-9]+\.[0-9]+-rc\.?[0-9]+|\1${RELEASE_TAG}|g" "$README"
 
 # Replace the CRD installation line: change "kubectl apply -k" to "kubectl apply -f" with the proper URL
 sed -i.bak "s|kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd|kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${RELEASE_TAG}/manifests.yaml|g" "$README"
+
+# -----------------------------------------------------------------------------
+# Update the conformance module dependency
+# -----------------------------------------------------------------------------
+CONFORMANCE_GOMOD="conformance/go.mod"
+echo "Updating ${CONFORMANCE_GOMOD} ..."
+(
+  cd conformance
+  go mod edit -require=sigs.k8s.io/gateway-api-inference-extension@"${RELEASE_TAG}"
+)
 
 # -----------------------------------------------------------------------------
 # Update image references
@@ -143,8 +153,8 @@ done
 # -----------------------------------------------------------------------------
 # Stage the changes
 # -----------------------------------------------------------------------------
-echo "Staging $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS ${VLLM_GPU_DEPLOYS[*]} $VLLM_CPU_DEPLOY ${VLLM_SIM_DEPLOYS[*]} files..."
-git add "$VERSION_FILE" "$UPDATED_CRD" "$README" "$EPP_HELM" "$LATENCY_ROUTING_HELM" "$BBR_HELM" "$STANDALONE_HELM" "$CONFORMANCE_MANIFESTS" "${VLLM_GPU_DEPLOYS[@]}" "$VLLM_CPU_DEPLOY" "${VLLM_SIM_DEPLOYS[@]}"
+echo "Staging $VERSION_FILE $UPDATED_CRD $README $CONFORMANCE_GOMOD $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS ${VLLM_GPU_DEPLOYS[*]} $VLLM_CPU_DEPLOY ${VLLM_SIM_DEPLOYS[*]} files..."
+git add "$VERSION_FILE" "$UPDATED_CRD" "$README" "$CONFORMANCE_GOMOD" "$EPP_HELM" "$LATENCY_ROUTING_HELM" "$BBR_HELM" "$STANDALONE_HELM" "$CONFORMANCE_MANIFESTS" "${VLLM_GPU_DEPLOYS[@]}" "$VLLM_CPU_DEPLOY" "${VLLM_SIM_DEPLOYS[@]}"
 
 # -----------------------------------------------------------------------------
 # Cleanup backup files and finish

--- a/hack/release-tags.sh
+++ b/hack/release-tags.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+: "${MAJOR:?MAJOR must be set}"
+: "${MINOR:?MINOR must be set}"
+: "${PATCH:?PATCH must be set}"
+
+REMOTE="${REMOTE:-origin}"
+PUSH="${PUSH:-true}"
+
+if [[ -n "${RC-}" ]]; then
+  RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}"
+  ROOT_MESSAGE="Gateway API Inference Extension ${RELEASE_TAG} Release Candidate"
+  CONFORMANCE_MESSAGE="Gateway API Inference Extension Conformance ${RELEASE_TAG} Release Candidate"
+else
+  RELEASE_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+  ROOT_MESSAGE="Gateway API Inference Extension ${RELEASE_TAG} Release"
+  CONFORMANCE_MESSAGE="Gateway API Inference Extension Conformance ${RELEASE_TAG} Release"
+fi
+
+CONFORMANCE_TAG="conformance/${RELEASE_TAG}"
+
+create_tag() {
+  local tag="$1"
+  local message="$2"
+
+  if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+    echo "error: tag ${tag} already exists" >&2
+    exit 1
+  fi
+
+  echo "Creating signed tag ${tag}"
+  git tag -s -a "${tag}" -m "${message}"
+}
+
+create_tag "${RELEASE_TAG}" "${ROOT_MESSAGE}"
+create_tag "${CONFORMANCE_TAG}" "${CONFORMANCE_MESSAGE}"
+
+if [[ "${PUSH}" == "false" ]]; then
+  echo "Skipping push because PUSH=false"
+  exit 0
+fi
+
+echo "Pushing ${RELEASE_TAG} and ${CONFORMANCE_TAG} to ${REMOTE}"
+git push --atomic "${REMOTE}" "${RELEASE_TAG}" "${CONFORMANCE_TAG}"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This completes the remaining work for issue #2691 so the `conformance` Go module is released alongside the root module instead of relying on docs alone.

It updates the release flow to:
- pin `conformance/go.mod` to the matching root-module version during `make release`
- create and push both signed tags together via `make release-tags`
- keep root build metadata derived from top-level `v*` tags instead of `conformance/*` tags
- align the release docs around the dual-tag workflow and the root-tag GitHub Release

Validation:
- `bash -n hack/release-tags.sh`
- `bash -n hack/release-quickstart.sh`
- `git diff --check`

**Which issue(s) this PR fixes**:
Fixes: #2691

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
