### PR TITLE
[release-1.5] Cherry-pick #2848: fix(predictedlatency): keep prefillTokensInFlight from drifting negative

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/plugin.go
@@ -52,7 +52,7 @@ const (
 	// TPOTSLOHeaderKey is the header key for the TPOT SLO.
 	TPOTSLOHeaderKey = "x-slo-tpot-ms"
 
-	// Experimental_DefaultPrefillProfile is the default profile name for prefill pods in disaggregated serving.
+	// Experimental_DefaultPrefillProfile is the default profile name for prefill endpoints in disaggregated serving.
 	Experimental_DefaultPrefillProfile = "prefill"
 )
 
@@ -70,13 +70,46 @@ type PredictedLatency struct {
 	runningRequestLists   sync.Map                                      // Key: types.NamespacedName, Value: *requestPriorityQueue
 	sloContextStore       *ttlcache.Cache[string, *predictedLatencyCtx] // TTL cache for request contexts
 	config                Config
-	prefillTokensInFlight sync.Map // Key: pod NamespacedName.String(), Value: *atomic.Int64
+	prefillTokensInFlight sync.Map // Key: endpoint NamespacedName.String(), Value: *atomic.Int64
 }
 
-// podCounter returns the atomic counter for the given pod key, creating it if necessary.
-func (t *PredictedLatency) podCounter(m *sync.Map, key string) *atomic.Int64 {
+// endpointCounter returns the atomic counter for the given endpoint key, creating it if necessary.
+func (t *PredictedLatency) endpointCounter(m *sync.Map, key string) *atomic.Int64 {
 	v, _ := m.LoadOrStore(key, new(atomic.Int64))
 	return v.(*atomic.Int64)
+}
+
+// decrementEndpointCounter subtracts delta from the counter at key with a hard
+// floor at zero, and removes the entry from the map once the counter reaches
+// zero. This is the only sanctioned way to decrement prefillTokensInFlight
+// (or any counter with the same shape): a naive Add(-delta) can drift the
+// counter negative if callers race (e.g. PrepareData publishing an SLO
+// context after PreRequest already skipped the increment), which used to
+// break prediction requests with `greater_than_equal: 0` validation errors.
+// Decrementing a missing key is a no-op and does not create a zero entry.
+func (t *PredictedLatency) decrementEndpointCounter(m *sync.Map, key string, delta int64) {
+	v, ok := m.Load(key)
+	if !ok {
+		return
+	}
+	counter := v.(*atomic.Int64)
+	for {
+		current := counter.Load()
+		if current <= 0 {
+			// Already at or below zero; clamp and don't over-decrement.
+			return
+		}
+		next := current - delta
+		if next < 0 {
+			next = 0
+		}
+		if counter.CompareAndSwap(current, next) {
+			if next == 0 {
+				m.Delete(key)
+			}
+			return
+		}
+	}
 }
 
 type Config struct {
@@ -160,19 +193,13 @@ func NewPredictedLatency(config Config, predictor latencypredictor.PredictorInte
 		}
 		plCtx := item.Value()
 		predictedLatency.removeRequestFromQueue(item.Key(), plCtx)
-		if plCtx.prefillTokensAtDispatch > 0 || plCtx.prefillTokensAtDispatchOnPrefill > 0 {
-			if plCtx.prefillTargetMetadata != nil && plCtx.ttft == 0 {
-				prefillPodKey := plCtx.prefillTargetMetadata.NamespacedName.String()
-				if predictedLatency.podCounter(&predictedLatency.prefillTokensInFlight, prefillPodKey).Add(-int64(plCtx.inputTokenCount)) == 0 {
-					predictedLatency.prefillTokensInFlight.Delete(prefillPodKey)
-				}
-			}
-			if plCtx.targetMetadata != nil {
-				decodePodKey := plCtx.targetMetadata.NamespacedName.String()
-				if predictedLatency.podCounter(&predictedLatency.prefillTokensInFlight, decodePodKey).Add(-int64(plCtx.inputTokenCount)) == 0 {
-					predictedLatency.prefillTokensInFlight.Delete(decodePodKey)
-				}
-			}
+		if plCtx.prefillTargetMetadata != nil && plCtx.ttft == 0 && plCtx.prefillTokensAtDispatchOnPrefill > 0 {
+			prefillEndpointKey := plCtx.prefillTargetMetadata.NamespacedName.String()
+			predictedLatency.decrementEndpointCounter(&predictedLatency.prefillTokensInFlight, prefillEndpointKey, int64(plCtx.inputTokenCount))
+		}
+		if plCtx.targetMetadata != nil && plCtx.prefillTokensAtDispatch > 0 {
+			decodeEndpointKey := plCtx.targetMetadata.NamespacedName.String()
+			predictedLatency.decrementEndpointCounter(&predictedLatency.prefillTokensInFlight, decodeEndpointKey, int64(plCtx.inputTokenCount))
 		}
 	})
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/prediction.go
@@ -69,7 +69,7 @@ func (s *PredictedLatency) generatePredictions(ctx context.Context, predictedLat
 		prefixCacheScores[i] = prefixCacheScore
 
 		podKey := endpoint.GetMetadata().NamespacedName.String()
-		prefillTokensInFlights[i] = s.podCounter(&s.prefillTokensInFlight, podKey).Load()
+		prefillTokensInFlights[i] = s.endpointCounter(&s.prefillTokensInFlight, podKey).Load()
 	}
 
 	// Bulk predict
@@ -151,7 +151,7 @@ func (s *PredictedLatency) validatePrediction(
 		// a podMinTPOTSLO of 0 means no either no requests, or no TPOT SLOs specified on running requests
 		if podMinTPOTSLO > 0 {
 			if podMinTPOTSLO < predictedLatencyCtx.avgTPOTSLO {
-				log.FromContext(context.Background()).V(logutil.DEBUG).Info("Pod min TPOT SLO is less than the req SLO, adjusting", "podMinTPOTSLO", podMinTPOTSLO, "bufferedTPOT", predictedLatencyCtx.avgTPOTSLO)
+				log.FromContext(context.Background()).V(logutil.DEBUG).Info("Endpoint min TPOT SLO is less than the req SLO, adjusting", "podMinTPOTSLO", podMinTPOTSLO, "bufferedTPOT", predictedLatencyCtx.avgTPOTSLO)
 			}
 			bufferedTPOT = min(bufferedTPOT, podMinTPOTSLO*s.config.SLOBufferFactor)
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks.go
@@ -58,6 +58,9 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 	}
 	if !s.config.PredictInPrepareData {
 		logger.V(logutil.DEBUG).Info("PredictInPrepareData disabled, skipping predictions")
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		s.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 		return nil
 	}
@@ -91,6 +94,13 @@ func (s *PredictedLatency) PrepareRequestData(ctx context.Context, request *sche
 		}
 	}
 
+	// Don't publish the SLO context after the director's PrepareData window has closed.
+	// If we did, PreRequest has already run (and skipped incrementing counters because the
+	// context wasn't yet present), but ResponseBody would later find the context and issue
+	// an orphan decrement — drifting prefillTokensInFlight negative under sustained load.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	s.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
 	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/preparedata_hooks_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package predictedlatency
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	fwksched "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	attrlatency "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
@@ -33,4 +35,44 @@ func TestProducesConsumes(t *testing.T) {
 
 	consumes := pl.Consumes()
 	assert.Contains(t, consumes, attrprefix.PrefixCacheMatchInfoKey)
+}
+
+// TestPrepareRequestData_CancelledContextDoesNotPublish verifies that when the
+// director's PrepareData window has already closed (ctx cancelled), the plugin
+// does not publish the SLO context into the ttlcache. If it did, ResponseBody
+// would later find the context and issue an orphan decrement against counters
+// PreRequest never incremented — draining prefillTokensInFlight negative.
+func TestPrepareRequestData_CancelledContextDoesNotPublish(t *testing.T) {
+	cfg := DefaultConfig
+	cfg.PredictInPrepareData = false // skip the prediction sidecar path
+	pl := NewPredictedLatency(cfg, nil)
+
+	request := createTestLLMRequest("cancel-test", 0, 0)
+	endpoint := createTestEndpoint("pod-a", 0.1, 0, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the plugin runs
+
+	err := pl.PrepareRequestData(ctx, request, []fwksched.Endpoint{endpoint})
+	assert.ErrorIs(t, err, context.Canceled, "should propagate ctx.Err() on cancelled context")
+
+	_, getErr := pl.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, getErr, "SLO context should NOT be stored when ctx is cancelled")
+}
+
+// TestPrepareRequestData_LivesContextPublishes is the positive control for the
+// cancellation test above: with a live context, the fast-path store still fires.
+func TestPrepareRequestData_LiveContextPublishes(t *testing.T) {
+	cfg := DefaultConfig
+	cfg.PredictInPrepareData = false
+	pl := NewPredictedLatency(cfg, nil)
+
+	request := createTestLLMRequest("live-test", 0, 0)
+	endpoint := createTestEndpoint("pod-a", 0.1, 0, 0)
+
+	err := pl.PrepareRequestData(context.Background(), request, []fwksched.Endpoint{endpoint})
+	assert.NoError(t, err)
+
+	_, getErr := pl.getPredictedLatencyContextForRequest(request)
+	assert.NoError(t, getErr, "SLO context should be stored on the happy path")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks.go
@@ -100,11 +100,11 @@ func (t *PredictedLatency) PreRequest(ctx context.Context, request *schedulingty
 	decodePodKey := endpointName.String()
 	if predictedLatencyCtx.prefillTargetMetadata != nil {
 		prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-		t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
-		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Load()
+		t.endpointCounter(&t.prefillTokensInFlight, prefillPodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+		predictedLatencyCtx.prefillTokensAtDispatchOnPrefill = t.endpointCounter(&t.prefillTokensInFlight, prefillPodKey).Load()
 	}
-	t.podCounter(&t.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
-	predictedLatencyCtx.prefillTokensAtDispatch = t.podCounter(&t.prefillTokensInFlight, decodePodKey).Load()
+	t.endpointCounter(&t.prefillTokensInFlight, decodePodKey).Add(int64(predictedLatencyCtx.inputTokenCount))
+	predictedLatencyCtx.prefillTokensAtDispatch = t.endpointCounter(&t.prefillTokensInFlight, decodePodKey).Load()
 	predictedLatencyCtx.decodeTokensAtDispatch = 0
 
 	processPreRequestForLatencyPrediction(ctx, predictedLatencyCtx)
@@ -141,11 +141,12 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 		if t.config.StreamingMode && !response.EndOfStream {
 			processFirstTokenForLatencyPrediction(ctx, t.latencypredictor, t.config.StreamingMode, t.config.EndpointRoleLabel, predictedLatencyCtx, now, t.config.SamplingMean, t.config.MaxDecodeTokenSamplesForPrediction)
 
-			if predictedLatencyCtx.prefillTargetMetadata != nil {
+			// Only decrement if PreRequest actually incremented the prefill pod counter.
+			// If PrepareData timed out, PreRequest may have skipped incrementing, and
+			// decrementing here would drift the counter negative.
+			if predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 				prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-				if t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Add(-int64(predictedLatencyCtx.inputTokenCount)) == 0 {
-					t.prefillTokensInFlight.Delete(prefillPodKey)
-				}
+				t.decrementEndpointCounter(&t.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
 			}
 		}
 	} else {
@@ -202,14 +203,16 @@ func (t *PredictedLatency) ResponseBody(ctx context.Context, request *scheduling
 		}
 
 		decodePodKey := targetMetadata.NamespacedName.String()
-		if ttftNotYetRecorded && predictedLatencyCtx.prefillTargetMetadata != nil {
+		// Only decrement counters that PreRequest actually incremented. See the TTFT
+		// branch above for the rationale: PrepareData timeouts can leave PreRequest
+		// without an SLO context, so the counter was never bumped up, and decrementing
+		// here would orphan the pod's counter into negative territory.
+		if ttftNotYetRecorded && predictedLatencyCtx.prefillTargetMetadata != nil && predictedLatencyCtx.prefillTokensAtDispatchOnPrefill > 0 {
 			prefillPodKey := predictedLatencyCtx.prefillTargetMetadata.NamespacedName.String()
-			if t.podCounter(&t.prefillTokensInFlight, prefillPodKey).Add(-int64(predictedLatencyCtx.inputTokenCount)) == 0 {
-				t.prefillTokensInFlight.Delete(prefillPodKey)
-			}
+			t.decrementEndpointCounter(&t.prefillTokensInFlight, prefillPodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
-		if t.podCounter(&t.prefillTokensInFlight, decodePodKey).Add(-int64(predictedLatencyCtx.inputTokenCount)) == 0 {
-			t.prefillTokensInFlight.Delete(decodePodKey)
+		if predictedLatencyCtx.prefillTokensAtDispatch > 0 {
+			t.decrementEndpointCounter(&t.prefillTokensInFlight, decodePodKey, int64(predictedLatencyCtx.inputTokenCount))
 		}
 
 		id := request.Headers[reqcommon.RequestIdHeaderKey]

--- a/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestdataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -19,6 +19,7 @@ package predictedlatency
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -769,6 +770,97 @@ func TestPredictedLatency_NonStreamingMode_ResponseBody_FinalToken(t *testing.T)
 	// Context should be deleted when EndOfStream is reached
 	_, err := router.getPredictedLatencyContextForRequest(request)
 	assert.Error(t, err)
+}
+
+// TestDecrementEndpointCounter_FloorAtZero verifies the last line of defense:
+// decrementEndpointCounter never lets a counter go below zero, regardless of
+// how many times it's called or how large the delta is. This is what keeps
+// prefillTokensInFlight valid even if callers race in surprising ways.
+func TestDecrementEndpointCounter_FloorAtZero(t *testing.T) {
+	pl := &PredictedLatency{}
+	var m sync.Map
+	key := "default/pod-a"
+
+	// Decrement a counter that doesn't exist yet: should be a no-op and not
+	// create a negative entry.
+	pl.decrementEndpointCounter(&m, key, 100)
+	_, exists := m.Load(key)
+	assert.False(t, exists, "decrementing a missing counter should not create a negative entry")
+
+	// Increment, then decrement by more than the current value: result must
+	// clamp at zero and the entry should be removed from the map.
+	pl.endpointCounter(&m, key).Add(50)
+	pl.decrementEndpointCounter(&m, key, 200)
+	_, exists = m.Load(key)
+	assert.False(t, exists, "counter should be deleted when it reaches zero")
+
+	// Decrement-after-delete: another no-op, still no negative entries.
+	pl.decrementEndpointCounter(&m, key, 10)
+	if counter, ok := m.Load(key); ok {
+		value := counter.(*atomic.Int64).Load()
+		assert.GreaterOrEqual(t, value, int64(0), "counter must never go below zero")
+	}
+
+	// Normal path: partial decrement keeps the counter positive.
+	pl.endpointCounter(&m, key).Add(100)
+	pl.decrementEndpointCounter(&m, key, 30)
+	counter, ok := m.Load(key)
+	assert.True(t, ok)
+	assert.Equal(t, int64(70), counter.(*atomic.Int64).Load())
+}
+
+// TestPredictedLatency_ResponseBody_NoOrphanDecrement_WhenPreRequestSkipped
+// simulates the race that drove prefill counters negative in production: the
+// director's PrepareData window timed out, PreRequest saw no SLO context and
+// skipped the counter increment, but the PrepareData goroutine later published
+// the context anyway. ResponseBody must refuse to decrement counters that
+// PreRequest never bumped up — otherwise prefillTokensInFlight drifts below
+// zero and the prediction server rejects every subsequent request with 422.
+func TestPredictedLatency_ResponseBody_NoOrphanDecrement_WhenPreRequestSkipped(t *testing.T) {
+	router := createTestRouter()
+	router.config.StreamingMode = false
+	mockPredictor := new(mockPredictor)
+	router.latencypredictor = mockPredictor
+
+	ctx := context.Background()
+	endpoint := createTestEndpoint("test-pod", 1, 1, 1)
+	request := createTestLLMRequest("orphan-test", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	// Build an SLO context the way PrepareData would have, but skip the
+	// PreRequest step that would have incremented prefillTokensAtDispatch.
+	// This mirrors the production bug: PrepareData raced past the director's
+	// timeout and published a context that PreRequest never saw.
+	predictedLatencyCtx := newPredictedLatencyContext(request)
+	predictedLatencyCtx.targetMetadata = endpoint.GetMetadata()
+	predictedLatencyCtx.schedulingResult = schedulingResult
+	predictedLatencyCtx.schedulingRequest = *request
+	predictedLatencyCtx.requestReceivedTimestamp = time.Now().Add(-50 * time.Millisecond)
+	predictedLatencyCtx.inputTokenCount = 4096
+	// prefillTokensAtDispatch stays zero — PreRequest never ran.
+	router.setPredictedLatencyContextForRequest(request, predictedLatencyCtx)
+
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIdHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().NamespacedName, queue)
+
+	decodePodKey := endpoint.GetMetadata().NamespacedName.String()
+
+	router.ResponseBody(ctx, request, response, endpoint.GetMetadata())
+
+	// The decode pod counter must not have been decremented below zero. It
+	// should either not exist (never created) or still be at its starting
+	// value of zero — either is acceptable, anything negative is the bug.
+	if counter, ok := router.prefillTokensInFlight.Load(decodePodKey); ok {
+		value := counter.(*atomic.Int64).Load()
+		assert.GreaterOrEqual(t, value, int64(0),
+			"prefillTokensInFlight must not drift negative when PreRequest skipped the increment")
+	}
+
+	// The SLO context should still be cleaned up so we don't leak memory.
+	_, err := router.getPredictedLatencyContextForRequest(request)
+	assert.Error(t, err, "SLO context should be removed at EOS even on the orphan path")
 }
 
 func TestPredictedLatency_CheckPredictor_NilPod(t *testing.T) {


### PR DESCRIPTION

(cherry picked from commit c307ce7ea0441f6a12eb2ea59c53f56ccf80bfc9)

Minor rebase conflict: upstream/main renamed
schedulingtypes.LLMRequest → schedulingtypes.InferenceRequest and the helper createTestLLMRequest → createTestInferenceRequest. release-1.5 still uses the pre-rename names, so the three call sites added by the new regression tests were adjusted back to createTestLLMRequest to compile against release-1.5. No behavior changes.
