### PR TITLE
fix: fixed regression failure for standalone without inference api support

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -417,7 +417,7 @@ func NewEndpointPoolFromOptions(
 	if namespace == "" {
 		return nil, errors.New("namespace must not be empty")
 	}
-	//name e will be from epp name in standalone mode without inference api support
+	//name will be from epp name in standalone mode without inference api support
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -413,11 +413,11 @@ func NewEndpointPoolFromOptions(
 	endpointSelector string,
 	endpointTargetPorts []int,
 ) (*datalayer.EndpointPool, error) {
-	//namespace will be from epp namespace in standalone mode without inference api support
+	// namespace is from epp namespace in standalone mode without inference api support
 	if namespace == "" {
 		return nil, errors.New("namespace must not be empty")
 	}
-	//name will be from epp name in standalone mode without inference api support
+	// name is from epp name in standalone mode without inference api support
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -258,7 +258,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	}
 
 	ds, err := setupDatastore(ctx, epf, int32(opts.ModelServerMetricsPort), startCrdReconcilers,
-		opts.PoolNamespace, opts.PoolName, opts.EndpointSelector, opts.EndpointTargetPorts)
+		gknn.Namespace, opts.PoolName, opts.EndpointSelector, opts.EndpointTargetPorts)
 	if err != nil {
 		setupLog.Error(err, "Failed to setup datastore")
 		return nil, nil, err
@@ -413,7 +413,9 @@ func NewEndpointPoolFromOptions(
 	endpointSelector string,
 	endpointTargetPorts []int,
 ) (*datalayer.EndpointPool, error) {
-
+	if namespace == "" {
+		return nil, errors.New("namespace must not be empty")
+	}
 	if endpointSelector == "" {
 		return nil, errors.New("endpoint selector must not be empty")
 	}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -258,7 +258,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	}
 
 	ds, err := setupDatastore(ctx, epf, int32(opts.ModelServerMetricsPort), startCrdReconcilers,
-		gknn.Namespace, opts.PoolName, opts.EndpointSelector, opts.EndpointTargetPorts)
+		gknn.Namespace, gknn.Name, opts.EndpointSelector, opts.EndpointTargetPorts)
 	if err != nil {
 		setupLog.Error(err, "Failed to setup datastore")
 		return nil, nil, err

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -416,6 +416,9 @@ func NewEndpointPoolFromOptions(
 	if namespace == "" {
 		return nil, errors.New("namespace must not be empty")
 	}
+	if name == "" {
+		return nil, errors.New("name must not be empty")
+	}
 	if endpointSelector == "" {
 		return nil, errors.New("endpoint selector must not be empty")
 	}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -413,9 +413,11 @@ func NewEndpointPoolFromOptions(
 	endpointSelector string,
 	endpointTargetPorts []int,
 ) (*datalayer.EndpointPool, error) {
+	//namespace will be from epp namespace in standalone mode without inference api support
 	if namespace == "" {
 		return nil, errors.New("namespace must not be empty")
 	}
+	//name e will be from epp name in standalone mode without inference api support
 	if name == "" {
 		return nil, errors.New("name must not be empty")
 	}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -414,12 +414,6 @@ func NewEndpointPoolFromOptions(
 	endpointTargetPorts []int,
 ) (*datalayer.EndpointPool, error) {
 
-	if namespace == "" {
-		return nil, errors.New("namespace must not be empty")
-	}
-	if name == "" {
-		return nil, errors.New("name must not be empty")
-	}
 	if endpointSelector == "" {
 		return nil, errors.New("endpoint selector must not be empty")
 	}

--- a/site-src/guides/standalone.md
+++ b/site-src/guides/standalone.md
@@ -126,7 +126,7 @@ EOF
 ```
 Send an inference request via
 ```bash
-kubectl exec curl -- curl -i http://vllm-qwen3-32b-epp:8081/v1/completions \
+kubectl exec curl -- curl -i http://vllm-qwen3-32b-epp-standalone:8081/v1/completions \
 -H 'Content-Type: application/json' \
 -d '{"model": "Qwen/Qwen3-32B","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
 ```

--- a/site-src/guides/standalone.md
+++ b/site-src/guides/standalone.md
@@ -92,7 +92,7 @@ Choose one of the following options to deploy an Endpoint Picker Extension with 
             helm install vllm-qwen3-32b-standalone \
             --dependency-update \
             --set inferenceExtension.endpointsServer.endpointSelector="app=vllm-qwen3-32b" \
-            --set inferenceExtension.endpointsServer.createInferencePool=false
+            --set inferenceExtension.endpointsServer.createInferencePool=false \
             --set provider.name=$PROVIDER \
             --version $STANDALONE_CHART_VERSION \
              oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
@@ -128,7 +128,7 @@ Send an inference request via
 ```bash
 kubectl exec curl -- curl -i http://vllm-qwen3-32b-epp:8081/v1/completions \
 -H 'Content-Type: application/json' \
--d '{"model": "food-review-1","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
+-d '{"model": "Qwen/Qwen3-32B","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
 ```
 
 #### Cleanup


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug
**What this PR does / why we need it**:

fixed #2858 

#2229 brought new validation check for standalone mode. However, pool namespace and pool name should not  specified by user in standalone mode without inference api support. I use epp namespace and name when constructing endpoint pool  in standalone mode without inference api support.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2858 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
