### PR TITLE
allow Parser.ParseRequest to signal skip and fallback to random endpoint

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -26,8 +26,8 @@ import (
 // Parser defines the interface for parsing payload(requests and responses).
 type Parser interface {
 	fwkplugin.Plugin
-	// ParseRequest parses the request body and headers and returns a map representation.
-	ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*InferenceRequestBody, error)
+	// ParseRequest parses the request body and headers and returns the parsed result.
+	ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*ParseResult, error)
 
 	// ParseResponse parses the response payload.
 	// For streaming responses , this method is invoked multiple times (once per chunk),
@@ -39,6 +39,14 @@ type Parser interface {
 	// SupportedAppProtocols returns the list of supported protocols.
 	// Returning an empty list means it supports all protocols.
 	SupportedAppProtocols() []v1.AppProtocol
+}
+
+// ParseResult contains the result of parsing the request.
+type ParseResult struct {
+	// Body contains the parsed inference request body.
+	Body *InferenceRequestBody
+	// Skip indicates whether to skip the remaining processing phases.
+	Skip bool
 }
 
 type ParsedResponse struct {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -91,7 +91,7 @@ func (p *OpenAIParser) WithName(name string) *OpenAIParser {
 }
 
 // ParseRequest parses the request body and headers and returns a map representation.
-func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.InferenceRequestBody, error) {
+func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
 	bodyMap := make(map[string]any)
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
@@ -104,7 +104,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true
 	}
-	return extractedBody, nil
+	return &fwkrh.ParseResult{Body: extractedBody, Skip: false}, nil
 }
 
 // ParseResponse extracts usage metadata from the provider's response.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -809,7 +809,11 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+			if got.Skip != false {
+				t.Errorf("ParseRequest() got.Skip = %v, want false", got.Skip)
+			}
+
+			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -66,9 +66,12 @@ func (p *PassthroughParser) WithName(name string) *PassthroughParser {
 }
 
 // ParseRequest converts the request to RawPayload.
-func (p *PassthroughParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.InferenceRequestBody, error) {
-	return &fwkrh.InferenceRequestBody{
-		Payload: fwkrh.RawPayload(body),
+func (p *PassthroughParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	return &fwkrh.ParseResult{
+		Body: &fwkrh.InferenceRequestBody{
+			Payload: fwkrh.RawPayload(body),
+		},
+		Skip: false,
 	}, nil
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
@@ -58,7 +58,10 @@ func TestPassthroughParser_ParseRequest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tt.wantBody, got); diff != "" {
+			if got.Skip != false {
+				t.Errorf("got.Skip = %v, want false", got.Skip)
+			}
+			if diff := cmp.Diff(tt.wantBody, got.Body); diff != "" {
 				t.Errorf("Unexpected body (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -78,28 +78,44 @@ func (p *VllmGRPCParser) SupportedAppProtocols() []v1.AppProtocol {
 	return []v1.AppProtocol{v1.AppProtocolH2C}
 }
 
-// ParseRequest parses the gRPC request body and headers and returns an LLMRequestBody.
-func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.InferenceRequestBody, error) {
+// ParseRequest parses the gRPC request body and headers and returns the parsed result.
+func (p *VllmGRPCParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
 	logger := log.FromContext(ctx)
+
+	parsedPayload, err := parseGrpcPayload(body)
+	if err != nil {
+		return nil, errors.New("invalid or unsupported gRPC payload")
+	}
 
 	path := headers[methodPathKey]
 	switch path {
 	case vllmEmbedPath:
-		extractedBody, err := convertEmbedToInferenceRequestBody(body)
+		var req pb.EmbedRequest
+		if err := proto.Unmarshal(parsedPayload, &req); err != nil {
+			return nil, fmt.Errorf("unmarshaling EmbedRequest: %w", err)
+		}
+		extractedBody, err := convertEmbedToInferenceRequestBody(&req)
 		if err != nil {
-			return nil, fmt.Errorf("parsing gRPC payload for Embed: %w", err)
+			return nil, err
 		}
 		logger.V(logutil.TRACE).Info("parsed EmbedRequest")
-		return extractedBody, nil
+		return &fwkrh.ParseResult{Body: extractedBody, Skip: false}, nil
+
 	case vllmGeneratePath:
-		extractedBody, err := convertToInferenceRequestBody(body)
+		var req pb.GenerateRequest
+		if err := proto.Unmarshal(parsedPayload, &req); err != nil {
+			return nil, fmt.Errorf("unmarshaling GenerateRequest: %w", err)
+		}
+		extractedBody, err := convertToInferenceRequestBody(&req)
 		if err != nil {
-			return nil, fmt.Errorf("parsing gRPC payload for Generate: %w", err)
+			return nil, err
 		}
 		logger.V(logutil.TRACE).Info("parsed GenerateRequest")
-		return extractedBody, nil
+		return &fwkrh.ParseResult{Body: extractedBody, Skip: false}, nil
+
 	default:
-		return nil, fmt.Errorf("unsupported gRPC path: %s", headers[":path"])
+		logger.V(logutil.TRACE).Info("unsupported gRPC path, skipping", "path", headers[":path"])
+		return &fwkrh.ParseResult{Skip: true}, nil
 	}
 }
 
@@ -166,23 +182,14 @@ func requestControlUsage(promptToken, completionToken, cachedToken int) *fwkrh.U
 }
 
 func toGenerateResponse(payload []byte, resp *pb.GenerateResponse) error {
-	parsedPayload, compressed, err := parseGrpcPayload(payload)
+	parsedPayload, err := parseGrpcPayload(payload)
 	if err != nil {
-		return errors.New("not able to parse payload")
+		return err
 	}
-	if compressed {
-		// TODO(#2635): handle compressed payload.
-		return errors.New("compressed vllmgrpc payload is not supported")
-	}
-
 	return proto.Unmarshal(parsedPayload, resp)
 }
 
-func convertToInferenceRequestBody(payload []byte) (*fwkrh.InferenceRequestBody, error) {
-	pbReq := &pb.GenerateRequest{}
-	if err := toGenerateRequest(payload, pbReq); err != nil {
-		return nil, err
-	}
+func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceRequestBody, error) {
 	var body *fwkrh.InferenceRequestBody
 	switch pbReq.Input.(type) {
 	case *pb.GenerateRequest_Text:
@@ -253,40 +260,26 @@ func convertMultiModalFeatures(mmInputs *pb.MultimodalInputs) []fwkrh.MultiModal
 // parseGrpcPayload extracts the message payload and its compression status from a gRPC frame.
 // A standard gRPC frame consists of a 1-byte compression flag, a 4-byte message length,
 // and the actual message payload.
-func parseGrpcPayload(data []byte) ([]byte, bool, error) {
+func parseGrpcPayload(data []byte) ([]byte, error) {
 	if len(data) < gRPCPayloadHeaderLen {
-		return nil, false, fmt.Errorf("invalid gRPC frame: expected at least %d bytes for header, got %d", gRPCPayloadHeaderLen, len(data))
+		return nil, fmt.Errorf("invalid gRPC frame: expected at least %d bytes for header, got %d", gRPCPayloadHeaderLen, len(data))
 	}
 
-	// gRPC frame header: [Compression Flag (1 byte)] [Message Length (4 bytes)]
-	// Compression Flag 0 = uncompressed, 1 = compressed
 	isCompressed := data[0] == 1
+	if isCompressed {
+		// TODO(#2635): handle compressed payload.
+		return nil, errors.New("compressed vllmgrpc payload is not supported")
+	}
+
 	msgLen := binary.BigEndian.Uint32(data[1:5])
 
 	if uint32(len(data)) < gRPCPayloadHeaderLen+msgLen {
-		return nil, false, fmt.Errorf("incomplete gRPC payload: header indicates %d bytes, but only %d bytes are available", msgLen, uint32(len(data))-gRPCPayloadHeaderLen)
+		return nil, fmt.Errorf("incomplete gRPC payload: header indicates %d bytes, but only %d bytes are available", msgLen, uint32(len(data))-gRPCPayloadHeaderLen)
 	}
-	return data[gRPCPayloadHeaderLen : gRPCPayloadHeaderLen+msgLen], isCompressed, nil
+	return data[gRPCPayloadHeaderLen : gRPCPayloadHeaderLen+msgLen], nil
 }
 
-func toGenerateRequest(payload []byte, req *pb.GenerateRequest) error {
-	parsedPayload, compressed, err := parseGrpcPayload(payload)
-	if err != nil {
-		return errors.New("not able to parse payload")
-	}
-	if compressed {
-		// TODO(#2635): handle compressed payload.
-		return errors.New("compressed vllmgrpc payload is not supported")
-	}
-
-	return proto.Unmarshal(parsedPayload, req)
-}
-
-func convertEmbedToInferenceRequestBody(payload []byte) (*fwkrh.InferenceRequestBody, error) {
-	pbReq := &pb.EmbedRequest{}
-	if err := toEmbedRequest(payload, pbReq); err != nil {
-		return nil, err
-	}
+func convertEmbedToInferenceRequestBody(pbReq *pb.EmbedRequest) (*fwkrh.InferenceRequestBody, error) {
 	var body *fwkrh.InferenceRequestBody
 	if pbReq.Tokenized != nil {
 		inputIds := pbReq.GetTokenized().InputIds
@@ -306,26 +299,10 @@ func convertEmbedToInferenceRequestBody(payload []byte) (*fwkrh.InferenceRequest
 	return body, nil
 }
 
-func toEmbedRequest(payload []byte, req *pb.EmbedRequest) error {
-	parsedPayload, compressed, err := parseGrpcPayload(payload)
-	if err != nil {
-		return errors.New("not able to parse payload")
-	}
-	if compressed {
-		return errors.New("compressed vllmgrpc payload is not supported")
-	}
-
-	return proto.Unmarshal(parsedPayload, req)
-}
-
 func toEmbedResponse(payload []byte, resp *pb.EmbedResponse) error {
-	parsedPayload, compressed, err := parseGrpcPayload(payload)
+	parsedPayload, err := parseGrpcPayload(payload)
 	if err != nil {
-		return errors.New("not able to parse payload")
+		return err
 	}
-	if compressed {
-		return errors.New("compressed vllmgrpc payload is not supported")
-	}
-
 	return proto.Unmarshal(parsedPayload, resp)
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -89,6 +89,7 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 		headers       map[string]string
 		malformedData []byte
 		wantErr       bool
+		wantSkip      bool
 		want          *fwkrh.InferenceRequestBody
 	}{
 		{
@@ -242,16 +243,19 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 		{
 			name:          "Malformed gRPC payload (too short)",
 			malformedData: []byte{0, 0, 0},
+			headers:       map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			wantErr:       true,
 		},
 		{
 			name:          "Compressed payload (unsupported)",
 			malformedData: []byte{1, 0, 0, 0, 0}, // Flag 1 = compressed
+			headers:       map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			wantErr:       true,
 		},
 		{
 			name:    "Nil Input Request",
 			reqMsg:  &pb.GenerateRequest{},
+			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			wantErr: true,
 		},
 		{
@@ -302,6 +306,18 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Unsupported Path skip",
+			reqMsg:   &pb.GenerateRequest{Input: &pb.GenerateRequest_Text{Text: "hello"}},
+			headers:  map[string]string{":path": "/unsupported/path"},
+			wantSkip: true,
+		},
+		{
+			name:    "Embed Request missing tokenized input",
+			reqMsg:  &pb.EmbedRequest{},
+			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Embed"},
+			wantErr: true,
+		},
 	}
 	parser := NewVllmGRPCParser()
 	ctx := context.Background()
@@ -325,7 +341,11 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+			if got.Skip != tt.wantSkip {
+				t.Errorf("got.Skip = %v, want %v", got.Skip, tt.wantSkip)
+			}
+
+			if diff := cmp.Diff(tt.want, got.Body, protocmp.Transform()); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -43,13 +43,9 @@ func (s *StreamingServer) HandleRequestHeaders(ctx context.Context, reqCtx *Requ
 		// More context: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/526
 		// The above PR will address endpoint admission, but currently any request without a body will be
 		// routed to a random upstream endpoint.
-		endpoint := s.director.GetRandomEndpoint()
-		if endpoint == nil {
-			return errcommon.Error{Code: errcommon.Internal, Msg: "no pods available in datastore"}
+		if err := s.fallbackToRandomEndpoint(ctx, reqCtx, 0); err != nil {
+			return err
 		}
-		reqCtx.TargetEndpoint = endpoint.GetIPAddress() + ":" + endpoint.GetPort()
-		reqCtx.RequestSize = 0
-		reqCtx.reqHeaderResp = s.generateRequestHeaderResponse(ctx, reqCtx)
 		return nil
 	}
 
@@ -69,6 +65,21 @@ func (s *StreamingServer) HandleRequestHeaders(ctx context.Context, reqCtx *Requ
 		reqCtx.FairnessID = metadata.DefaultFairnessID
 	}
 
+	return nil
+}
+
+func (s *StreamingServer) fallbackToRandomEndpoint(ctx context.Context, reqCtx *RequestContext, requestSize int) error {
+	endpoint := s.director.GetRandomEndpoint()
+	if endpoint == nil {
+		return errcommon.Error{Code: errcommon.Internal, Msg: "no pods available in datastore"}
+	}
+	reqCtx.TargetEndpoint = endpoint.GetIPAddress() + ":" + endpoint.GetPort()
+	reqCtx.RequestSize = requestSize
+	reqCtx.reqHeaderResp = s.generateRequestHeaderResponse(ctx, reqCtx)
+
+	if requestSize > 0 {
+		reqCtx.reqBodyResp = envoy.GenerateRequestBodyResponses(reqCtx.Request.RawBody)
+	}
 	return nil
 }
 

--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -24,6 +24,7 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/structpb"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
@@ -149,4 +150,63 @@ func TestGenerateRequestHeaderResponse_MergeMetadata(t *testing.T) {
 	endpointKey, ok := endpointNamespace.GetStructValue().Fields[metadata.DestinationEndpointKey]
 	assert.True(t, ok, "Expected DestinationEndpointKey to be in DestinationEndpointNamespace")
 	assert.Equal(t, "1.2.3.4:8080", endpointKey.GetStringValue(), "Unexpected value for DestinationEndpointKey")
+}
+
+func TestFallbackToRandomEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		requestSize     int
+		wantBodyRespLen int
+	}{
+		{
+			name:            "No body",
+			requestSize:     0,
+			wantBodyRespLen: 0,
+		},
+		{
+			name:            "With body",
+			requestSize:     9,
+			wantBodyRespLen: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &StreamingServer{
+				director: &mockDirectorRequest{},
+			}
+			reqCtx := &RequestContext{
+				Request:  &Request{Headers: make(map[string]string), RawBody: []byte("test body")},
+				Response: &Response{Headers: make(map[string]string)},
+			}
+
+			err := server.fallbackToRandomEndpoint(context.Background(), reqCtx, tc.requestSize)
+			assert.NoError(t, err)
+
+			if tc.wantBodyRespLen > 0 {
+				assert.NotNil(t, reqCtx.reqBodyResp)
+				assert.Len(t, reqCtx.reqBodyResp, tc.wantBodyRespLen)
+				bodyResp := reqCtx.reqBodyResp[0].GetRequestBody().GetResponse()
+				assert.NotNil(t, bodyResp.BodyMutation)
+				streamedResp := bodyResp.BodyMutation.GetStreamedResponse()
+				assert.NotNil(t, streamedResp)
+				assert.Equal(t, []byte("test body"), streamedResp.Body)
+			} else {
+				assert.Nil(t, reqCtx.reqBodyResp)
+			}
+		})
+	}
+}
+
+type mockDirectorRequest struct {
+	Director
+}
+
+func (m *mockDirectorRequest) GetRandomEndpoint() *datalayer.EndpointMetadata {
+	return &datalayer.EndpointMetadata{
+		Address: "1.2.3.4",
+		Port:    "80",
+	}
 }

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -151,6 +151,9 @@ const (
 	// RequestEvicted indicates the request was evicted by flow control.
 	// The state machine sends an ImmediateResponse(429) to Envoy.
 	RequestEvicted StreamRequestState = 8
+	// RequestSkipped indicates the request parsing was skipped.
+	// The state machine sends a HeadersResponse with fallback routing(randomly pick an endpoint from inferencePool) to Envoy.
+	RequestSkipped StreamRequestState = 9
 )
 
 // recvResult holds the result of a srv.Recv() call from the reader goroutine.
@@ -316,14 +319,25 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				reqCtx.RequestSize = len(body)
 				body = []byte{}
 
-				inferenceRequestBody, parseErr := s.parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+				parseResult, parseErr := s.parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 				if parseErr != nil {
 					err = errcommon.Error{Code: errcommon.BadRequest, Msg: parseErr.Error()}
 					logger.Error(err, "Error parsing request")
 					break
 				}
 
-				reqCtx, err = s.director.HandleRequest(ctx, reqCtx, inferenceRequestBody)
+				if parseResult.Skip {
+					logger.Info("Skipping phases as requested by parser")
+
+					if err = s.fallbackToRandomEndpoint(ctx, reqCtx, reqCtx.RequestSize); err != nil {
+						logger.Error(err, "Error falling back to random endpoint")
+						break
+					}
+					reqCtx.RequestState = RequestSkipped
+					break
+				}
+
+				reqCtx, err = s.director.HandleRequest(ctx, reqCtx, parseResult.Body)
 				if err != nil {
 					logger.Error(err, "Error handling request")
 					break
@@ -416,6 +430,13 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		if err := reqCtx.updateStateAndSendIfNeeded(srv, logger); err != nil {
 			return err
 		}
+		if reqCtx.RequestState == RequestSkipped {
+			logger.V(logutil.DEFAULT).Info("EPP skipped the request")
+			// Gracefully close the gRPC stream to stop external processing for this request.
+			// This ensures Envoy continues with the request without calling further phases.
+			// See: https://github.com/envoyproxy/envoy/blob/0533de0acca281110945e5726bbb306fbb12bde5/api/envoy/service/ext_proc/v3/external_processor.proto#L40-L41
+			return nil
+		}
 	}
 }
 
@@ -477,6 +498,25 @@ func (r *RequestContext) updateStateAndSendIfNeeded(srv extProcPb.ExternalProces
 				},
 			},
 		})
+	}
+
+	// Handle skip — send response with fallback routing to Envoy.
+	if r.RequestState == RequestSkipped {
+		if r.reqHeaderResp != nil {
+			if err := srv.Send(r.reqHeaderResp); err != nil {
+				logger.Error(err, "error sending response")
+				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
+			}
+		}
+		if r.reqBodyResp != nil {
+			for _, response := range r.reqBodyResp {
+				if err := srv.Send(response); err != nil {
+					logger.Error(err, "error sending response")
+					return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
+				}
+			}
+		}
+		return nil
 	}
 
 	// No switch statement as we could send multiple responses in one pass.

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -790,12 +790,12 @@ func TestDirector_HandleRequest(t *testing.T) {
 					reqCtx.Request.Headers[":path"] = "/v1/chat/completions"
 				}
 
-				inferenceRequestBody, parseErr := openai.NewOpenAIParser().ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+				parseResult, parseErr := openai.NewOpenAIParser().ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 				var returnedReqCtx *handlers.RequestContext
 				if parseErr != nil {
 					err = errcommon.Error{Code: errcommon.BadRequest, Msg: parseErr.Error()}
 				} else {
-					returnedReqCtx, err = director.HandleRequest(ctx, reqCtx, inferenceRequestBody)
+					returnedReqCtx, err = director.HandleRequest(ctx, reqCtx, parseResult.Body)
 				}
 
 				if test.wantErrCode != "" {

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -24,11 +24,14 @@ import (
 	"testing"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	extv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	fwkdl "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/datalayer"
+	fwkplugin "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/openai"
@@ -379,5 +382,94 @@ func (ts *testDirector) HandleResponseBody(ctx context.Context, reqCtx *handlers
 	return reqCtx
 }
 func (ts *testDirector) GetRandomEndpoint() *fwkdl.EndpointMetadata {
+	return &fwkdl.EndpointMetadata{
+		Address: podAddress,
+		Port:    strconv.Itoa(int(poolPort)),
+	}
+}
+
+type mockParser struct {
+	skip bool
+}
+
+func (m *mockParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	return &fwkrh.ParseResult{Skip: m.skip, Body: &fwkrh.InferenceRequestBody{}}, nil
+}
+
+func (m *mockParser) ParseResponse(ctx context.Context, body []byte, headers map[string]string, endofStream bool) (*fwkrh.ParsedResponse, error) {
+	return nil, nil
+}
+
+func (m *mockParser) SupportedAppProtocols() []extv1.AppProtocol {
 	return nil
+}
+
+func (m *mockParser) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock-parser", Name: "mock-parser"}
+}
+
+func TestServer_Skip(t *testing.T) {
+	t.Parallel()
+
+	director := &testDirector{}
+	mockPar := &mockParser{skip: true}
+
+	model := testutil.MakeInferenceObjective("v1").
+		CreationTimestamp(metav1.Unix(1000, 0)).ObjRef()
+
+	ctx, cancel, ds, _ := utils.PrepareForTestStreamingServer([]*v1alpha2.InferenceObjective{model},
+		[]*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: podName}}}, "test-pool1", namespace, poolPort)
+	streamingServer := handlers.NewStreamingServer(ds, director, mockPar)
+
+	testListener, errChan := utils.SetupTestStreamingServer(t, ctx, streamingServer)
+	process, conn := utils.GetStreamingServerClient(ctx, t)
+	defer conn.Close()
+
+	// Send request headers
+	headers := utils.BuildEnvoyGRPCHeaders(map[string]string{
+		"x-request-id": "test-request-id",
+	}, false)
+	request := &pb.ProcessingRequest{
+		Request: &pb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: headers,
+		},
+	}
+	err := process.Send(request)
+	require.NoError(t, err)
+
+	// Send request body (which will trigger ParseRequest)
+	request = &pb.ProcessingRequest{
+		Request: &pb.ProcessingRequest_RequestBody{
+			RequestBody: &pb.HttpBody{
+				Body:        []byte(`{"model":"test"}`),
+				EndOfStream: true,
+			},
+		},
+	}
+	err = process.Send(request)
+	require.NoError(t, err)
+
+	// Receive request headers and check
+	response, err := process.Recv()
+	require.NoError(t, err)
+
+	if response == nil || response.GetRequestHeaders() == nil {
+		t.Fatal("Expected RequestHeaders response")
+	}
+
+	// Receive request body and check
+	response, err = process.Recv()
+	require.NoError(t, err)
+
+	if response == nil || response.GetRequestBody() == nil {
+		t.Fatal("Expected RequestBody response")
+	}
+
+	// Verify that the stream is closed by checking if Recv returns EOF or error
+	_, err = process.Recv()
+	require.Error(t, err, "Expected error or EOF when receiving after skip")
+
+	cancel()
+	<-errChan
+	testListener.Close()
 }

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -136,19 +136,16 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectReject(
 				envoyTypePb.StatusCode_BadRequest,
-				"inference error: BadRequest - parsing gRPC payload for Generate: not able to parse payload",
+				"inference error: BadRequest - invalid or unsupported gRPC payload",
 			),
 		},
 		{
-			name:     "unsupported gRPC method",
+			name:     "unsupported gRPC method bypass",
 			requests: integration.ReqGRPCLLM(logger, "test2", "", "unsupportedMethod"),
 			pods: []podState{
 				P(0, 0, 0.2, "foo", "bar"),
 			},
-			wantResponses: ExpectReject(
-				envoyTypePb.StatusCode_BadRequest,
-				"inference error: BadRequest - unsupported gRPC path: unsupportedMethod",
-			),
+			wantResponses: ExpectGRPCRouteTo("192.168.1.1:8000", "test2", "unsupportedMethod"),
 		},
 		{
 			name: "split body across chunks",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind feature

**What this PR does / why we need it**:
Currently, when `ParseRequest` fails or encounters an unsupported condition, it errors out immediately. We want to be able to skip subsequent phases and fallback to a random endpoint instead of failing, for example when encountering unsupported paths or input types that might still be valid for the backend.

#### Solution
1.  **Interface Change**: Modified `Parser` interface to return `*ParseResult` instead of `*InferenceRequestBody`. `ParseResult` contains `Body` and a `Skip` boolean flag. This makes the interface more self-documenting and extensible.
2.  **State Machine Update**: Added `RequestSkipped` state in `server.go`. If `Skip` is true, the server falls back to a random endpoint, generates routing headers, and transitions to `RequestSkipped` state. `updateStateAndSendIfNeeded` sends the `HeadersResponse` and the stream is closed.
3.  **Refactoring**:
    *   Extracted `fallbackToRandomEndpoint` in `request.go` to reduce duplication between header-only requests and skipped requests.
    *   Refactored `VllmGRPCParser` to parse the gRPC payload first at the top of `ParseRequest` and fail early on malformed frames, while skipping on unsupported paths. This is the first parser that has the skip logic.

#### Tests
-   Updated unittest in `openai_test.go`, `passthrough_test.go`, and `vllmgrpc_test.go`.
-   Added `TestServer_Skip` in `pkg/epp/server/server_test.go`.
-   Updated `grpc_test.go` integration test case for unsupported method to expect bypass with explicit header construction.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
