### PR TITLE
fix(requestcontrol): cancel PrepareData plugin context on timeout

### DIFF
--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -38,19 +38,25 @@ func executePluginsAsDAG(plugins []fwk.DataProducer, ctx context.Context, reques
 }
 
 // prepareDataPluginsWithTimeout executes the PrepareRequestData plugins with retries and timeout.
+// The child context is cancelled when the timeout fires so plugins can observe cancellation
+// (e.g. abort outbound HTTP calls) and avoid committing state after the director has moved on.
 func prepareDataPluginsWithTimeout(timeout time.Duration, plugins []fwk.DataProducer,
 	ctx context.Context, request *schedulingtypes.InferenceRequest, endpoints []schedulingtypes.Endpoint) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- executePluginsAsDAG(plugins, ctx, request, endpoints)
 	}()
 
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
 	case err := <-errCh:
 		return err
-	case <-time.After(timeout):
-		return errors.New("prepare data plugin timed out")
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return errors.New("prepare data plugin timed out")
+		}
+		return ctx.Err()
 	}
 }

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -62,6 +62,59 @@ func (m *mockPrepareRequestDataPlugin) Consumes() map[string]any {
 	return nil
 }
 
+// ctxObservingPlugin records the context it received so tests can verify the
+// timeout wrapper cancels the plugin's context when the deadline fires.
+type ctxObservingPlugin struct {
+	name           string
+	block          time.Duration
+	observedCtxErr error
+	wg             sync.WaitGroup
+}
+
+func (p *ctxObservingPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock", Name: p.name}
+}
+
+func (p *ctxObservingPlugin) PrepareRequestData(ctx context.Context, _ *schedulingtypes.InferenceRequest, _ []schedulingtypes.Endpoint) error {
+	defer p.wg.Done()
+	select {
+	case <-time.After(p.block):
+	case <-ctx.Done():
+	}
+	p.observedCtxErr = ctx.Err()
+	return ctx.Err()
+}
+
+func (p *ctxObservingPlugin) Produces() map[string]any { return nil }
+func (p *ctxObservingPlugin) Consumes() map[string]any { return nil }
+
+// TestPrepareDataPluginsWithTimeout_CancelsPluginContext verifies that the
+// child context passed to plugins is cancelled with DeadlineExceeded when the
+// timeout fires. Without this cancellation, a slow plugin would continue
+// executing past the director's deadline and potentially commit state after
+// downstream hooks have already observed an "empty" state — the root cause of
+// the orphan-decrement drift we're fixing in the predicted-latency producer.
+func TestPrepareDataPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
+	plugin := &ctxObservingPlugin{name: "slow", block: time.Second}
+	plugin.wg.Add(1)
+
+	err := prepareDataPluginsWithTimeout(
+		20*time.Millisecond,
+		[]fwk.DataProducer{plugin},
+		context.Background(),
+		&schedulingtypes.InferenceRequest{},
+		nil,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "prepare data plugin timed out")
+
+	// Wait for the plugin goroutine to observe cancellation before asserting
+	// on the recorded context error.
+	plugin.wg.Wait()
+	assert.ErrorIs(t, plugin.observedCtxErr, context.DeadlineExceeded,
+		"plugin's context should be cancelled with DeadlineExceeded when timeout fires")
+}
+
 func TestPrepareDataPluginsWithTimeout(t *testing.T) {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Propagate cancellation to `PrepareRequestData` plugins when the director's timeout fires. The existing `time.After` path returned an error to the director but left the plugin goroutine running with a context that was still alive, so a slow plugin could keep executing long after the director moved on.

## Motivation

`prepareDataPluginsWithTimeout` enforces the director's 400ms budget for per-request data preparation. Today the timeout only affects the **director's** return — the plugin itself receives an uncancelled `context.Context` and can keep running indefinitely:

```go
errCh := make(chan error, 1)
go func() {
    errCh <- executePluginsAsDAG(plugins, ctx, request, endpoints) // ctx is parent
}()

select {
case <-time.After(timeout):
    return errors.New("prepare data plugin timed out") // director returns; goroutine lives on
...
}
```

Consequences observed in production under load:

1. **Wasted work.** Plugins continue issuing outbound HTTP calls (e.g. to sidecars) even though the director already discarded their output.
2. **Late state commits.** Plugins that publish into shared state (maps, counters, caches) at the end of `PrepareRequestData` can commit *after* the request's downstream hooks (`PreRequest`, `ResponseBody`) have already run against an "empty" view of that state. This is the root cause of an orphan-decrement bug we saw in the `predicted-latency` producer, where `prefillTokensInFlight` drifted negative fast enough to start failing every bulk prediction with `greater_than_equal: 0` validation errors.
3. **No backpressure signal.** Plugins have no way to learn the director gave up, so they can't short-circuit cooperative work or log the abandonment.

None of this requires a plugin to misbehave on purpose — it's the difference between "the director timed out" and "the plugin should stop."

## Change

Wrap the plugin execution in `context.WithTimeout` so the child context is cancelled when the deadline fires:

```go
ctx, cancel := context.WithTimeout(ctx, timeout)
defer cancel()

errCh := make(chan error, 1)
go func() {
    errCh <- executePluginsAsDAG(plugins, ctx, request, endpoints)
}()

select {
case err := <-errCh:
    return err
case <-ctx.Done():
    if errors.Is(ctx.Err(), context.DeadlineExceeded) {
        return errors.New("prepare data plugin timed out")
    }
    return ctx.Err()
}
```

Effects:
- Plugin HTTP calls bound to `ctx` abort immediately when the deadline passes.
- Plugins that `select` on `ctx.Done()` wake up and can short-circuit.
- Plugins that inspect `ctx.Err()` before committing state can skip publication when the director has already moved on.

This does **not** force-kill the goroutine — Go has no safe way to do that — but it gives every cooperating path the signal it needs.

## Follow-up

This PR is narrowly scoped to the executor. A follow-up will harden individual `PrepareData` plugins that still commit state unconditionally once they start running (notably the `predicted-latency` producer, where late publication drives `prefillTokensInFlight` negative and causes prediction 422s under sustained load on undersized sidecars).

## Testing

- Added `TestPrepareDataPluginsWithTimeout_CancelsPluginContext`: runs a plugin that blocks far past the timeout and asserts the plugin's observed `ctx.Err()` is `context.DeadlineExceeded`.
- Existing `TestPrepareDataPluginsWithTimeout` and `TestExecutePluginsAsDAG` suites pass unchanged.

## Risk

Low.
- Plugins that already honor `ctx` (the common case) now exit faster on timeout — a strict improvement.
- Plugins that ignore `ctx` behave exactly as before: the director still returns the timeout error at the same moment; the goroutine still runs to completion. No new failure modes.
- No API or configuration change; the 400ms timeout constant is unchanged.
