### PR TITLE
Update vLLM manifest image tags

### DIFF
--- a/config/manifests/vllm/cpu-deployment.yaml
+++ b/config/manifests/vllm/cpu-deployment.yaml
@@ -14,8 +14,8 @@ spec:
         inference.networking.k8s.io/engine-type: vllm
     spec:
       containers:
-        - name: lora
-          image: "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.10.2" # formal images can be found in https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
+        - name: vllm
+          image: "vllm/vllm-openai-cpu:latest" # formal images can be found in https://hub.docker.com/r/vllm/vllm-openai-cpu/tags
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/config/manifests/vllm/gpu-deployment.yaml
+++ b/config/manifests/vllm/gpu-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: "vllm/vllm-openai:v0.15.1"
+          image: "vllm/vllm-openai:latest"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/config/manifests/vllm/gpu-grpc-deployment.yaml
+++ b/config/manifests/vllm/gpu-grpc-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm-server
-          image: vllm/vllm-openai:v0.15.1
+          image: vllm/vllm-openai:latest
           command: ["python3", "-m", "vllm.entrypoints.grpc_server"]
           args:
           - "--model"

--- a/config/manifests/vllm/gpu-prefix-cache-deployment.yaml
+++ b/config/manifests/vllm/gpu-prefix-cache-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: "vllm/vllm-openai:v0.15.1"
+          image: "vllm/vllm-openai:latest"
           imagePullPolicy: Always
           command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
           args:

--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
+        image: ghcr.io/llm-d/llm-d-inference-sim:latest
         imagePullPolicy: Always
         args:
         - --model

--- a/config/manifests/vllm/sim-grpc-deployment.yaml
+++ b/config/manifests/vllm/sim-grpc-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
+        image: ghcr.io/llm-d/llm-d-inference-sim:latest
         imagePullPolicy: Always
         args:
         - --model

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -32,11 +32,11 @@ fi
 
 # The vLLM image versions
 # The GPU image is from https://hub.docker.com/r/vllm/vllm-openai/tags
-VLLM_GPU="${VLLM_GPU:-0.10.0}"
-# The CPU image is from https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
-VLLM_CPU="${VLLM_CPU:-0.10.0}"
+VLLM_GPU="${VLLM_GPU:-0.18.1}"
+# The CPU image is from https://hub.docker.com/r/vllm/vllm-openai-cpu/tags
+VLLM_CPU="${VLLM_CPU:-0.18.1}"
 # The sim image is from https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim
-VLLM_SIM="${VLLM_SIM:-0.3.2-fix}"
+VLLM_SIM="${VLLM_SIM:-0.8.2}"
 
 echo "Using release tag: ${RELEASE_TAG}"
 echo "Using vLLM GPU image version: ${VLLM_GPU}"
@@ -104,38 +104,47 @@ sed -i.bak -E "s|us-central1-docker\.pkg\.dev/k8s-staging-images|registry.k8s.io
 # -----------------------------------------------------------------------------
 # Update vLLM deployment manifests
 # -----------------------------------------------------------------------------
-VLLM_GPU_DEPLOY="config/manifests/vllm/gpu-deployment.yaml"
-echo "Updating ${VLLM_GPU_DEPLOY} ..."
+VLLM_GPU_DEPLOYS=(
+  "config/manifests/vllm/gpu-deployment.yaml"
+  "config/manifests/vllm/gpu-grpc-deployment.yaml"
+  "config/manifests/vllm/gpu-prefix-cache-deployment.yaml"
+)
+echo "Updating ${VLLM_GPU_DEPLOYS[*]} ..."
 
-# Update the vLLM GPU image version
-sed -i.bak -E "s|(vllm/vllm-openai:)[^\"[:space:]]+|\1v${VLLM_GPU}|g" "$VLLM_GPU_DEPLOY"
-
-# Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM image.
-sed -i.bak '/vllm\/vllm-openai/{n;s/Always/IfNotPresent/;}' "$VLLM_GPU_DEPLOY"
+for vllm_gpu_deploy in "${VLLM_GPU_DEPLOYS[@]}"; do
+  # Replace the floating GPU tag with the latest semver tag for the release.
+  sed -i.bak -E "s|(vllm/vllm-openai:)[^\"[:space:]]+|\1v${VLLM_GPU}|g" "$vllm_gpu_deploy"
+  # Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM image.
+  sed -i.bak '/vllm\/vllm-openai/{n;s/Always/IfNotPresent/;}' "$vllm_gpu_deploy"
+done
 
 VLLM_CPU_DEPLOY="config/manifests/vllm/cpu-deployment.yaml"
 echo "Updating ${VLLM_CPU_DEPLOY} ..."
 
 # Update the vLLM CPU image version
-sed -i.bak -E "s|(q9t5s3a7/vllm-cpu-release-repo:)[^\"[:space:]]+|\1v${VLLM_CPU}|g" "$VLLM_CPU_DEPLOY"
+sed -i.bak -E "s|(vllm/vllm-openai-cpu:)[^\"[:space:]]+|\1v${VLLM_CPU}|g" "$VLLM_CPU_DEPLOY"
 
 # Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM CPU image.
-sed -i.bak '/q9t5s3a7\/vllm-cpu-release-repo/{n;s/Always/IfNotPresent/;}' "$VLLM_CPU_DEPLOY"
+sed -i.bak '/vllm\/vllm-openai-cpu/{n;s/Always/IfNotPresent/;}' "$VLLM_CPU_DEPLOY"
 
-VLLM_SIM_DEPLOY="config/manifests/vllm/sim-deployment.yaml"
-echo "Updating ${VLLM_SIM_DEPLOY} ..."
+VLLM_SIM_DEPLOYS=(
+  "config/manifests/vllm/sim-deployment.yaml"
+  "config/manifests/vllm/sim-grpc-deployment.yaml"
+)
+echo "Updating ${VLLM_SIM_DEPLOYS[*]} ..."
 
-# Update the vLLM Simulator image version
-sed -i.bak -E "s|(llm-d/llm-d-inference-sim:)[^\"[:space:]]+|\1v${VLLM_SIM}|g" "$VLLM_SIM_DEPLOY"
-
-# Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM image.
-sed -i.bak '/llm-d\/llm-d-inference-sim/{n;s/Always/IfNotPresent/;}' "$VLLM_SIM_DEPLOY"
+for vllm_sim_deploy in "${VLLM_SIM_DEPLOYS[@]}"; do
+  # Replace the floating simulator tag with the latest semver tag for the release.
+  sed -i.bak -E "s|(llm-d/llm-d-inference-sim:)[^\"[:space:]]+|\1v${VLLM_SIM}|g" "$vllm_sim_deploy"
+  # Also change the imagePullPolicy from Always to IfNotPresent on lines containing the vLLM image.
+  sed -i.bak '/llm-d\/llm-d-inference-sim/{n;s/Always/IfNotPresent/;}' "$vllm_sim_deploy"
+done
 
 # -----------------------------------------------------------------------------
 # Stage the changes
 # -----------------------------------------------------------------------------
-echo "Staging $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS $VLLM_GPU_DEPLOY $VLLM_CPU_DEPLOY $VLLM_SIM_DEPLOY files..."
-git add $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS $VLLM_GPU_DEPLOY $VLLM_CPU_DEPLOY $VLLM_SIM_DEPLOY
+echo "Staging $VERSION_FILE $UPDATED_CRD $README $EPP_HELM $LATENCY_ROUTING_HELM $BBR_HELM $STANDALONE_HELM $CONFORMANCE_MANIFESTS ${VLLM_GPU_DEPLOYS[*]} $VLLM_CPU_DEPLOY ${VLLM_SIM_DEPLOYS[*]} files..."
+git add "$VERSION_FILE" "$UPDATED_CRD" "$README" "$EPP_HELM" "$LATENCY_ROUTING_HELM" "$BBR_HELM" "$STANDALONE_HELM" "$CONFORMANCE_MANIFESTS" "${VLLM_GPU_DEPLOYS[@]}" "$VLLM_CPU_DEPLOY" "${VLLM_SIM_DEPLOYS[@]}"
 
 # -----------------------------------------------------------------------------
 # Cleanup backup files and finish


### PR DESCRIPTION
## Summary
- Switch the non-CPU vLLM manifests under `config/manifests/vllm/` to floating `latest` tags.
- Move the CPU manifest to `vllm/vllm-openai-cpu`, rename the main container to `vllm`, and keep a single multi-arch example manifest.
- Update `hack/release-quickstart.sh` to stamp all GPU, CPU, and simulator manifests to the latest semver tags during release.

## Why
The checked-in manifests were using a mix of stale pinned tags, and the release quickstart only updated a subset of the vLLM example manifests. This keeps the examples current by default while preserving semver-pinned release artifacts.

## Impact
- GPU manifests now track `vllm/vllm-openai:latest`.
- Simulator manifests now track `ghcr.io/llm-d/llm-d-inference-sim:latest`.
- The CPU manifest now uses the multi-arch `vllm/vllm-openai-cpu` image instead of the older ECR repository.
- Release quickstart currently resolves those floating tags to `v0.18.1` for GPU/CPU and `v0.8.2` for the simulator.

## Validation
- `bash -n hack/release-quickstart.sh`
