### PR TITLE
fix(helm): not set inferencePool.AppProtocol when modelServerProtocol is not set

### DIFF
--- a/config/charts/inferencepool/templates/inferencepool.yaml
+++ b/config/charts/inferencepool/templates/inferencepool.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- include "gateway-api-inference-extension.labels" . | nindent 4 }}
 spec:
   targetPortNumber: {{ .Values.inferencePool.targetPortNumber | default 8000 }}
-  appProtocol: {{ if eq .Values.inferencePool.modelServerProtocol "grpc" }}"kubernetes.io/h2c"{{ else }}{{ .Values.inferencePool.appProtocol | default "http" }}{{ end }}
   selector:
     {{- if .Values.inferencePool.modelServers.matchLabels }}
     {{- range $key, $value := .Values.inferencePool.modelServers.matchLabels }}
@@ -33,7 +32,11 @@ spec:
     {{- range .Values.inferencePool.targetPorts }}
       - number: {{ .number }}
     {{- end }}
-  appProtocol: {{ if eq .Values.inferencePool.modelServerProtocol "grpc" }}"kubernetes.io/h2c"{{ else }}{{ .Values.inferencePool.appProtocol | default "http" }}{{ end }}
+  {{- if eq .Values.inferencePool.modelServerProtocol "grpc" }}
+  appProtocol: "kubernetes.io/h2c"
+  {{- else if eq .Values.inferencePool.modelServerProtocol "http" }}
+  appProtocol: "http"
+  {{- end }}
   selector:
     matchLabels:
       {{- if .Values.inferencePool.modelServers.matchLabels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

Currently even if helm modelServerProtocol is not set. AppProtocol is still populated.
The issue is if people who didn't install the GAIE InferencePool v1.4.0 or above. It will error out.
but it is not required if people don't want to use gRPC

Also this fixes the AppProtocol set for v1alpha2 since we didn't add AppProtocol to v1alpha2 it should not be set.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
