### PR TITLE
fix(latencypredictor): reload model in every sync cycle, not just when this worker downloaded

### DIFF
--- a/latencypredictor/prediction_server.py
+++ b/latencypredictor/prediction_server.py
@@ -279,12 +279,17 @@ class ModelSyncer:
     def _sync_loop(self):
         while not self._shutdown_event.is_set():
             try:
-                updated = self.sync_models()
-                # Always try to load models if predictor isn't ready yet,
-                # even if no new files were downloaded (another worker may
-                # have already written them to disk).
-                if updated or not predictor.is_ready:
-                    predictor.load_models()
+                # Download the latest model files from the training server.
+                # sync_models() returns True only if THIS worker downloaded a
+                # new file. In multi-worker mode only one of the N workers
+                # wins that race per cycle, so we must call load_models()
+                # unconditionally — otherwise the N-1 workers that lost the
+                # download race would keep serving a stale in-memory model.
+                # load_models() has its own checksum-based early return, so
+                # the cost when the file on disk hasn't changed is just a
+                # file-checksum read.
+                self.sync_models()
+                predictor.load_models()
             except Exception as e:
                 logging.error(f"Error in sync loop: {e}")
             self._shutdown_event.wait(timeout=settings.MODEL_SYNC_INTERVAL_SEC)


### PR DESCRIPTION

The prediction server runs N uvicorn workers (default 8, configurable via UVICORN_WORKERS), each with its own background sync thread that ticks every MODEL_SYNC_INTERVAL_SEC. Each worker independently checks the training server for a newer model and downloads it atomically via os.replace. load_models() was then only called if *that specific worker* had downloaded a new file OR the worker was still starting up.

Under multi-worker deployments that's the wrong condition. Every sync cycle only ONE worker wins the race to replace the file on disk: the first worker to run _download_model_if_newer sees server_mtime > local_mtime, downloads, and writes. When the other N-1 workers check a few milliseconds later, they see local_mtime >= server_mtime (local was just updated by the winner), return False from sync_models, and — with predictor.is_ready already True from startup — skip load_models entirely. The file on disk has the fresh model, but 27 out of 28 workers are still serving the in-memory model they loaded at startup.

Sleep-timer drift between workers eventually rotates the "winner" over many cycles, so each worker gets at least one load roughly every (workers × cycle_seconds) — ~14 minutes average and ~40 minutes p95 for the default 28-worker configuration. In the meantime, predictions are dominated by the stale startup model (~constant 10ms for XGBoost on zero/one training samples), poisoning the request_predicted_ttft histogram under any Prometheus window shorter than that drift interval.

Call load_models() unconditionally in every sync tick. It already has a checksum-based early return:

    if self.is_ready and all_checksums == self._loaded_checksums:
        return True

so when the file on disk hasn't changed the cost is just a file- checksum read — no deserialization, no model swap. When the file HAS changed (either because this worker downloaded it or another worker did), every worker reloads its in-memory model promptly.

Reproduced on a test cluster: with 28 workers and the old code, 30 back-to-back probe requests routed across 6 different workers all returned the untrained default ttft_ms=10.0, even though the training server had just trained on 225 samples with MAE ~6200ms. After this change, all workers pick up each new model within one sync cycle.
