### PR TITLE
Rename PrepareDataPlugin to DataProducer

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -579,7 +579,7 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 		return nil, fmt.Errorf("failed to load the configuration - %w", err)
 	}
 	// The plugins will be executed in topologically sorted order to ensure that data is produced before it is consumed.
-	r.requestControlConfig.OrderPrepareDataPlugins(dag)
+	r.requestControlConfig.OrderDataProducers(dag)
 
 	r.parser = handlers.NewParser(cfg.ParserConfig)
 	logger.Info("loaded configuration from file/text successfully")

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -77,7 +77,7 @@ func pluginToLayerExecutionOrder(plugin plugin.Plugin) int {
 	}
 
 	// Request control plugins
-	if _, ok := plugin.(fwkrq.PrepareDataPlugin); ok {
+	if _, ok := plugin.(fwkrq.DataProducer); ok {
 		return RequestControlLayer
 	}
 	if _, ok := plugin.(fwkrq.AdmissionPlugin); ok {

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -92,8 +92,8 @@ func TestValidatePluginExecutionOrder(t *testing.T) {
 	consumerFairnessPolicyPlugin := MockConsumerFairnessPolicy{consumes: map[string]any{"keyA": nil}}
 	// Scheduling plugin.
 	consumerSchedulingPlugin := MockSchedulingPlugin{consumes: map[string]any{"keyA": nil}}
-	if _, ok := any(pluginA).(fwkrc.PrepareDataPlugin); !ok {
-		t.Fatalf("pluginA should implement PrepareDataPlugin")
+	if _, ok := any(pluginA).(fwkrc.DataProducer); !ok {
+		t.Fatalf("pluginA should implement DataProducer")
 	}
 
 	testCases := []struct {
@@ -152,19 +152,19 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		plugins     []fwkrc.PrepareDataPlugin
+		plugins     []fwkrc.DataProducer
 		expectedDAG map[string][]string
 		expectedErr string
 	}{
 		{
 			name:        "No plugins",
-			plugins:     []fwkrc.PrepareDataPlugin{},
+			plugins:     []fwkrc.DataProducer{},
 			expectedDAG: map[string][]string{},
 			expectedErr: "",
 		},
 		{
 			name:    "Plugins with no dependencies",
-			plugins: []fwkrc.PrepareDataPlugin{pluginA, pluginE},
+			plugins: []fwkrc.DataProducer{pluginA, pluginE},
 			expectedDAG: map[string][]string{
 				"A/mock": {},
 				"E/mock": {},
@@ -173,7 +173,7 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 		},
 		{
 			name:    "Simple linear dependency (C -> B -> A)",
-			plugins: []fwkrc.PrepareDataPlugin{pluginA, pluginB, pluginC},
+			plugins: []fwkrc.DataProducer{pluginA, pluginB, pluginC},
 			expectedDAG: map[string][]string{
 				"A/mock": {},
 				"B/mock": {"A/mock"},
@@ -183,7 +183,7 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 		},
 		{
 			name:    "DAG with multiple dependencies (B -> A, D -> A, E independent)",
-			plugins: []fwkrc.PrepareDataPlugin{pluginA, pluginB, pluginD, pluginE},
+			plugins: []fwkrc.DataProducer{pluginA, pluginB, pluginD, pluginE},
 			expectedDAG: map[string][]string{
 				"A/mock": {},
 				"B/mock": {"A/mock"},
@@ -194,19 +194,19 @@ func TestDAGAndTopologicalOrder(t *testing.T) {
 		},
 		{
 			name:        "Graph with a cycle (X -> Y, Y -> X)",
-			plugins:     []fwkrc.PrepareDataPlugin{pluginX, pluginY},
+			plugins:     []fwkrc.DataProducer{pluginX, pluginY},
 			expectedDAG: nil,
 			expectedErr: "cycle detected",
 		},
 		{
 			name:        "Data type mismatch between produced and consumed data",
-			plugins:     []fwkrc.PrepareDataPlugin{pluginZ1, pluginZ2},
+			plugins:     []fwkrc.DataProducer{pluginZ1, pluginZ2},
 			expectedDAG: nil,
 			expectedErr: "data type mismatch between produced and consumed data",
 		},
 		{
 			name:    "Same type different pointers (should succeed)",
-			plugins: []fwkrc.PrepareDataPlugin{pluginP1, pluginP2},
+			plugins: []fwkrc.DataProducer{pluginP1, pluginP2},
 			expectedDAG: map[string][]string{
 				"P1/mock": {},
 				"P2/mock": {"P1/mock"},

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -65,8 +65,8 @@ type ResponseBody interface {
 }
 
 // PrepareRequestData is called by the director before scheduling requests.
-// PrepareDataPlugin plugin is implemented by data producers which produce data from different sources.
-type PrepareDataPlugin interface {
+// DataProducer plugin is implemented by data producers which produce data from different sources.
+type DataProducer interface {
 	plugin.ProducerPlugin
 	plugin.ConsumerPlugin
 	PrepareRequestData(ctx context.Context, request *types.InferenceRequest, pods []types.Endpoint) error

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	_ requestcontrol.PrepareDataPlugin = &prepareData{}
+	_ requestcontrol.DataProducer = &prepareData{}
 	_ requestcontrol.PreRequest        = &prepareData{}
 )
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/inflightload/producer.go
@@ -51,7 +51,7 @@ func InFlightLoadProducerFactory(name string, _ json.RawMessage, _ fwkplugin.Han
 var (
 	_ requestcontrol.PreRequest        = &InFlightLoadProducer{}
 	_ requestcontrol.ResponseBody      = &InFlightLoadProducer{}
-	_ requestcontrol.PrepareDataPlugin = &InFlightLoadProducer{}
+	_ requestcontrol.DataProducer = &InFlightLoadProducer{}
 	_ datalayer.NotificationExtractor  = &InFlightLoadProducer{}
 )
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/README.md
@@ -4,7 +4,7 @@ Trains XGBoost models via a sidecar and generates per-endpoint TTFT/TPOT predict
 
 ## Interfaces
 
-PrepareDataPlugin, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
+DataProducer, PreRequest, ResponseHeader, ResponseBody, Producer, Consumer
 
 ## Responsibilities
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
@@ -29,7 +29,7 @@ import (
 	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
-var _ requestcontrol.PrepareDataPlugin = &PredictedLatency{}
+var _ requestcontrol.DataProducer = &PredictedLatency{}
 
 // PrepareRequestData prepares the SLO context for the request, including
 // parsing SLO headers, gathering prefix cache scores, and generating predictions.

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -176,7 +176,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	snapshotOfCandidatePods := d.toSchedulerEndpoints(endpointCandidates)
 	// Prepare per request data by running PrepareData plugins.
-	err = d.runPrepareDataPlugins(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
+	err = d.runDataProducers(ctx, reqCtx.SchedulingRequest, snapshotOfCandidatePods)
 	if err != nil {
 		// Don't fail the request if PrepareData plugins fail.
 		logger.Error(err, "failed to prepare per request data")
@@ -384,12 +384,12 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 	}
 }
 
-func (d *Director) runPrepareDataPlugins(ctx context.Context,
+func (d *Director) runDataProducers(ctx context.Context,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
-	if len(d.requestControlPlugins.prepareDataPlugins) == 0 {
+	if len(d.requestControlPlugins.dataProducers) == 0 {
 		return nil
 	}
-	return prepareDataPluginsWithTimeout(prepareDataTimeout, d.requestControlPlugins.prepareDataPlugins, ctx, request, endpoints)
+	return dataProducersWithTimeout(prepareDataTimeout, d.requestControlPlugins.dataProducers, ctx, request, endpoints)
 }
 
 func (d *Director) runAdmissionPlugins(ctx context.Context,

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -107,31 +107,31 @@ func (ds *mockDatastore) PodList(predicate func(fwkdl.Endpoint) bool) []fwkdl.En
 	return res
 }
 
-type mockPrepareDataPlugin struct {
+type mockDataProducer struct {
 	name     string
 	produces map[string]any
 	consumes map[string]any
 }
 
-func (m *mockPrepareDataPlugin) TypedName() fwkplugin.TypedName {
+func (m *mockDataProducer) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
 }
 
-func (m *mockPrepareDataPlugin) Produces() map[string]any {
+func (m *mockDataProducer) Produces() map[string]any {
 	return m.produces
 }
 
-func (m *mockPrepareDataPlugin) Consumes() map[string]any {
+func (m *mockDataProducer) Consumes() map[string]any {
 	return m.consumes
 }
 
-func (m *mockPrepareDataPlugin) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+func (m *mockDataProducer) PrepareRequestData(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(mockProducedDataKey, mockProducedDataType{value: 42})
 	return nil
 }
 
-func newMockPrepareDataPlugin(name string) *mockPrepareDataPlugin {
-	return &mockPrepareDataPlugin{
+func newMockDataProducer(name string) *mockDataProducer {
+	return &mockDataProducer{
 		name:     name,
 		produces: map[string]any{mockProducedDataKey: 0},
 		consumes: map[string]any{},
@@ -307,7 +307,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		wantMutatedBodyModel    string                   // Expected model in reqCtx.Request.Body after PostDispatch
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
-		prepareDataPlugin       *mockPrepareDataPlugin
+		prepareDataPlugin       *mockDataProducer
 	}{
 		{
 			name: "successful completions request",
@@ -414,7 +414,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 			},
 			wantMutatedBodyModel: model,
 			targetModelName:      model,
-			prepareDataPlugin:    newMockPrepareDataPlugin("test-plugin"),
+			prepareDataPlugin:    newMockDataProducer("test-plugin"),
 		},
 		{
 			name: "successful chat completions request with admit request plugins",
@@ -651,7 +651,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 				}
 				config := NewConfig()
 				if test.prepareDataPlugin != nil {
-					config = config.WithPrepareDataPlugins(test.prepareDataPlugin)
+					config = config.WithDataProducers(test.prepareDataPlugin)
 				}
 				config = config.WithAdmissionPlugins(newMockAdmissionPlugin("test-admit-plugin", test.admitRequestDenialError))
 

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -25,20 +25,20 @@ import (
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
-// executePluginsAsDAG executes PrepareData plugins as a DAG based on their dependencies asynchronously.
+// executePluginsAsDAG executes DataProducer plugins as a DAG based on their dependencies asynchronously.
 // So, a plugin is executed only after all its dependencies have been executed.
 // If there is a cycle or any plugin fails with error, it returns an error.
-func executePluginsAsDAG(plugins []fwk.PrepareDataPlugin, ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+func executePluginsAsDAG(plugins []fwk.DataProducer, ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	for _, plugin := range plugins {
 		if err := plugin.PrepareRequestData(ctx, request, endpoints); err != nil {
-			return errors.New("prepare data plugin " + plugin.TypedName().String() + " failed: " + err.Error())
+			return errors.New("data producer " + plugin.TypedName().String() + " failed: " + err.Error())
 		}
 	}
 	return nil
 }
 
-// prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
-func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.PrepareDataPlugin,
+// dataProducersWithTimeout executes the DataProducer plugins with retries and timeout.
+func dataProducersWithTimeout(timeout time.Duration, plugins []fwk.DataProducer,
 	ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
 	errCh := make(chan error, 1)
 	go func() {
@@ -51,6 +51,6 @@ func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.PrepareD
 	case err := <-errCh:
 		return err
 	case <-time.After(timeout):
-		return errors.New("prepare data plugin timed out")
+		return errors.New("data producer timed out")
 	}
 }

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -29,7 +29,7 @@ import (
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
-var _ fwk.PrepareDataPlugin = &mockPrepareRequestDataPlugin{}
+var _ fwk.DataProducer = &mockPrepareRequestDataPlugin{}
 
 type mockPrepareRequestDataPlugin struct {
 	name      string
@@ -62,56 +62,56 @@ func (m *mockPrepareRequestDataPlugin) Consumes() map[string]any {
 	return nil
 }
 
-func TestPrepareDataPluginsWithTimeout(t *testing.T) {
+func TestDataProducersWithTimeout(t *testing.T) {
 	testCases := []struct {
 		name          string
 		timeout       time.Duration
-		plugins       []fwk.PrepareDataPlugin
+		plugins       []fwk.DataProducer
 		ctxFn         func() (context.Context, context.CancelFunc)
 		expectErrStr  string
-		checkPlugins  func(t *testing.T, plugins []fwk.PrepareDataPlugin)
+		checkPlugins  func(t *testing.T, plugins []fwk.DataProducer)
 		expectSuccess bool
 	}{
 		{
 			name:    "success with one plugin",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1"},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
-			checkPlugins: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			checkPlugins: func(t *testing.T, plugins []fwk.DataProducer) {
 				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
 			},
 		},
 		{
 			name:    "plugin returns error",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", returnErr: errors.New("plugin failed")},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
-			expectErrStr: "prepare data plugin p1/mock failed: plugin failed",
+			expectErrStr: "data producer p1/mock failed: plugin failed",
 		},
 		{
 			name:    "plugins time out",
 			timeout: 50 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
 				return context.Background(), func() {}
 			},
-			expectErrStr: "prepare data plugin timed out",
+			expectErrStr: "data producer timed out",
 		},
 		{
 			name:    "context cancelled",
 			timeout: 200 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1", delay: 100 * time.Millisecond},
 			},
 			ctxFn: func() (context.Context, context.CancelFunc) {
@@ -124,7 +124,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 		{
 			name:    "multiple plugins success",
 			timeout: 100 * time.Millisecond,
-			plugins: []fwk.PrepareDataPlugin{
+			plugins: []fwk.DataProducer{
 				&mockPrepareRequestDataPlugin{name: "p1"},
 				&mockPrepareRequestDataPlugin{name: "p2"},
 			},
@@ -132,7 +132,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 				return context.Background(), func() {}
 			},
 			expectSuccess: true,
-			checkPlugins: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			checkPlugins: func(t *testing.T, plugins []fwk.DataProducer) {
 				assert.True(t, plugins[0].(*mockPrepareRequestDataPlugin).executed)
 				assert.True(t, plugins[1].(*mockPrepareRequestDataPlugin).executed)
 			},
@@ -144,7 +144,7 @@ func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 			ctx, cancel := tc.ctxFn()
 			defer cancel()
 
-			err := prepareDataPluginsWithTimeout(tc.timeout, tc.plugins, ctx, &schedulingtypes.InferenceRequest{}, nil)
+			err := dataProducersWithTimeout(tc.timeout, tc.plugins, ctx, &schedulingtypes.InferenceRequest{}, nil)
 
 			if tc.expectSuccess {
 				assert.NoError(t, err)
@@ -215,18 +215,18 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		plugins   []fwk.PrepareDataPlugin
+		plugins   []fwk.DataProducer
 		expectErr bool
-		checkFunc func(t *testing.T, plugins []fwk.PrepareDataPlugin)
+		checkFunc func(t *testing.T, plugins []fwk.DataProducer)
 	}{
 		{
 			name:    "no plugins",
-			plugins: []fwk.PrepareDataPlugin{},
+			plugins: []fwk.DataProducer{},
 		},
 		{
 			name:    "simple linear dependency (A -> B -> C)",
-			plugins: []fwk.PrepareDataPlugin{pluginA, pluginB, pluginC},
-			checkFunc: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			plugins: []fwk.DataProducer{pluginA, pluginB, pluginC},
+			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
 				pA := plugins[0].(*dagTestPlugin)
 				pB := plugins[1].(*dagTestPlugin)
 				pC := plugins[2].(*dagTestPlugin)
@@ -241,8 +241,8 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		},
 		{
 			name:    "DAG with multiple dependencies (A -> B, A -> D) and one independent (E)",
-			plugins: []fwk.PrepareDataPlugin{pluginA, pluginB, pluginD, pluginE},
-			checkFunc: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			plugins: []fwk.DataProducer{pluginA, pluginB, pluginD, pluginE},
+			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
 				pA := plugins[0].(*dagTestPlugin)
 				pB := plugins[1].(*dagTestPlugin)
 				pD := plugins[2].(*dagTestPlugin)
@@ -259,9 +259,9 @@ func TestExecutePluginsAsDAG(t *testing.T) {
 		},
 		{
 			name:      "dependency fails",
-			plugins:   []fwk.PrepareDataPlugin{pluginFail, pluginDependsOnFail},
+			plugins:   []fwk.DataProducer{pluginFail, pluginDependsOnFail},
 			expectErr: true,
-			checkFunc: func(t *testing.T, plugins []fwk.PrepareDataPlugin) {
+			checkFunc: func(t *testing.T, plugins []fwk.DataProducer) {
 				pF := plugins[0].(*dagTestPlugin)
 				pDOF := plugins[1].(*dagTestPlugin)
 

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -25,7 +25,7 @@ import (
 func NewConfig() *Config {
 	return &Config{
 		admissionPlugins:         []fwk.AdmissionPlugin{},
-		prepareDataPlugins:       []fwk.PrepareDataPlugin{},
+		dataProducers:            []fwk.DataProducer{},
 		preRequestPlugins:        []fwk.PreRequest{},
 		responseReceivedPlugins:  []fwk.ResponseHeader{},
 		responseStreamingPlugins: []fwk.ResponseBody{},
@@ -35,7 +35,7 @@ func NewConfig() *Config {
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
 	admissionPlugins         []fwk.AdmissionPlugin
-	prepareDataPlugins       []fwk.PrepareDataPlugin
+	dataProducers            []fwk.DataProducer
 	preRequestPlugins        []fwk.PreRequest
 	responseReceivedPlugins  []fwk.ResponseHeader
 	responseStreamingPlugins []fwk.ResponseBody
@@ -62,9 +62,9 @@ func (c *Config) WithResponseStreamingPlugins(plugins ...fwk.ResponseBody) *Conf
 	return c
 }
 
-// WithPrepareDataPlugins sets the given plugins as the PrepareData plugins.
-func (c *Config) WithPrepareDataPlugins(plugins ...fwk.PrepareDataPlugin) *Config {
-	c.prepareDataPlugins = plugins
+// WithDataProducers sets the given plugins as the DataProducer plugins.
+func (c *Config) WithDataProducers(plugins ...fwk.DataProducer) *Config {
+	c.dataProducers = plugins
 	return c
 }
 
@@ -88,8 +88,8 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 		if responseStreamingPlugin, ok := plugin.(fwk.ResponseBody); ok {
 			c.responseStreamingPlugins = append(c.responseStreamingPlugins, responseStreamingPlugin)
 		}
-		if prepareDataPlugin, ok := plugin.(fwk.PrepareDataPlugin); ok {
-			c.prepareDataPlugins = append(c.prepareDataPlugins, prepareDataPlugin)
+		if dataProducer, ok := plugin.(fwk.DataProducer); ok {
+			c.dataProducers = append(c.dataProducers, dataProducer)
 		}
 		if admissionPlugin, ok := plugin.(fwk.AdmissionPlugin); ok {
 			c.admissionPlugins = append(c.admissionPlugins, admissionPlugin)
@@ -97,11 +97,11 @@ func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 	}
 }
 
-// OrderPrepareDataPlugins reorders the prepareDataPlugins in the Config based on the given sorted plugin names.
-func (c *Config) OrderPrepareDataPlugins(sortedPluginNames []string) {
-	sortedPlugins := make([]fwk.PrepareDataPlugin, 0, len(sortedPluginNames))
-	nameToPlugin := make(map[string]fwk.PrepareDataPlugin)
-	for _, plugin := range c.prepareDataPlugins {
+// OrderDataProducers reorders the dataProducers in the Config based on the given sorted plugin names.
+func (c *Config) OrderDataProducers(sortedPluginNames []string) {
+	sortedPlugins := make([]fwk.DataProducer, 0, len(sortedPluginNames))
+	nameToPlugin := make(map[string]fwk.DataProducer)
+	for _, plugin := range c.dataProducers {
 		nameToPlugin[plugin.TypedName().String()] = plugin
 	}
 	for _, name := range sortedPluginNames {
@@ -109,5 +109,5 @@ func (c *Config) OrderPrepareDataPlugins(sortedPluginNames []string) {
 			sortedPlugins = append(sortedPlugins, plugin)
 		}
 	}
-	c.prepareDataPlugins = sortedPlugins
+	c.dataProducers = sortedPlugins
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->
Rename PrepareDataPlugin to DataProducer to address #2789
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2789

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
