### PR TITLE
refactor(requestcontrol): rename several requestcontrol plugin interface

### DIFF
--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -77,16 +77,16 @@ func pluginToLayerExecutionOrder(plugin plugin.Plugin) int {
 	}
 
 	// Request control plugins
-	if _, ok := plugin.(fwkrq.PrepareDataPlugin); ok {
+	if _, ok := plugin.(fwkrq.DataProducer); ok {
 		return RequestControlLayer
 	}
-	if _, ok := plugin.(fwkrq.AdmissionPlugin); ok {
+	if _, ok := plugin.(fwkrq.Admitter); ok {
 		return RequestControlLayer
 	}
 	if _, ok := plugin.(fwkrq.PreRequest); ok {
 		return RequestControlLayer
 	}
-	if _, ok := plugin.(fwkrq.ResponseHeader); ok {
+	if _, ok := plugin.(fwkrq.ResponseHeaderProcessor); ok {
 		return RequestControlLayer
 	}
 

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -92,7 +92,7 @@ func TestValidatePluginExecutionOrder(t *testing.T) {
 	consumerFairnessPolicyPlugin := MockConsumerFairnessPolicy{consumes: map[string]any{"keyA": nil}}
 	// Scheduling plugin.
 	consumerSchedulingPlugin := MockSchedulingPlugin{consumes: map[string]any{"keyA": nil}}
-	if _, ok := any(pluginA).(fwkrc.PrepareDataPlugin); !ok {
+	if _, ok := any(pluginA).(fwkrc.DataProducer); !ok {
 		t.Fatalf("pluginA should implement PrepareDataPlugin")
 	}
 
@@ -152,19 +152,19 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		plugins     []fwkrc.PrepareDataPlugin
+		plugins     []fwkrc.DataProducer
 		expectedDAG map[string][]string
 		expectedErr string
 	}{
 		{
 			name:        "No plugins",
-			plugins:     []fwkrc.PrepareDataPlugin{},
+			plugins:     []fwkrc.DataProducer{},
 			expectedDAG: map[string][]string{},
 			expectedErr: "",
 		},
 		{
 			name:    "Plugins with no dependencies",
-			plugins: []fwkrc.PrepareDataPlugin{pluginA, pluginE},
+			plugins: []fwkrc.DataProducer{pluginA, pluginE},
 			expectedDAG: map[string][]string{
 				"A/mock": {},
 				"E/mock": {},
@@ -173,7 +173,7 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 		},
 		{
 			name:    "Simple linear dependency (C -> B -> A)",
-			plugins: []fwkrc.PrepareDataPlugin{pluginA, pluginB, pluginC},
+			plugins: []fwkrc.DataProducer{pluginA, pluginB, pluginC},
 			expectedDAG: map[string][]string{
 				"A/mock": {},
 				"B/mock": {"A/mock"},
@@ -183,7 +183,7 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 		},
 		{
 			name:    "DAG with multiple dependencies (B -> A, D -> A, E independent)",
-			plugins: []fwkrc.PrepareDataPlugin{pluginA, pluginB, pluginD, pluginE},
+			plugins: []fwkrc.DataProducer{pluginA, pluginB, pluginD, pluginE},
 			expectedDAG: map[string][]string{
 				"A/mock": {},
 				"B/mock": {"A/mock"},
@@ -194,19 +194,19 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 		},
 		{
 			name:        "Graph with a cycle (X -> Y, Y -> X)",
-			plugins:     []fwkrc.PrepareDataPlugin{pluginX, pluginY},
+			plugins:     []fwkrc.DataProducer{pluginX, pluginY},
 			expectedDAG: nil,
 			expectedErr: "cycle detected",
 		},
 		{
 			name:        "Data type mismatch between produced and consumed data",
-			plugins:     []fwkrc.PrepareDataPlugin{pluginZ1, pluginZ2},
+			plugins:     []fwkrc.DataProducer{pluginZ1, pluginZ2},
 			expectedDAG: nil,
 			expectedErr: "data type mismatch between produced and consumed data",
 		},
 		{
 			name:    "Same type different pointers (should succeed)",
-			plugins: []fwkrc.PrepareDataPlugin{pluginP1, pluginP2},
+			plugins: []fwkrc.DataProducer{pluginP1, pluginP2},
 			expectedDAG: map[string][]string{
 				"P1/mock": {},
 				"P2/mock": {"P1/mock"},

--- a/pkg/epp/flowcontrol/eviction/plugin.go
+++ b/pkg/epp/flowcontrol/eviction/plugin.go
@@ -33,7 +33,7 @@ import (
 )
 
 var _ requestcontrol.PreRequest = &Plugin{}
-var _ requestcontrol.ResponseBody = &Plugin{}
+var _ requestcontrol.ResponseBodyProcessor = &Plugin{}
 
 // Plugin tracks in-flight requests via RequestControl hooks and provides eviction capability.
 type Plugin struct {

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -72,7 +72,7 @@ type DataProducer interface {
 	PrepareRequestData(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error
 }
 
-// Admitter is called by the director after the prepare data phase and before scheduling.
+// Admitter is called by the director after the data producer and before scheduling.
 // When a request has to go through multiple Admitter,
 // the request is admitted only if all plugins say that the request should be admitted.
 type Admitter interface {

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -38,15 +38,15 @@ type PreRequest interface {
 	PreRequest(ctx context.Context, request *types.InferenceRequest, schedulingResult *types.SchedulingResult)
 }
 
-// ResponseHeader is called by the director after the response headers are successfully received
+// ResponseHeaderProcessor is called by the director after the response headers are successfully received
 // which indicates the beginning of the response handling by the model server.
 // The given pod argument is the pod that served the request.
-type ResponseHeader interface {
+type ResponseHeaderProcessor interface {
 	plugin.Plugin
 	ResponseHeader(ctx context.Context, request *types.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
-// ResponseBody is the primary hook for processing response data.
+// ResponseBodyProcessor is the primary hook for processing response data.
 // It is called by the director for every data chunk in a streaming response, or exactly once
 // for non-streaming responses.
 //
@@ -59,23 +59,23 @@ type ResponseHeader interface {
 // TODO(https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2079):
 // Update signature to pass error/termination state. This is a breaking change required for plugins to distinguish
 // between success, errors, and disconnects.
-type ResponseBody interface {
+type ResponseBodyProcessor interface {
 	plugin.Plugin
 	ResponseBody(ctx context.Context, request *types.InferenceRequest, response *Response, targetEndpoint *datalayer.EndpointMetadata)
 }
 
+// DataProducer is implemented by data producers which produce data from different sources.
 // PrepareRequestData is called by the director before scheduling requests.
-// PrepareDataPlugin plugin is implemented by data producers which produce data from different sources.
-type PrepareDataPlugin interface {
+type DataProducer interface {
 	plugin.ProducerPlugin
 	plugin.ConsumerPlugin
 	PrepareRequestData(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error
 }
 
-// AdmissionPlugin is called by the director after the prepare data phase and before scheduling.
-// When a request has to go through multiple AdmissionPlugin,
+// Admitter is called by the director after the prepare data phase and before scheduling.
+// When a request has to go through multiple Admitter,
 // the request is admitted only if all plugins say that the request should be admitted.
-type AdmissionPlugin interface {
+type Admitter interface {
 	plugin.Plugin
 	// AdmitRequest returns the denial reason, wrapped as error if the request is denied.
 	// If the request is allowed, it returns nil.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -40,7 +40,7 @@ const (
 )
 
 // compile-time validation
-var _ requestcontrol.AdmissionPlugin = &LatencyAdmission{}
+var _ requestcontrol.Admitter = &LatencyAdmission{}
 
 // LatencyAdmissionConfig holds configuration for the latency admission plugin.
 type LatencyAdmissionConfig struct{}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	_ requestcontrol.PrepareDataPlugin = &prepareData{}
+	_ requestcontrol.DataProducer = &prepareData{}
 	_ requestcontrol.PreRequest        = &prepareData{}
 )
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	_ requestcontrol.DataProducer = &prepareData{}
-	_ requestcontrol.PreRequest        = &prepareData{}
+	_ requestcontrol.PreRequest   = &prepareData{}
 )
 
 // prepareData is a plugin that prepares data consumed by approx prefix cache aware scheduling.

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Test interface satisfaction at compile time.
-var _ requestcontrol.ResponseBody = &Plugin{}
+var _ requestcontrol.ResponseBodyProcessor = &Plugin{}
 
 // Plugin state
 type Plugin struct {

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
@@ -50,8 +50,8 @@ func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Han
 
 var (
 	_ requestcontrol.PreRequest        = &InFlightLoadProducer{}
-	_ requestcontrol.ResponseBody      = &InFlightLoadProducer{}
-	_ requestcontrol.PrepareDataPlugin = &InFlightLoadProducer{}
+	_ requestcontrol.ResponseBodyProcessor      = &InFlightLoadProducer{}
+	_ requestcontrol.DataProducer = &InFlightLoadProducer{}
 	_ datalayer.NotificationExtractor  = &InFlightLoadProducer{}
 )
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
@@ -49,10 +49,10 @@ func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Han
 }
 
 var (
-	_ requestcontrol.PreRequest        = &InFlightLoadProducer{}
-	_ requestcontrol.ResponseBodyProcessor      = &InFlightLoadProducer{}
-	_ requestcontrol.DataProducer = &InFlightLoadProducer{}
-	_ datalayer.NotificationExtractor  = &InFlightLoadProducer{}
+	_ requestcontrol.PreRequest            = &InFlightLoadProducer{}
+	_ requestcontrol.ResponseBodyProcessor = &InFlightLoadProducer{}
+	_ requestcontrol.DataProducer          = &InFlightLoadProducer{}
+	_ datalayer.NotificationExtractor      = &InFlightLoadProducer{}
 )
 
 type InFlightLoadProducer struct {

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
@@ -29,7 +29,7 @@ import (
 	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
-var _ requestcontrol.PrepareDataPlugin = &PredictedLatency{}
+var _ requestcontrol.DataProducer = &PredictedLatency{}
 
 // PrepareRequestData prepares the SLO context for the request, including
 // parsing SLO headers, gathering prefix cache scores, and generating predictions.

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks.go
@@ -35,8 +35,8 @@ import (
 )
 
 var _ requestcontrol.PreRequest = &PredictedLatency{}
-var _ requestcontrol.ResponseHeader = &PredictedLatency{}
-var _ requestcontrol.ResponseBody = &PredictedLatency{}
+var _ requestcontrol.ResponseHeaderProcessor = &PredictedLatency{}
+var _ requestcontrol.ResponseBodyProcessor = &PredictedLatency{}
 
 // --- RequestControl Hooks ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -36,7 +36,7 @@ const (
 	DestinationEndpointServedVerifierType = "destination-endpoint-served-verifier"
 )
 
-var _ requestcontrol.ResponseHeader = &DestinationEndpointServedVerifier{}
+var _ requestcontrol.ResponseHeaderProcessor = &DestinationEndpointServedVerifier{}
 
 // DestinationEndpointServedVerifier is a test-only plugin for conformance tests.
 // It verifies that the request was served by the expected endpoint.

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -28,7 +28,7 @@ import (
 // executePluginsAsDAG executes PrepareData plugins as a DAG based on their dependencies asynchronously.
 // So, a plugin is executed only after all its dependencies have been executed.
 // If there is a cycle or any plugin fails with error, it returns an error.
-func executePluginsAsDAG(plugins []fwk.PrepareDataPlugin, ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func executePluginsAsDAG(plugins []fwk.DataProducer, ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	for _, plugin := range plugins {
 		if err := plugin.PrepareRequestData(ctx, request, endpoints); err != nil {
 			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
@@ -38,7 +38,7 @@ func executePluginsAsDAG(plugins []fwk.PrepareDataPlugin, ctx context.Context, r
 }
 
 // prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
-func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.PrepareDataPlugin,
+func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.DataProducer,
 	ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	errCh := make(chan error, 1)
 	go func() {

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -29,7 +29,7 @@ import (
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
-var _ fwk.PrepareDataPlugin = &mockPrepareRequestDataPlugin{}
+var _ fwk.DataProducer = &mockPrepareRequestDataPlugin{}
 
 type mockPrepareRequestDataPlugin struct {
 	name      string
@@ -66,30 +66,30 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 	testCases := []struct {
 		name          string
 		timeout       time.Duration
-		plugins       []fwk.PrepareDataPlugin
+		plugins       []fwk.DataProducer
 		ctxFn         func() (context.Context, context.CancelFunc)
 		expectErrStr  string
-		checkPlugins  func(t *testing.T, plugins []fwk.PrepareDataPlugin)
+		checkPlugins  func(t *testing.T, plugins []fwk.DataProducer)
 		expectSuccess bool
 	}{
 		{
 			name:    "success with one plugin",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1"},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
-			checkPlugins: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			checkPlugins: func(t *testing.T, plugins []fwk.DataProducer) {
 				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
 			},
 		},
 		{
 			name:    "plugin returns error",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", returnErr: errors.New("plugin failed")},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -100,7 +100,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "plugins time out",
 			timeout: 50 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -111,7 +111,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "context cancelled",
 			timeout: 200 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -124,7 +124,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "multiple plugins success",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1"},
 				&mockPrepareRequestDataPlugin{name: "p2"},
 			},
@@ -132,7 +132,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
-			checkPlugins: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			checkPlugins: func(t *testing.T, plugins []fwk.DataProducer) {
 				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
 				assert.True(t, plugins[1].(*mockPrepareRequestDataPlugin).executed)
 			},
@@ -215,18 +215,18 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		plugins   []fwk.PrepareDataPlugin
+		plugins   []fwk.DataProducer
 		expectErr bool
-		checkFunc func(t *testing.T, plugins []fwk.PrepareDataPlugin)
+		checkFunc func(t *testing.T, plugins []fwk.DataProducer)
 	}{
 		{
 			name:    "no plugins",
-			plugins: []fwk.PrepareDataPlugin{},
+			plugins: []fwk.DataProducer{},
 		},
 		{
 			name:    "simple linear dependency (A -> B -> C)",
-			plugins: []fwk.PrepareDataPlugin{pluginA, pluginB, pluginC},
-			checkFunc: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			plugins: []fwk.DataProducer{pluginA, pluginB, pluginC},
+			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
 				pA := plugins[0].(*dagTestPlugin)
 				pB := plugins[1].(*dagTestPlugin)
 				pC := plugins[2].(*dagTestPlugin)
@@ -241,8 +241,8 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		},
 		{
 			name:    "DAG with multiple dependencies (A -> B, A -> D) and one independent (E)",
-			plugins: []fwk.PrepareDataPlugin{pluginA, pluginB, pluginD, pluginE},
-			checkFunc: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			plugins: []fwk.DataProducer{pluginA, pluginB, pluginD, pluginE},
+			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
 				pA := plugins[0].(*dagTestPlugin)
 				pB := plugins[1].(*dagTestPlugin)
 				pD := plugins[2].(*dagTestPlugin)
@@ -259,9 +259,9 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		},
 		{
 			name:      "dependency fails",
-			plugins:   []fwk.PrepareDataPlugin{pluginFail, pluginDependsOnFail},
+			plugins:   []fwk.DataProducer{pluginFail, pluginDependsOnFail},
 			expectErr: true,
-			checkFunc: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
 				pF := plugins[0].(*dagTestPlugin)
 				pDOF := plugins[1].(*dagTestPlugin)
 

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -24,21 +24,21 @@ import (
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
-		admissionPlugins:         []fwk.AdmissionPlugin{},
-		prepareDataPlugins:       []fwk.PrepareDataPlugin{},
+		admissionPlugins:         []fwk.Admitter{},
+		prepareDataPlugins:       []fwk.DataProducer{},
 		preRequestPlugins:        []fwk.PreRequest{},
-		responseReceivedPlugins:  []fwk.ResponseHeader{},
-		responseStreamingPlugins: []fwk.ResponseBody{},
+		responseReceivedPlugins:  []fwk.ResponseHeaderProcessor{},
+		responseStreamingPlugins: []fwk.ResponseBodyProcessor{},
 	}
 }
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
-	admissionPlugins         []fwk.AdmissionPlugin
-	prepareDataPlugins       []fwk.PrepareDataPlugin
+	admissionPlugins         []fwk.Admitter
+	prepareDataPlugins       []fwk.DataProducer
 	preRequestPlugins        []fwk.PreRequest
-	responseReceivedPlugins  []fwk.ResponseHeader
-	responseStreamingPlugins []fwk.ResponseBody
+	responseReceivedPlugins  []fwk.ResponseHeaderProcessor
+	responseStreamingPlugins []fwk.ResponseBodyProcessor
 }
 
 // WithPreRequestPlugins sets the given plugins as the PreRequest plugins.
@@ -50,26 +50,26 @@ func (c *Config) WithPreRequestPlugins(plugins ...fwk.PreRequest) *Config {
 
 // WithResponseReceivedPlugins sets the given plugins as the ResponseReceived plugins.
 // If the Config has ResponseReceived plugins already, this call replaces the existing plugins with the given ones.
-func (c *Config) WithResponseReceivedPlugins(plugins ...fwk.ResponseHeader) *Config {
+func (c *Config) WithResponseReceivedPlugins(plugins ...fwk.ResponseHeaderProcessor) *Config {
 	c.responseReceivedPlugins = plugins
 	return c
 }
 
 // WithResponseStreamingPlugins sets the given plugins as the ResponseStreaming plugins.
 // If the Config has ResponseStreaming plugins already, this call replaces the existing plugins with the given ones.
-func (c *Config) WithResponseStreamingPlugins(plugins ...fwk.ResponseBody) *Config {
+func (c *Config) WithResponseStreamingPlugins(plugins ...fwk.ResponseBodyProcessor) *Config {
 	c.responseStreamingPlugins = plugins
 	return c
 }
 
 // WithPrepareDataPlugins sets the given plugins as the PrepareData plugins.
-func (c *Config) WithPrepareDataPlugins(plugins ...fwk.PrepareDataPlugin) *Config {
+func (c *Config) WithPrepareDataPlugins(plugins ...fwk.DataProducer) *Config {
 	c.prepareDataPlugins = plugins
 	return c
 }
 
 // WithAdmissionPlugins sets the given plugins as the AdmitRequest plugins.
-func (c *Config) WithAdmissionPlugins(plugins ...fwk.AdmissionPlugin) *Config {
+func (c *Config) WithAdmissionPlugins(plugins ...fwk.Admitter) *Config {
 	c.admissionPlugins = plugins
 	return c
 }
@@ -82,16 +82,16 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 		if preRequestPlugin, ok := plugin.(fwk.PreRequest); ok {
 			c.preRequestPlugins = append(c.preRequestPlugins, preRequestPlugin)
 		}
-		if responseReceivedPlugin, ok := plugin.(fwk.ResponseHeader); ok {
+		if responseReceivedPlugin, ok := plugin.(fwk.ResponseHeaderProcessor); ok {
 			c.responseReceivedPlugins = append(c.responseReceivedPlugins, responseReceivedPlugin)
 		}
-		if responseStreamingPlugin, ok := plugin.(fwk.ResponseBody); ok {
+		if responseStreamingPlugin, ok := plugin.(fwk.ResponseBodyProcessor); ok {
 			c.responseStreamingPlugins = append(c.responseStreamingPlugins, responseStreamingPlugin)
 		}
-		if prepareDataPlugin, ok := plugin.(fwk.PrepareDataPlugin); ok {
+		if prepareDataPlugin, ok := plugin.(fwk.DataProducer); ok {
 			c.prepareDataPlugins = append(c.prepareDataPlugins, prepareDataPlugin)
 		}
-		if admissionPlugin, ok := plugin.(fwk.AdmissionPlugin); ok {
+		if admissionPlugin, ok := plugin.(fwk.Admitter); ok {
 			c.admissionPlugins = append(c.admissionPlugins, admissionPlugin)
 		}
 	}
@@ -99,8 +99,8 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 
 // OrderPrepareDataPlugins reorders the prepareDataPlugins in the Config based on the given sorted plugin names.
 func (c *Config) OrderPrepareDataPlugins(sortedPluginNames []string) {
-	sortedPlugins := make([]fwk.PrepareDataPlugin, 0, len(sortedPluginNames))
-	nameToPlugin := make(map[string]fwk.PrepareDataPlugin)
+	sortedPlugins := make([]fwk.DataProducer, 0, len(sortedPluginNames))
+	nameToPlugin := make(map[string]fwk.DataProducer)
 	for _, plugin := range c.prepareDataPlugins {
 		nameToPlugin[plugin.TypedName().String()] = plugin
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

 Renamed several request control plugin types and variables in `pkg/epp/requestcontrol` to match their interface definitions in `pkg/epp/framework/interface/requestcontrol/plugins.go`.                           

- `PrepareDataPlugin` -> `DataProducer`
- `AdmissionPlugin` -> `Admitter`
- `ResponseHeader` -> `ResponseHeaderProcessor`
- `ResponseBody` -> `ResponseBodyProcessor`
   
The `PreRequest` interface was kept as-is after evaluating alternative names.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
