### PR TITLE
fix: support http token-ID inputs for v1/completions and v1/embeddings

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -181,12 +181,12 @@ func (r *InferenceRequestBody) CacheSalt() string {
 type Prompt struct {
 	Raw      string
 	Strings  []string
-	TokenIDs []int
+	TokenIDs []uint32
 }
 
 type arrayInputResult struct {
 	Strings  []string
-	TokenIDs []int
+	TokenIDs []uint32
 }
 
 func parseArrayInput(v []any, errorPrefix string) (arrayInputResult, error) {
@@ -205,15 +205,18 @@ func parseArrayInput(v []any, errorPrefix string) (arrayInputResult, error) {
 		}
 		return arrayInputResult{Strings: strings}, nil
 	case float64:
-		ints := make([]int, len(v))
+		uint32s := make([]uint32, len(v))
 		for i, val := range v {
 			flt, ok := val.(float64)
 			if !ok {
 				return arrayInputResult{}, fmt.Errorf("%s: mixed types in array", errorPrefix)
 			}
-			ints[i] = int(flt)
+			if flt != float64(uint32(flt)) {
+				return arrayInputResult{}, fmt.Errorf("%s: floating-point number %f is not a valid token ID", errorPrefix, flt)
+			}
+			uint32s[i] = uint32(flt)
 		}
-		return arrayInputResult{TokenIDs: ints}, nil
+		return arrayInputResult{TokenIDs: uint32s}, nil
 	default:
 		return arrayInputResult{}, fmt.Errorf("%s: unsupported array element type", errorPrefix)
 	}
@@ -361,7 +364,7 @@ func (c *ConversationsRequest) String() string {
 type EmbeddingsInput struct {
 	Raw      string
 	Strings  []string
-	TokenIDs []int
+	TokenIDs []uint32
 }
 
 func (e *EmbeddingsInput) UnmarshalJSON(data []byte) error {

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -136,9 +136,24 @@ func (r *InferenceRequestBody) PromptText() string {
 	case r.Conversations != nil:
 		b, _ := json.Marshal(r.Conversations.Items)
 		return string(b)
+	case r.Embeddings != nil:
+		return r.Embeddings.Input.PlainText()
 	default:
 		return ""
 	}
+}
+
+// InputTokenCountHint returns a best-effort input token count when the
+// caller knows it exactly (token-ID inputs), or -1 when the count has
+// to be estimated from text.
+func (r *InferenceRequestBody) InputTokenCountHint() int {
+	if r.Completions != nil {
+		return r.Completions.Prompt.TokenCountHint()
+	}
+	if r.Embeddings != nil {
+		return r.Embeddings.Input.TokenCountHint()
+	}
+	return -1
 }
 
 func (r *InferenceRequestBody) CacheSalt() string {
@@ -164,18 +179,74 @@ func (r *InferenceRequestBody) CacheSalt() string {
 // Per the OpenAI spec it can be a string or an array of strings.
 // See https://platform.openai.com/docs/api-reference/completions/create#completions-create-prompt
 type Prompt struct {
-	Raw     string
-	Strings []string
+	Raw      string
+	Strings  []string
+	TokenIDs []int
+}
+
+type arrayInputResult struct {
+	Strings  []string
+	TokenIDs []int
+}
+
+func parseArrayInput(v []any, errorPrefix string) (arrayInputResult, error) {
+	if len(v) == 0 {
+		return arrayInputResult{}, nil
+	}
+	switch v[0].(type) {
+	case string:
+		strings := make([]string, len(v))
+		for i, val := range v {
+			str, ok := val.(string)
+			if !ok {
+				return arrayInputResult{}, fmt.Errorf("%s: mixed types in array", errorPrefix)
+			}
+			strings[i] = str
+		}
+		return arrayInputResult{Strings: strings}, nil
+	case float64:
+		ints := make([]int, len(v))
+		for i, val := range v {
+			flt, ok := val.(float64)
+			if !ok {
+				return arrayInputResult{}, fmt.Errorf("%s: mixed types in array", errorPrefix)
+			}
+			ints[i] = int(flt)
+		}
+		return arrayInputResult{TokenIDs: ints}, nil
+	default:
+		return arrayInputResult{}, fmt.Errorf("%s: unsupported array element type", errorPrefix)
+	}
 }
 
 func (p *Prompt) UnmarshalJSON(data []byte) error {
-	if len(data) > 0 && data[0] == '"' {
-		return json.Unmarshal(data, &p.Raw)
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
 	}
-	if len(data) > 0 && data[0] == '[' {
-		return json.Unmarshal(data, &p.Strings)
+
+	switch v := raw.(type) {
+	case string:
+		p.Raw = v
+		return nil
+	case []any:
+		res, err := parseArrayInput(v, "prompt")
+		if err != nil {
+			return err
+		}
+		p.Strings = res.Strings
+		p.TokenIDs = res.TokenIDs
+		return nil
+	default:
+		return errors.New("prompt: must be a string or an array")
 	}
-	return errors.New("prompt: must be a string or an array of strings")
+}
+
+func (p Prompt) TokenCountHint() int {
+	if len(p.TokenIDs) > 0 {
+		return len(p.TokenIDs)
+	}
+	return -1
 }
 
 func (p Prompt) MarshalJSON() ([]byte, error) {
@@ -196,7 +267,7 @@ func (p Prompt) PlainText() string {
 }
 
 func (p Prompt) IsEmpty() bool {
-	return p.Raw == "" && len(p.Strings) == 0
+	return p.Raw == "" && len(p.Strings) == 0 && len(p.TokenIDs) == 0
 }
 
 // CompletionsRequest is a structured representation of the fields we parse out of the /v1/completions request
@@ -285,11 +356,60 @@ func (c *ConversationsRequest) String() string {
 	return fmt.Sprintf("{ItemsCount: %d}", len(c.Items))
 }
 
+// EmbeddingsInput represents the input field in a /v1/embeddings request.
+// Per the OpenAI spec it can be a string, an array of strings, or an array of integers.
+type EmbeddingsInput struct {
+	Raw      string
+	Strings  []string
+	TokenIDs []int
+}
+
+func (e *EmbeddingsInput) UnmarshalJSON(data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	switch v := raw.(type) {
+	case string:
+		e.Raw = v
+		return nil
+	case []any:
+		res, err := parseArrayInput(v, "embeddings input")
+		if err != nil {
+			return err
+		}
+		e.Strings = res.Strings
+		e.TokenIDs = res.TokenIDs
+		return nil
+	default:
+		return errors.New("embeddings input: must be a string or an array")
+	}
+}
+
+func (e EmbeddingsInput) TokenCountHint() int {
+	if len(e.TokenIDs) > 0 {
+		return len(e.TokenIDs)
+	}
+	return -1
+}
+
+func (e EmbeddingsInput) PlainText() string {
+	if e.Raw != "" {
+		return e.Raw
+	}
+	return strings.Join(e.Strings, " ")
+}
+
+func (e EmbeddingsInput) IsEmpty() bool {
+	return e.Raw == "" && len(e.Strings) == 0 && len(e.TokenIDs) == 0
+}
+
 // EmbeddingsRequest represents the OpenAI /v1/embeddings request body structure.
 // Input can be a string or array of strings; see https://platform.openai.com/docs/api-reference/embeddings.
 type EmbeddingsRequest struct {
 	// Input is the text to embed (string or array of strings).
-	Input any `json:"input,omitempty"`
+	Input EmbeddingsInput `json:"input,omitempty"`
 	// CacheSalt is an optional request parameter to isolate prefix caches for security reasons.
 	CacheSalt string `json:"cache_salt,omitempty"`
 }

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -131,6 +131,24 @@ func TestLLMRequestBody_PromptText(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "embeddings request with string input",
+			body: &InferenceRequestBody{
+				Embeddings: &EmbeddingsRequest{
+					Input: EmbeddingsInput{Raw: "hello world"},
+				},
+			},
+			expected: "hello world",
+		},
+		{
+			name: "embeddings request with array of strings input",
+			body: &InferenceRequestBody{
+				Embeddings: &EmbeddingsRequest{
+					Input: EmbeddingsInput{Strings: []string{"hello", "world"}},
+				},
+			},
+			expected: "hello world",
+		},
 	}
 
 	for _, tt := range tests {
@@ -164,6 +182,18 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 			want:  Prompt{Strings: []string{"hello world"}},
 		},
 		{
+			name:  "array of integers prompt",
+			input: `[1,2,3]`,
+			want:  Prompt{TokenIDs: []int{1, 2, 3}},
+		},
+
+		{
+			name:    "array of arrays of integers prompt is rejected for now",
+			input:   `[[1,2],[3,4]]`,
+			wantErr: true,
+		},
+
+		{
 			name:    "integer prompt is rejected",
 			input:   `123`,
 			wantErr: true,
@@ -185,6 +215,112 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, p)
 			}
+		})
+	}
+}
+
+func TestEmbeddingsInput_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    EmbeddingsInput
+		wantErr bool
+	}{
+		{
+			name:  "string input",
+			input: `"hello world"`,
+			want:  EmbeddingsInput{Raw: "hello world"},
+		},
+		{
+			name:  "array of strings input",
+			input: `["hello","world"]`,
+			want:  EmbeddingsInput{Strings: []string{"hello", "world"}},
+		},
+		{
+			name:  "array of integers input",
+			input: `[1,2,3]`,
+			want:  EmbeddingsInput{TokenIDs: []int{1, 2, 3}},
+		},
+
+		{
+			name:    "array of arrays of integers input is rejected for now",
+			input:   `[[1,2],[3,4]]`,
+			wantErr: true,
+		},
+
+		{
+			name:    "integer input is rejected",
+			input:   `123`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e EmbeddingsInput
+			err := e.UnmarshalJSON([]byte(tt.input))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, e)
+			}
+		})
+	}
+}
+
+func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     *InferenceRequestBody
+		wantHint int
+	}{
+		{
+			name: "completions with token IDs returns count",
+			body: &InferenceRequestBody{
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{TokenIDs: []int{1, 2, 3}},
+				},
+			},
+			wantHint: 3,
+		},
+		{
+			name: "completions with text returns -1",
+			body: &InferenceRequestBody{
+				Completions: &CompletionsRequest{
+					Prompt: Prompt{Raw: "hello"},
+				},
+			},
+			wantHint: -1,
+		},
+		{
+			name: "embeddings with token IDs returns count",
+			body: &InferenceRequestBody{
+				Embeddings: &EmbeddingsRequest{
+					Input: EmbeddingsInput{TokenIDs: []int{1, 2, 3, 4}},
+				},
+			},
+			wantHint: 4,
+		},
+		{
+			name: "embeddings with text returns -1",
+			body: &InferenceRequestBody{
+				Embeddings: &EmbeddingsRequest{
+					Input: EmbeddingsInput{Raw: "hello"},
+				},
+			},
+			wantHint: -1,
+		},
+		{
+			name:     "empty body returns -1",
+			body:     &InferenceRequestBody{},
+			wantHint: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantHint, tt.body.InputTokenCountHint())
 		})
 	}
 }

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -184,7 +184,12 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 		{
 			name:  "array of integers prompt",
 			input: `[1,2,3]`,
-			want:  Prompt{TokenIDs: []int{1, 2, 3}},
+			want:  Prompt{TokenIDs: []uint32{1, 2, 3}},
+		},
+		{
+			name:    "array of floats prompt is rejected",
+			input:   `[1.5,2.7]`,
+			wantErr: true,
 		},
 
 		{
@@ -239,7 +244,12 @@ func TestEmbeddingsInput_UnmarshalJSON(t *testing.T) {
 		{
 			name:  "array of integers input",
 			input: `[1,2,3]`,
-			want:  EmbeddingsInput{TokenIDs: []int{1, 2, 3}},
+			want:  EmbeddingsInput{TokenIDs: []uint32{1, 2, 3}},
+		},
+		{
+			name:    "array of floats input is rejected",
+			input:   `[1.5,2.7]`,
+			wantErr: true,
 		},
 
 		{
@@ -279,7 +289,7 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			name: "completions with token IDs returns count",
 			body: &InferenceRequestBody{
 				Completions: &CompletionsRequest{
-					Prompt: Prompt{TokenIDs: []int{1, 2, 3}},
+					Prompt: Prompt{TokenIDs: []uint32{1, 2, 3}},
 				},
 			},
 			wantHint: 3,
@@ -297,7 +307,7 @@ func TestInferenceRequestBody_InputTokenCountHint(t *testing.T) {
 			name: "embeddings with token IDs returns count",
 			body: &InferenceRequestBody{
 				Embeddings: &EmbeddingsRequest{
-					Input: EmbeddingsInput{TokenIDs: []int{1, 2, 3, 4}},
+					Input: EmbeddingsInput{TokenIDs: []uint32{1, 2, 3, 4}},
 				},
 			},
 			wantHint: 4,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -55,10 +55,15 @@ func (e *SimpleTokenEstimator) Estimate(request *framework.InferenceRequest) int
 	case request.RequestSizeBytes > 0:
 		inputTokens = max(int64(request.RequestSizeBytes)/4, 1)
 	case request.Body != nil:
-		// Fallback: character count from prompt text across all API types
-		// (completions, chat/completions, responses, conversations).
-		chars := len(request.Body.PromptText())
-		inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
+		hint := request.Body.InputTokenCountHint()
+		if hint >= 0 {
+			inputTokens = int64(hint)
+		} else {
+			// Fallback: character count from prompt text across all API types
+			// (completions, chat/completions, responses, conversations).
+			chars := len(request.Body.PromptText())
+			inputTokens = int64(math.Max(1, math.Round(float64(chars)/e.CharactersPerToken)))
+		}
 	default:
 		return 0
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	"k8s.io/apimachinery/pkg/types"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -279,17 +280,10 @@ func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedL
 	if request.Body != nil {
 		promptText = request.Body.PromptText()
 	}
-	inputTokenCount := -1
-	if request.Body != nil {
-		inputTokenCount = request.Body.InputTokenCountHint()
-	}
-	if inputTokenCount < 0 {
-		inputTokenCount = len(strings.Fields(promptText))
-	}
 	return &predictedLatencyCtx{
 		schedulingRequest:             *request,
 		promptText:                    promptText,
-		inputTokenCount:               inputTokenCount,
+		inputTokenCount:               len(strings.Fields(promptText)),
 		lastSeenMetrics:               make(map[string]*fwkdl.Metrics),
 		prefixCacheScoresForEndpoints: make(map[string]float64),
 		predictionsForScheduling:      make(map[string]endpointPredictionResult),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	"k8s.io/apimachinery/pkg/types"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -280,10 +279,17 @@ func newPredictedLatencyContext(request *framework.InferenceRequest) *predictedL
 	if request.Body != nil {
 		promptText = request.Body.PromptText()
 	}
+	inputTokenCount := -1
+	if request.Body != nil {
+		inputTokenCount = request.Body.InputTokenCountHint()
+	}
+	if inputTokenCount < 0 {
+		inputTokenCount = len(strings.Fields(promptText))
+	}
 	return &predictedLatencyCtx{
 		schedulingRequest:             *request,
 		promptText:                    promptText,
-		inputTokenCount:               len(strings.Fields(promptText)),
+		inputTokenCount:               inputTokenCount,
 		lastSeenMetrics:               make(map[string]*fwkdl.Metrics),
 		prefixCacheScoresForEndpoints: make(map[string]float64),
 		predictionsForScheduling:      make(map[string]endpointPredictionResult),

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -226,11 +226,10 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 
 	case embeddingsAPI:
 		var embeddings fwkrh.EmbeddingsRequest
-		if err := json.Unmarshal(rawBody, &embeddings); err == nil && embeddings.Input != nil {
+		if err := json.Unmarshal(rawBody, &embeddings); err == nil && !embeddings.Input.IsEmpty() {
 			return &fwkrh.InferenceRequestBody{Embeddings: &embeddings}, nil
 		}
 		return nil, errors.New("invalid embeddings request: must have input field")
-
 	default:
 		return nil, errors.New("unsupported API endpoint")
 	}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -111,7 +111,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{TokenIDs: []int{1, 2, 3}},
+					Prompt: fwkrh.Prompt{TokenIDs: []uint32{1, 2, 3}},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":  "test",
@@ -730,7 +730,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input: fwkrh.EmbeddingsInput{TokenIDs: []int{1, 2, 3}},
+					Input: fwkrh.EmbeddingsInput{TokenIDs: []uint32{1, 2, 3}},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -103,6 +103,23 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 		},
 		{
+			name:    "completions request with token IDs",
+			headers: map[string]string{":path": "/v1/completions"},
+			body: map[string]any{
+				"model":  "test",
+				"prompt": []any{1, 2, 3},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Completions: &fwkrh.CompletionsRequest{
+					Prompt: fwkrh.Prompt{TokenIDs: []int{1, 2, 3}},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model":  "test",
+					"prompt": []any{float64(1), float64(2), float64(3)},
+				},
+			},
+		},
+		{
 			name:    "completions request with empty string array prompt rejected",
 			headers: map[string]string{":path": "/v1/completions"},
 			body: map[string]any{
@@ -679,7 +696,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input: "The food was delicious and the waiter...",
+					Input: fwkrh.EmbeddingsInput{Raw: "The food was delicious and the waiter..."},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",
@@ -696,11 +713,28 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input: []any{"First document", "Second document"},
+					Input: fwkrh.EmbeddingsInput{Strings: []string{"First document", "Second document"}},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",
 					"input": []any{"First document", "Second document"},
+				},
+			},
+		},
+		{
+			name:    "embeddings request with token IDs",
+			headers: map[string]string{":path": "/v1/embeddings"},
+			body: map[string]any{
+				"model": "text-embedding-3-small",
+				"input": []any{1, 2, 3},
+			},
+			want: &fwkrh.InferenceRequestBody{
+				Embeddings: &fwkrh.EmbeddingsRequest{
+					Input: fwkrh.EmbeddingsInput{TokenIDs: []int{1, 2, 3}},
+				},
+				Payload: fwkrh.PayloadMap{
+					"model": "text-embedding-3-small",
+					"input": []any{float64(1), float64(2), float64(3)},
 				},
 			},
 		},
@@ -714,7 +748,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input:     "embed this text",
+					Input:     fwkrh.EmbeddingsInput{Raw: "embed this text"},
 					CacheSalt: "embeddings-salt-123",
 				},
 				Payload: fwkrh.PayloadMap{
@@ -733,7 +767,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input: "text to embed",
+					Input: fwkrh.EmbeddingsInput{Raw: "text to embed"},
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -197,33 +197,24 @@ func convertToInferenceRequestBody(payload []byte) (*fwkrh.InferenceRequestBody,
 		if tokenized == nil {
 			return nil, errors.New("missing tokenized input")
 		}
+		inputIDs := tokenized.GetInputIds()
+		copiedTokenIDsInt := make([]uint32, len(inputIDs))
+		copy(copiedTokenIDsInt, inputIDs)
 		body = &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{Raw: tokenized.GetOriginalText()},
+				Prompt: fwkrh.Prompt{TokenIDs: copiedTokenIDsInt},
 			},
-			Payload:         fwkrh.PayloadProto{Message: pbReq},
-			TokenizedPrompt: convertTokenizedPrompt(tokenized, pbReq.GetMmInputs()),
+			Payload: fwkrh.PayloadProto{Message: pbReq},
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{
+				TokenIDs:           copiedTokenIDsInt,
+				MultiModalFeatures: convertMultiModalFeatures(pbReq.GetMmInputs()),
+			},
 		}
 	default:
 		return nil, errors.New("not supported request inputType")
 	}
 	body.Stream = pbReq.GetStream()
 	return body, nil
-}
-
-func convertTokenizedPrompt(tokenized *pb.TokenizedInput, mmInputs *pb.MultimodalInputs) *fwkrh.TokenizedPrompt {
-	if tokenized == nil {
-		return nil
-	}
-
-	inputIDs := tokenized.GetInputIds()
-	copiedTokenIDs := make([]uint32, len(inputIDs))
-	copy(copiedTokenIDs, inputIDs)
-
-	return &fwkrh.TokenizedPrompt{
-		TokenIDs:           copiedTokenIDs,
-		MultiModalFeatures: convertMultiModalFeatures(mmInputs),
-	}
 }
 
 func convertMultiModalFeatures(mmInputs *pb.MultimodalInputs) []fwkrh.MultiModalFeature {
@@ -298,13 +289,9 @@ func convertEmbedToInferenceRequestBody(payload []byte) (*fwkrh.InferenceRequest
 	}
 	var body *fwkrh.InferenceRequestBody
 	if pbReq.Tokenized != nil {
-		var tokenIDs []int
-		if pbReq.GetTokenized().InputIds != nil {
-			tokenIDs = make([]int, len(pbReq.GetTokenized().InputIds))
-			for i, v := range pbReq.GetTokenized().InputIds {
-				tokenIDs[i] = int(v)
-			}
-		}
+		inputIds := pbReq.GetTokenized().InputIds
+		tokenIDs := make([]uint32, len(inputIds))
+		copy(tokenIDs, inputIds)
 		body = &fwkrh.InferenceRequestBody{
 			Embeddings: &fwkrh.EmbeddingsRequest{
 				Input: fwkrh.EmbeddingsInput{

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -298,9 +298,18 @@ func convertEmbedToInferenceRequestBody(payload []byte) (*fwkrh.InferenceRequest
 	}
 	var body *fwkrh.InferenceRequestBody
 	if pbReq.Tokenized != nil {
+		var tokenIDs []int
+		if pbReq.GetTokenized().InputIds != nil {
+			tokenIDs = make([]int, len(pbReq.GetTokenized().InputIds))
+			for i, v := range pbReq.GetTokenized().InputIds {
+				tokenIDs[i] = int(v)
+			}
+		}
 		body = &fwkrh.InferenceRequestBody{
 			Embeddings: &fwkrh.EmbeddingsRequest{
-				Input: pbReq.GetTokenized().OriginalText,
+				Input: fwkrh.EmbeddingsInput{
+					TokenIDs: tokenIDs,
+				},
 			},
 			Payload: fwkrh.PayloadProto{Message: pbReq},
 		}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -112,7 +112,6 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "Valid Tokenized Request",
 			reqMsg: &pb.GenerateRequest{
@@ -127,7 +126,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
 					Prompt: fwkrh.Prompt{
-						TokenIDs: []int{1, 2, 3},
+						TokenIDs: []uint32{11, 12, 13},
 					},
 				},
 				Payload: fwkrh.PayloadProto{
@@ -164,7 +163,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{Raw: "Describe image"},
+					Prompt: fwkrh.Prompt{TokenIDs: []uint32{101, 102, 103, 104, 105}},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -212,7 +211,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{Raw: "Two images"},
+					Prompt: fwkrh.Prompt{TokenIDs: []uint32{201, 202, 203, 204}},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -240,7 +239,6 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name:          "Malformed gRPC payload (too short)",
 			malformedData: []byte{0, 0, 0},
@@ -291,7 +289,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
 					Input: fwkrh.EmbeddingsInput{
-						TokenIDs: []int{4, 5, 6},
+						TokenIDs: []uint32{4, 5, 6},
 					},
 				},
 				Payload: fwkrh.PayloadProto{
@@ -305,7 +303,6 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 		},
 	}
-
 	parser := NewVllmGRPCParser()
 	ctx := context.Background()
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -126,7 +126,9 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
 				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{Raw: "Tokenized hello"},
+					Prompt: fwkrh.Prompt{
+						TokenIDs: []int{1, 2, 3},
+					},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -282,17 +284,21 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			reqMsg: &pb.EmbedRequest{
 				Tokenized: &pb.TokenizedInput{
 					OriginalText: "Embed this",
+					InputIds:     []uint32{4, 5, 6},
 				},
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Embed"},
 			want: &fwkrh.InferenceRequestBody{
 				Embeddings: &fwkrh.EmbeddingsRequest{
-					Input: "Embed this",
+					Input: fwkrh.EmbeddingsInput{
+						TokenIDs: []int{4, 5, 6},
+					},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.EmbedRequest{
 						Tokenized: &pb.TokenizedInput{
 							OriginalText: "Embed this",
+							InputIds:     []uint32{4, 5, 6},
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

This PR implements support for pre-tokenized inputs (token IDs) in `/v1/completions` and `/v1/embeddings` endpoints. Previously, these endpoints did not accept token arrays, leading to parse failures or incorrect token count estimations (silent length corruption).


The OpenAI API spec allows `prompt` and `input` to be arrays of integers (token IDs). Our EPP request-body parser only supported strings or arrays of strings. This caused parse errors when clients sent pre-tokenized inputs, or resulted in an estimated token count of 0.

## Changes
1.  Extended `Prompt` and created `EmbeddingsInput` to support `[]int` (TokenIDs).
2.  Added `InputTokenCountHint()` to provide exact token counts for token-ID inputs, avoiding inaccurate string-based estimation.
3.  Optimized `UnmarshalJSON` in `types.go` to decode once into `any` and perform type inspection, improving performance.
7.  Updated `vllmgrpc` parser to correctly populate `TokenIDs` from gRPC `TokenizedInput`, enforcing oneof semantics by setting only one field in `Prompt`/`EmbeddingsInput`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially #2835

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
