### PR TITLE
fix: Remove test-specific field from Runner by generalizing NewDefaultManager options

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -127,8 +127,6 @@ type Runner struct {
 	customCollectors     []prometheus.Collector
 	parser               fwkrh.Parser
 	dlRuntime            *datalayer.Runtime
-
-	testOverrideSkipNameValidation bool
 }
 
 // WithExecutableName sets the name of the executable containing the runner.
@@ -209,7 +207,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	mgr, _, err := r.setup(ctx, cfg, opts, pmc)
+	mgr, _, err := r.setup(ctx, cfg, opts, pmc, nil)
 	if err != nil {
 		return err
 	}
@@ -227,10 +225,11 @@ func (r *Runner) Run(ctx context.Context) error {
 
 // setup configures the internal state of the Runner, including the manager,
 // datastore, and other server components. It returns the initialized Manager
-// without starting it, allowing for flexible in integration test.
+// without starting it, allowing for flexible use in integration tests.
 //
-// The returned Datastore is **only** meant to use in the integration test.
-func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Options, pmc backendmetrics.PodMetricsClient) (ctrl.Manager, datastore.Datastore, error) {
+// The returned Datastore is **only** meant to be used in the integration test.
+// Optional managerOverrides are applied to the controller manager options before creation.
+func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Options, pmc backendmetrics.PodMetricsClient, managerOverrides []func(*ctrl.Options)) (ctrl.Manager, datastore.Datastore, error) {
 	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse configuration")
@@ -286,10 +285,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	isLeader := &atomic.Bool{}
 	isLeader.Store(false)
 
-	mgr, err := runserver.NewDefaultManager(controllerCfg, *gknn, cfg, metricsServerOptions, opts.EnableLeaderElection, r.testOverrideSkipNameValidation)
-	if r.testOverrideSkipNameValidation {
-		setupLog.Info("Warning: testOverrideSkipNameValidation is set to true, this should be only used in test.")
-	}
+	mgr, err := runserver.NewDefaultManager(controllerCfg, *gknn, cfg, metricsServerOptions, opts.EnableLeaderElection, managerOverrides...)
 	if err != nil {
 		setupLog.Error(err, "Failed to create controller manager")
 		return nil, nil, err

--- a/cmd/epp/runner/test_runner.go
+++ b/cmd/epp/runner/test_runner.go
@@ -35,7 +35,6 @@ import (
 // automatically. Pass nil to fall back to the legacy metrics system with pmc.
 func NewTestRunnerSetup(ctx context.Context, cfg *rest.Config, opts *runserver.Options, pmc backendmetrics.PodMetricsClient, mockDataSource fwkdl.DataSource) (ctrl.Manager, datastore.Datastore, error) {
 	runner := NewRunner()
-	runner.testOverrideSkipNameValidation = true
 
 	if mockDataSource != nil {
 		mockType := mockDataSource.TypedName().Type
@@ -45,5 +44,14 @@ func NewTestRunnerSetup(ctx context.Context, cfg *rest.Config, opts *runserver.O
 		defer delete(fwkplugin.Registry, mockType)
 	}
 
-	return runner.setup(ctx, cfg, opts, pmc)
+	// Skip controller name validation in integration tests to avoid collisions
+	// when multiple controllers are registered within the same test process.
+	skipNameValidation := true
+	managerOverrides := []func(*ctrl.Options){
+		func(o *ctrl.Options) {
+			o.Controller.SkipNameValidation = &skipNameValidation
+		},
+	}
+
+	return runner.setup(ctx, cfg, opts, pmc, managerOverrides)
 }

--- a/pkg/epp/server/controller_manager.go
+++ b/pkg/epp/server/controller_manager.go
@@ -80,7 +80,8 @@ func defaultManagerOptions(cfg ControllerConfig, gknn common.GKNN, metricsServer
 }
 
 // NewDefaultManager creates a new controller manager with default configuration.
-func NewDefaultManager(controllerCfg ControllerConfig, gknn common.GKNN, restConfig *rest.Config, metricsServerOptions metricsserver.Options, leaderElectionEnabled bool, testOverrideSkipNameValidation bool) (ctrl.Manager, error) {
+// Optional override functions can be passed to customize the manager options (e.g., for testing).
+func NewDefaultManager(controllerCfg ControllerConfig, gknn common.GKNN, restConfig *rest.Config, metricsServerOptions metricsserver.Options, leaderElectionEnabled bool, overrides ...func(*ctrl.Options)) (ctrl.Manager, error) {
 	opt := defaultManagerOptions(controllerCfg, gknn, metricsServerOptions)
 	if leaderElectionEnabled {
 		opt.LeaderElection = true
@@ -91,7 +92,9 @@ func NewDefaultManager(controllerCfg ControllerConfig, gknn common.GKNN, restCon
 		opt.LeaderElectionReleaseOnCancel = true
 	}
 
-	opt.Controller.SkipNameValidation = &testOverrideSkipNameValidation
+	for _, override := range overrides {
+		override(&opt)
+	}
 
 	manager, err := ctrl.NewManager(restConfig, opt)
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2332 

/kind bug


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
