### PR TITLE
feat: add VTC (Virtual Token Counting) fairness policy for flow control

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -63,6 +63,7 @@ import (
 	sourcenotifications "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/source/notifications"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/fairness/vtc"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/ordering/edf"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
 	slodeadline "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline"
@@ -467,6 +468,7 @@ func (r *Runner) registerInTreePlugins() {
 	// Flow Control plugins
 	fwkplugin.Register(globalstrict.GlobalStrictFairnessPolicyType, globalstrict.GlobalStrictFairnessPolicyFactory)
 	fwkplugin.Register(roundrobin.RoundRobinFairnessPolicyType, roundrobin.RoundRobinFairnessPolicyFactory)
+	fwkplugin.Register(vtc.VTCFairnessPolicyType, vtc.VTCFairnessPolicyFactory)
 	fwkplugin.Register(fcfs.FCFSOrderingPolicyType, fcfs.FCFSOrderingPolicyFactory)
 	fwkplugin.Register(edf.EDFOrderingPolicyType, edf.EDFOrderingPolicyFactory)
 	fwkplugin.Register(slodeadline.SLODeadlineOrderingPolicyType, slodeadline.SLODeadlineOrderingPolicyFactory)

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
@@ -29,6 +29,7 @@ import (
 	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/flowcontrol/fairness/vtc"
 )
 
 // TestFairnessPolicyConformance is the main conformance test suite for FairnessPolicy implementations.
@@ -40,6 +41,7 @@ func TestFairnessPolicyConformance(t *testing.T) {
 	policies := map[string]fwkplugin.FactoryFunc{
 		globalstrict.GlobalStrictFairnessPolicyType: globalstrict.GlobalStrictFairnessPolicyFactory,
 		roundrobin.RoundRobinFairnessPolicyType:     roundrobin.RoundRobinFairnessPolicyFactory,
+		vtc.VTCFairnessPolicyType:                   vtc.VTCFairnessPolicyFactory,
 	}
 
 	for name, f := range policies {

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/vtc/vtc.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/vtc/vtc.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vtc implements a fairness policy based on Virtual Token Counting (VTC).
+//
+// Unlike round-robin (which gives each flow one turn regardless of request size), VTC tracks the
+// cumulative "virtual work" dispatched per flow. The flow with the lowest virtual counter gets the
+// next dispatch opportunity. This ensures that a tenant sending large prompts does not receive the
+// same number of dispatch turns as one sending small prompts.
+//
+// For detailed documentation, see README.md.
+package vtc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+	"sync"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+)
+
+// VTCFairnessPolicyType is the registration type for the VTC fairness policy.
+const VTCFairnessPolicyType = "vtc-fairness-policy"
+
+// normalizationThreshold is the value at which counters are normalized to prevent unbounded growth and float64
+// precision loss. When any counter exceeds this, the global minimum is subtracted from all counters.
+const normalizationThreshold = 1e12
+
+// VTCFairnessPolicyFactory creates a VTC fairness policy from optional JSON parameters.
+//
+// Supported parameters:
+//
+//	{
+//	  "weights": {"tenant-a": 2.0, "tenant-b": 1.0},
+//	  "defaultWeight": 1.0
+//	}
+//
+// - weights: per-flow-ID weight overrides. Higher weight = larger share of dispatch opportunities.
+// - defaultWeight: weight for flows not listed in weights. Defaults to 1.0 if omitted or <= 0.
+func VTCFairnessPolicyFactory(name string, params json.RawMessage, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	return newVTC(name, params)
+}
+
+// vtcConfig holds the JSON-parsed configuration for the VTC policy.
+type vtcConfig struct {
+	Weights       map[string]float64 `json:"weights"`
+	DefaultWeight float64            `json:"defaultWeight"`
+}
+
+// vtc implements FairnessPolicy using Virtual Token Counting.
+// The struct is immutable after construction and shared across all priority bands (Singleton).
+type vtc struct {
+	name          string
+	weights       map[string]float64
+	defaultWeight float64
+}
+
+func newVTC(name string, params json.RawMessage) (*vtc, error) {
+	if name == "" {
+		name = VTCFairnessPolicyType
+	}
+
+	cfg := vtcConfig{
+		DefaultWeight: 1.0,
+	}
+
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse VTC parameters: %w", err)
+		}
+	}
+
+	if cfg.DefaultWeight <= 0 {
+		cfg.DefaultWeight = 1.0
+	}
+
+	for id, w := range cfg.Weights {
+		if w <= 0 {
+			return nil, fmt.Errorf("weight for flow %q must be positive, got %f", id, w)
+		}
+	}
+
+	return &vtc{
+		name:          name,
+		weights:       cfg.Weights,
+		defaultWeight: cfg.DefaultWeight,
+	}, nil
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *vtc) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{
+		Type: VTCFairnessPolicyType,
+		Name: p.name,
+	}
+}
+
+// vtcState holds the mutable per-band state for the VTC policy (Flyweight pattern).
+type vtcState struct {
+	mu       sync.Mutex
+	counters map[string]float64 // flow ID -> cumulative virtual work
+}
+
+// NewState initializes the policy state for a specific priority band.
+func (p *vtc) NewState(_ context.Context) any {
+	return &vtcState{
+		counters: make(map[string]float64),
+	}
+}
+
+// Pick selects the flow with the lowest virtual counter from the given priority band.
+//
+// Algorithm (Weighted Fair Queuing):
+//  1. For each non-empty flow queue, look up (or initialize) its virtual counter.
+//  2. Select the flow with the smallest counter. Ties are broken by deterministic FlowKey ordering.
+//  3. Advance the winner's counter by cost/weight, where cost is the head item's ByteSize.
+//  4. Prune counters for flows no longer in the active set and normalize if needed.
+func (p *vtc) Pick(
+	_ context.Context,
+	flowGroup flowcontrol.PriorityBandAccessor,
+) (flowcontrol.FlowQueueAccessor, error) {
+	if flowGroup == nil {
+		return nil, nil
+	}
+
+	v := flowGroup.PolicyState()
+	s, ok := v.(*vtcState)
+	if !ok {
+		return nil, fmt.Errorf("invalid state type for VTC policy: expected *vtcState, got %T", v)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	keys := flowGroup.FlowKeys()
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	// Sort for deterministic tie-breaking.
+	slices.SortFunc(keys, func(a, b flowcontrol.FlowKey) int { return a.Compare(b) })
+
+	// Find the current global minimum counter among tracked flows.
+	globalMin := math.MaxFloat64
+	for _, c := range s.counters {
+		if c < globalMin {
+			globalMin = c
+		}
+	}
+	if globalMin == math.MaxFloat64 {
+		globalMin = 0
+	}
+
+	// Find the non-empty flow with the lowest virtual counter.
+	var bestQueue flowcontrol.FlowQueueAccessor
+	bestCounter := math.MaxFloat64
+	activeIDs := make(map[string]struct{}, len(keys))
+
+	for _, key := range keys {
+		activeIDs[key.ID] = struct{}{}
+
+		queue := flowGroup.Queue(key.ID)
+		if queue == nil || queue.Len() == 0 {
+			continue
+		}
+
+		// Initialize counter for new flows to the current global minimum.
+		if _, exists := s.counters[key.ID]; !exists {
+			s.counters[key.ID] = globalMin
+		}
+
+		counter := s.counters[key.ID]
+		if counter < bestCounter {
+			bestCounter = counter
+			bestQueue = queue
+		}
+	}
+
+	if bestQueue == nil {
+		return nil, nil
+	}
+
+	// Advance the winner's counter: counter += cost / weight.
+	winnerID := bestQueue.FlowKey().ID
+	var cost float64
+	if head := bestQueue.PeekHead(); head != nil {
+		if req := head.OriginalRequest(); req != nil {
+			cost = float64(req.ByteSize())
+		}
+	}
+	s.counters[winnerID] += cost / p.weightFor(winnerID)
+
+	// Prune counters for flows no longer in the active set.
+	for id := range s.counters {
+		if _, active := activeIDs[id]; !active {
+			delete(s.counters, id)
+		}
+	}
+
+	// Normalize counters if any value exceeds the threshold.
+	normalizeCounters(s)
+
+	return bestQueue, nil
+}
+
+// weightFor returns the configured weight for the given flow ID, or the default weight.
+func (p *vtc) weightFor(flowID string) float64 {
+	if w, ok := p.weights[flowID]; ok {
+		return w
+	}
+	return p.defaultWeight
+}
+
+// normalizeCounters subtracts the global minimum from all counters when any counter exceeds the threshold.
+// This preserves relative differences while preventing unbounded growth.
+func normalizeCounters(s *vtcState) {
+	var maxCounter float64
+	for _, c := range s.counters {
+		if c > maxCounter {
+			maxCounter = c
+		}
+	}
+
+	if maxCounter <= normalizationThreshold {
+		return
+	}
+
+	minCounter := math.MaxFloat64
+	for _, c := range s.counters {
+		if c < minCounter {
+			minCounter = c
+		}
+	}
+
+	for id := range s.counters {
+		s.counters[id] -= minCounter
+	}
+}

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/vtc/vtc_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/vtc/vtc_test.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtc
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
+	frameworkmocks "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol/mocks"
+)
+
+func TestVTC_TypedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("my-vtc", nil)
+	require.NoError(t, err)
+	assert.Equal(t, VTCFairnessPolicyType, p.TypedName().Type)
+	assert.Equal(t, "my-vtc", p.TypedName().Name)
+}
+
+func TestVTC_TypedName_Default(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("", nil)
+	require.NoError(t, err)
+	assert.Equal(t, VTCFairnessPolicyType, p.TypedName().Name)
+}
+
+func TestVTC_Factory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		params    json.RawMessage
+		expectErr bool
+	}{
+		{
+			name:   "nil params uses defaults",
+			params: nil,
+		},
+		{
+			name:   "empty params uses defaults",
+			params: json.RawMessage{},
+		},
+		{
+			name:   "valid params",
+			params: json.RawMessage(`{"weights": {"a": 2.0}, "defaultWeight": 0.5}`),
+		},
+		{
+			name:   "zero defaultWeight gets corrected to 1.0",
+			params: json.RawMessage(`{"defaultWeight": 0}`),
+		},
+		{
+			name:      "invalid JSON",
+			params:    json.RawMessage(`{invalid`),
+			expectErr: true,
+		},
+		{
+			name:      "negative weight",
+			params:    json.RawMessage(`{"weights": {"a": -1.0}}`),
+			expectErr: true,
+		},
+		{
+			name:      "zero weight",
+			params:    json.RawMessage(`{"weights": {"a": 0}}`),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			plugin, err := VTCFairnessPolicyFactory("test", tc.params, nil)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, plugin)
+		})
+	}
+}
+
+// newMockQueueWithCost creates a mock queue with a head item of the given byte size.
+func newMockQueueWithCost(key flowcontrol.FlowKey, queueLen int, headByteSize uint64) *frameworkmocks.MockFlowQueueAccessor {
+	var peekHead flowcontrol.QueueItemAccessor
+	if queueLen > 0 {
+		peekHead = frameworkmocks.NewMockQueueItemAccessor(headByteSize, "req-"+key.ID, key)
+	}
+	return &frameworkmocks.MockFlowQueueAccessor{
+		LenV:      queueLen,
+		PeekHeadV: peekHead,
+		FlowKeyV:  key,
+	}
+}
+
+// buildBand creates a MockPriorityBandAccessor from a list of queues and a policy state.
+func buildBand(state any, queues ...*frameworkmocks.MockFlowQueueAccessor) *frameworkmocks.MockPriorityBandAccessor {
+	queueMap := make(map[string]*frameworkmocks.MockFlowQueueAccessor, len(queues))
+	keys := make([]flowcontrol.FlowKey, 0, len(queues))
+	for _, q := range queues {
+		queueMap[q.FlowKeyV.ID] = q
+		keys = append(keys, q.FlowKeyV)
+	}
+
+	return &frameworkmocks.MockPriorityBandAccessor{
+		PolicyStateV: state,
+		FlowKeysFunc: func() []flowcontrol.FlowKey { return keys },
+		QueueFunc: func(id string) flowcontrol.FlowQueueAccessor {
+			if q, ok := queueMap[id]; ok {
+				return q
+			}
+			return nil
+		},
+		IterateQueuesFunc: func(callback func(flow flowcontrol.FlowQueueAccessor) bool) {
+			for _, q := range queues {
+				if !callback(q) {
+					return
+				}
+			}
+		},
+	}
+}
+
+func TestVTC_Pick_NilBand(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+
+	q, err := p.Pick(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, q)
+}
+
+func TestVTC_Pick_EmptyBand(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	band := &frameworkmocks.MockPriorityBandAccessor{
+		PolicyStateV: state,
+		FlowKeysFunc: func() []flowcontrol.FlowKey { return nil },
+	}
+
+	q, err := p.Pick(context.Background(), band)
+	require.NoError(t, err)
+	assert.Nil(t, q)
+}
+
+func TestVTC_Pick_AllQueuesEmpty(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	qA := newMockQueueWithCost(flowcontrol.FlowKey{ID: "a"}, 0, 0)
+	qB := newMockQueueWithCost(flowcontrol.FlowKey{ID: "b"}, 0, 0)
+	band := buildBand(state, qA, qB)
+
+	q, err := p.Pick(context.Background(), band)
+	require.NoError(t, err)
+	assert.Nil(t, q)
+}
+
+func TestVTC_Pick_SingleFlow(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	qA := newMockQueueWithCost(keyA, 5, 100)
+	band := buildBand(state, qA)
+
+	q, err := p.Pick(context.Background(), band)
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	assert.Equal(t, "a", q.FlowKey().ID)
+}
+
+func TestVTC_Pick_LowestCounterSelected(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+
+	// Pre-seed counters: b has lower counter than a.
+	state := &vtcState{
+		counters: map[string]float64{
+			"a": 500,
+			"b": 100,
+		},
+	}
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	keyB := flowcontrol.FlowKey{ID: "b"}
+	qA := newMockQueueWithCost(keyA, 3, 100)
+	qB := newMockQueueWithCost(keyB, 3, 100)
+	band := buildBand(state, qA, qB)
+
+	q, err := p.Pick(context.Background(), band)
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	assert.Equal(t, "b", q.FlowKey().ID, "flow with lower counter should be selected")
+}
+
+func TestVTC_Pick_EqualWeightBalancedDistribution(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	keyB := flowcontrol.FlowKey{ID: "b"}
+
+	// Both flows send 100-byte requests with equal weight.
+	counts := map[string]int{"a": 0, "b": 0}
+
+	for range 20 {
+		qA := newMockQueueWithCost(keyA, 5, 100)
+		qB := newMockQueueWithCost(keyB, 5, 100)
+		band := buildBand(state, qA, qB)
+
+		q, err := p.Pick(context.Background(), band)
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		counts[q.FlowKey().ID]++
+	}
+
+	assert.Equal(t, 10, counts["a"], "equal-weight flows should each get half the dispatches")
+	assert.Equal(t, 10, counts["b"], "equal-weight flows should each get half the dispatches")
+}
+
+func TestVTC_Pick_HigherWeightGetsMoreTurns(t *testing.T) {
+	t.Parallel()
+
+	// Flow a: weight=2.0, flow b: weight=1.0, same request size (100 bytes).
+	// Per pick: a advances by 100/2=50, b advances by 100/1=100.
+	// Over 30 picks: a should get ~20, b should get ~10.
+	params := json.RawMessage(`{"weights": {"a": 2.0, "b": 1.0}}`)
+	p, err := newVTC("test", params)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	keyB := flowcontrol.FlowKey{ID: "b"}
+
+	counts := map[string]int{"a": 0, "b": 0}
+
+	for range 30 {
+		qA := newMockQueueWithCost(keyA, 5, 100)
+		qB := newMockQueueWithCost(keyB, 5, 100)
+		band := buildBand(state, qA, qB)
+
+		q, err := p.Pick(context.Background(), band)
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		counts[q.FlowKey().ID]++
+	}
+
+	assert.Equal(t, 20, counts["a"], "weight-2 flow should get 2/3 of dispatches")
+	assert.Equal(t, 10, counts["b"], "weight-1 flow should get 1/3 of dispatches")
+}
+
+func TestVTC_Pick_LargeRequestAdvancesCounterFaster(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	keyA := flowcontrol.FlowKey{ID: "a"} // 1000-byte requests
+	keyB := flowcontrol.FlowKey{ID: "b"} // 100-byte requests
+
+	counts := map[string]int{"a": 0, "b": 0}
+
+	for range 11 {
+		qA := newMockQueueWithCost(keyA, 5, 1000)
+		qB := newMockQueueWithCost(keyB, 5, 100)
+		band := buildBand(state, qA, qB)
+
+		q, err := p.Pick(context.Background(), band)
+		require.NoError(t, err)
+		require.NotNil(t, q)
+		counts[q.FlowKey().ID]++
+	}
+
+	// After a's first pick (counter=1000), b needs 10 picks of 100 to catch up.
+	// Then a picks again. Total: a=2, b=10 over 12 picks... but we only do 11.
+	// So: a=1, b=10.
+	assert.Equal(t, 1, counts["a"], "large-request flow should get fewer turns")
+	assert.Equal(t, 10, counts["b"], "small-request flow should get more turns")
+}
+
+func TestVTC_Pick_NewFlowJoinsAtMinCounter(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+
+	// Run a few picks for flow a to build up its counter.
+	for range 5 {
+		qA := newMockQueueWithCost(keyA, 5, 100)
+		band := buildBand(state, qA)
+
+		_, err := p.Pick(context.Background(), band)
+		require.NoError(t, err)
+	}
+
+	// Now add flow b. It should start at the current minimum (a's counter = 500).
+	// Both have counter=500, so the first (by sort order) wins. "a" < "b", so a wins.
+	// After a wins (counter=600), b's turn (counter=500 < 600).
+	keyB := flowcontrol.FlowKey{ID: "b"}
+
+	qA := newMockQueueWithCost(keyA, 5, 100)
+	qB := newMockQueueWithCost(keyB, 5, 100)
+	band := buildBand(state, qA, qB)
+
+	// First pick with both: a wins (tie-break by sort, a < b)
+	q, err := p.Pick(context.Background(), band)
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	assert.Equal(t, "a", q.FlowKey().ID)
+
+	// Second pick: b has counter=500, a has counter=600 -> b wins
+	qA = newMockQueueWithCost(keyA, 5, 100)
+	qB = newMockQueueWithCost(keyB, 5, 100)
+	band = buildBand(state, qA, qB)
+
+	q, err = p.Pick(context.Background(), band)
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	assert.Equal(t, "b", q.FlowKey().ID, "new flow should get a turn after joining at min counter")
+}
+
+func TestVTC_Pick_PrunesStaleCounters(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+
+	state := &vtcState{
+		counters: map[string]float64{
+			"a":     100,
+			"stale": 999,
+		},
+	}
+
+	// Only flow a is active now.
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	qA := newMockQueueWithCost(keyA, 5, 100)
+	band := buildBand(state, qA)
+
+	_, err = p.Pick(context.Background(), band)
+	require.NoError(t, err)
+
+	state.mu.Lock()
+	_, hasStale := state.counters["stale"]
+	state.mu.Unlock()
+
+	assert.False(t, hasStale, "counter for inactive flow should be pruned")
+}
+
+func TestVTC_Pick_CounterNormalization(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+
+	// Set counters near the normalization threshold.
+	state := &vtcState{
+		counters: map[string]float64{
+			"a": normalizationThreshold + 100,
+			"b": normalizationThreshold - 50,
+		},
+	}
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	keyB := flowcontrol.FlowKey{ID: "b"}
+	qA := newMockQueueWithCost(keyA, 5, 100)
+	qB := newMockQueueWithCost(keyB, 5, 100)
+	band := buildBand(state, qA, qB)
+
+	_, err = p.Pick(context.Background(), band)
+	require.NoError(t, err)
+
+	// After pick, b was selected (lower counter), its counter advanced by 100.
+	// Then normalization should subtract the new minimum from all counters.
+	state.mu.Lock()
+	for _, c := range state.counters {
+		assert.Less(t, c, normalizationThreshold, "counters should be normalized below threshold")
+	}
+	state.mu.Unlock()
+}
+
+func TestVTC_Pick_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	p, err := newVTC("test", nil)
+	require.NoError(t, err)
+	state := p.NewState(context.Background())
+
+	keyA := flowcontrol.FlowKey{ID: "a"}
+	keyB := flowcontrol.FlowKey{ID: "b"}
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	picksPerGoroutine := 50
+
+	for range numGoroutines {
+		wg.Go(func() {
+			for range picksPerGoroutine {
+				qA := newMockQueueWithCost(keyA, 5, 100)
+				qB := newMockQueueWithCost(keyB, 5, 100)
+				band := buildBand(state, qA, qB)
+
+				_, err := p.Pick(context.Background(), band)
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind feature

**What this PR does / why we need it**:

Add a new `vtc-fairness-policy` plugin that distributes dispatch opportunities proportionally based on cumulative request byte size per flow, addressing the inter-flow fairness gap identified in #1797.

Unlike round-robin (which treats all requests equally), VTC tracks a virtual counter per flow (`cost / weight`) so tenants sending large prompts don't starve tenants sending small ones.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixed part of #1797 

/cc @kfswain 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
