### PR TITLE
Pin github/codeql-action/upload-sarif to full-length commit SHA

### DIFF
--- a/.github/workflows/trivy-image-scan.yaml
+++ b/.github/workflows/trivy-image-scan.yaml
@@ -70,7 +70,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Pins `github/codeql-action/upload-sarif@v3` to full-length commit SHA `865f5f5c36632f18690a3d569fa0a764f2da0c3e` in `trivy-image-scan.yaml`.

The kubernetes-sigs org requires all GitHub Actions to be pinned to full-length commit SHAs. This was the only unpinned action remaining in the workflow.