### PR TITLE
feat(helm/bbr): make ext_proc events configurable

### DIFF
--- a/config/charts/body-based-routing/README.md
+++ b/config/charts/body-based-routing/README.md
@@ -58,6 +58,34 @@ bbr:
     - type: ...
 ```
 
+### Configure ext_proc Events
+
+By default, BBR receives all HTTP lifecycle events (request and response headers, body, trailers). If your plugins only need specific events, you can disable the others to reduce latency:
+
+```bash
+# Disable response events if plugins only need request data
+$ helm install body-based-router ./config/charts/body-based-routing \
+    --set provider.name=istio \
+    --set provider.supportedEvents.responseHeaders=false \
+    --set provider.supportedEvents.responseBody=false \
+    --set provider.supportedEvents.responseTrailers=false
+```
+
+Or in `values.yaml`:
+```yaml
+provider:
+  name: istio
+  supportedEvents:
+    requestHeaders: true
+    requestBody: true
+    requestTrailers: true
+    responseHeaders: false  # Disable if plugins don't need response headers
+    responseBody: false     # Disable if plugins don't need response body
+    responseTrailers: false
+```
+
+> **Tip:** Only enable events your plugins need. Each extra event adds a network hop between the proxy and BBR.
+
 ### Uninstall
 
 Run the following command to uninstall the chart:
@@ -84,6 +112,12 @@ The following table list the configurable parameters of the chart.
 | `bbr.flags`                  | map of flags which are passed through to bbr. Refer to [runner.go](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/cmd/bbr/runner/runner.go) for complete list.                                                                                                     |
 | `bbr.plugins`   | Custom ordered plugins array to set for BBR. each plugin have fields: type, name and optionally json (which represents parameters of the plugin). If not specified, BBR will use by default the `body-field-to-header` to extract the `model` field, and `base-model-to-header` (in that order). |
 | `provider.name`              | Name of the Inference Gateway implementation being used. Possible values: `istio`, `gke`. Defaults to `none`.                                                                                                                                                                                    |
+| `provider.supportedEvents.requestHeaders` | Enable Request Headers event. Defaults to `true`. |
+| `provider.supportedEvents.requestBody` | Enable Request Body event. Defaults to `true`. |
+| `provider.supportedEvents.requestTrailers` | Enable Request Trailers event. Defaults to `true`. |
+| `provider.supportedEvents.responseHeaders` | Enable Response Headers event. Defaults to `false`. |
+| `provider.supportedEvents.responseBody` | Enable Response Body event. Defaults to `false`. |
+| `provider.supportedEvents.responseTrailers` | Enable Response Trailers event. Defaults to `false`. |
 | `inferenceGateway.name`      | The name of the Gateway. Defaults to `inference-gateway`.                                                                                                                                                                                                                                       |
 
 ## Notes

--- a/config/charts/body-based-routing/templates/gke.yaml
+++ b/config/charts/body-based-routing/templates/gke.yaml
@@ -17,10 +17,30 @@ spec:
       authority: "myext.com"
       timeout: 1s
       supportedEvents:
+      {{- if .Values.provider.supportedEvents.requestHeaders }}
       - RequestHeaders
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.requestBody }}
       - RequestBody
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.requestTrailers }}
       - RequestTrailers
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.responseHeaders }}
+      - ResponseHeaders
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.responseBody }}
+      - ResponseBody
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.responseTrailers }}
+      - ResponseTrailers
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.requestBody }}
       requestBodySendMode: "FullDuplexStreamed"
+      {{- end }}
+      {{- if .Values.provider.supportedEvents.responseBody }}
+      responseBodySendMode: "FullDuplexStreamed"
+      {{- end }}
       backendRef:
         group: ""
         kind: Service

--- a/config/charts/body-based-routing/templates/istio.yaml
+++ b/config/charts/body-based-routing/templates/istio.yaml
@@ -31,12 +31,12 @@ spec:
           failure_mode_allow: false
           allow_mode_override: true
           processing_mode:
-            request_header_mode: "SEND"
-            response_header_mode: "SEND"
-            request_body_mode: "FULL_DUPLEX_STREAMED"
-            response_body_mode: "FULL_DUPLEX_STREAMED"
-            request_trailer_mode: "SEND"
-            response_trailer_mode: "SEND"
+            request_header_mode: {{ if .Values.provider.supportedEvents.requestHeaders }}"SEND"{{ else }}"SKIP"{{ end }}
+            response_header_mode: {{ if .Values.provider.supportedEvents.responseHeaders }}"SEND"{{ else }}"SKIP"{{ end }}
+            request_body_mode: {{ if .Values.provider.supportedEvents.requestBody }}"FULL_DUPLEX_STREAMED"{{ else }}"NONE"{{ end }}
+            response_body_mode: {{ if .Values.provider.supportedEvents.responseBody }}"FULL_DUPLEX_STREAMED"{{ else }}"NONE"{{ end }}
+            request_trailer_mode: {{ if .Values.provider.supportedEvents.requestTrailers }}"SEND"{{ else }}"SKIP"{{ end }}
+            response_trailer_mode: {{ if .Values.provider.supportedEvents.responseTrailers }}"SEND"{{ else }}"SKIP"{{ end }}
           grpc_service:
             envoy_grpc:
               cluster_name: outbound|{{ .Values.bbr.port }}||{{ .Values.bbr.name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/config/charts/body-based-routing/values.yaml
+++ b/config/charts/body-based-routing/values.yaml
@@ -38,6 +38,17 @@ bbr:
 provider:
   name: none
 
+  # ext_proc events configuration.
+  # Controls which HTTP lifecycle events are sent to BBR for processing.
+  # Enable only the events that plugins actually need to process.
+  supportedEvents:
+    requestHeaders: true
+    requestBody: true
+    requestTrailers: true
+    responseHeaders: true
+    responseBody: true
+    responseTrailers: true
+
   # Istio-specific configuration.
   # This block is only used if name is "istio".
   istio:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Makes ext_proc events configurable via `values.yaml` in the BBR Helm chart. Previously, events were hardcoded in the GKE and Istio templates. Now users can enable/disable events based on their plugins needs, avoiding unnecessary network hops when response events aren't required.

**Which issue(s) this PR fixes**:

Fixes #2855

**Does this PR introduce a user-facing change?**:

```release-note
The body-based-routing Helm chart now supports configuring ext_proc events via `provider.supportedEvents`. Request events are enabled by default; response events are disabled by default.