### PR TITLE
[Flow Control] Add FlowRegistryControlPlane interface for priority band reconciliation

### DIFF
--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -49,6 +49,7 @@ import (
 type FlowRegistry interface {
 	FlowRegistryObserver
 	FlowRegistryDataPlane
+	FlowRegistryControlPlane
 }
 
 // FlowRegistryObserver defines the read-only, observation interface for the registry.
@@ -58,6 +59,29 @@ type FlowRegistryObserver interface {
 
 	// ShardStats returns a near-consistent slice of statistics snapshots, one for each `RegistryShard`.
 	ShardStats() []ShardStats
+}
+
+// FlowRegistryControlPlane defines the control-plane interface for managing the registry's priority band topology.
+// It allows controllers (e.g., the InferenceObjective reconciler) to pre-provision priority bands ahead of data-plane
+// traffic, moving this responsibility out of the request hot path.
+//
+// # Conformance: Implementations MUST be goroutine-safe.
+type FlowRegistryControlPlane interface {
+	// ReconcilePriorities synchronizes the registry's set of priority bands to match the desired set of priorities.
+	//
+	// It performs a three-way diff against the current state:
+	//   - Priorities in `desiredPriorities` that do not exist in the registry are created using the DefaultPriorityBand
+	//     template.
+	//   - Priorities that exist in the registry but are NOT in `desiredPriorities` and were dynamically provisioned
+	//     (not part of the initial static configuration) are removed, along with all their associated resources
+	//     (queues, stats, shard state).
+	//   - Priorities that exist in both are left unchanged (no-op).
+	//
+	// This method is idempotent: calling it multiple times with the same set produces the same result.
+	//
+	// Note: Statically configured priority bands (those provided at registry construction via Config.PriorityBands) are
+	// never removed by this method, even if they are absent from `desiredPriorities`.
+	ReconcilePriorities(desiredPriorities []int)
 }
 
 // FlowRegistryDataPlane defines the high-throughput, request-path interface for the registry.

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -195,6 +195,7 @@ func (m *mockActiveFlowConnection) FlowKey() flowcontrol.FlowKey {
 type mockRegistryClient struct {
 	contracts.FlowRegistryObserver
 	contracts.FlowRegistryDataPlane
+	contracts.FlowRegistryControlPlane
 	WithConnectionFunc func(key flowcontrol.FlowKey, fn func(conn contracts.ActiveFlowConnection) error) error
 	ShardStatsFunc     func() []contracts.ShardStats
 }

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -105,6 +105,10 @@ type FlowRegistry struct {
 
 	mu    sync.RWMutex
 	shard *registryShard
+
+	// staticPriorities is the set of priority levels that were configured at construction time via Config.PriorityBands.
+	// These priorities are never removed by ReconcilePriorities. Protected by `mu`.
+	staticPriorities map[int]struct{}
 }
 
 var _ contracts.FlowRegistry = &FlowRegistry{}
@@ -137,7 +141,9 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 		fr.clock = &clock.RealClock{}
 	}
 
+	fr.staticPriorities = make(map[int]struct{}, len(cfg.PriorityBands))
 	for prio := range cfg.PriorityBands {
+		fr.staticPriorities[prio] = struct{}{}
 		fr.perPriorityBandStats.Store(prio, &bandStats{})
 	}
 
@@ -298,6 +304,52 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 func (fr *FlowRegistry) deletePriorityBand(priority int) {
 	fr.priorityBandStates.Delete(priority)           // Logical delete
 	fr.cleanupPriorityBandResources([]int{priority}) // Physical cleanup
+}
+
+// --- `contracts.FlowRegistryControlPlane` Implementation ---
+
+// ReconcilePriorities synchronizes the registry's priority bands to match the desired set of priorities.
+//
+// It creates bands that are in `desiredPriorities` but missing from the registry, and removes dynamically provisioned
+// bands that are no longer in `desiredPriorities`. Statically configured bands (those provided at construction) are
+// never removed.
+func (fr *FlowRegistry) ReconcilePriorities(desiredPriorities []int) {
+	desiredSet := make(map[int]struct{}, len(desiredPriorities))
+	for _, p := range desiredPriorities {
+		desiredSet[p] = struct{}{}
+	}
+
+	// Determine which bands to add and which to remove.
+	fr.mu.RLock()
+	var toAdd []int
+	for p := range desiredSet {
+		if _, exists := fr.config.PriorityBands[p]; !exists {
+			toAdd = append(toAdd, p)
+		}
+	}
+
+	var toRemove []int
+	for p := range fr.config.PriorityBands {
+		if _, desired := desiredSet[p]; !desired {
+			if _, isStatic := fr.staticPriorities[p]; !isStatic {
+				toRemove = append(toRemove, p)
+			}
+		}
+	}
+	fr.mu.RUnlock()
+
+	// Add missing bands.
+	for _, p := range toAdd {
+		if err := fr.ensurePriorityBand(p); err != nil {
+			fr.logger.Error(err, "Failed to provision priority band during reconciliation", "priority", p)
+		}
+	}
+
+	// Remove stale dynamic bands.
+	for _, p := range toRemove {
+		fr.logger.V(logging.DEFAULT).Info("Removing stale dynamic priority band during reconciliation", "priority", p)
+		fr.deletePriorityBand(p)
+	}
 }
 
 // --- `contracts.FlowRegistryObserver` Implementation ---

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -1224,3 +1224,187 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	assert.Equal(t, int32(concurrency), errorCount.Load(), "All requests should fail JIT provisioning")
 	assert.Equal(t, int32(0), successCount.Load(), "No request should succeed if JIT failed")
 }
+
+// --- ReconcilePriorities Tests ---
+
+func TestFlowRegistry_ReconcilePriorities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ShouldAddMissingPriorityBands", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+
+		newPrio := 50
+		h.fr.mu.RLock()
+		_, existsBefore := h.fr.config.PriorityBands[newPrio]
+		h.fr.mu.RUnlock()
+		require.False(t, existsBefore, "Priority band should not exist before reconciliation")
+
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, newPrio})
+
+		// Verify the new band was created.
+		h.fr.mu.RLock()
+		_, existsAfter := h.fr.config.PriorityBands[newPrio]
+		h.fr.mu.RUnlock()
+		assert.True(t, existsAfter, "Priority band should exist after reconciliation")
+
+		// Verify it exists on the registry shard.
+		h.fr.mu.RLock()
+		shard := h.fr.shard
+		h.fr.mu.RUnlock()
+		require.NotNil(t, shard)
+		_, err := shard.FairnessPolicy(newPrio)
+		assert.NoError(t, err, "New priority band must be provisioned on shard %s", shard.ID())
+
+		// Verify stats tracking is set up.
+		_, existsInStats := h.fr.perPriorityBandStats.Load(newPrio)
+		assert.True(t, existsInStats, "Stats tracking should be set up for the new band")
+	})
+
+	t.Run("ShouldRemoveStaleDynamicBands", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
+		dynamicPrio := 77
+
+		// First, provision a dynamic band via JIT.
+		key := flowcontrol.FlowKey{ID: "dynamic-flow", Priority: dynamicPrio}
+		h.openConnectionOnFlow(key)
+
+		h.fr.mu.RLock()
+		_, exists := h.fr.config.PriorityBands[dynamicPrio]
+		h.fr.mu.RUnlock()
+		require.True(t, exists, "Dynamic band should exist after JIT provisioning")
+
+		// Reconcile without the dynamic priority — it should be removed.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority})
+
+		h.fr.mu.RLock()
+		_, existsAfter := h.fr.config.PriorityBands[dynamicPrio]
+		h.fr.mu.RUnlock()
+		assert.False(t, existsAfter, "Dynamic band should be removed by reconciliation")
+
+		// Verify removed from stats.
+		_, existsInStats := h.fr.perPriorityBandStats.Load(dynamicPrio)
+		assert.False(t, existsInStats, "Stats tracking should be removed for the deleted band")
+	})
+
+	t.Run("ShouldNeverRemoveStaticBands", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+
+		// Reconcile with an empty set — static bands must survive.
+		h.fr.ReconcilePriorities([]int{})
+
+		h.fr.mu.RLock()
+		_, highExists := h.fr.config.PriorityBands[highPriority]
+		_, lowExists := h.fr.config.PriorityBands[lowPriority]
+		h.fr.mu.RUnlock()
+
+		assert.True(t, highExists, "Static high priority band must never be removed by ReconcilePriorities")
+		assert.True(t, lowExists, "Static low priority band must never be removed by ReconcilePriorities")
+	})
+
+	t.Run("ShouldBeNoOp_WhenDesiredMatchesCurrent", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+
+		// Reconcile with exactly the existing static bands.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority})
+
+		h.fr.mu.RLock()
+		bandCount := len(h.fr.config.PriorityBands)
+		h.fr.mu.RUnlock()
+
+		assert.Equal(t, 2, bandCount, "No bands should be added or removed when desired matches current")
+	})
+
+	t.Run("ShouldBeIdempotent", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		newPrio := 42
+
+		desired := []int{highPriority, lowPriority, newPrio}
+
+		// Call multiple times.
+		h.fr.ReconcilePriorities(desired)
+		h.fr.ReconcilePriorities(desired)
+		h.fr.ReconcilePriorities(desired)
+
+		h.fr.mu.RLock()
+		bandCount := len(h.fr.config.PriorityBands)
+		_, exists := h.fr.config.PriorityBands[newPrio]
+		h.fr.mu.RUnlock()
+
+		assert.Equal(t, 3, bandCount, "Repeated reconciliation should not create duplicate bands")
+		assert.True(t, exists, "Band should exist after repeated reconciliation")
+	})
+
+	t.Run("ShouldAddAndRemoveInSingleCall", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		dynOld := 60
+		dynNew := 70
+
+		// Pre-provision a dynamic band.
+		err := h.fr.ensurePriorityBand(dynOld)
+		require.NoError(t, err)
+		h.fr.mu.RLock()
+		_, oldExists := h.fr.config.PriorityBands[dynOld]
+		h.fr.mu.RUnlock()
+		require.True(t, oldExists)
+
+		// Reconcile: remove dynOld, add dynNew.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, dynNew})
+
+		h.fr.mu.RLock()
+		_, oldExistsAfter := h.fr.config.PriorityBands[dynOld]
+		_, newExistsAfter := h.fr.config.PriorityBands[dynNew]
+		h.fr.mu.RUnlock()
+
+		assert.False(t, oldExistsAfter, "Old dynamic band should be removed")
+		assert.True(t, newExistsAfter, "New dynamic band should be created")
+	})
+
+	t.Run("ShouldHandleEmptyDesiredSet", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+		dynPrio := 99
+
+		// Pre-provision a dynamic band.
+		err := h.fr.ensurePriorityBand(dynPrio)
+		require.NoError(t, err)
+
+		// Reconcile with empty set — only static bands should remain.
+		h.fr.ReconcilePriorities([]int{})
+
+		h.fr.mu.RLock()
+		_, dynExists := h.fr.config.PriorityBands[dynPrio]
+		_, highExists := h.fr.config.PriorityBands[highPriority]
+		_, lowExists := h.fr.config.PriorityBands[lowPriority]
+		bandCount := len(h.fr.config.PriorityBands)
+		h.fr.mu.RUnlock()
+
+		assert.False(t, dynExists, "Dynamic band should be removed")
+		assert.True(t, highExists, "Static high band should survive")
+		assert.True(t, lowExists, "Static low band should survive")
+		assert.Equal(t, 2, bandCount, "Only static bands should remain")
+	})
+
+	t.Run("ShouldHandleNilDesiredSet", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+
+		// Reconcile with nil — same as empty, only static bands remain.
+		require.NotPanics(t, func() {
+			h.fr.ReconcilePriorities(nil)
+		})
+
+		h.fr.mu.RLock()
+		_, highExists := h.fr.config.PriorityBands[highPriority]
+		_, lowExists := h.fr.config.PriorityBands[lowPriority]
+		h.fr.mu.RUnlock()
+
+		assert.True(t, highExists, "Static high band should survive")
+		assert.True(t, lowExists, "Static low band should survive")
+	})
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind feature

**What this PR does / why we need it**:
Adds a control-plane API to the FlowRegistry, enabling controllers to pre-provision and reconcile priority bands outside the request hot path.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixed part of #2011 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
