### PR TITLE
CI: Add CloudBuild step for LWEPP image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,6 +33,14 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
     entrypoint: make
     args:
+      - lwepp-image-push
+    env:
+    - GIT_TAG=$_GIT_TAG
+    - EXTRA_TAG=$_PULL_BASE_REF
+    - DOCKER_BUILDX_CMD=/buildx-entrypoint
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+    entrypoint: make
+    args:
       - latency-training-image-push
       - latency-prediction-image-push
       - latency-prediction-test-image-push

--- a/lwepp.Dockerfile
+++ b/lwepp.Dockerfile
@@ -1,0 +1,37 @@
+# Dockerfile has specific requirement to put this ARG at the beginning:
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG BUILDER_IMAGE=golang:1.25
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+
+## Multistage build
+FROM ${BUILDER_IMAGE} AS builder
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+ARG COMMIT_SHA=unknown
+ARG BUILD_REF
+
+# Dependencies
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Sources
+COPY cmd/lwepp ./cmd/lwepp
+COPY pkg/common ./pkg/common
+COPY pkg/lwepp ./pkg/lwepp
+COPY internal ./internal
+COPY apix ./apix
+COPY api ./api
+COPY version ./version
+COPY sidecars ./sidecars
+WORKDIR /src/cmd/lwepp
+RUN go build -ldflags="-X sigs.k8s.io/gateway-api-inference-extension/version.CommitSHA=${COMMIT_SHA} -X sigs.k8s.io/gateway-api-inference-extension/version.BuildRef=${BUILD_REF}" -o /lwepp
+
+## Multistage deploy
+FROM ${BASE_IMAGE}
+
+WORKDIR /
+COPY --from=builder /lwepp /lwepp
+
+ENTRYPOINT ["/lwepp"]


### PR DESCRIPTION
**What type of PR is this?**

Add one of the following kinds:
/kind cleanup

**What this PR does / why we need it**:

Adds a CloudBuild step to build LWEPP image on push.

**Which issue(s) this PR fixes**:
Fixes #2874 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
