### PR TITLE
feat(bbr): return client.Client from Handle instead of Reader

### DIFF
--- a/cmd/bbr/runner/runner.go
+++ b/cmd/bbr/runner/runner.go
@@ -187,7 +187,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		// Create BaseModelToHeaderPlugin instance for extracting the "model" field into X-Gateway-Base-Model-Name
 		baseModelToHeaderPlugin, err := basemodelextractor.NewBaseModelToHeaderPlugin(func() *builder.Builder {
 			return ctrl.NewControllerManagedBy(mgr)
-		}, mgr.GetAPIReader())
+		}, mgr.GetClient())
 		if err != nil {
 			setupLog.Error(err, "Failed to create plugin", "pluginType", basemodelextractor.BaseModelToHeaderPluginType)
 			return err

--- a/pkg/bbr/framework/handle.go
+++ b/pkg/bbr/framework/handle.go
@@ -28,7 +28,7 @@ import (
 type Handle interface {
 	// Context returns a context the plugins can use, if they need one
 	Context() context.Context
-	ClientReader() client.Reader
+	Client() client.Client
 	ReconcilerBuilder() *ctrlbuilder.Builder
 }
 
@@ -43,8 +43,8 @@ func (h *bbrHandle) Context() context.Context {
 	return h.ctx
 }
 
-func (h *bbrHandle) ClientReader() client.Reader {
-	return h.mgr.GetAPIReader()
+func (h *bbrHandle) Client() client.Client {
+	return h.mgr.GetClient()
 }
 
 func (h *bbrHandle) ReconcilerBuilder() *ctrlbuilder.Builder {

--- a/pkg/bbr/plugins/basemodelextractor/base_model_to_header.go
+++ b/pkg/bbr/plugins/basemodelextractor/base_model_to_header.go
@@ -47,7 +47,7 @@ type BaseModelToHeaderPlugin struct {
 
 // BaseModelToHeaderPluginFactory defines the factory function for BaseModelToHeaderPlugin
 func BaseModelToHeaderPluginFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
-	plugin, err := NewBaseModelToHeaderPlugin(handle.ReconcilerBuilder, handle.ClientReader())
+	plugin, err := NewBaseModelToHeaderPlugin(handle.ReconcilerBuilder, handle.Client())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin '%s' - %w", BaseModelToHeaderPluginType, err)
 	}


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Changes the BBR framework `Handle` interface to return `client.Client` instead of `client.Reader`. This enables future plugins to write Kubernetes objects (Create, Update, Delete), not just read them.


**Does this PR introduce a user-facing change?**:
```release-note
NONE