### PR TITLE
fix: helm chart flags rendering for boolean values

### DIFF
--- a/config/charts/body-based-routing/templates/bbr.yaml
+++ b/config/charts/body-based-routing/templates/bbr.yaml
@@ -22,8 +22,7 @@ spec:
         - "--streaming"
         # Pass additional flags via the bbr.flags field in values.yaml.
         {{- range $key, $value := .Values.bbr.flags }}
-        - --{{ $key }}
-        - "{{ $value }}"
+        - --{{ $key }}={{ $value }}
         {{- end }}      
         {{- range .Values.bbr.plugins }}
         - --plugin

--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -132,8 +132,7 @@ spec:
           {{- end }}
               # Pass additional flags via the inferenceExtension.flags field in values.yaml.
           {{- range $key, $value := .Values.inferenceExtension.flags }}
-              - --{{ $key }}
-              - "{{ $value }}"
+              - --{{ $key }}={{ $value }}
           {{- end }}
           {{- if .Values.inferenceExtension.tracing.enabled }}
               - --tracing=true


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

The `inferenceExtension.flags` and `bbr.flags` fields in the Helm charts render each flag as two separate container args. For Go `pflag` boolean flags, `--flag` (without `=`) is interpreted as `true` regardless of the next positional argument.

### Affected charts
- `config/charts/epplib/templates/_deployment.yaml` (EPP)
- `config/charts/body-based-routing/templates/bbr.yaml` (BBR)

### Before (rendered container args)

```yaml
# values.yaml: secure-serving: false
# Template renders as:
args:
  - --secure-serving
  - "false"
# pflag interprets --secure-serving (no =) as true, "false" becomes ignored positional arg
# Result: secure-serving=true ❌
```

### After (rendered container args)

```yaml
# values.yaml: secure-serving: false
# Template renders as:
args:
  - --secure-serving=false
# pflag correctly parses --key=value format
# Result: secure-serving=false ✅
```

### Template change (both EPP and BBR)

```diff
 {{- range $key, $value := .Values.inferenceExtension.flags }}
-            - --{{ $key }}
-            - "{{ $value }}"
+            - --{{ $key }}={{ $value }}
 {{- end }}
```

This works correctly for all flag types (bool, string, int). The `--key=value` format is the standard way to pass flags in Kubernetes container args and is how other flags in the same template are already rendered (e.g., `--tracing=false`).

## Which issue(s) this PR fixes

Discovered while integrating [KAITO](https://github.com/kaito-project/kaito) with the InferencePool chart — setting `secure-serving: false` via the `flags` field had no effect because of this rendering issue.

## How was this PR tested?

Verified on a live AKS cluster with KAITO InferenceSet:
1. Set `inferenceExtension.flags.secure-serving: false` in HelmRelease values
2. Before fix: EPP logs showed `"secure-serving":true`
3. After fix: EPP logs show `"secure-serving":false`

 - details: after I run following command 
```bash
# kubectl patch helmrelease phi-4-mini-inferencepool --type merge -p '
spec:
  values:
    inferenceExtension:
      flags:
        secure-serving: "false"
'
```

I could see `phi-4-mini-inferencepool-epp-59d75c9dfc-c24tm` logs with `"secure-serving":false` log, without this fix, `secure-serving` is always `true` no matter what I patch in `helmrelease phi-4-mini-inferencepool`:

```
{"level":"info","ts":"2026-04-22T07:39:56Z","logger":"setup","caller":"runner/runner.go:169","msg":"Flags processed","flags":{"cache-info-metric":"vllm:cache_config_info","cert-path":"","config-file":"/config/default-plugins.yaml","config-text":"","disable-endpoint-subset-filter":false,"enable-cert-reload":false,"enable-pprof":true,"endpoint-selector":"","endpoint-target-ports":{},"grpc-health-port":9003,"grpc-port":9002,"ha-enable-leader-election":false,"health-checking":false,"kv-cache-usage-percentage-metric":"vllm:kv_cache_usage_perc","lora-info-metric":"vllm:lora_requests_info","metrics-endpoint-auth":true,"metrics-port":9090,"metrics-staleness-threshold":2000000000,"model-server-metrics-https-insecure-skip-verify":true,"model-server-metrics-path":"/metrics","model-server-metrics-port":0,"model-server-metrics-scheme":"http","pool-group":"inference.networking.k8s.io","pool-name":"phi-4-mini-inferencepool","pool-namespace":"default","refresh-metrics-interval":50000000,"refresh-prometheus-metrics-interval":5000000000,"secure-serving":false,"total-queued-requests-metric":"vllm:num_requests_waiting","total-running-requests-metric":"vllm:num_requests_running","tracing":false,"v":1,"zap-devel":{},"zap-encoder":{},"zap-log-level":{},"zap-stacktrace-level":{},"zap-time-encoding":{}}}
```