### PR TITLE
fix(dynamo integration): reorder mutate place so that jsonPayload can be mutated by preRequest plugins

### DIFF
--- a/.github/workflows/crd-validation.yml
+++ b/.github/workflows/crd-validation.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: "1.25"
           cache: true

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -205,9 +205,8 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 }
 
 func (d *Director) modelRewriteIfNeeded(reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
-	switch v := inferenceRequestBody.Payload.(type) {
-	case fwkrh.PayloadMap:
-		// Mutate the model name inside the map, this is currently only supported if the payload is a map.
+	if v, ok := inferenceRequestBody.Payload.(fwkrh.PayloadMap); ok {
+		// Mutate the model name inside the map, this is currently only supported if the payload is a PayloadMap.
 		_, err := d.mutateModel(reqCtx, v)
 		if err != nil {
 			return err

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -133,8 +133,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	logger := log.FromContext(ctx)
 
-	// Parse, mutate, and extract the request body
-	llmRequestBody, err := d.processParsedBody(ctx, reqCtx, inferenceRequestBody)
+	err := d.modelRewriteIfNeeded(reqCtx, inferenceRequestBody)
 	if err != nil {
 		return reqCtx, err
 	}
@@ -152,7 +151,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	reqCtx.SchedulingRequest = &fwksched.InferenceRequest{
 		RequestId:        reqCtx.Request.Headers[reqcommon.RequestIdHeaderKey],
 		TargetModel:      reqCtx.TargetModelName,
-		Body:             llmRequestBody,
+		Body:             inferenceRequestBody,
 		Headers:          reqCtx.Request.Headers,
 		Objectives:       requestObjectives,
 		RequestSizeBytes: reqCtx.RequestSize,
@@ -199,46 +198,21 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	if err != nil {
 		return reqCtx, err
 	}
-
+	if err := d.repackage(ctx, reqCtx, inferenceRequestBody); err != nil {
+		return reqCtx, err
+	}
 	return reqCtx, nil
 }
 
-func (d *Director) processParsedBody(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (*fwkrh.InferenceRequestBody, error) {
+func (d *Director) modelRewriteIfNeeded(reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
 	switch v := inferenceRequestBody.Payload.(type) {
-	case fwkrh.PayloadProto:
-		// Protos are not currently mutated, return as-is.
-		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
 	case fwkrh.PayloadMap:
-		if err := d.mutateAndRepackage(ctx, reqCtx, v); err != nil {
-			return nil, err
+		// Mutate the model name inside the map, this is currently only supported if the payload is a map.
+		_, err := d.mutateModel(reqCtx, v)
+		if err != nil {
+			return err
 		}
-	case fwkrh.RawPayload:
-		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
-	default:
-		return nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
 	}
-	return inferenceRequestBody, nil
-}
-
-func (d *Director) mutateAndRepackage(ctx context.Context, reqCtx *handlers.RequestContext, bodyMap map[string]any) error {
-	logger := log.FromContext(ctx)
-
-	// Mutate the model name inside the map
-	_, err := d.mutateModel(reqCtx, bodyMap)
-	if err != nil {
-		return err
-	}
-
-	// Marshal back to bytes so downstream ExtProc filters see the updated model
-	requestBodyBytes, err := json.Marshal(bodyMap)
-	if err != nil {
-		logger.Error(err, "Error marshalling request body")
-		return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
-	}
-
-	reqCtx.Request.RawBody = requestBodyBytes
-	reqCtx.RequestSize = len(requestBodyBytes)
-
 	return nil
 }
 
@@ -255,6 +229,25 @@ func (d *Director) mutateModel(reqCtx *handlers.RequestContext, bodyMap map[stri
 	d.applyWeightedModelRewrite(reqCtx)
 	bodyMap["model"] = reqCtx.TargetModelName
 	return reqCtx, nil
+}
+
+func (d *Director) repackage(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
+	logger := log.FromContext(ctx)
+	switch v := inferenceRequestBody.Payload.(type) {
+	case fwkrh.PayloadMap:
+		requestBodyBytes, err := json.Marshal(v)
+		if err != nil {
+			logger.Error(err, "Error marshalling request body")
+			return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
+		}
+		reqCtx.Request.RawBody = requestBodyBytes
+		reqCtx.RequestSize = len(requestBodyBytes)
+	case fwkrh.PayloadProto, fwkrh.RawPayload:
+		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
+	default:
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
+	}
+	return nil
 }
 
 func (d *Director) applyWeightedModelRewrite(reqCtx *handlers.RequestContext) {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -158,6 +158,21 @@ func (m *mockAdmissionPlugin) AdmitRequest(ctx context.Context, request *fwksche
 	return m.denialError
 }
 
+type mockPreRequestPlugin struct {
+	name     string
+	modifyFn func(request *fwksched.InferenceRequest)
+}
+
+func (m *mockPreRequestPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
+}
+
+func (m *mockPreRequestPlugin) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) {
+	if m.modifyFn != nil {
+		m.modifyFn(request)
+	}
+}
+
 type mockProducedDataType struct {
 	value int
 }
@@ -304,10 +319,11 @@ func TestDirector_HandleRequest(t *testing.T) {
 		parser                  fwkrh.Parser
 		wantErrCode             string                   // Expected errcommon code string
 		wantReqCtx              *handlers.RequestContext // Fields to check in the returned RequestContext
-		wantMutatedBodyModel    string                   // Expected model in reqCtx.Request.Body after PostDispatch
 		targetModelName         string                   // Expected model name after target model resolution
 		admitRequestDenialError error                    // Expected denial error from admission plugin
 		prepareDataPlugin       *mockPrepareDataPlugin
+		preRequestPlugin        *mockPreRequestPlugin
+		wantMutatedBody         map[string]any
 	}{
 		{
 			name: "successful completions request",
@@ -331,8 +347,48 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel:   model,
+			wantMutatedBody: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
 			inferenceObjectiveName: objectiveName,
+		},
+		{
+			name: "successful request with preRequest plugin adding key",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "original prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			wantReqCtx: &handlers.RequestContext{
+				ObjectiveKey:    objectiveName,
+				TargetModelName: model,
+				TargetPod: &fwkdl.EndpointMetadata{
+					NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"},
+					Address:        "192.168.1.100",
+					Port:           "8000",
+					MetricsHost:    "192.168.1.100:8000",
+				},
+				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
+			},
+			wantMutatedBody: map[string]any{
+				"model":   model,
+				"prompt":  "original prompt",
+				"new_key": "new_value",
+			},
+			inferenceObjectiveName: objectiveName,
+			preRequestPlugin: &mockPreRequestPlugin{
+				name: "test-pre-request-plugin",
+				modifyFn: func(request *fwksched.InferenceRequest) {
+					if payloadMap, ok := request.Body.Payload.(fwkrh.PayloadMap); ok {
+						payloadMap["new_key"] = "new_value"
+					}
+				},
+			},
 		}, {
 			name: "successful request with model rewrite",
 			reqBodyMap: map[string]any{
@@ -355,7 +411,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel:   modelRewritten,
+			wantMutatedBody: map[string]any{
+				"model":  modelRewritten,
+				"prompt": "some prompt",
+			},
 			inferenceObjectiveName: model,
 		}, {
 			name: "successful chat completions request",
@@ -383,7 +442,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel: model,
+			wantMutatedBody: map[string]any{
+				"model": model,
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": "critical prompt",
+					},
+				},
+			},
 			targetModelName:      model,
 		},
 		{
@@ -412,7 +479,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel: model,
+			wantMutatedBody: map[string]any{
+				"model": model,
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": "critical prompt",
+					},
+				},
+			},
 			targetModelName:      model,
 			prepareDataPlugin:    newMockPrepareDataPlugin("test-plugin"),
 		},
@@ -441,7 +516,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel:    model,
+			wantMutatedBody: map[string]any{
+				"model": model,
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": "critical prompt",
+					},
+				},
+			},
 			targetModelName:         model,
 			admitRequestDenialError: nil,
 		},
@@ -460,7 +543,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 			schedulerMockSetup: func(m *mockScheduler) {
 				m.scheduleResults = defaultSuccessfulScheduleResults
 			},
-			wantMutatedBodyModel:    model,
+			wantMutatedBody: map[string]any{
+				"model": model,
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": "critical prompt",
+					},
+				},
+			},
 			targetModelName:         model,
 			admitRequestDenialError: errors.New("denied by admit plugin"),
 			wantErrCode:             errcommon.Internal,
@@ -519,7 +610,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel:   "resolved-target-model-A",
+			wantMutatedBody: map[string]any{
+				"model":  "resolved-target-model-A",
+				"prompt": "prompt for target resolution",
+			},
 			inferenceObjectiveName: objectiveNameResolve,
 		},
 		{
@@ -539,7 +633,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 				},
 				TargetEndpoint: "192.168.1.100:8000,192.168.2.100:8000,192.168.4.100:8000",
 			},
-			wantMutatedBodyModel: "food-review-1",
+			wantMutatedBody: map[string]any{
+				"model":  "food-review-1",
+				"prompt": "test prompt",
+			},
 			reqBodyMap: map[string]any{
 				"model":  "food-review-1",
 				"prompt": "test prompt",
@@ -653,6 +750,9 @@ func TestDirector_HandleRequest(t *testing.T) {
 				if test.prepareDataPlugin != nil {
 					config = config.WithPrepareDataPlugins(test.prepareDataPlugin)
 				}
+				if test.preRequestPlugin != nil {
+					config = config.WithPreRequestPlugins(test.preRequestPlugin)
+				}
 				config = config.WithAdmissionPlugins(newMockAdmissionPlugin("test-admit-plugin", test.admitRequestDenialError))
 
 				endpointCandidates := NewCachedEndpointCandidates(context.Background(), NewDatastoreEndpointCandidates(ds), time.Minute)
@@ -717,14 +817,15 @@ func TestDirector_HandleRequest(t *testing.T) {
 					assert.Equal(t, test.wantReqCtx.TargetEndpoint, returnedReqCtx.TargetEndpoint, "reqCtx.TargetEndpoint mismatch")
 				}
 
-				if test.wantMutatedBodyModel != "" {
+				if test.wantMutatedBody != nil {
 					assert.NotEmpty(t, returnedReqCtx.Request.RawBody, "Expected mutated body, but reqCtx.Request.Body is nil")
 					updatedBodyMap := make(map[string]any)
 					if err := json.Unmarshal(reqCtx.Request.RawBody, &updatedBodyMap); err != nil {
 						t.Errorf("Error to Unmarshal reqCtx.Request.UpdatedBody, err is %v", err)
 					}
-					assert.Equal(t, test.wantMutatedBodyModel, updatedBodyMap["model"],
-						"Mutated reqCtx.Request.Body model mismatch")
+					if diff := cmp.Diff(test.wantMutatedBody, updatedBodyMap); diff != "" {
+						t.Errorf("reqCtx.Request.RawBody mismatch (-want +got):\n%s", diff)
+					}
 				}
 				assert.Equal(t, len(reqCtx.Request.RawBody), reqCtx.RequestSize)
 			})

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -451,7 +451,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 					},
 				},
 			},
-			targetModelName:      model,
+			targetModelName: model,
 		},
 		{
 			name: "successful chat completions request with prepare data plugins",
@@ -488,8 +488,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 					},
 				},
 			},
-			targetModelName:      model,
-			prepareDataPlugin:    newMockPrepareDataPlugin("test-plugin"),
+			targetModelName:   model,
+			prepareDataPlugin: newMockPrepareDataPlugin("test-plugin"),
 		},
 		{
 			name: "successful chat completions request with admit request plugins",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

This PR reorders the request handling flow in the `Director` to allow `PreRequest` plugins to mutate the request body.
The `repackage` step is moved to after `prepareRequest` (where plugins are executed), ensuring that any modifications    
made by plugins to the parsed payload JSON Map format are correctly reflected in the final raw request body. Unit tests have been updated to verify this behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
