### PR TITLE
[Flow Control] Drive priority band lifecycle from InferenceObjective controller

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -337,6 +337,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	// --- Admission Control Initialization ---
 	var admissionController requestcontrol.AdmissionController
 	var endpointCandidates contracts.EndpointCandidates
+	var flowControlPlane contracts.FlowRegistryControlPlane
 	endpointCandidates = requestcontrol.NewDatastoreEndpointCandidates(ds, requestcontrol.WithDisableEndpointSubsetFilter(opts.DisableEndpointSubsetFilter))
 	if r.featureGates[flowcontrol.FeatureGate] {
 		endpointCandidates = requestcontrol.NewCachedEndpointCandidates(ctx, endpointCandidates, time.Millisecond*50)
@@ -360,6 +361,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 			return nil, nil, fmt.Errorf("failed to initialize Flow Controller: %w", err)
 		}
 		go registry.Run(ctx)
+		flowControlPlane = registry
 		admissionController = requestcontrol.NewFlowControlAdmissionController(fc, opts.PoolName)
 	} else {
 		setupLog.Info("Experimental Flow Control layer is disabled, using legacy admission control")
@@ -383,6 +385,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		Parser:                           r.parser,
 		SaturationDetector:               eppConfig.SaturationDetector,
 		UseExperimentalDatalayerV2:       r.featureGates[datalayer.ExperimentalDatalayerFeatureGate] || !r.featureGates[datalayer.EnableLegacyMetricsFeatureGate],
+		FlowControlPlane:                 flowControlPlane,
 	}
 
 	if err := serverRunner.SetupWithManager(mgr); err != nil {

--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -31,12 +31,17 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/common"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 )
 
 type InferenceObjectiveReconciler struct {
 	client.Reader
 	Datastore datastore.Datastore
 	PoolGKNN  common.GKNN
+	// FlowControlPlane is an optional dependency for pre-provisioning priority bands.
+	// When non-nil, the reconciler calls ReconcilePriorities after every objective change.
+	// This is nil when the Flow Control feature gate is disabled.
+	FlowControlPlane contracts.FlowRegistryControlPlane
 }
 
 func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -57,15 +62,42 @@ func (c *InferenceObjectiveReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if notFound || !infObjective.DeletionTimestamp.IsZero() || infObjective.Spec.PoolRef.Name != v1alpha2.ObjectName(c.PoolGKNN.Name) || infObjective.Spec.PoolRef.Group != v1alpha2.Group(c.PoolGKNN.Group) {
 		// InferenceObjective object got deleted or changed the referenced inferencePool.
 		c.Datastore.ObjectiveDelete(req.NamespacedName)
+		c.reconcilePriorityBands()
 		return ctrl.Result{}, nil
 	}
 
 	// Add or update if the InferenceObjective instance has a creation timestamp older than the existing entry of the model.
 	logger = logger.WithValues("poolRef", infObjective.Spec.PoolRef)
 	c.Datastore.ObjectiveSet(infObjective)
+	c.reconcilePriorityBands()
 	logger.Info("Added/Updated InferenceObjective")
 
 	return ctrl.Result{}, nil
+}
+
+// reconcilePriorityBands collects all distinct priorities from current InferenceObjectives and
+// pre-provisions the corresponding priority bands in the FlowRegistry.
+func (c *InferenceObjectiveReconciler) reconcilePriorityBands() {
+	if c.FlowControlPlane == nil {
+		return
+	}
+
+	objectives := c.Datastore.ObjectiveGetAll()
+	seen := make(map[int]struct{}, len(objectives))
+	for _, obj := range objectives {
+		p := 0
+		if obj.Spec.Priority != nil {
+			p = *obj.Spec.Priority
+		}
+		seen[p] = struct{}{}
+	}
+
+	priorities := make([]int, 0, len(seen))
+	for p := range seen {
+		priorities = append(priorities, p)
+	}
+
+	c.FlowControlPlane.ReconcilePriorities(priorities)
 }
 
 func (c *InferenceObjectiveReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -18,10 +18,14 @@ package controller
 
 import (
 	"context"
+	"sort"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -205,4 +209,141 @@ func TestInferenceObjectiveReconciler(t *testing.T) {
 			})
 		}
 	}
+}
+
+// --- FlowControlPlane Integration Tests ---
+
+// mockFlowControlPlane records calls to ReconcilePriorities.
+type mockFlowControlPlane struct {
+	mu             sync.Mutex
+	callCount      int
+	lastPriorities []int
+}
+
+func (m *mockFlowControlPlane) ReconcilePriorities(priorities []int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	m.lastPriorities = make([]int, len(priorities))
+	copy(m.lastPriorities, priorities)
+	sort.Ints(m.lastPriorities)
+}
+
+func (m *mockFlowControlPlane) getCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+func (m *mockFlowControlPlane) getLastPriorities() []int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]int, len(m.lastPriorities))
+	copy(result, m.lastPriorities)
+	return result
+}
+
+func TestInferenceObjectiveReconciler_FlowControlPlane(t *testing.T) {
+	newReconciler := func(t *testing.T, fakeClient client.Client, ds datastore.Datastore, fcp *mockFlowControlPlane) *InferenceObjectiveReconciler {
+		t.Helper()
+		reconciler := &InferenceObjectiveReconciler{
+			Reader:    fakeClient,
+			Datastore: ds,
+			PoolGKNN: common.GKNN{
+				NamespacedName: types.NamespacedName{Name: inferencePool.Name, Namespace: inferencePool.Namespace},
+				GroupKind:      schema.GroupKind{Group: inferencePool.GroupVersionKind().Group, Kind: inferencePool.GroupVersionKind().Kind},
+			},
+		}
+		if fcp != nil {
+			reconciler.FlowControlPlane = fcp
+		}
+		return reconciler
+	}
+
+	newFakeClient := func(t *testing.T, objs ...client.Object) client.Client {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		_ = clientgoscheme.AddToScheme(scheme)
+		_ = v1alpha2.Install(scheme)
+		_ = v1.Install(scheme)
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	}
+
+	t.Run("ShouldCallReconcilePriorities_OnObjectiveSet", func(t *testing.T) {
+		fcp := &mockFlowControlPlane{}
+		ds := datastore.NewDatastore(t.Context(), backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, time.Second), 0)
+		endpointPool := poolutil.InferencePoolToEndpointPool(inferencePool)
+		_ = ds.PoolSet(context.Background(), newFakeClient(t), endpointPool)
+
+		fakeClient := newFakeClient(t, infObjective1)
+		reconciler := newReconciler(t, fakeClient, ds, fcp)
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: infObjective1.Name, Namespace: infObjective1.Namespace},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, fcp.getCallCount(), "ReconcilePriorities should be called once")
+		assert.Equal(t, []int{1}, fcp.getLastPriorities(), "Should reconcile with the objective's priority")
+	})
+
+	t.Run("ShouldCallReconcilePriorities_OnObjectiveDelete", func(t *testing.T) {
+		fcp := &mockFlowControlPlane{}
+		ds := datastore.NewDatastore(t.Context(), backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, time.Second), 0)
+		endpointPool := poolutil.InferencePoolToEndpointPool(inferencePool)
+		_ = ds.PoolSet(context.Background(), newFakeClient(t), endpointPool)
+
+		// Pre-populate the store with objective1.
+		ds.ObjectiveSet(infObjective1)
+
+		// Simulate a delete: the objective is not in the API server.
+		fakeClient := newFakeClient(t)
+		reconciler := newReconciler(t, fakeClient, ds, fcp)
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: infObjective1.Name, Namespace: infObjective1.Namespace},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, fcp.getCallCount(), "ReconcilePriorities should be called once on delete")
+		assert.Equal(t, []int{}, fcp.getLastPriorities(), "Should reconcile with empty priorities after last objective deleted")
+	})
+
+	t.Run("ShouldNotPanic_WhenFlowControlPlaneIsNil", func(t *testing.T) {
+		ds := datastore.NewDatastore(t.Context(), backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, time.Second), 0)
+		endpointPool := poolutil.InferencePoolToEndpointPool(inferencePool)
+		_ = ds.PoolSet(context.Background(), newFakeClient(t), endpointPool)
+
+		fakeClient := newFakeClient(t, infObjective1)
+		reconciler := newReconciler(t, fakeClient, ds, nil) // No FlowControlPlane
+
+		require.NotPanics(t, func() {
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: infObjective1.Name, Namespace: infObjective1.Namespace},
+			})
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("ShouldReconcileWithAllPriorities_WhenMultipleObjectivesExist", func(t *testing.T) {
+		fcp := &mockFlowControlPlane{}
+		ds := datastore.NewDatastore(t.Context(), backendmetrics.NewPodMetricsFactory(&backendmetrics.FakePodMetricsClient{}, time.Second), 0)
+		endpointPool := poolutil.InferencePoolToEndpointPool(inferencePool)
+		_ = ds.PoolSet(context.Background(), newFakeClient(t), endpointPool)
+
+		// Pre-populate with objective1 (priority 1).
+		ds.ObjectiveSet(infObjective1)
+
+		// Add objective2 (no priority → defaults to 0).
+		fakeClient := newFakeClient(t, infObjective2)
+		reconciler := newReconciler(t, fakeClient, ds, fcp)
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: infObjective2.Name, Namespace: infObjective2.Namespace},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, fcp.getCallCount(), "ReconcilePriorities should be called once")
+		assert.Equal(t, []int{0, 1}, fcp.getLastPriorities(), "Should reconcile with priorities from all objectives")
+	})
 }

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -49,6 +49,7 @@ import (
 type FlowRegistry interface {
 	FlowRegistryObserver
 	FlowRegistryDataPlane
+	FlowRegistryControlPlane
 }
 
 // FlowRegistryObserver defines the read-only, observation interface for the registry.
@@ -58,6 +59,29 @@ type FlowRegistryObserver interface {
 
 	// ShardStats returns a near-consistent slice of statistics snapshots, one for each `RegistryShard`.
 	ShardStats() []ShardStats
+}
+
+// FlowRegistryControlPlane defines the control-plane interface for managing the registry's priority band topology.
+// It allows controllers (e.g., the InferenceObjective reconciler) to pre-provision priority bands ahead of data-plane
+// traffic, moving this responsibility out of the request hot path.
+//
+// # Conformance: Implementations MUST be goroutine-safe.
+type FlowRegistryControlPlane interface {
+	// ReconcilePriorities synchronizes the registry's set of priority bands to match the desired set of priorities.
+	//
+	// It performs a three-way diff against the current state:
+	//   - Priorities in `desiredPriorities` that do not exist in the registry are created using the DefaultPriorityBand
+	//     template.
+	//   - Priorities that exist in the registry but are NOT in `desiredPriorities` and were dynamically provisioned
+	//     (not part of the initial static configuration) are removed, along with all their associated resources
+	//     (queues, stats, shard state).
+	//   - Priorities that exist in both are left unchanged (no-op).
+	//
+	// This method is idempotent: calling it multiple times with the same set produces the same result.
+	//
+	// Note: Statically configured priority bands (those provided at registry construction via Config.PriorityBands) are
+	// never removed by this method, even if they are absent from `desiredPriorities`.
+	ReconcilePriorities(desiredPriorities []int)
 }
 
 // FlowRegistryDataPlane defines the high-throughput, request-path interface for the registry.

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -195,6 +195,7 @@ func (m *mockActiveFlowConnection) FlowKey() flowcontrol.FlowKey {
 type mockRegistryClient struct {
 	contracts.FlowRegistryObserver
 	contracts.FlowRegistryDataPlane
+	contracts.FlowRegistryControlPlane
 	WithConnectionFunc func(key flowcontrol.FlowKey, fn func(conn contracts.ActiveFlowConnection) error) error
 	ShardStatsFunc     func() []contracts.ShardStats
 }

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -187,7 +187,8 @@ func (fr *FlowRegistry) Run(ctx context.Context) {
 // This method relies on an atomic leasing mechanism, ensuring that active flows are never garbage collected while
 // requests are in flight.
 //
-// If the flow does not exist, it is provisioned Just-In-Time (JIT).
+// If the flow does not exist, it is provisioned on-demand. The priority band for the flow MUST already exist
+// (pre-provisioned by ReconcilePriorities); otherwise, the method returns ErrPriorityBandNotFound.
 //
 // When a NEW flow is created, this method also increments the corresponding priority band's lease count,
 // establishing the invariant: bandState.leaseCount = number of active flows at this priority.
@@ -216,7 +217,7 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 	}
 	defer state.unpin(fr.clock.Now())
 
-	// 2. JIT provisioning: Ensure physical resources exist on shards.
+	// 2. Flow provisioning: Ensure physical resources exist on shards.
 	// We use sync.Once to ensure we only pay the initialization cost (building components, locking shards) exactly once
 	// per flowState object.
 	state.initialized.Do(func() {
@@ -236,7 +237,7 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 			}
 		}
 
-		return fmt.Errorf("failed to provision JIT flow resources: %w", state.initErr)
+		return fmt.Errorf("failed to provision flow resources: %w", state.initErr)
 	}
 
 	// 3. Execute callback.
@@ -244,25 +245,14 @@ func (fr *FlowRegistry) WithConnection(key flowcontrol.FlowKey, fn func(conn con
 	return fn(&connection{registry: fr, key: key})
 }
 
-// ensureFlowInfrastructure guarantees that the Priority Band exists and that the flow's queues are synchronized across
-// all active shards.
+// ensureFlowInfrastructure guarantees that the flow's queues are synchronized across all active shards.
+//
+// The Priority Band for the flow's priority level MUST already exist (pre-provisioned by the control plane via
+// ReconcilePriorities). If it does not, this method returns ErrPriorityBandNotFound.
 //
 // NOTE: The caller (WithConnection) must already hold a lease on the priority band to prevent GC during this operation.
 func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error {
-	// 1. Ensure Priority Band exists.
-	fr.mu.RLock()
-	_, exists := fr.config.PriorityBands[key.Priority]
-	fr.mu.RUnlock()
-
-	if !exists {
-		if err := fr.ensurePriorityBand(key.Priority); err != nil {
-			return err
-		}
-	}
-
-	// Now we know the band exists (or we errored). Re-acquire Read Lock to safely read the topology and build components.
-
-	// 2. Synchronize shards.
+	// Synchronize shards.
 	// Acquire Read Lock to iterate the shard topology safely.
 	fr.mu.RLock()
 	defer fr.mu.RUnlock()
@@ -276,7 +266,7 @@ func (fr *FlowRegistry) ensureFlowInfrastructure(key flowcontrol.FlowKey) error 
 		shard.synchronizeFlow(key, components[i].policy, components[i].queue)
 	}
 
-	fr.logger.V(logging.DEBUG).Info("JIT provisioned flow infrastructure", "flowKey", key)
+	fr.logger.V(logging.DEBUG).Info("Provisioned flow infrastructure", "flowKey", key)
 	return nil
 }
 

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -110,6 +110,10 @@ type FlowRegistry struct {
 	drainingShards map[string]*registryShard
 	allShards      []*registryShard // Cached, sorted combination of Active and Draining shards
 	nextShardID    uint64
+
+	// staticPriorities is the set of priority levels that were configured at construction time via Config.PriorityBands.
+	// These priorities are never removed by ReconcilePriorities. Protected by `mu`.
+	staticPriorities map[int]struct{}
 }
 
 var _ contracts.FlowRegistry = &FlowRegistry{}
@@ -144,7 +148,9 @@ func NewFlowRegistry(config *Config, logger logr.Logger, opts ...RegistryOption)
 		fr.clock = &clock.RealClock{}
 	}
 
+	fr.staticPriorities = make(map[int]struct{}, len(cfg.PriorityBands))
 	for prio := range cfg.PriorityBands {
+		fr.staticPriorities[prio] = struct{}{}
 		fr.perPriorityBandStats.Store(prio, &bandStats{})
 	}
 
@@ -309,6 +315,52 @@ func (fr *FlowRegistry) ensurePriorityBand(priority int) error {
 func (fr *FlowRegistry) deletePriorityBand(priority int) {
 	fr.priorityBandStates.Delete(priority)           // Logical delete
 	fr.cleanupPriorityBandResources([]int{priority}) // Physical cleanup
+}
+
+// --- `contracts.FlowRegistryControlPlane` Implementation ---
+
+// ReconcilePriorities synchronizes the registry's priority bands to match the desired set of priorities.
+//
+// It creates bands that are in `desiredPriorities` but missing from the registry, and removes dynamically provisioned
+// bands that are no longer in `desiredPriorities`. Statically configured bands (those provided at construction) are
+// never removed.
+func (fr *FlowRegistry) ReconcilePriorities(desiredPriorities []int) {
+	desiredSet := make(map[int]struct{}, len(desiredPriorities))
+	for _, p := range desiredPriorities {
+		desiredSet[p] = struct{}{}
+	}
+
+	// Determine which bands to add and which to remove.
+	fr.mu.RLock()
+	var toAdd []int
+	for p := range desiredSet {
+		if _, exists := fr.config.PriorityBands[p]; !exists {
+			toAdd = append(toAdd, p)
+		}
+	}
+
+	var toRemove []int
+	for p := range fr.config.PriorityBands {
+		if _, desired := desiredSet[p]; !desired {
+			if _, isStatic := fr.staticPriorities[p]; !isStatic {
+				toRemove = append(toRemove, p)
+			}
+		}
+	}
+	fr.mu.RUnlock()
+
+	// Add missing bands.
+	for _, p := range toAdd {
+		if err := fr.ensurePriorityBand(p); err != nil {
+			fr.logger.Error(err, "Failed to provision priority band during reconciliation", "priority", p)
+		}
+	}
+
+	// Remove stale dynamic bands.
+	for _, p := range toRemove {
+		fr.logger.V(logging.DEFAULT).Info("Removing stale dynamic priority band during reconciliation", "priority", p)
+		fr.deletePriorityBand(p)
+	}
 }
 
 // --- `contracts.FlowRegistryObserver` Implementation ---

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -516,40 +516,56 @@ func TestFlowRegistry_UpdateShardCount(t *testing.T) {
 func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ShouldCreateBand_WhenPriorityIsUnknown", func(t *testing.T) {
+	t.Run("ShouldRejectFlow_WhenPriorityBandNotProvisioned", func(t *testing.T) {
 		t.Parallel()
-		// Start with 2 shards to ensure propagation works across the cluster.
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		unknownPrio := 55
+		key := flowcontrol.FlowKey{ID: "unknown-prio-flow", Priority: unknownPrio}
+
+		// Without pre-provisioning the band, WithConnection must fail.
+		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
+			t.Fatal("Callback must not be executed when the priority band does not exist")
+			return nil
+		})
+		require.Error(t, err, "WithConnection must fail for an unknown priority")
+		assert.ErrorIs(t, err, contracts.ErrPriorityBandNotFound,
+			"The error must indicate that the priority band was not found")
+	})
+
+	t.Run("ShouldSucceed_WhenBandPreProvisionedViaReconcile", func(t *testing.T) {
+		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
 		dynamicPrio := 55
 		key := flowcontrol.FlowKey{ID: "dynamic-flow", Priority: dynamicPrio}
 
-		// Connect with a new priority.
+		// Pre-provision the band via the control-plane API.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, dynamicPrio})
+
 		err := h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error {
 			return nil
 		})
-		require.NoError(t, err, "WithConnection should succeed for dynamic priority")
+		require.NoError(t, err, "WithConnection should succeed after band is pre-provisioned")
 
 		h.fr.mu.RLock()
 		_, existsInConfig := h.fr.config.PriorityBands[dynamicPrio]
 		h.fr.mu.RUnlock()
-		assert.True(t, existsInConfig, "Dynamic priority must be added to global config definition")
-
-		stats := h.fr.Stats()
-		_, existsInStats := stats.PerPriorityBandStats[dynamicPrio]
-		assert.True(t, existsInStats, "Dynamic priority must appear in global stats")
+		assert.True(t, existsInConfig, "Pre-provisioned priority must exist in global config")
 
 		for _, shard := range h.fr.activeShards {
 			_, err := shard.ManagedQueue(key)
-			assert.NoError(t, err, "Dynamic band must be provisioned on shard %s", shard.ID())
+			assert.NoError(t, err, "Flow must be provisioned on shard %s", shard.ID())
 		}
 	})
 
-	t.Run("ShouldHandleConcurrentDynamicCreation", func(t *testing.T) {
+	t.Run("ShouldHandleConcurrentConnections_OnPreProvisionedBand", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
 		dynamicPrio := 77
-		key := flowcontrol.FlowKey{ID: "race-flow", Priority: dynamicPrio}
 
+		// Pre-provision the band.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, dynamicPrio})
+
+		key := flowcontrol.FlowKey{ID: "race-flow", Priority: dynamicPrio}
 		var wg sync.WaitGroup
 		concurrency := 10
 		wg.Add(concurrency)
@@ -557,7 +573,6 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		for range concurrency {
 			go func() {
 				defer wg.Done()
-				// Everyone tries to trigger provisioning simultaneously.
 				_ = h.fr.WithConnection(key, func(conn contracts.ActiveFlowConnection) error { return nil })
 			}()
 		}
@@ -566,16 +581,17 @@ func TestFlowRegistry_DynamicProvisioning(t *testing.T) {
 		h.fr.mu.RLock()
 		_, exists := h.fr.config.PriorityBands[dynamicPrio]
 		h.fr.mu.RUnlock()
-		assert.True(t, exists, "Band should exist after concurrent creation attempts")
+		assert.True(t, exists, "Band should exist after concurrent connection attempts")
 	})
 
-	t.Run("ShouldPersistDynamicBands_AcrossScalingEvents", func(t *testing.T) {
+	t.Run("ShouldPersistPreProvisionedBands_AcrossScalingEvents", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 1})
 		dynamicPrio := 88
 		key := flowcontrol.FlowKey{ID: "scaling-flow", Priority: dynamicPrio}
 
-		// Create dynamic band on Shard 0.
+		// Pre-provision band and create a flow on Shard 0.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, dynamicPrio})
 		h.openConnectionOnFlow(key)
 
 		// Scale Up -> Shard 1 created.
@@ -769,20 +785,25 @@ func TestFlowRegistry_Concurrency(t *testing.T) {
 		assert.Equal(t, numWorkers*opsPerWorker, flowCount, "All concurrently registered flows must be present")
 	})
 
-	t.Run("ConcurrentDynamicBandProvisioning_WithGC", func(t *testing.T) {
+	t.Run("ConcurrentBandProvisioning_WithGC", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{})
 
 		const (
 			numWorkers    = 10
-			numPriorities = 20 // Create 20 different dynamic bands
+			numPriorities = 20 // Use 20 different pre-provisioned bands
 			opsPerWorker  = 10
 		)
+
+		// Pre-provision all dynamic bands before starting concurrent work.
+		for j := range numPriorities {
+			require.NoError(t, h.fr.ensurePriorityBand(100+j))
+		}
 
 		var wg sync.WaitGroup
 		wg.Add(numWorkers + 1) // +1 for GC goroutine
 
-		// Workers: Create flows at random priorities
+		// Workers: Create flows at pre-provisioned priorities
 		for i := range numWorkers {
 			go func() {
 				defer wg.Done()
@@ -799,24 +820,6 @@ func TestFlowRegistry_Concurrency(t *testing.T) {
 				}
 			}()
 		}
-
-		// Wait for at least one band to be created.
-		require.Eventually(t, func() bool {
-			count := 0
-			h.fr.priorityBandStates.Range(func(_, _ any) bool {
-				count++
-				return true
-			})
-			return count > 0
-		}, 5*time.Second, 10*time.Millisecond, "Dynamic bands should be created")
-
-		// Check bands were created before GC collects them all
-		bandCount := 0
-		h.fr.priorityBandStates.Range(func(_, _ any) bool {
-			bandCount++
-			return true
-		})
-		require.True(t, bandCount > 0, "Dynamic bands should be created during concurrent workload")
 
 		// GC Worker: Constantly running GC cycles
 		go func() {
@@ -956,7 +959,8 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 
-		// Create dynamic band via JIT provisioning
+		// Pre-provision the dynamic band and create a flow.
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		h.openConnectionOnFlow(key)
 
 		// Verify band exists
@@ -1009,8 +1013,11 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 
-		// Create 3 dynamic bands
+		// Pre-provision 3 dynamic bands and create flows.
 		prio1, prio2, prio3 := 101, 102, 103
+		require.NoError(t, h.fr.ensurePriorityBand(prio1))
+		require.NoError(t, h.fr.ensurePriorityBand(prio2))
+		require.NoError(t, h.fr.ensurePriorityBand(prio3))
 		h.openConnectionOnFlow(flowcontrol.FlowKey{ID: "flow-1", Priority: prio1})
 		h.openConnectionOnFlow(flowcontrol.FlowKey{ID: "flow-2", Priority: prio2})
 		h.openConnectionOnFlow(flowcontrol.FlowKey{ID: "flow-3", Priority: prio3})
@@ -1048,7 +1055,8 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 3})
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 
-		// Create flow on all shards
+		// Pre-provision the dynamic band and create a flow.
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		h.openConnectionOnFlow(key)
 
 		// Verify band exists on all shards
@@ -1094,7 +1102,8 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 
-		// Create and collect flow (band becomes empty)
+		// Pre-provision the dynamic band, create and collect flow (band becomes empty).
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		h.openConnectionOnFlow(key)
 		h.fakeClock.Step(h.config.FlowGCTimeout + time.Second)
 		h.fr.executeGCCycle()
@@ -1136,7 +1145,7 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		assert.False(t, isIdle, "Band should not be idle when it has flows")
 	})
 
-	t.Run("ShouldReleaseBandLease_OnJITFailure", func(t *testing.T) {
+	t.Run("ShouldReleaseBandLease_OnProvisioningFailure", func(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 
@@ -1180,7 +1189,8 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 
-		// Create 3 flows at the same priority
+		// Pre-provision the dynamic band and create 3 flows at the same priority.
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		key1 := flowcontrol.FlowKey{ID: "flow-1", Priority: dynamicPrio}
 		key2 := flowcontrol.FlowKey{ID: "flow-2", Priority: dynamicPrio}
 		key3 := flowcontrol.FlowKey{ID: "flow-3", Priority: dynamicPrio}
@@ -1237,7 +1247,8 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 
-		// Create 3 flows at the same priority
+		// Pre-provision the dynamic band and create 3 flows at the same priority.
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		key1 := flowcontrol.FlowKey{ID: "flow-1", Priority: dynamicPrio}
 		key2 := flowcontrol.FlowKey{ID: "flow-2", Priority: dynamicPrio}
 		key3 := flowcontrol.FlowKey{ID: "flow-3", Priority: dynamicPrio}
@@ -1321,6 +1332,8 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 		t.Parallel()
 		h := newRegistryTestHarness(t, harnessOptions{manualGC: true})
 
+		// Pre-provision the dynamic band.
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		key := flowcontrol.FlowKey{ID: "test-flow", Priority: dynamicPrio}
 		h.openConnectionOnFlow(key)
 
@@ -1370,14 +1383,14 @@ func TestFlowRegistry_PriorityBandGarbageCollection(t *testing.T) {
 	})
 }
 
-// TestFlowRegistry_JITErrorScoping ensures that JIT provisioning errors are correctly propagated to all concurrent
-// requests waiting on the same flow initialization.
-func TestFlowRegistry_JITErrorScoping(t *testing.T) {
+// TestFlowRegistry_ProvisioningErrorScoping ensures that flow provisioning errors are correctly propagated to all
+// concurrent requests waiting on the same flow initialization.
+func TestFlowRegistry_ProvisioningErrorScoping(t *testing.T) {
 	t.Parallel()
 	handle := newTestPluginsHandle(t)
 
 	// Create a registry with a capability checker that passes validation but using a queue name that doesn't exist.
-	// This ensures NewConfig succeeds, but JIT (ensureFlowInfrastructure) fails when trying to instantiate the queue.
+	// This ensures NewConfig succeeds, but ensureFlowInfrastructure fails when trying to instantiate the queue.
 	failQueueName := queue.RegisteredQueueName("NonExistentQueue")
 	mockChecker := &mockCapabilityChecker{
 		checkCompatibilityFunc: func(p flowcontrol.OrderingPolicy, q queue.RegisteredQueueName) error {
@@ -1396,16 +1409,16 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	registry, err := NewFlowRegistry(cfg, logr.Discard())
 	require.NoError(t, err)
 
+	// Pre-provision the band (using the bad default template) so the band exists but has a broken queue config.
+	require.NoError(t, registry.ensurePriorityBand(100))
+
 	key := flowcontrol.FlowKey{
-		Priority: 100, // Dynamic, will trigger ensurePriorityBand
+		Priority: 100,
 		ID:       "flow-should-fail",
 	}
 
 	// Simulate contention:
-	// We acquire the registry RLock.
-	// JIT provisioning (dynamic band) requires registry Lock (Write Lock).
-	// So the first thread to reach ensurePriorityBand will block until we release this lock.
-	// All other threads will pile up behind it on sync.Once.
+	// We acquire the registry RLock so all goroutines block in ensureFlowInfrastructure until we release.
 	registry.mu.RLock()
 
 	const concurrency = 10
@@ -1442,8 +1455,8 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	wg.Wait()
 
 	// Assertion: all requests should fail.
-	assert.Equal(t, int32(concurrency), errorCount.Load(), "All requests should fail JIT provisioning")
-	assert.Equal(t, int32(0), successCount.Load(), "No request should succeed if JIT failed")
+	assert.Equal(t, int32(concurrency), errorCount.Load(), "All requests should fail provisioning")
+	assert.Equal(t, int32(0), successCount.Load(), "No request should succeed if provisioning failed")
 }
 
 // --- ReconcilePriorities Tests ---
@@ -1487,7 +1500,8 @@ func TestFlowRegistry_ReconcilePriorities(t *testing.T) {
 		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
 		dynamicPrio := 77
 
-		// First, provision a dynamic band via JIT.
+		// Pre-provision a dynamic band and create a flow.
+		require.NoError(t, h.fr.ensurePriorityBand(dynamicPrio))
 		key := flowcontrol.FlowKey{ID: "dynamic-flow", Priority: dynamicPrio}
 		h.openConnectionOnFlow(key)
 

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -1445,3 +1445,187 @@ func TestFlowRegistry_JITErrorScoping(t *testing.T) {
 	assert.Equal(t, int32(concurrency), errorCount.Load(), "All requests should fail JIT provisioning")
 	assert.Equal(t, int32(0), successCount.Load(), "No request should succeed if JIT failed")
 }
+
+// --- ReconcilePriorities Tests ---
+
+func TestFlowRegistry_ReconcilePriorities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ShouldAddMissingPriorityBands", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+
+		newPrio := 50
+		h.fr.mu.RLock()
+		_, existsBefore := h.fr.config.PriorityBands[newPrio]
+		h.fr.mu.RUnlock()
+		require.False(t, existsBefore, "Priority band should not exist before reconciliation")
+
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, newPrio})
+
+		// Verify the new band was created.
+		h.fr.mu.RLock()
+		_, existsAfter := h.fr.config.PriorityBands[newPrio]
+		h.fr.mu.RUnlock()
+		assert.True(t, existsAfter, "Priority band should exist after reconciliation")
+
+		// Verify it exists on all shards.
+		h.fr.mu.RLock()
+		for _, shard := range h.fr.allShards {
+			_, err := shard.FairnessPolicy(newPrio)
+			assert.NoError(t, err, "New priority band must be provisioned on shard %s", shard.ID())
+		}
+		h.fr.mu.RUnlock()
+
+		// Verify stats tracking is set up.
+		_, existsInStats := h.fr.perPriorityBandStats.Load(newPrio)
+		assert.True(t, existsInStats, "Stats tracking should be set up for the new band")
+	})
+
+	t.Run("ShouldRemoveStaleDynamicBands", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		dynamicPrio := 77
+
+		// First, provision a dynamic band via JIT.
+		key := flowcontrol.FlowKey{ID: "dynamic-flow", Priority: dynamicPrio}
+		h.openConnectionOnFlow(key)
+
+		h.fr.mu.RLock()
+		_, exists := h.fr.config.PriorityBands[dynamicPrio]
+		h.fr.mu.RUnlock()
+		require.True(t, exists, "Dynamic band should exist after JIT provisioning")
+
+		// Reconcile without the dynamic priority — it should be removed.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority})
+
+		h.fr.mu.RLock()
+		_, existsAfter := h.fr.config.PriorityBands[dynamicPrio]
+		h.fr.mu.RUnlock()
+		assert.False(t, existsAfter, "Dynamic band should be removed by reconciliation")
+
+		// Verify removed from stats.
+		_, existsInStats := h.fr.perPriorityBandStats.Load(dynamicPrio)
+		assert.False(t, existsInStats, "Stats tracking should be removed for the deleted band")
+	})
+
+	t.Run("ShouldNeverRemoveStaticBands", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+
+		// Reconcile with an empty set — static bands must survive.
+		h.fr.ReconcilePriorities([]int{})
+
+		h.fr.mu.RLock()
+		_, highExists := h.fr.config.PriorityBands[highPriority]
+		_, lowExists := h.fr.config.PriorityBands[lowPriority]
+		h.fr.mu.RUnlock()
+
+		assert.True(t, highExists, "Static high priority band must never be removed by ReconcilePriorities")
+		assert.True(t, lowExists, "Static low priority band must never be removed by ReconcilePriorities")
+	})
+
+	t.Run("ShouldBeNoOp_WhenDesiredMatchesCurrent", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+
+		// Reconcile with exactly the existing static bands.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority})
+
+		h.fr.mu.RLock()
+		bandCount := len(h.fr.config.PriorityBands)
+		h.fr.mu.RUnlock()
+
+		assert.Equal(t, 2, bandCount, "No bands should be added or removed when desired matches current")
+	})
+
+	t.Run("ShouldBeIdempotent", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		newPrio := 42
+
+		desired := []int{highPriority, lowPriority, newPrio}
+
+		// Call multiple times.
+		h.fr.ReconcilePriorities(desired)
+		h.fr.ReconcilePriorities(desired)
+		h.fr.ReconcilePriorities(desired)
+
+		h.fr.mu.RLock()
+		bandCount := len(h.fr.config.PriorityBands)
+		_, exists := h.fr.config.PriorityBands[newPrio]
+		h.fr.mu.RUnlock()
+
+		assert.Equal(t, 3, bandCount, "Repeated reconciliation should not create duplicate bands")
+		assert.True(t, exists, "Band should exist after repeated reconciliation")
+	})
+
+	t.Run("ShouldAddAndRemoveInSingleCall", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{initialShardCount: 2})
+		dynOld := 60
+		dynNew := 70
+
+		// Pre-provision a dynamic band.
+		err := h.fr.ensurePriorityBand(dynOld)
+		require.NoError(t, err)
+		h.fr.mu.RLock()
+		_, oldExists := h.fr.config.PriorityBands[dynOld]
+		h.fr.mu.RUnlock()
+		require.True(t, oldExists)
+
+		// Reconcile: remove dynOld, add dynNew.
+		h.fr.ReconcilePriorities([]int{highPriority, lowPriority, dynNew})
+
+		h.fr.mu.RLock()
+		_, oldExistsAfter := h.fr.config.PriorityBands[dynOld]
+		_, newExistsAfter := h.fr.config.PriorityBands[dynNew]
+		h.fr.mu.RUnlock()
+
+		assert.False(t, oldExistsAfter, "Old dynamic band should be removed")
+		assert.True(t, newExistsAfter, "New dynamic band should be created")
+	})
+
+	t.Run("ShouldHandleEmptyDesiredSet", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+		dynPrio := 99
+
+		// Pre-provision a dynamic band.
+		err := h.fr.ensurePriorityBand(dynPrio)
+		require.NoError(t, err)
+
+		// Reconcile with empty set — only static bands should remain.
+		h.fr.ReconcilePriorities([]int{})
+
+		h.fr.mu.RLock()
+		_, dynExists := h.fr.config.PriorityBands[dynPrio]
+		_, highExists := h.fr.config.PriorityBands[highPriority]
+		_, lowExists := h.fr.config.PriorityBands[lowPriority]
+		bandCount := len(h.fr.config.PriorityBands)
+		h.fr.mu.RUnlock()
+
+		assert.False(t, dynExists, "Dynamic band should be removed")
+		assert.True(t, highExists, "Static high band should survive")
+		assert.True(t, lowExists, "Static low band should survive")
+		assert.Equal(t, 2, bandCount, "Only static bands should remain")
+	})
+
+	t.Run("ShouldHandleNilDesiredSet", func(t *testing.T) {
+		t.Parallel()
+		h := newRegistryTestHarness(t, harnessOptions{})
+
+		// Reconcile with nil — same as empty, only static bands remain.
+		require.NotPanics(t, func() {
+			h.fr.ReconcilePriorities(nil)
+		})
+
+		h.fr.mu.RLock()
+		_, highExists := h.fr.config.PriorityBands[highPriority]
+		_, lowExists := h.fr.config.PriorityBands[lowPriority]
+		h.fr.mu.RUnlock()
+
+		assert.True(t, highExists, "Static high band should survive")
+		assert.True(t, lowExists, "Static low band should survive")
+	})
+}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/controller"
 	datalayerlogger "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer/logger"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datastore"
+	fccontracts "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/flowcontrol/contracts"
 	fwkflowcontrol "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/flowcontrol"
 	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/handlers"
@@ -62,6 +63,10 @@ type ExtProcServerRunner struct {
 	Parser                           fwkrh.Parser
 	SaturationDetector               fwkflowcontrol.SaturationDetector
 	UseExperimentalDatalayerV2       bool // Pluggable data layer feature flag
+	// FlowControlPlane is an optional reference to the FlowRegistry's control-plane interface.
+	// When set (flow control enabled), it is injected into the InferenceObjectiveReconciler
+	// to pre-provision priority bands.
+	FlowControlPlane fccontracts.FlowRegistryControlPlane
 }
 
 // NewDefaultExtProcServerRunner creates a runner with default values.
@@ -104,9 +109,10 @@ func (r *ExtProcServerRunner) SetupWithManager(mgr ctrl.Manager) error {
 
 		if r.ControllerCfg.hasInferenceObjective {
 			if err := (&controller.InferenceObjectiveReconciler{
-				Datastore: r.Datastore,
-				Reader:    mgr.GetClient(),
-				PoolGKNN:  r.GKNN,
+				Datastore:        r.Datastore,
+				Reader:           mgr.GetClient(),
+				PoolGKNN:         r.GKNN,
+				FlowControlPlane: r.FlowControlPlane,
 			}).SetupWithManager(mgr); err != nil {
 				return fmt.Errorf("failed setting up InferenceObjectiveReconciler - %w", err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind feature

**What this PR does / why we need it**:

- Integrate the FlowRegistry control-plane API (`ReconcilePriorities`) into the `InferenceObjectiveReconciler`, so priority bands are pre-provisioned from the control plane instead of the request hot path
- Remove Just-In-Time (JIT) priority band provisioning from `ensureFlowInfrastructure` — requests with unknown priorities now return `ErrPriorityBandNotFound`
- Wire the FlowRegistry into the reconciler via `ExtProcServerRunner` (only when the Flow Control feature gate is enabled)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #2011

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
