### PR TITLE
Add minimum for blockSizeTokens autotuning

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -81,6 +81,15 @@ func newPrepareData(ctx context.Context, config config, handle plugin.Handle) (*
 	if config.MaxPrefixTokensToMatch < 0 {
 		return nil, fmt.Errorf("invalid configuration: MaxPrefixTokensToMatch must be >= 0 (current value: %d)", config.MaxPrefixTokensToMatch)
 	}
+	if config.BlockSizeTokens > 0 && config.BlockSizeTokens < minBlockSizeTokens {
+		log.FromContext(ctx).Info(
+			"WARNING: prefix-cache-scorer BlockSizeTokens is below the recommended minimum; "+
+				"this can cause excessive EPP memory usage and OOMs under load. "+
+				"Consider matching the model server's cache block size (vLLM default is 16).",
+			"blockSizeTokens", config.BlockSizeTokens,
+			"recommendedMinimum", minBlockSizeTokens,
+		)
+	}
 	indexer := newIndexer(ctx, config.LRUCapacityPerServer)
 
 	p := &prepareData{
@@ -235,18 +244,23 @@ func (p *prepareData) matchLongestPrefix(ctx context.Context, hashes []blockHash
 }
 
 // GetBlockSize returns the block size in tokens, potentially auto-tuned from endpoint metrics.
+// When AutoTune is enabled, the returned value is clamped to minBlockSizeTokens to prevent
+// the indexer from blowing up memory on misreported or misconfigured small values.
 func (p *prepareData) GetBlockSize(endpoints []framework.Endpoint) int {
 	if !p.config.AutoTune || len(endpoints) == 0 {
 		return p.config.BlockSizeTokens
 	}
 
+	blockSize := p.config.BlockSizeTokens
 	if endpoint := endpoints[0]; endpoint.GetMetrics() != nil {
-		cacheBlockSize := endpoint.GetMetrics().CacheBlockSize
-		if cacheBlockSize > 0 {
-			return cacheBlockSize
+		if cacheBlockSize := endpoint.GetMetrics().CacheBlockSize; cacheBlockSize > 0 {
+			blockSize = cacheBlockSize
 		}
 	}
-	return p.config.BlockSizeTokens
+	if blockSize < minBlockSizeTokens {
+		return minBlockSizeTokens
+	}
+	return blockSize
 }
 
 // ApproxPrefixCacheFactory is the factory function for the prefix cache prepare data plugin.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -484,6 +484,64 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	assert.Contains(t, p.indexer().Pods(), ServerID(endpoint.GetMetadata().NamespacedName))
 }
 
+func TestAutoTuneBlockSizeFloor(t *testing.T) {
+	makeEndpoint := func(name string, metrics *fwkdl.Metrics) fwksched.Endpoint {
+		return fwksched.NewEndpoint(
+			&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: name}},
+			metrics, fwkdl.NewAttributes(),
+		)
+	}
+
+	t.Run("metric below minimum is clamped to floor", func(t *testing.T) {
+		cfg := config{
+			AutoTune:        true,
+			BlockSizeTokens: defaultBlockSizeTokens,
+		}
+		p, err := newPrepareData(context.Background(), cfg, nil)
+		assert.NoError(t, err)
+
+		ep := makeEndpoint("pod1", &fwkdl.Metrics{CacheBlockSize: 1})
+		assert.Equal(t, minBlockSizeTokens, p.GetBlockSize([]fwksched.Endpoint{ep}))
+	})
+
+	t.Run("metric above minimum is honored", func(t *testing.T) {
+		cfg := config{
+			AutoTune:        true,
+			BlockSizeTokens: defaultBlockSizeTokens,
+		}
+		p, err := newPrepareData(context.Background(), cfg, nil)
+		assert.NoError(t, err)
+
+		ep := makeEndpoint("pod1", &fwkdl.Metrics{CacheBlockSize: 32})
+		assert.Equal(t, 32, p.GetBlockSize([]fwksched.Endpoint{ep}))
+	})
+
+	t.Run("fallback below minimum is clamped when metric is unavailable", func(t *testing.T) {
+		cfg := config{
+			AutoTune:        true,
+			BlockSizeTokens: 4,
+		}
+		p, err := newPrepareData(context.Background(), cfg, nil)
+		assert.NoError(t, err)
+
+		// Endpoint with no CacheBlockSize metric: falls back to config, then floored.
+		ep := makeEndpoint("pod1", &fwkdl.Metrics{})
+		assert.Equal(t, minBlockSizeTokens, p.GetBlockSize([]fwksched.Endpoint{ep}))
+	})
+
+	t.Run("manual mode is not clamped", func(t *testing.T) {
+		cfg := config{
+			AutoTune:        false,
+			BlockSizeTokens: 4,
+		}
+		p, err := newPrepareData(context.Background(), cfg, nil)
+		assert.NoError(t, err)
+
+		ep := makeEndpoint("pod1", &fwkdl.Metrics{CacheBlockSize: 1})
+		assert.Equal(t, 4, p.GetBlockSize([]fwksched.Endpoint{ep}))
+	})
+}
+
 func TestMaxPrefixTokensToMatch(t *testing.T) {
 	// BlockSizeTokens=1 means each block is 4 chars (1 token * 4 chars/token).
 	// With MaxPrefixTokensToMatch=2, maxBlocks = 2/1 = 2, so only the first

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -87,8 +87,14 @@ const (
 	// podActiveCheckInterval is the interval at which we check if pods are still active.
 	podActiveCheckInterval = 2 * time.Minute
 
-	// defaultBlockSizeTokens is the default token block size (vLLM default is 16).
-	defaultBlockSizeTokens = 16
+	// minBlockSizeTokens is the minimum block size in tokens. Values below this lead to
+	// excessive memory consumption in the LRU indexer (~60-70 bytes per entry per pod) and
+	// can OOM the EPP under load. The autotune path enforces this floor; manually configured
+	// values below this threshold trigger a startup warning but are still honored.
+	minBlockSizeTokens = 16
+
+	// defaultBlockSizeTokens is the default token block size (matches vLLM's default).
+	defaultBlockSizeTokens = minBlockSizeTokens
 
 	// defaultMaxPrefixBlocks is the maximum number of blocks to match.
 	// Two long requests with the same prefix up to this limit will be indistinguishable.

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/README.md
@@ -36,7 +36,9 @@ The plugin config supports:
 - `autoTune` (default true)
   - If true, block size and per-pod capacity can be inferred from endpoint metrics.
 - `blockSizeTokens`
-  - Prefix block size in tokens.
+  - Prefix block size in tokens. Should reflect the underlying model server's cache chunk size (vLLM default: 16).
+  - Minimum recommended value: **16**. Lower values cause the per-pod LRU indexer to consume excessive memory (~60–70 bytes per entry × `lruCapacityPerServer` × number of pods) and can OOM the EPP under load.
+  - When `autoTune` is enabled, the effective block size is clamped to a floor of 16 even if the model server reports a smaller value. Manually configured values below 16 are honored but trigger a startup warning.
 - `maxPrefixBlocksToMatch`
   - Caps how much of a long prompt is considered.
 - `lruCapacityPerServer`

--- a/site-src/guides/epp-configuration/config-text.md
+++ b/site-src/guides/epp-configuration/config-text.md
@@ -70,7 +70,7 @@ kind: EndpointPickerConfig
 plugins:
 - type: prefix-cache-scorer
   parameters:
-    blockSizeTokens: 5
+    blockSizeTokens: 16
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
 schedulingProfiles:
@@ -137,7 +137,7 @@ spec:
           plugins:
           - type: prefix-cache-scorer
             parameters:
-              blockSizeTokens: 5
+              blockSizeTokens: 16
               maxPrefixBlocksToMatch: 256
               lruCapacityPerServer: 31250
           schedulingProfiles:
@@ -156,7 +156,7 @@ kind: EndpointPickerConfig
 plugins:
 - type: prefix-cache-scorer
   parameters:
-    blockSizeTokens: 5
+    blockSizeTokens: 16
     maxPrefixBlocksToMatch: 256
     lruCapacityPerServer: 31250
 - type: single-profile-handler

--- a/site-src/guides/epp-configuration/prefix-aware.md
+++ b/site-src/guides/epp-configuration/prefix-aware.md
@@ -14,24 +14,38 @@ Like any other plugins, the prefix cache aware plugin can be enabled/disabled vi
 
 The prefix cache plugin exposes the following advanced configuration parameters:
 
-* `blockSize`: The plugin matches prefixes in the unit of blocks. This is the size
-of each block in number of bytes. At runtime, EPP can dynamically fetch this information from the
-inference engine metrics, therefore this config is only used when such metric is not available. In
-vLLM, the metric name is `vllm:cache_config_info` and the metric label is `block_size`. See the
+* `blockSizeTokens`: The plugin matches prefixes in the unit of blocks. This is the size
+of each block in tokens, and should reflect the underlying model server's cache chunk size.
+When `autoTune` is enabled, EPP dynamically fetches this from the inference engine metrics
+and only falls back to the configured value when the metric is unavailable. In vLLM, the
+metric name is `vllm:cache_config_info` and the metric label is `block_size`. See the
 [model server protocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals/003-model-server-protocol)
 for more details.
 
-    vLLM default block size is 16 tokens. Assume 4 characters per token, the default
-    is set to 64 in EPP. The default is recommended unless performance is critical for use cases with
-    extremely long inputs.
+    The default is **16 tokens**, which matches vLLM's default block size and is recommended
+    for most deployments.
+
+    > Note on memory usage:
+        Each LRU indexer entry costs ~60–70 bytes of EPP memory, and the indexer holds
+        `lruCapacityPerServer × num_pods` entries. Setting `blockSizeTokens` below **16**
+        scales the indexer state to potentially gigabytes and can OOM the EPP under load.
+        For this reason:
+
+        * When `autoTune` is enabled, the effective block size is clamped to a floor of 16
+          even if the model server reports a smaller value.
+        * Manually configured values below 16 are honored but trigger a startup warning.
+
+* `blockSize` (deprecated): Legacy block size defined in number of characters. Use
+`blockSizeTokens` instead.
 
 * `maxPrefixBlocksToMatch`: The maximum number of blocks to find prefix match. The default is
-256 (or 256*64=16384 characters, or roughly 4096 tokens). This is useful to tradeoff prefix match accuracy
+256 (roughly 4096 tokens at the default block size). This is useful to tradeoff prefix match accuracy
 for performance.
 
-* `lruCapacityPerServer`: Maximum capacity the prefix LRU cache in number of block hashes per server (pod). 
-Similar to `blockSize`, EPP can dynamically fetch this from the inference engine metrics endpoints. 
-In vLLM, the metric name is `vllm:cache_config_info` and the metric label is `num_gpu_blocks`. See the
+* `lruCapacityPerServer`: Maximum capacity of the prefix LRU cache in number of block hashes per
+server (pod). Similar to `blockSizeTokens`, EPP can dynamically fetch this from the inference engine
+metrics endpoints when `autoTune` is enabled. In vLLM, the metric name is `vllm:cache_config_info`
+and the metric label is `num_gpu_blocks`. See the
 [model server protocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals/003-model-server-protocol)
 for more details.
 
@@ -43,14 +57,11 @@ for more details.
         false cache misses. If the EPP cache is larger than the HBM cache, then there are more false cache hits.
         Therefore **the EPP prefix cache indexer size should be as close as possible to the HBM cache size.**
 
-        NOTE: EPP builds prefix cache based on characters, while model server maintains prefix cache entries
-        in tokens, a conversion between character <-> token is needed.
-
         Below are the formulas to estimate the EPP prefix indexer size:
 
         ```
-        max_kv_tokens_per_server = (HBM_size - model_size)/ kv_size_per_token
-        lru_indexer_capacity_per_server = (max_kv_tokens_per_server * avg_chars_per_token)/prefix_indexer_hash_block_size
+        max_kv_tokens_per_server = (HBM_size - model_size) / kv_size_per_token
+        lru_indexer_capacity_per_server = max_kv_tokens_per_server / blockSizeTokens
         ```
 
         Let's take an example:
@@ -58,11 +69,9 @@ for more details.
         * Model: qwen3 32B
         * Accelerator: Nvidia H100 80GB
         * Num replicas: 3
-        * Estimated # characters per token: 4 ([source](https://genai.stackexchange.com/questions/34/how-long-is-a-token))
 
         ```
         max_kv_tokens_per_server = (80GB - 16GB) / 128KB = 500,000
-        # assume avg_chars_per_token = 4, prefix_indexer_hash_block_size = 64 (default)
-        # each entry is about 358KB, so the memory footprint is about 11 MB per server
-        lru_indexer_capacity_per_server = 500,000*4/64 = 31250
+        # assume blockSizeTokens = 16 (default, matches vLLM)
+        lru_indexer_capacity_per_server = 500,000 / 16 = 31,250
         ```

--- a/site-src/guides/troubleshooting.md
+++ b/site-src/guides/troubleshooting.md
@@ -101,6 +101,7 @@ This mismatch causes the EPP to fundamentally misunderstand the caching behavior
 
 *   **Overpredicting Cache Hits (Hotspots):** If EPP believes a pod has a prefix match when it doesn't (e.g., due to an incorrect `blockSize` or `lruCapacityPerServer` that is too large), it will aggressively funnel requests to that single pod. The pod effectively experiences a cache miss for every request, recalculating the full prompt while other pods sit idle.
 *   **Underpredicting Cache Hits (Missed Opportunities):** Conversely, if `lruCapacityPerServer` is too small, EPP may believe a pod has evicted a prefix that is actually still present. This leads to inefficient routing where requests are sent to suboptimal pods, missing out on "free" acceleration.
+*   **Excessive EPP Memory / OOMs:** Setting `blockSizeTokens` too low (below 16) causes the per-pod LRU indexer to balloon in memory (~60–70 bytes per entry × `lruCapacityPerServer` × number of pods) and can OOM the EPP under load. Auto-tune now enforces a floor of 16; manually configured values below 16 are honored but trigger a startup warning.
 
 **Solution**:
 *   **v1.2+**: We recommend using the auto-tuning capability, which automatically syncs configuration with the model server. This feature is currently only supported for model servers that expose the required memory block metrics (e.g., vLLM). It is not currently supported for `sglang` because the necessary metrics regarding memory blocks (`Block Size` and `Number of GPU Blocks`) are not yet exposed.


### PR DESCRIPTION
<!--
/kind documentation
/kind feature
-->

## Summary

Enforces a 16-token floor on `prefix-cache-scorer`'s `blockSizeTokens` when `autoTune` is enabled, and warns at startup when a smaller value is configured manually. Prevents the LRU indexer from expanding to multiple gigabytes (~60–70 bytes/entry × `lruCapacityPerServer` × num pods) and OOM-ing the EPP under load.

## Behavior

| Mode | Configured value | Behavior |
|------|------------------|----------|
| `autoTune: true`, metric reports < 16 | any | Returns 16 (clamped) |
| `autoTune: true`, metric reports ≥ 16 | any | Returns metric value |
| `autoTune: true`, no metric | < 16 | Returns 16 (clamped) + startup warning |
| `autoTune: true`, no metric | ≥ 16 | Returns configured value |
| `autoTune: false` | < 16 | Returns configured value + startup warning |
| `autoTune: false` | ≥ 16 | Returns configured value |

## Testing

Added new `TestAutoTuneBlockSizeFloor`:
`go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/...` 

**Which issue(s) this PR fixes**:
Fixes #2878 

**Does this PR introduce a user-facing change?**:
```release-note
Set minimum threshold for prefix cache scorer `blockSizeTokens` to 16 for autotuning (warns when manually set below)
```
