### PR TITLE
Fix TOCTOU port race causing flaky integration test failures

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -372,6 +373,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 	serverRunner := &runserver.ExtProcServerRunner{
 		GrpcPort:                         opts.GRPCPort,
+		GrpcListener:                     opts.GRPCListener,
 		GKNN:                             *gknn,
 		Datastore:                        ds,
 		ControllerCfg:                    controllerCfg,
@@ -394,7 +396,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 	// --- Add Runnables to Manager ---
 	// Register health server.
-	if err := registerHealthServer(mgr, ctrl.Log.WithName("health"), ds, opts.GRPCHealthPort, isLeader, opts.EnableLeaderElection, r.parser); err != nil {
+	if err := registerHealthServer(mgr, ctrl.Log.WithName("health"), ds, opts.GRPCHealthPort, opts.GRPCHealthListener, isLeader, opts.EnableLeaderElection, r.parser); err != nil {
 		return nil, nil, err
 	}
 
@@ -654,7 +656,7 @@ func registerExtProcServer(mgr manager.Manager, runner *runserver.ExtProcServerR
 }
 
 // registerHealthServer adds the Health gRPC server as a Runnable to the given manager.
-func registerHealthServer(mgr manager.Manager, logger logr.Logger, ds datastore.Datastore, port int, isLeader *atomic.Bool, leaderElectionEnabled bool, supporter appProtocolSupporter) error {
+func registerHealthServer(mgr manager.Manager, logger logr.Logger, ds datastore.Datastore, port int, lis net.Listener, isLeader *atomic.Bool, leaderElectionEnabled bool, supporter appProtocolSupporter) error {
 	srv := grpc.NewServer()
 	healthPb.RegisterHealthServer(srv, &healthServer{
 		logger:                logger,
@@ -663,8 +665,13 @@ func registerHealthServer(mgr manager.Manager, logger logr.Logger, ds datastore.
 		leaderElectionEnabled: leaderElectionEnabled,
 		supporter:             supporter,
 	})
-	if err := mgr.Add(
-		runnable.NoLeaderElection(runnable.GRPCServer("health", srv, port))); err != nil {
+	var r manager.Runnable
+	if lis != nil {
+		r = runnable.NoLeaderElection(runnable.GRPCServerWithListener("health", srv, lis))
+	} else {
+		r = runnable.NoLeaderElection(runnable.GRPCServer("health", srv, port))
+	}
+	if err := mgr.Add(r); err != nil {
 		setupLog.Error(err, "Failed to register health server")
 		return err
 	}

--- a/internal/runnable/grpc.go
+++ b/internal/runnable/grpc.go
@@ -26,41 +26,52 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// GRPCServer converts the given gRPC server into a runnable.
+// GRPCServer converts the given gRPC server into a runnable that listens on the given port.
 // The server name is just being used for logging.
 func GRPCServer(name string, srv *grpc.Server, port int) manager.Runnable {
 	return manager.RunnableFunc(func(ctx context.Context) error {
-		// Use "name" key as that is what manager.Server does as well.
-		log := ctrl.Log.WithValues("name", name)
-		log.Info("gRPC server starting")
-
-		// Start listening.
 		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err != nil {
 			return fmt.Errorf("gRPC server failed to listen - %w", err)
 		}
-
-		log.Info("gRPC server listening", "port", port)
-
-		// Shutdown on context closed.
-		// Terminate the server on context closed.
-		// Make sure the goroutine does not leak.
-		doneCh := make(chan struct{})
-		defer close(doneCh)
-		go func() {
-			select {
-			case <-ctx.Done():
-				log.Info("gRPC server shutting down")
-				srv.GracefulStop()
-			case <-doneCh:
-			}
-		}()
-
-		// Keep serving until terminated.
-		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
-			return fmt.Errorf("gRPC server failed - %w", err)
-		}
-		log.Info("gRPC server terminated")
-		return nil
+		return serveGRPC(ctx, name, srv, lis)
 	})
+}
+
+// GRPCServerWithListener converts the given gRPC server into a runnable using
+// a pre-created listener. This avoids TOCTOU port races in tests where
+// GetFreePort() closes a listener and the subsequent bind can be interleaved
+// by other processes grabbing the same port.
+func GRPCServerWithListener(name string, srv *grpc.Server, lis net.Listener) manager.Runnable {
+	return manager.RunnableFunc(func(ctx context.Context) error {
+		return serveGRPC(ctx, name, srv, lis)
+	})
+}
+
+func serveGRPC(ctx context.Context, name string, srv *grpc.Server, lis net.Listener) error {
+	// Use "name" key as that is what manager.Server does as well.
+	log := ctrl.Log.WithValues("name", name)
+	log.Info("gRPC server starting")
+	log.Info("gRPC server listening", "addr", lis.Addr().String())
+
+	// Shutdown on context closed.
+	// Terminate the server on context closed.
+	// Make sure the goroutine does not leak.
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.Info("gRPC server shutting down")
+			srv.GracefulStop()
+		case <-doneCh:
+		}
+	}()
+
+	// Keep serving until terminated.
+	if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+		return fmt.Errorf("gRPC server failed - %w", err)
+	}
+	log.Info("gRPC server terminated")
+	return nil
 }

--- a/pkg/bbr/server/runserver.go
+++ b/pkg/bbr/server/runserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/go-logr/logr"
@@ -36,6 +37,7 @@ import (
 // ExtProcServerRunner provides methods to manage an external process server.
 type ExtProcServerRunner struct {
 	GrpcPort        int
+	GrpcListener    net.Listener // Pre-bound listener; if set, GrpcPort is ignored.
 	SecureServing   bool
 	Streaming       bool
 	RequestPlugins  []framework.RequestProcessor
@@ -73,6 +75,9 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		extProcPb.RegisterExternalProcessorServer(srv, handlers.NewServer(r.Streaming, r.RequestPlugins, r.ResponsePlugins))
 
 		// Forward to the gRPC runnable.
+		if r.GrpcListener != nil {
+			return runnable.GRPCServerWithListener("ext-proc", srv, r.GrpcListener).Start(ctx)
+		}
 		return runnable.GRPCServer("ext-proc", srv, r.GrpcPort).Start(ctx)
 	}))
 }

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -19,6 +19,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -79,6 +80,11 @@ type Options struct {
 	EnableCertReload       bool   // Enables certificate reloading of the certificates specified in --cert-path.
 	SecureServing          bool   // Enables secure serving.
 	MetricsEndpointAuth    bool   // Enables authentication and authorization of the metrics endpoint.
+	//
+	// Pre-bound listeners for tests to avoid TOCTOU port races. If set, the corresponding port field is ignored.
+	//
+	GRPCListener       net.Listener
+	GRPCHealthListener net.Listener
 	//
 	// Configuration.
 	//

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -49,6 +50,7 @@ import (
 // ExtProcServerRunner provides methods to manage an external process server.
 type ExtProcServerRunner struct {
 	GrpcPort                         int
+	GrpcListener                     net.Listener // Pre-bound listener; if set, GrpcPort is ignored.
 	GKNN                             common.GKNN
 	ControllerCfg                    ControllerConfig
 	Datastore                        datastore.Datastore
@@ -81,6 +83,7 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 	}
 	return &ExtProcServerRunner{
 		GrpcPort:                         opts.GRPCPort,
+		GrpcListener:                     opts.GRPCListener,
 		GKNN:                             gknn,
 		ControllerCfg:                    ControllerConfig{true, true, true},
 		SecureServing:                    opts.SecureServing,
@@ -193,6 +196,9 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		}
 
 		// Forward to the gRPC runnable.
+		if r.GrpcListener != nil {
+			return runnable.GRPCServerWithListener("ext-proc", srv, r.GrpcListener).Start(ctx)
+		}
 		return runnable.GRPCServer("ext-proc", srv, r.GrpcPort).Start(ctx)
 	}))
 }

--- a/test/integration/bbr/harness.go
+++ b/test/integration/bbr/harness.go
@@ -108,12 +108,13 @@ func NewBBRHarnessWithPlugins(
 ) *BBRHarness {
 	t.Helper()
 
-	// 1. Allocate Free Port
-	port, err := integration.GetFreePort()
-	require.NoError(t, err, "failed to acquire free port for BBR server")
+	// 1. Allocate Free Listener (avoids TOCTOU port race)
+	listener, port, err := integration.GetFreeListener()
+	require.NoError(t, err, "failed to acquire free listener for BBR server")
 
 	// 2. Configure BBR Server with plugins
 	runner := runserver.NewDefaultExtProcServerRunner(port, false)
+	runner.GrpcListener = listener
 	runner.SecureServing = false
 	runner.Streaming = streaming
 	runner.RequestPlugins = requestPlugins

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -339,13 +339,15 @@ func defaultEppServerOptions(t *testing.T, namespace, configText string) *eppSer
 	require.NoError(t, err)
 	eppOptions.MetricsPort = metricsPort
 
-	grpcPort, err := integration.GetFreePort()
+	grpcListener, grpcPort, err := integration.GetFreeListener()
 	require.NoError(t, err)
 	eppOptions.GRPCPort = grpcPort
+	eppOptions.GRPCListener = grpcListener
 
-	healthPort, err := integration.GetFreePort()
+	healthListener, healthPort, err := integration.GetFreeListener()
 	require.NoError(t, err)
 	eppOptions.GRPCHealthPort = healthPort
+	eppOptions.GRPCHealthListener = healthListener
 	eppOptions.EndpointTargetPorts = []int{8000}
 	eppOptions.SecureServing = false
 	return eppOptions

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -624,6 +624,7 @@ func ExtProcServerClient(
 //
 // Note: There is a theoretical race condition where another process grabs the port between the Close() call and the
 // subsequent usage, but this is generally acceptable in hermetic test environments.
+// Prefer GetFreeListener where possible to avoid this race.
 func GetFreePort() (int, error) {
 	// Force IPv4 to prevent flakes on dual-stack CI environments
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -639,6 +640,23 @@ func GetFreePort() (int, error) {
 		return 0, errors.New("failed to cast listener address to TCPAddr")
 	}
 	return addr.Port, nil
+}
+
+// GetFreeListener returns a net.Listener bound to an available IPv4 TCP port
+// on localhost. Unlike GetFreePort, the listener stays open, eliminating the
+// TOCTOU race where another process can steal the port between close and rebind.
+// The caller is responsible for passing the listener to the server or closing it.
+func GetFreeListener() (net.Listener, int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to listen on a free port: %w", err)
+	}
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		listener.Close()
+		return nil, 0, errors.New("failed to cast listener address to TCPAddr")
+	}
+	return listener, addr.Port, nil
 }
 
 // --- Internal Helpers ---


### PR DESCRIPTION
## What this PR does

Fixes a TOCTOU (time-of-check-time-of-use) race condition in integration tests that causes flaky `address already in use` failures in CI.

## Problem

`GetFreePort()` allocates a port by listening on `:0`, capturing the port, then **closing the listener**. The gRPC server later tries to re-bind the same port. Between close and re-bind, another process can steal the port:

```
Server failed to bind port 127.0.0.1:38733
gRPC server failed to listen - listen tcp :38733: bind: address already in use
```

This has caused repeated flaky failures in `TestFullDuplexStreamed_KubeInferenceObjectiveRequest`:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_gateway-api-inference-extension/2871/pull-gateway-api-inference-extension-test-unit-main/2046910774252670976
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_gateway-api-inference-extension/2871/pull-gateway-api-inference-extension-test-unit-main/2046919368926826496

## Solution

1. **`GetFreeListener()`** — new helper that returns a `net.Listener` that **stays open**, eliminating the race window
2. **`GRPCServerWithListener()`** — new runnable variant that accepts a pre-bound listener instead of a port
3. **`GRPCListener` fields** on EPP and BBR server runners — when set, uses the pre-bound listener
4. **Test harnesses updated** to use `GetFreeListener()` for the gRPC ext-proc port

Production code paths are **unchanged** — they continue using port-based `GRPCServer()`. The listener-based path is only exercised in tests.

## Changes

| File | Change |
|------|--------|
| `internal/runnable/grpc.go` | Refactored into `serveGRPC()` helper; added `GRPCServerWithListener()` |
| `pkg/epp/server/options.go` | Added `GRPCListener net.Listener` field |
| `pkg/epp/server/runserver.go` | Wire listener through runner; use if set |
| `pkg/bbr/server/runserver.go` | Same listener support for BBR |
| `test/integration/util.go` | Added `GetFreeListener()` |
| `test/integration/epp/harness.go` | Use `GetFreeListener()` for gRPC port |
| `test/integration/bbr/harness.go` | Use `GetFreeListener()` for gRPC port |