### PR TITLE
Add prefix cache benchmarking scenarios

### DIFF
--- a/.github/workflows/e2e-prefix-cache-aware-gke.yaml
+++ b/.github/workflows/e2e-prefix-cache-aware-gke.yaml
@@ -277,7 +277,7 @@ jobs:
           fi
           port=80
           svc_host="${host}:${port}"
-          helm upgrade --install prefix-cache-benchmark ../inference-perf/ -f high-cache-values.yaml \
+          helm upgrade --install prefix-cache-benchmark ../inference-perf/ -f short-questions__many-system-prompts-values.yaml \
             --namespace "${NAMESPACE}" \
             --create-namespace \
             --set token.hfToken="${HF_TOKEN}" \

--- a/benchmarking/prefix-cache-aware/long-questions__few-system-prompts__multi-chat-values.yaml
+++ b/benchmarking/prefix-cache-aware/long-questions__few-system-prompts__multi-chat-values.yaml
@@ -1,4 +1,5 @@
-# High-Cache Configuration
+# Long-Questions__Few-System-Prompts__Multi-Chat Configuration
+# Low System Prompt Overlap, Low System Cache Pressure
 job:
   image:
     repository: quay.io/inference-perf/inference-perf
@@ -44,35 +45,29 @@ token:
 config:
   load:
     type: poisson
-    worker_max_concurrency: 1200
+    num_workers: 6
+    worker_max_concurrency: 3000
     stages:
-      # Warmup — seat residents (~1×S)
-      - rate: 15
-        duration: 50            # 15*50  = 750
-
-      # Main ladder
+      - rate: 1
+        duration: 100
+      - rate: 2
+        duration: 100
+      - rate: 3
+        duration: 100                   
+      - rate: 4
+        duration: 100
+      - rate: 5
+        duration: 100
+      - rate: 6
+        duration: 100
+      - rate: 7
+        duration: 100
+      - rate: 8
+        duration: 100
+      - rate: 9
+        duration: 100
       - rate: 10
-        duration: 20
-      - rate: 15
-        duration: 20
-      - rate: 20
-        duration: 38                   
-      - rate: 25
-        duration: 30           
-      - rate: 30
-        duration: 25           
-      - rate: 35
-        duration: 21           
-      - rate: 40               
-        duration: 38           
-      - rate: 45
-        duration: 36                   
-      - rate: 50
-        duration: 30                 
-      - rate: 55
-        duration: 27                 
-      - rate: 60
-        duration: 25 
+        duration: 100
   api:
     type: completion
     streaming: true
@@ -86,12 +81,22 @@ config:
   data:
     type: shared_prefix
     shared_prefix:
-      num_groups: 150             # Ensures a pool of 10k unique prompts
-      num_prompts_per_group: 5
-      system_prompt_len: 6000      # Large shared system prompt
-      question_len: 1200           # Short unique user query
+      num_groups: 6
+      num_prompts_per_group: 1000  # Ensures a pool of 6k unique prompts
+      system_prompt_len: 1000      # Large shared system prompt
+      question_len: 3000           # Long unique user query
       output_len: 1000
-      enable_multi_turn_chat: false
+      question_distribution:
+        mean: 3000
+        std_dev: 900
+        min: 1
+        max: 10000
+      output_distribution:
+        mean: 1000
+        std_dev: 300
+        min: 1
+        max: 10000
+      enable_multi_turn_chat: true
   metrics:
     type: prometheus
     prometheus:

--- a/benchmarking/prefix-cache-aware/long-questions__many-system-prompts-values.yaml
+++ b/benchmarking/prefix-cache-aware/long-questions__many-system-prompts-values.yaml
@@ -1,0 +1,107 @@
+# Long-Questions__Many-System-Prompts Configuration
+# Low System Prompt Overlap, Low System Cache Pressure
+job:
+  image:
+    repository: quay.io/inference-perf/inference-perf
+    tag: "" # Defaults to .Chart.AppVersion
+  nodeSelector: {}
+  serviceAccountName: ""
+  # Example resources:
+  # resources:
+  #   requests:
+  #     cpu: "1"
+  #     memory: "4Gi"
+  #   limits:
+  #     cpu: "2"
+  #     memory: "8Gi"
+  resources: {}
+
+logLevel: INFO
+
+# A GCS bucket path that points to the dataset file.
+# The file will be copied from this path to the local file system
+# at /gcsDataset/gcs-dataset.json for use during the run.
+# NOTE: For this dataset to be used, config.data.path must also be explicitly set to /gcsDataset/gcs-dataset.json.
+# Format: bucket-name/folder/to/dataset/file
+gcsPath: ""
+
+# An S3 bucket path that points to the dataset file.
+# The file will be copied from this path to the local file system
+# at /s3Dataset/s3-dataset.json for use during the run.
+# NOTE: For this dataset to be used, config.data.path must also be explicitly set to /s3Dataset/s3-dataset.json.
+# Format: bucket-name/folder/to/dataset/file
+s3Path: ""
+
+# Optional Token configuration for Hugging Face authentication.
+# hfSecret: Configures a pre-existing Kubernetes Secret.
+# hfToken: Creates a new kubernetes secret with the specified token.
+# If both specified, 'hfSecret' takes precedence over 'hfToken'.
+token:
+  hfSecret:
+    name: "" # The name of the existing Secret (e.g., 'my-hf-secret').
+    key: ""  # The key within the Secret that holds the token value (e.g., 'token' or 'hf-token').
+  hfToken: ""
+
+config:
+  load:
+    type: poisson
+    worker_max_concurrency: 1200
+    stages:
+      # Warmup — seat residents (~1×S)
+      - rate: 15
+        duration: 50            # 15*50  = 750
+
+      # Main ladder
+      - rate: 10
+        duration: 20
+      - rate: 15
+        duration: 20
+      - rate: 20
+        duration: 38                   
+      - rate: 25
+        duration: 30           
+      - rate: 30
+        duration: 25           
+      - rate: 35
+        duration: 21           
+      - rate: 40               
+        duration: 38           
+      - rate: 45
+        duration: 36                   
+      - rate: 50
+        duration: 30                 
+      - rate: 55
+        duration: 27                 
+      - rate: 60
+        duration: 25 
+  api:
+    type: completion
+    streaming: true
+  server:
+    type: vllm
+    model_name: Qwen/Qwen3-32B
+    base_url: http://0.0.0.0:8000
+    ignore_eos: true
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen3-32B
+  data:
+    type: shared_prefix
+    shared_prefix:
+      num_groups: 150             # Ensures a pool of 10k unique prompts
+      num_prompts_per_group: 5
+      system_prompt_len: 1000      # Low shared system prompt
+      question_len: 6200           # Long query - flipped for low cache
+      output_len: 1000
+      enable_multi_turn_chat: false
+  metrics:
+    type: prometheus
+    prometheus:
+      google_managed: true
+  report:
+    request_lifecycle:
+      summary: true
+      per_stage: true
+      per_request: true
+    prometheus:
+      summary: true
+      per_stage: true

--- a/benchmarking/prefix-cache-aware/short-questions__few-system-prompts__multi-chat-values.yaml
+++ b/benchmarking/prefix-cache-aware/short-questions__few-system-prompts__multi-chat-values.yaml
@@ -1,0 +1,108 @@
+# Short-Questions__Few-System-Prompts__Multi-Chat Configuration
+# High System Prompt Overlap, Low System Cache Pressure
+job:
+  image:
+    repository: quay.io/inference-perf/inference-perf
+    tag: "" # Defaults to .Chart.AppVersion
+  nodeSelector: {}
+  serviceAccountName: ""
+  # Example resources:
+  # resources:
+  #   requests:
+  #     cpu: "1"
+  #     memory: "4Gi"
+  #   limits:
+  #     cpu: "2"
+  #     memory: "8Gi"
+  resources: {}
+
+logLevel: INFO
+
+# A GCS bucket path that points to the dataset file.
+# The file will be copied from this path to the local file system
+# at /gcsDataset/gcs-dataset.json for use during the run.
+# NOTE: For this dataset to be used, config.data.path must also be explicitly set to /gcsDataset/gcs-dataset.json.
+# Format: bucket-name/folder/to/dataset/file
+gcsPath: ""
+
+# An S3 bucket path that points to the dataset file.
+# The file will be copied from this path to the local file system
+# at /s3Dataset/s3-dataset.json for use during the run.
+# NOTE: For this dataset to be used, config.data.path must also be explicitly set to /s3Dataset/s3-dataset.json.
+# Format: bucket-name/folder/to/dataset/file
+s3Path: ""
+
+# Optional Token configuration for Hugging Face authentication.
+# hfSecret: Configures a pre-existing Kubernetes Secret.
+# hfToken: Creates a new kubernetes secret with the specified token.
+# If both specified, 'hfSecret' takes precedence over 'hfToken'.
+token:
+  hfSecret:
+    name: "" # The name of the existing Secret (e.g., 'my-hf-secret').
+    key: ""  # The key within the Secret that holds the token value (e.g., 'token' or 'hf-token').
+  hfToken: ""
+
+config:
+  load:
+    type: poisson
+    num_workers: 6
+    worker_max_concurrency: 3000
+    stages:
+      - rate: 1
+        duration: 100
+      - rate: 3
+        duration: 100
+      - rate: 5
+        duration: 100
+      - rate: 7
+        duration: 100
+      - rate: 9
+        duration: 100
+      - rate: 11
+        duration: 100
+      - rate: 13
+        duration: 100
+      - rate: 15
+        duration: 100
+      - rate: 17
+        duration: 100
+      
+  api:
+    type: completion
+    streaming: true
+  server:
+    type: vllm
+    model_name: Qwen/Qwen3-32B
+    base_url: http://0.0.0.0:8000
+    ignore_eos: true
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen3-32B
+  data:
+    type: shared_prefix
+    shared_prefix:
+      num_groups: 6
+      num_prompts_per_group: 1000
+      system_prompt_len: 1000
+      question_distribution:
+        mean: 30
+        std_dev: 9
+        min: 1
+        max: 10000
+      output_distribution:
+        mean: 1000
+        std_dev: 300
+        min: 1
+        max: 10000
+      enable_multi_turn_chat: true
+  metrics:
+    type: prometheus
+    prometheus:
+      google_managed: true
+  report:
+    request_lifecycle:
+      summary: true
+      per_stage: true
+      per_request: true
+    prometheus:
+      summary: true
+      per_stage: true

--- a/benchmarking/prefix-cache-aware/short-questions__many-system-prompts-values.yaml
+++ b/benchmarking/prefix-cache-aware/short-questions__many-system-prompts-values.yaml
@@ -1,4 +1,5 @@
-# Low-Cache Configuration
+# Short-Questions__Many-System-Prompts Configuration
+# Low System Prompt Overlap, High System Cache Pressure
 job:
   image:
     repository: quay.io/inference-perf/inference-perf
@@ -88,8 +89,8 @@ config:
     shared_prefix:
       num_groups: 150             # Ensures a pool of 10k unique prompts
       num_prompts_per_group: 5
-      system_prompt_len: 1200      # Low shared system prompt
-      question_len: 6000           # Long query - flipped for low cache
+      system_prompt_len: 6000      # Large shared system prompt
+      question_len: 1200           # Short unique user query
       output_len: 1000
       enable_multi_turn_chat: false
   metrics:

--- a/site-src/performance/benchmark/advanced-configs/prefix-cache-aware.md
+++ b/site-src/performance/benchmark/advanced-configs/prefix-cache-aware.md
@@ -22,18 +22,25 @@ The chart uses the `shared_prefix` dataset type, which is designed to test cachi
 *   `system_prompt_len`: The length of the system prompt.
 *   `question_len`: The length of the question part of the prompt.
 *   `output_len`: The desired length of the model's output.
+*   `enable_multi_turn_chat`: Creates a user session to keep the conversation where the chat context will be appended for the each request.
 
 The default values for the dataset are defined in the chart, but you can override them using `--set config.data.shared_prefix.<parameter>` flags. 
 
 Example:
 
 ```bash
-helm install my-release ../inference-perf -f high-cache-values.yaml --set config.data.shared_prefix.num_groups=512
+helm install my-release ../inference-perf -f long-prefix__many-templates-values.yaml --set config.data.shared_prefix.num_groups=512
 ```
 
 ## Deployment
 
-This chart supports two main configurations, defined in `high-cache-values.yaml` and `low-cache-values.yaml`.
+This chart supports four configurations located under `gateway-api-inference-extension/benchmarking/prefix-cache-aware`:
+
+*   `short-questions__many-system-prompts-values.yaml`: Low System Prompt Overlap, High System Cache Pressure
+*   `long-questions__many-system-prompts-values.yaml`: Low System Prompt Overlap, Low System Cache Pressure
+*   `short-questions__few-system-prompts-values__multi-chat-values.yaml`: High System Prompt Overlap, No System Cache Pressure
+*   `long-questions__few-system-prompts-values__multi-chat-values.yaml`: Low System Prompt Overlap, No System Cache Pressure
+
 
 ### 1. Check out the repo.
 
@@ -56,9 +63,9 @@ cd gateway-api-inference-extension/benchmarking/prefix-cache-aware
   echo $SVC_IP
   ```
 
-### 3. Deploying the High-Cache Configuration
+### 3. Deploying the Configuration
 
-This configuration is optimized for scenarios where a high cache hit rate is expected. It uses the `high-cache-values.yaml` file.
+This example uses the `short-questions__many-system-prompts-values.yaml` file which is optimized for scenarios where a high cache hit rate is expected. It
 
 ```bash
 export IP='<YOUR_IP>'
@@ -71,7 +78,7 @@ export HF_TOKEN='<YOUR_HUGGINGFACE_TOKEN>'
 export HF_SECRET_NAME='<YOUR_SECRET_NAME>'
 export HF_SECRET_KEY='<YOUR_SECRET_KEY>'
 
-helm install high-cache ../inference-perf -f high-cache-values.yaml \
+helm install prefix-cache-benchmark ../inference-perf -f long-prefix__many-templates-values.yaml \
   --set "config.server.base_url=http://${IP}:${PORT}"
   # ------------------------------------------------
   # HUGGINGFACE OPTION A
@@ -85,55 +92,20 @@ helm install high-cache ../inference-perf -f high-cache-values.yaml \
 
 **Parameters to customize:**
 
-*   `high-cache`: A unique name for this deployment.
+*   `prefix-cache-benchmark`: A unique name for this deployment. Note, you can deploy multiple charts as long as they have different names.
+*.  `long-prefix__many-templates-values.yaml`: The appropriate benchmark config you want to test.
 *   `token.hfToken`: Your hugging face token. Inference Perf chart will create a new kubernetes secret containing this token.
 *   `hfSecret.name`: The name of your Kubernetes Secret containing the Hugging Face token (default: `hf-token`).
 *   `hfSecret.key`: The key in your Kubernetes Secret pointing to the Hugging Face token (default: `token`).
 *   `config.server.base_url`: The base URL (IP and port) of your inference server for the high-cache scenario.
 
-### 4. Deploying the Low-Cache Configuration
 
-This configuration is designed for scenarios with a lower cache hit rate. It uses the `low-cache-values.yaml` file.
-
-```bash
-cd gateway-api-inference-extension/benchmarking/prefix-cache-aware
-export IP='<YOUR_IP>'
-export PORT='<YOUR_PORT>'
-
-# HUGGINGFACE PARAMETERS
-# Option A: Pass Token Directly
-export HF_TOKEN='<YOUR_HUGGINGFACE_TOKEN>'
-# Option B: Use Existing Kubernetes Secret
-export HF_SECRET_NAME='<YOUR_SECRET_NAME>'
-export HF_SECRET_KEY='<YOUR_SECRET_KEY>'
-
-helm install low-cache ../inference-perf -f low-cache-values.yaml \
-  --set "config.server.base_url=http://${IP}:${PORT}"
-  # ------------------------------------------------
-  # HUGGINGFACE OPTION A
-  --set token.hfToken=${HF_TOKEN} \ 
-  # ------------------------------------------------
-  # HUGGINGFACE OPTION B
-  # --set token.hfSecret.name=${HF_SECRET_NAME} \
-  # --set token.hfSecret.key=${HF_SECRET_KEY} \
-  # ------------------------------------------------
-```
-
-**Parameters to customize:**
-
-*   `low-cache`: A unique name for this deployment.
-*   `token.hfToken`: Your hugging face token. Inference Perf chart will create a new kubernetes secret containing this token.
-*   `hfSecret.name`: The name of your Kubernetes Secret containing the Hugging Face token (default: `hf-token`).
-*   `hfSecret.key`: The key in your Kubernetes Secret pointing to the Hugging Face token (default: `token`).
-*   `config.server.base_url`: The base URL (IP and port) of your inference server for the high-cache scenario.
-
-## Clean Up
+## 4. Clean Up
 
 To uninstall the deployed charts:
 
 ```bash
-helm uninstall my-high-cache-release
-helm uninstall my-low-cache-release
+helm uninstall prefix-cache-benchmark
 ```
 
 ## Post Benchmark Analysis


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Add more prefix cache benchmarking scenarios to cover high/low system prompts with low system cache.
Configs are aligned with configurations determined in [blog](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms#benchmark-configuration)

**Does this PR introduce a user-facing change?**:
```release-note
Update prefix cache guide to reference more benchmarking scenarios
```
