### PR TITLE
Restore standalone Agentgateway proxy support

### DIFF
--- a/config/charts/epplib/templates/_config.yaml
+++ b/config/charts/epplib/templates/_config.yaml
@@ -92,14 +92,15 @@ data:
   {{- end }}
   
 ---
-{{- if and .Values.inferenceExtension.sidecar.enabled }}
+{{- $sidecar := include "gateway-api-inference-extension.sidecar" . | fromYaml | default dict }}
+{{- if and $sidecar.enabled $sidecar.configMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.inferenceExtension.sidecar.configMap.name }}
+  name: {{ $sidecar.configMap.name }}
   namespace: {{ .Release.Namespace }}
 data:
-  {{- .Values.inferenceExtension.sidecar.configMap.data | toYaml | nindent 2 }}
+  {{- include "gateway-api-inference-extension.sidecarConfigMapData" . | nindent 2 }}
 {{- end }}
 ---
 {{- if .Values.inferenceExtension.latencyPredictor.enabled }}

--- a/config/charts/epplib/templates/_deployment.yaml
+++ b/config/charts/epplib/templates/_deployment.yaml
@@ -26,47 +26,70 @@ spec:
         {{- include "gateway-api-inference-extension.selectorLabels" . | nindent 8 }}
         {{- include "gateway-api-inference-extension.modeLabels" . | nindent 8 }}
     spec:
+      {{- $sidecar := include "gateway-api-inference-extension.sidecar" . | fromYaml | default dict }}
+      {{- $proxyType := include "gateway-api-inference-extension.sidecarProxyType" . | trim }}
+      {{- $sidecarConfigMap := index $sidecar "configMap" | default dict }}
+      {{- $sidecarConfigMapName := index $sidecarConfigMap "name" | default "" }}
+      {{- $inferenceExtensionFlags := deepCopy (.Values.inferenceExtension.flags | default dict) }}
+      {{- if and (eq $proxyType "agentgateway") (not (hasKey $inferenceExtensionFlags "secure-serving")) }}
+        {{- $_ := set $inferenceExtensionFlags "secure-serving" false }}
+      {{- end }}
       serviceAccountName: {{ include "gateway-api-inference-extension.name" . }}
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
       terminationGracePeriodSeconds: 130
       containers:
-      {{- if .Values.inferenceExtension.sidecar.enabled }}
-        - name: {{ .Values.inferenceExtension.sidecar.name }}
-          image: {{ .Values.inferenceExtension.sidecar.image }}
-          imagePullPolicy: {{ .Values.inferenceExtension.sidecar.imagePullPolicy | default "IfNotPresent" }}
-        {{- with .Values.inferenceExtension.sidecar.command }}
+      {{- if $sidecar.enabled }}
+        - name: {{ $sidecar.name }}
+          image: {{ $sidecar.image }}
+          imagePullPolicy: {{ $sidecar.imagePullPolicy | default "IfNotPresent" }}
+        {{- with $sidecar.command }}
           command:
             - {{ . | quote }}
         {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.args }}
+        {{- with $sidecar.args }}
           args:
           {{- range . }}
             - {{ . | quote }}
           {{- end }}
         {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.env }}
+        {{- with $sidecar.env }}
           env:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.ports }}
+        {{- with $sidecar.ports }}
           ports:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.livenessProbe }}
+        {{- with $sidecar.livenessProbe }}
           livenessProbe:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.readinessProbe }}
+        {{- with $sidecar.readinessProbe }}
           readinessProbe:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.resources }}
+        {{- with $sidecar.startupProbe }}
+          startupProbe:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $sidecar.securityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $sidecar.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-        {{- with .Values.inferenceExtension.sidecar.volumeMounts }}
+        {{- if or (and (eq $proxyType "agentgateway") $sidecarConfigMapName) $sidecar.volumeMounts }}
           volumeMounts:
+          {{- if and (eq $proxyType "agentgateway") $sidecarConfigMapName }}
+            - name: agentgateway-config-template
+              mountPath: /config
+              readOnly: true
+          {{- end }}
+          {{- with $sidecar.volumeMounts }}
           {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- end }}
         - name: epp
@@ -85,7 +108,7 @@ spec:
               - --endpoint-selector
               - {{ .Values.inferenceExtension.endpointsServer.endpointSelector | quote }}
               - --endpoint-target-ports
-              - {{ .Values.inferenceExtension.endpointsServer.targetPorts | quote }}
+              - {{ include "gateway-api-inference-extension.standaloneEndpointTargetPorts" . | quote }}
           {{- else }}
               - --pool-name
               - {{ .Release.Name }}
@@ -131,8 +154,9 @@ spec:
               - --ha-enable-leader-election
           {{- end }}
               # Pass additional flags via the inferenceExtension.flags field in values.yaml.
-          {{- range $key, $value := .Values.inferenceExtension.flags }}
-              - --{{ $key }}={{ $value }}
+              # Render them as --flag=value so boolean values are parsed correctly.
+          {{- range $key, $value := $inferenceExtensionFlags }}
+              - {{ printf "--%s=%v" $key $value | quote }}
           {{- end }}
           {{- if .Values.inferenceExtension.tracing.enabled }}
               - --tracing=true
@@ -227,8 +251,16 @@ spec:
       {{- if .Values.inferenceExtension.volumes }}
       {{- toYaml .Values.inferenceExtension.volumes | nindent 8 }}
       {{- end }}
-      {{- if .Values.inferenceExtension.sidecar.volumes }}
-      {{- tpl (toYaml .Values.inferenceExtension.sidecar.volumes) $ | nindent 8 }}
+      {{- if and $sidecar.enabled (eq $proxyType "agentgateway") $sidecarConfigMapName }}
+        - name: agentgateway-config-template
+          configMap:
+            name: {{ $sidecarConfigMapName }}
+            items:
+              - key: config.yaml
+                path: config.yaml
+      {{- end }}
+      {{- with $sidecar.volumes }}
+      {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
         - name: plugins-config-volume
           configMap:

--- a/config/charts/epplib/templates/_helpers.tpl
+++ b/config/charts/epplib/templates/_helpers.tpl
@@ -61,3 +61,223 @@ Create a default fully qualified app name for inferenceGateway.
     {{- printf "%s-inference-gateway" .Release.Name| trunc 63 | trimSuffix "-" -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return the standalone sidecar proxy type.
+*/}}
+{{- define "gateway-api-inference-extension.sidecarProxyType" -}}
+{{- $sidecar := .Values.inferenceExtension.sidecar | default dict -}}
+{{- default "envoy" ($sidecar.proxyType | default "envoy") | lower -}}
+{{- end -}}
+
+{{/*
+Normalize a scalar, comma-separated string, or list of ports into a
+comma-separated numeric string.
+*/}}
+{{- define "gateway-api-inference-extension.normalizedPortList" -}}
+{{- $path := .path -}}
+{{- $value := .value -}}
+{{- if empty $value -}}
+  {{- fail (printf "%s is required" $path) -}}
+{{- end -}}
+{{- $rawPorts := list -}}
+{{- if kindIs "slice" $value -}}
+  {{- $rawPorts = $value -}}
+{{- else -}}
+  {{- $rawPorts = splitList "," (toString $value) -}}
+{{- end -}}
+{{- $ports := list -}}
+{{- range $raw := $rawPorts -}}
+  {{- $rawString := trim (toString $raw) -}}
+  {{- if not (regexMatch "^[0-9]+$" $rawString) -}}
+    {{- fail (printf "%s must contain only numeric ports, got %q" $path $rawString) -}}
+  {{- end -}}
+  {{- $port := int $rawString -}}
+  {{- if or (lt $port 1) (gt $port 65535) -}}
+    {{- fail (printf "%s must contain ports between 1 and 65535, got %d" $path $port) -}}
+  {{- end -}}
+  {{- $ports = append $ports (toString $port) -}}
+{{- end -}}
+{{- if eq (len $ports) 0 -}}
+  {{- fail (printf "%s must contain at least one port" $path) -}}
+{{- end -}}
+{{- join "," $ports -}}
+{{- end -}}
+
+{{/*
+Return the standalone proxy listener port exposed by the EPP Service.
+The port is selected by the Service port named "http" so selection is
+deterministic even when additional Service ports are configured.
+*/}}
+{{- define "gateway-api-inference-extension.standaloneProxyListenerPort" -}}
+{{- $servicePorts := .Values.inferenceExtension.extraServicePorts | default list -}}
+{{- $found := false -}}
+{{- $listenerPort := "" -}}
+{{- $targetPort := "" -}}
+{{- $hasTargetPort := false -}}
+{{- range $index, $servicePort := $servicePorts -}}
+  {{- if eq (toString (index $servicePort "name")) "http" -}}
+    {{- if $found -}}
+      {{- fail ".Values.inferenceExtension.extraServicePorts must contain exactly one port named \"http\" when proxyType=agentgateway" -}}
+    {{- end -}}
+    {{- $found = true -}}
+    {{- if not (hasKey $servicePort "port") -}}
+      {{- fail (printf ".Values.inferenceExtension.extraServicePorts[%d].port is required for the port named \"http\"" $index) -}}
+    {{- end -}}
+    {{- $listenerPort = index $servicePort "port" -}}
+    {{- if hasKey $servicePort "targetPort" -}}
+      {{- $hasTargetPort = true -}}
+      {{- $targetPort = index $servicePort "targetPort" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $found -}}
+  {{- fail ".Values.inferenceExtension.extraServicePorts must contain exactly one port named \"http\" when proxyType=agentgateway" -}}
+{{- end -}}
+{{- if kindIs "slice" $listenerPort -}}
+  {{- fail ".Values.inferenceExtension.extraServicePorts[name=http].port must be a single numeric port" -}}
+{{- end -}}
+{{- $listenerPortString := trim (toString $listenerPort) -}}
+{{- if not (regexMatch "^[0-9]+$" $listenerPortString) -}}
+  {{- fail (printf ".Values.inferenceExtension.extraServicePorts[name=http].port must be numeric, got %q" $listenerPortString) -}}
+{{- end -}}
+{{- $listenerPortNumber := int $listenerPortString -}}
+{{- if or (lt $listenerPortNumber 1) (gt $listenerPortNumber 65535) -}}
+  {{- fail (printf ".Values.inferenceExtension.extraServicePorts[name=http].port must be between 1 and 65535, got %d" $listenerPortNumber) -}}
+{{- end -}}
+{{- if $hasTargetPort -}}
+  {{- $targetPortString := trim (toString $targetPort) -}}
+  {{- if and (ne $targetPortString $listenerPortString) (ne $targetPortString "http") -}}
+    {{- fail (printf ".Values.inferenceExtension.extraServicePorts[name=http].targetPort must be omitted, %q, or \"http\" when proxyType=agentgateway, got %q" $listenerPortString $targetPortString) -}}
+  {{- end -}}
+{{- end -}}
+{{- $listenerPortString -}}
+{{- end -}}
+
+{{/*
+Return the standalone EPP model-server target ports.
+*/}}
+{{- define "gateway-api-inference-extension.standaloneEndpointTargetPorts" -}}
+{{- include "gateway-api-inference-extension.normalizedPortList" (dict "path" ".Values.inferenceExtension.endpointsServer.targetPorts" "value" .Values.inferenceExtension.endpointsServer.targetPorts) -}}
+{{- end -}}
+
+{{/*
+Return the agentgateway model Service ports.
+*/}}
+{{- define "gateway-api-inference-extension.agentgateway.modelServicePorts" -}}
+{{- $sidecarValues := .Values.inferenceExtension.sidecar | default dict -}}
+{{- $agentgateway := index $sidecarValues "agentgateway" | default dict -}}
+{{- $service := index $agentgateway "service" | default dict -}}
+{{- include "gateway-api-inference-extension.normalizedPortList" (dict "path" ".Values.inferenceExtension.sidecar.agentgateway.service.ports" "value" (index $service "ports")) -}}
+{{- end -}}
+
+{{/*
+Return the resolved sidecar configuration for the current chart.
+Standalone uses proxy presets merged with explicit sidecar overrides.
+*/}}
+{{- define "gateway-api-inference-extension.sidecar" -}}
+{{- $sidecar := deepCopy (.Values.inferenceExtension.sidecar | default dict) -}}
+{{- $resolved := $sidecar -}}
+{{- if eq .Chart.Name "standalone" -}}
+  {{- $proxyType := include "gateway-api-inference-extension.sidecarProxyType" . -}}
+  {{- $presets := index $sidecar "presets" | default dict -}}
+  {{- $preset := deepCopy ((index $presets $proxyType) | default dict) -}}
+  {{- $resolved = mergeOverwrite $preset $sidecar -}}
+  {{- if eq $proxyType "agentgateway" -}}
+    {{- $listenerPort := include "gateway-api-inference-extension.standaloneProxyListenerPort" . | int -}}
+    {{- $ports := index $resolved "ports" | default list -}}
+    {{- $resolvedPorts := list (dict "containerPort" $listenerPort "name" "http") -}}
+    {{- range $index, $port := $ports -}}
+      {{- if gt $index 0 -}}
+        {{- $resolvedPorts = append $resolvedPorts $port -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $_ := set $resolved "ports" $resolvedPorts -}}
+  {{- end -}}
+{{- end -}}
+{{- $resolved = omit $resolved "agentgateway" "presets" "proxyType" -}}
+{{- toYaml $resolved -}}
+{{- end -}}
+
+{{/*
+Return the rendered sidecar ConfigMap data.
+*/}}
+{{- define "gateway-api-inference-extension.sidecarConfigMapData" -}}
+{{- $sidecar := include "gateway-api-inference-extension.sidecar" . | fromYaml | default dict -}}
+{{- $configMap := index $sidecar "configMap" | default dict -}}
+{{- $data := deepCopy ((index $configMap "data") | default dict) -}}
+{{- if and (eq .Chart.Name "standalone") (eq (include "gateway-api-inference-extension.sidecarProxyType" .) "agentgateway") -}}
+  {{- $generated := dict "config.yaml" (include "gateway-api-inference-extension.sidecar.agentgatewayConfig" .) -}}
+  {{- $data = mergeOverwrite $data $generated -}}
+{{- end -}}
+{{- toYaml $data -}}
+{{- end -}}
+
+{{/*
+Render labels from the standalone endpoint selector for the generated model Service.
+Only equality-based selectors are supported because Service selectors are a map.
+*/}}
+{{- define "gateway-api-inference-extension.agentgateway.modelServiceSelectorLabels" -}}
+{{- $selector := .Values.inferenceExtension.endpointsServer.endpointSelector | default "" -}}
+{{- if empty $selector -}}
+  {{- fail ".Values.inferenceExtension.endpointsServer.endpointSelector is required when creating an agentgateway model Service" -}}
+{{- end -}}
+{{- range $raw := splitList "," $selector }}
+  {{- $part := trim $raw -}}
+  {{- $kv := splitList "=" $part -}}
+  {{- if ne (len $kv) 2 -}}
+    {{- fail (printf ".Values.inferenceExtension.endpointsServer.endpointSelector must use comma-separated key=value labels when creating an agentgateway model Service, got %q" $selector) -}}
+  {{- end -}}
+  {{- $key := trim (index $kv 0) -}}
+  {{- $value := trim (index $kv 1) -}}
+  {{- if or (empty $key) (empty $value) -}}
+    {{- fail (printf ".Values.inferenceExtension.endpointsServer.endpointSelector must use non-empty key=value labels when creating an agentgateway model Service, got %q" $selector) -}}
+  {{- end -}}
+{{- printf "%s: %s\n" ($key | quote) ($value | quote) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render the default standalone agentgateway sidecar config template.
+*/}}
+{{- define "gateway-api-inference-extension.sidecar.agentgatewayConfig" -}}
+{{- $sidecarValues := .Values.inferenceExtension.sidecar | default dict -}}
+{{- $agentgateway := index $sidecarValues "agentgateway" | default dict -}}
+{{- $service := index $agentgateway "service" | default dict -}}
+{{- $serviceName := index $service "name" | default "" -}}
+{{- $serviceNamespace := index $service "namespace" | default .Release.Namespace -}}
+{{- $servicePorts := splitList "," (include "gateway-api-inference-extension.agentgateway.modelServicePorts" .) -}}
+{{- $backendPort := index $servicePorts 0 -}}
+{{- $listenerPort := include "gateway-api-inference-extension.standaloneProxyListenerPort" . | int -}}
+config:
+  statsAddr: "0.0.0.0:15020"
+  readinessAddr: "0.0.0.0:15021"
+binds:
+- port: {{ $listenerPort }}
+  listeners:
+  - name: default
+    protocol: HTTP
+    routes:
+    - name: standalone-epp
+      matches:
+      - path:
+          pathPrefix: /
+      backends:
+      - service:
+          name: {{ printf "%s/%s" $serviceNamespace $serviceName | quote }}
+          port: {{ $backendPort }}
+        policies:
+          inferenceRouting:
+            endpointPicker:
+              host: {{ printf "127.0.0.1:%v" (.Values.inferenceExtension.extProcPort | default 9002) | quote }}
+            destinationMode: passthrough
+services:
+- name: {{ $serviceName | quote }}
+  namespace: {{ $serviceNamespace | quote }}
+  hostname: {{ $serviceName | quote }}
+  vips: []
+  ports:
+    {{- range $servicePort := $servicePorts }}
+    {{ $servicePort }}: {{ $servicePort }}
+    {{- end }}
+{{- end -}}

--- a/config/charts/standalone/templates/_validations.tpl
+++ b/config/charts/standalone/templates/_validations.tpl
@@ -8,3 +8,44 @@ common validations
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+standalone validations
+*/}}
+{{- define "gateway-api-inference-extension.validations.standalone" -}}
+{{- $sidecar := .Values.inferenceExtension.sidecar | default dict -}}
+{{- if $sidecar.enabled -}}
+  {{- $proxyType := default "envoy" ($sidecar.proxyType | default "envoy") | lower -}}
+  {{- if not (or (eq $proxyType "envoy") (eq $proxyType "agentgateway")) -}}
+    {{- fail (printf ".Values.inferenceExtension.sidecar.proxyType must be one of [envoy, agentgateway], got %q" $proxyType) -}}
+  {{- end -}}
+  {{- if eq $proxyType "agentgateway" -}}
+    {{- if and .Values.inferenceExtension.endpointsServer .Values.inferenceExtension.endpointsServer.createInferencePool -}}
+      {{- fail ".Values.inferenceExtension.endpointsServer.createInferencePool=false is required when proxyType=agentgateway; standalone agentgateway currently supports only service-backed routing" -}}
+    {{- end -}}
+    {{- $agentgateway := index $sidecar "agentgateway" | default dict -}}
+    {{- $service := index $agentgateway "service" | default dict -}}
+    {{- $serviceName := index $service "name" | default "" -}}
+    {{- $serviceCreate := index $service "create" | default true -}}
+    {{- if hasKey $service "port" -}}
+      {{- fail ".Values.inferenceExtension.sidecar.agentgateway.service.port has been replaced by .Values.inferenceExtension.sidecar.agentgateway.service.ports" -}}
+    {{- end -}}
+    {{- if empty $serviceName -}}
+      {{- fail ".Values.inferenceExtension.sidecar.agentgateway.service.name is required when proxyType=agentgateway" -}}
+    {{- end -}}
+    {{- $targetPorts := include "gateway-api-inference-extension.standaloneEndpointTargetPorts" . -}}
+    {{- $servicePorts := include "gateway-api-inference-extension.agentgateway.modelServicePorts" . -}}
+    {{- if ne $targetPorts $servicePorts -}}
+      {{- fail (printf ".Values.inferenceExtension.sidecar.agentgateway.service.ports must match .Values.inferenceExtension.endpointsServer.targetPorts when proxyType=agentgateway, got service ports %q and target ports %q" $servicePorts $targetPorts) -}}
+    {{- end -}}
+    {{- $listenerPort := include "gateway-api-inference-extension.standaloneProxyListenerPort" . -}}
+    {{- $flags := .Values.inferenceExtension.flags | default dict -}}
+    {{- if and (hasKey $flags "secure-serving") (ne (toString (index $flags "secure-serving")) "false") -}}
+      {{- fail ".Values.inferenceExtension.flags.secure-serving must be false when proxyType=agentgateway; standalone agentgateway uses plaintext gRPC to EPP over localhost" -}}
+    {{- end -}}
+    {{- if $serviceCreate -}}
+      {{- $selectorLabels := include "gateway-api-inference-extension.agentgateway.modelServiceSelectorLabels" . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/config/charts/standalone/templates/agentgateway-service.yaml
+++ b/config/charts/standalone/templates/agentgateway-service.yaml
@@ -1,0 +1,32 @@
+{{- $sidecar := .Values.inferenceExtension.sidecar | default dict -}}
+{{- $proxyType := default "envoy" ($sidecar.proxyType | default "envoy") | lower -}}
+{{- $agentgateway := index $sidecar "agentgateway" | default dict -}}
+{{- $service := index $agentgateway "service" | default dict -}}
+{{- $serviceCreate := index $service "create" | default true -}}
+{{- $serviceName := index $service "name" | default "" -}}
+{{- if and $sidecar.enabled (eq $proxyType "agentgateway") $serviceCreate (not (empty $serviceName)) -}}
+{{- $serviceNamespace := index $service "namespace" | default .Release.Namespace -}}
+{{- $servicePorts := splitList "," (include "gateway-api-inference-extension.agentgateway.modelServicePorts" .) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName | quote }}
+  namespace: {{ $serviceNamespace | quote }}
+  labels:
+    app.kubernetes.io/component: agentgateway-model-service
+    app.kubernetes.io/part-of: {{ include "gateway-api-inference-extension.name" . | quote }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- end }}
+spec:
+  selector:
+    {{- include "gateway-api-inference-extension.agentgateway.modelServiceSelectorLabels" . | trim | nindent 4 }}
+  ports:
+    {{- range $servicePort := $servicePorts }}
+    - name: http-{{ $servicePort }}
+      port: {{ $servicePort }}
+      protocol: TCP
+      targetPort: {{ $servicePort }}
+    {{- end }}
+  type: ClusterIP
+{{- end -}}

--- a/config/charts/standalone/templates/inferenceextension.yaml
+++ b/config/charts/standalone/templates/inferenceextension.yaml
@@ -1,3 +1,4 @@
+{{ include "gateway-api-inference-extension.validations.standalone" . }}
 {{ include "inference-extension.config" . }}
 {{ include "inference-extension.deployment" . }}
 {{ include "inference-extension.gke" . }}

--- a/config/charts/standalone/values.yaml
+++ b/config/charts/standalone/values.yaml
@@ -20,271 +20,326 @@ inferenceExtension:
     # Required when createInferencePool is false
 #    endpointSelector: app=vllm-qwen3-32b
     # unused when createInferencePool is true
-    targetPorts: 8000
+    targetPorts:
+      - 8000
     # unused when createInferencePool is true
     modelServerType: vllm # vllm, sglang, triton-tensorrt-llm, trtllm-serve
 
 
   sidecar:
     enabled: true
-    configMap:
-      name: envoy
-      # Because the template just dumps this section, the keys become filenames.
-      # The values MUST be strings (note the literal block scalar '|')
-      data:
-        envoy.yaml: |
-          admin:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 19000
-            access_log:
-              - name: envoy.access_loggers.file
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                  path: /dev/null
-          static_resources:
-            listeners:
-              - name: envoy-proxy-ready-0.0.0.0-19001
-                address:
-                  socket_address:
-                    address: 0.0.0.0
-                    port_value: 19001
-                filter_chains:
-                  - filters:
-                      - name: envoy.filters.network.http_connection_manager
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                          stat_prefix: envoy-ready-http
-                          route_config:
-                            name: local_route
-                            virtual_hosts:
-                              - name: prometheus_stats
-                                domains: ["*"]
-                                routes:
-                                  - match:
-                                      prefix: "/stats/prometheus"
-                                    route:
-                                      cluster: "prometheus_stats"
-                          http_filters:
-                            - name: envoy.filters.http.health_check
-                              typed_config:
-                                "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                                pass_through_mode: false
-                                headers:
-                                  - name: ":path"
-                                    string_match:
-                                      exact: "/ready"
-                            - name: envoy.filters.http.router
-                              typed_config:
-                                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              - name: vllm
-                address:
-                  socket_address:
-                    address: 0.0.0.0
-                    port_value: 8081
-                per_connection_buffer_limit_bytes: 32768
-                access_log:
-                  - name: envoy.access_loggers.file
-                    filter:
-                      response_flag_filter:
-                        flags: ["NR"]
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      path: /dev/stdout
-                      log_format:
-                        text_format_source:
-                          inline_string: "{\"start_time\":\"%START_TIME%\",\"method\":\"%REQ(:METHOD)%\",...}\n"
-                filter_chains:
-                  - name: vllm
-                    filters:
-                      - name: envoy.filters.network.http_connection_manager
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                          stat_prefix: http-8081
-                          route_config:
-                            name: vllm
-                            virtual_hosts:
-                              - name: vllm-default
-                                domains: ["*"]
-                                routes:
-                                  - match:
-                                      prefix: "/"
-                                    route:
-                                      cluster: original_destination_cluster
-                                      timeout: 86400s
-                                      idle_timeout: 86400s
-                                      upgrade_configs:
-                                        - upgrade_type: websocket
-                                    typed_per_filter_config:
-                                      envoy.filters.http.ext_proc:
-                                        "@type": type.googleapis.com/envoy.config.route.v3.FilterConfig
-                                        config: {}
-                          http_filters:
-                            - name: envoy.filters.http.ext_proc
-                              typed_config:
-                                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
-                                grpc_service:
-                                  envoy_grpc:
-                                    cluster_name: ext_proc
-                                    authority: localhost:9002
-                                  timeout: 10s
-                                processing_mode:
-                                  request_header_mode: SEND
-                                  response_header_mode: SEND
-                                  request_body_mode: FULL_DUPLEX_STREAMED
-                                  response_body_mode: FULL_DUPLEX_STREAMED
-                                  request_trailer_mode: SEND
-                                  response_trailer_mode: SEND
-                                message_timeout: 1000s
-                            - name: envoy.filters.http.router
-                              typed_config:
-                                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                                suppress_envoy_headers: true
-                          http2_protocol_options:
-                            max_concurrent_streams: 100
-                            initial_stream_window_size: 65536
-                            initial_connection_window_size: 1048576
-                          use_remote_address: true
-                          normalize_path: true
-                          merge_slashes: true
-                          server_header_transformation: PASS_THROUGH
-                          common_http_protocol_options:
-                            headers_with_underscores_action: REJECT_REQUEST
-                          path_with_escaped_slashes_action: UNESCAPE_AND_REDIRECT
-                          access_log:
-                            - name: envoy.access_loggers.file
-                              typed_config:
-                                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                                path: /dev/stdout
-                                log_format:
-                                  text_format_source:
-                                    inline_string: "{\"start_time\":\"%START_TIME%\",\"method\":\"%REQ(:METHOD)%\",...}\n"
-            clusters:
-              - name: prometheus_stats
-                type: STATIC
-                connect_timeout: 0.250s
-                load_assignment:
-                  cluster_name: prometheus_stats
-                  endpoints:
-                    - lb_endpoints:
-                        - endpoint:
-                            address:
-                              socket_address:
-                                address: 127.0.0.1
-                                port_value: 19000
-              - name: original_destination_cluster
-                type: ORIGINAL_DST
-                connect_timeout: 1000s
-                lb_policy: CLUSTER_PROVIDED
-                circuit_breakers:
-                  thresholds:
-                    - max_connections: 40000
-                      max_pending_requests: 40000
-                      max_requests: 40000
-                original_dst_lb_config:
-                  use_http_header: true
-                  http_header_name: x-gateway-destination-endpoint
-              - name: ext_proc
-                type: STATIC
-                connect_timeout: 86400s
-                lb_policy: LEAST_REQUEST
-                circuit_breakers:
-                  thresholds:
-                    - max_connections: 40000
-                      max_pending_requests: 40000
-                      max_requests: 40000
-                      max_retries: 1024
-                health_checks:
-                  - timeout: 2s
-                    interval: 10s
-                    unhealthy_threshold: 3
-                    healthy_threshold: 2
-                    reuse_connection: true
-                    grpc_health_check:
-                      service_name: "envoy.service.ext_proc.v3.ExternalProcessor"
-                    tls_options:
-                      alpn_protocols: ["h2"]
-                transport_socket:
-                  name: "envoy.transport_sockets.tls"
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-                    common_tls_context:
-                      validation_context:
-                typed_extension_protocol_options:
-                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-                    "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-                    explicit_http_config:
-                      http2_protocol_options:
-                        initial_stream_window_size: 65536
-                        initial_connection_window_size: 1048576
-                load_assignment:
-                  cluster_name: ext_proc
-                  endpoints:
-                    - locality:
-                        region: ext_proc/e2e/0
-                      lb_endpoints:
-                        - endpoint:
-                            address:
-                              socket_address:
-                                address: 127.0.0.1
-                                port_value: 9002
-                          load_balancing_weight: 1
-    name: envoy-sidecar
-    image: docker.io/envoyproxy/envoy:distroless-v1.33.2
-    command: "envoy"
-    args:
-      - "--service-node"
-      - "envoy-sidecar"
-      - "--log-level"
-      - "trace"
-      - "--cpuset-threads"
-      - "--drain-strategy"
-      - "immediate"
-      - "--drain-time-s"
-      - "60"
-      - "-c"
-      - "/etc/envoy/envoy.yaml"
-    env:
-      - name: NS_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-    ports:
-      - containerPort: 8081
-        name: http-8081
-      - containerPort: 19001
-        name: metrics-19001
-    resources:
-      requests:
-        cpu: 100m
-        memory: 512Mi
+    proxyType: envoy
 
-    readinessProbe:
-      failureThreshold: 1
-      httpGet:
-        path: /ready
-        port: 19001
-        scheme: HTTP
-      periodSeconds: 5
-      successThreshold: 1
-      timeoutSeconds: 1
+    # Agentgateway-specific settings used by the built-in preset when
+    # proxyType=agentgateway. service.name is required.
+    agentgateway:
+      service:
+        create: true
+        name: ""
+        namespace: ""
+        # Must match inferenceExtension.endpointsServer.targetPorts.
+        ports:
+          - 8000
 
-    volumeMounts:
-      - name: config
-        mountPath: /etc/envoy
-        readOnly: true
-    volumes:
-      - name: config
+    # Built-in standalone proxy presets. The selected preset is merged with the
+    # top-level sidecar.* fields below, so explicit user overrides still win.
+    presets:
+      envoy:
         configMap:
           name: envoy
-          items:
-            - key: envoy.yaml
-              path: envoy.yaml
+          data:
+            envoy.yaml: |
+              admin:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 19000
+                access_log:
+                  - name: envoy.access_loggers.file
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                      path: /dev/null
+              static_resources:
+                listeners:
+                  - name: envoy-proxy-ready-0.0.0.0-19001
+                    address:
+                      socket_address:
+                        address: 0.0.0.0
+                        port_value: 19001
+                    filter_chains:
+                      - filters:
+                          - name: envoy.filters.network.http_connection_manager
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                              stat_prefix: envoy-ready-http
+                              route_config:
+                                name: local_route
+                                virtual_hosts:
+                                  - name: prometheus_stats
+                                    domains: ["*"]
+                                    routes:
+                                      - match:
+                                          prefix: "/stats/prometheus"
+                                        route:
+                                          cluster: "prometheus_stats"
+                              http_filters:
+                                - name: envoy.filters.http.health_check
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                                    pass_through_mode: false
+                                    headers:
+                                      - name: ":path"
+                                        string_match:
+                                          exact: "/ready"
+                                - name: envoy.filters.http.router
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  - name: vllm
+                    address:
+                      socket_address:
+                        address: 0.0.0.0
+                        port_value: 8081
+                    per_connection_buffer_limit_bytes: 32768
+                    access_log:
+                      - name: envoy.access_loggers.file
+                        filter:
+                          response_flag_filter:
+                            flags: ["NR"]
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                          path: /dev/stdout
+                          log_format:
+                            text_format_source:
+                              inline_string: "{\"start_time\":\"%START_TIME%\",\"method\":\"%REQ(:METHOD)%\",...}\n"
+                    filter_chains:
+                      - name: vllm
+                        filters:
+                          - name: envoy.filters.network.http_connection_manager
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                              stat_prefix: http-8081
+                              route_config:
+                                name: vllm
+                                virtual_hosts:
+                                  - name: vllm-default
+                                    domains: ["*"]
+                                    routes:
+                                      - match:
+                                          prefix: "/"
+                                        route:
+                                          cluster: original_destination_cluster
+                                          timeout: 86400s
+                                          idle_timeout: 86400s
+                                          upgrade_configs:
+                                            - upgrade_type: websocket
+                                        typed_per_filter_config:
+                                          envoy.filters.http.ext_proc:
+                                            "@type": type.googleapis.com/envoy.config.route.v3.FilterConfig
+                                            config: {}
+                              http_filters:
+                                - name: envoy.filters.http.ext_proc
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                                    grpc_service:
+                                      envoy_grpc:
+                                        cluster_name: ext_proc
+                                        authority: localhost:9002
+                                      timeout: 10s
+                                    processing_mode:
+                                      request_header_mode: SEND
+                                      response_header_mode: SEND
+                                      request_body_mode: FULL_DUPLEX_STREAMED
+                                      response_body_mode: FULL_DUPLEX_STREAMED
+                                      request_trailer_mode: SEND
+                                      response_trailer_mode: SEND
+                                    message_timeout: 1000s
+                                - name: envoy.filters.http.router
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                                    suppress_envoy_headers: true
+                              http2_protocol_options:
+                                max_concurrent_streams: 100
+                                initial_stream_window_size: 65536
+                                initial_connection_window_size: 1048576
+                              use_remote_address: true
+                              normalize_path: true
+                              merge_slashes: true
+                              server_header_transformation: PASS_THROUGH
+                              common_http_protocol_options:
+                                headers_with_underscores_action: REJECT_REQUEST
+                              path_with_escaped_slashes_action: UNESCAPE_AND_REDIRECT
+                              access_log:
+                                - name: envoy.access_loggers.file
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                                    path: /dev/stdout
+                                    log_format:
+                                      text_format_source:
+                                        inline_string: "{\"start_time\":\"%START_TIME%\",\"method\":\"%REQ(:METHOD)%\",...}\n"
+                clusters:
+                  - name: prometheus_stats
+                    type: STATIC
+                    connect_timeout: 0.250s
+                    load_assignment:
+                      cluster_name: prometheus_stats
+                      endpoints:
+                        - lb_endpoints:
+                            - endpoint:
+                                address:
+                                  socket_address:
+                                    address: 127.0.0.1
+                                    port_value: 19000
+                  - name: original_destination_cluster
+                    type: ORIGINAL_DST
+                    connect_timeout: 1000s
+                    lb_policy: CLUSTER_PROVIDED
+                    circuit_breakers:
+                      thresholds:
+                        - max_connections: 40000
+                          max_pending_requests: 40000
+                          max_requests: 40000
+                    original_dst_lb_config:
+                      use_http_header: true
+                      http_header_name: x-gateway-destination-endpoint
+                  - name: ext_proc
+                    type: STATIC
+                    connect_timeout: 86400s
+                    lb_policy: LEAST_REQUEST
+                    circuit_breakers:
+                      thresholds:
+                        - max_connections: 40000
+                          max_pending_requests: 40000
+                          max_requests: 40000
+                          max_retries: 1024
+                    health_checks:
+                      - timeout: 2s
+                        interval: 10s
+                        unhealthy_threshold: 3
+                        healthy_threshold: 2
+                        reuse_connection: true
+                        grpc_health_check:
+                          service_name: "envoy.service.ext_proc.v3.ExternalProcessor"
+                        tls_options:
+                          alpn_protocols: ["h2"]
+                    transport_socket:
+                      name: "envoy.transport_sockets.tls"
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+                        common_tls_context:
+                          validation_context:
+                    typed_extension_protocol_options:
+                      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                        explicit_http_config:
+                          http2_protocol_options:
+                            initial_stream_window_size: 65536
+                            initial_connection_window_size: 1048576
+                    load_assignment:
+                      cluster_name: ext_proc
+                      endpoints:
+                        - locality:
+                            region: ext_proc/e2e/0
+                          lb_endpoints:
+                            - endpoint:
+                                address:
+                                  socket_address:
+                                    address: 127.0.0.1
+                                    port_value: 9002
+                              load_balancing_weight: 1
+        name: envoy-sidecar
+        image: docker.io/envoyproxy/envoy:distroless-v1.33.2
+        command: "envoy"
+        args:
+          - "--service-node"
+          - "envoy-sidecar"
+          - "--log-level"
+          - "trace"
+          - "--cpuset-threads"
+          - "--drain-strategy"
+          - "immediate"
+          - "--drain-time-s"
+          - "60"
+          - "-c"
+          - "/etc/envoy/envoy.yaml"
+        env:
+          - name: NS_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        ports:
+          - containerPort: 8081
+            name: http-8081
+          - containerPort: 19001
+            name: metrics-19001
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        readinessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /ready
+            port: 19001
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+          - name: config
+            mountPath: /etc/envoy
+            readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: envoy
+              items:
+                - key: envoy.yaml
+                  path: envoy.yaml
+      agentgateway:
+        configMap:
+          name: agentgateway
+        name: agentgateway-sidecar
+        # Keep main on latest-dev; release tooling rewrites this to a stable tag.
+        image: cr.agentgateway.dev/agentgateway:latest-dev
+        args:
+          - "-f"
+          - "/config/config.yaml"
+        ports:
+          - containerPort: 8081
+            name: http
+          - containerPort: 15020
+            name: metrics-15020
+          - containerPort: 15021
+            name: readiness-15021
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        readinessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 2
+
+    # Optional explicit sidecar overrides applied on top of the selected
+    # preset. For example, set sidecar.image to replace the preset image.
   monitoring:
     interval: "10s"
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection

--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -20,8 +20,10 @@ set -o pipefail
 
 DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
 
-EXTRA_TAG=${EXTRA_TAG:-$(git branch --show-current)} 
+EXTRA_TAG=${EXTRA_TAG:-$(git branch --show-current)}
 CHART_VERSION=${CHART_VERSION:-"v0"}
+AGENTGATEWAY_TAG=${AGENTGATEWAY_TAG:-${EXTRA_TAG}}
+export EXTRA_TAG AGENTGATEWAY_TAG
 
 STAGING_IMAGE_REGISTRY=${STAGING_IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images}
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-${STAGING_IMAGE_REGISTRY}/gateway-api-inference-extension}
@@ -36,6 +38,11 @@ chart_version=${CHART_VERSION}
 if [[ ${EXTRA_TAG} =~ ${semver_regex} ]]
 then
   ${YQ} -i '.inferenceExtension.image.tag=strenv(EXTRA_TAG)' config/charts/${CHART}/values.yaml
+  if [[ ${CHART} == "standalone" ]]; then
+    ${YQ} -i \
+      '.inferenceExtension.sidecar.presets.agentgateway.image="cr.agentgateway.dev/agentgateway:" + strenv(AGENTGATEWAY_TAG)' \
+      config/charts/${CHART}/values.yaml
+  fi
   chart_version=${EXTRA_TAG}
 fi
 

--- a/hack/release-quickstart.sh
+++ b/hack/release-quickstart.sh
@@ -37,11 +37,14 @@ VLLM_GPU="${VLLM_GPU:-0.18.1}"
 VLLM_CPU="${VLLM_CPU:-0.18.1}"
 # The sim image is from https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim
 VLLM_SIM="${VLLM_SIM:-0.8.2}"
+# The agentgateway image is from https://github.com/agentgateway/agentgateway/pkgs/container/agentgateway
+AGENTGATEWAY_TAG="${AGENTGATEWAY_TAG:-${RELEASE_TAG}}"
 
 echo "Using release tag: ${RELEASE_TAG}"
 echo "Using vLLM GPU image version: ${VLLM_GPU}"
 echo "Using vLLM CPU image version: ${VLLM_CPU}"
 echo "Using vLLM Simulator image version: ${VLLM_SIM}"
+echo "Using agentgateway image tag: ${AGENTGATEWAY_TAG}"
 
 # -----------------------------------------------------------------------------
 # Update version/version.go and generating CRDs with new version annotations
@@ -93,6 +96,7 @@ BBR_HELM="config/charts/body-based-routing/values.yaml"
 STANDALONE_HELM="config/charts/standalone/values.yaml"
 CONFORMANCE_MANIFESTS="conformance/resources/base.yaml"
 CONFORMANCE_EPP_STAGING_IMAGE="us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp"
+AGENTGATEWAY_IMAGE_REGEX="cr\.agentgateway\.dev/agentgateway"
 echo "Updating ${EPP_HELM}, ${LATENCY_ROUTING_HELM}, ${BBR_HELM}, ${STANDALONE_HELM} and ${CONFORMANCE_MANIFESTS} ..."
 
 # Update the container tag.
@@ -100,6 +104,9 @@ sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$EPP_HELM"
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$LATENCY_ROUTING_HELM"
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$BBR_HELM"
 sed -i.bak -E "s|(tag: )[^\"[:space:]]+|\1${RELEASE_TAG}|g" "$STANDALONE_HELM"
+# Update the standalone agentgateway preset from the floating development tag
+# to the stable tag selected for the release.
+sed -i.bak -E "s|(${AGENTGATEWAY_IMAGE_REGEX}:)[^\"[:space:]]+|\1${AGENTGATEWAY_TAG}|g" "$STANDALONE_HELM"
 # Update the conformance EPP image from the staging `main` tag to the release tag.
 sed -i.bak -E "s|${CONFORMANCE_EPP_STAGING_IMAGE}:[^\"[:space:]]+|${CONFORMANCE_EPP_STAGING_IMAGE}:${RELEASE_TAG}|g" "$CONFORMANCE_MANIFESTS"
 # Update the container image pull policy.

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -93,10 +93,11 @@ done
 declare -A test_cases_standalone
 
 # InferencePool Helm Chart test cases
-test_cases_standalone["basic"]="--set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway --set inferenceExtension.endpointsServer.createInferencePool=false"
+test_cases_standalone["basic"]="--set inferenceExtension.endpointsServer.endpointSelector=app=llm-instance-gateway --set inferenceExtension.endpointsServer.createInferencePool=false"
 test_cases_standalone["gke-provider"]="--set provider.name=gke --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false"
 test_cases_standalone["latency-predictor"]="--set inferenceExtension.latencyPredictor.enabled=true --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false"
 test_cases_standalone["inferencepool"]="--set inferenceExtension.endpointsServer.createInferencePool=true --set inferencePool.modelServers.matchLabels.app=llm-instance-gateway"
+test_cases_standalone["agentgateway"]="--set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000'"
 
 
 echo "Processing dependencies for standalone chart..."
@@ -127,3 +128,99 @@ for key in "${!test_cases_standalone[@]}"; do
   echo "Test case ${key} passed validation."
 done
 
+echo "Running standalone negative validation tests..."
+invalid_proxy_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set inferenceExtension.sidecar.proxyType=bogus >/dev/null"
+echo "Executing: ${invalid_proxy_command}"
+if eval "${invalid_proxy_command}"; then
+  echo "Helm template unexpectedly succeeded for invalid proxyType"
+  exit 1
+fi
+
+missing_agentgateway_service_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set inferenceExtension.sidecar.proxyType=agentgateway >/dev/null"
+echo "Executing: ${missing_agentgateway_service_command}"
+if eval "${missing_agentgateway_service_command}"; then
+  echo "Helm template unexpectedly succeeded for missing agentgateway service.name"
+  exit 1
+fi
+
+unsupported_agentgateway_inferencepool_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' --set inferenceExtension.endpointsServer.createInferencePool=true --set inferencePool.modelServers.matchLabels.app=llm-instance-gateway >/dev/null"
+echo "Executing: ${unsupported_agentgateway_inferencepool_command}"
+if eval "${unsupported_agentgateway_inferencepool_command}"; then
+  echo "Helm template unexpectedly succeeded for unsupported agentgateway createInferencePool=true configuration"
+  exit 1
+fi
+
+unsupported_agentgateway_selector_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' --set inferenceExtension.endpointsServer.endpointSelector='app in (llm-instance-gateway)' --set inferenceExtension.endpointsServer.createInferencePool=false --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000' >/dev/null"
+echo "Executing: ${unsupported_agentgateway_selector_command}"
+if eval "${unsupported_agentgateway_selector_command}"; then
+  echo "Helm template unexpectedly succeeded for unsupported agentgateway model Service selector"
+  exit 1
+fi
+
+mismatched_agentgateway_ports_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8001' --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000' >/dev/null"
+echo "Executing: ${mismatched_agentgateway_ports_command}"
+if eval "${mismatched_agentgateway_ports_command}"; then
+  echo "Helm template unexpectedly succeeded for mismatched agentgateway service.ports"
+  exit 1
+fi
+
+unsupported_agentgateway_listener_port_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000' --set 'inferenceExtension.extraServicePorts[0].name=proxy' --set 'inferenceExtension.extraServicePorts[0].port=9000' --set 'inferenceExtension.extraServicePorts[0].protocol=TCP' --set 'inferenceExtension.extraServicePorts[0].targetPort=9000' >/dev/null"
+echo "Executing: ${unsupported_agentgateway_listener_port_command}"
+if eval "${unsupported_agentgateway_listener_port_command}"; then
+  echo "Helm template unexpectedly succeeded without an agentgateway listener Service port named http"
+  exit 1
+fi
+
+mismatched_agentgateway_listener_target_port_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000' --set 'inferenceExtension.extraServicePorts[0].name=http' --set 'inferenceExtension.extraServicePorts[0].port=9000' --set 'inferenceExtension.extraServicePorts[0].protocol=TCP' --set 'inferenceExtension.extraServicePorts[0].targetPort=9001' >/dev/null"
+echo "Executing: ${mismatched_agentgateway_listener_target_port_command}"
+if eval "${mismatched_agentgateway_listener_target_port_command}"; then
+  echo "Helm template unexpectedly succeeded for an agentgateway listener targetPort that does not match port"
+  exit 1
+fi
+
+echo "Verifying standalone extra flags render as --flag=value..."
+flag_render_output="${TEMP_DIR}/standalone-flag-render.yaml"
+flag_render_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set-string inferenceExtension.flags.secure-serving=false > ${flag_render_output}"
+echo "Executing: ${flag_render_command}"
+eval "${flag_render_command}"
+if ! grep -q -- '--secure-serving=false' "${flag_render_output}"; then
+  echo "Helm template did not render extra flags as --flag=value"
+  exit 1
+fi
+
+echo "Verifying standalone agentgateway renders plaintext EPP and custom listener ports..."
+agentgateway_render_output="${TEMP_DIR}/standalone-agentgateway-render.yaml"
+agentgateway_render_command="${SCRIPT_ROOT}/bin/helm template ${SCRIPT_ROOT}/config/charts/standalone --set inferenceExtension.sidecar.proxyType=agentgateway --set inferenceExtension.sidecar.agentgateway.service.name=llm-instance-gateway --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' --set inferenceExtension.endpointsServer.endpointSelector='app=llm-instance-gateway' --set inferenceExtension.endpointsServer.createInferencePool=false --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000' --set 'inferenceExtension.extraServicePorts[0].name=http' --set 'inferenceExtension.extraServicePorts[0].port=9000' --set 'inferenceExtension.extraServicePorts[0].protocol=TCP' --set 'inferenceExtension.extraServicePorts[0].targetPort=http' > ${agentgateway_render_output}"
+echo "Executing: ${agentgateway_render_command}"
+eval "${agentgateway_render_command}"
+if ! grep -q -- '--secure-serving=false' "${agentgateway_render_output}"; then
+  echo "Agentgateway Helm template did not render plaintext EPP serving"
+  exit 1
+fi
+if ! grep -q -- 'containerPort: 9000' "${agentgateway_render_output}"; then
+  echo "Agentgateway Helm template did not render the custom listener containerPort"
+  exit 1
+fi
+if ! grep -A1 -- 'containerPort: 9000' "${agentgateway_render_output}" | grep -q -- 'name: http'; then
+  echo "Agentgateway Helm template did not render the listener containerPort named http"
+  exit 1
+fi
+if ! grep -q -- '    - port: 9000' "${agentgateway_render_output}"; then
+  echo "Agentgateway Helm template did not render the custom listener bind port"
+  exit 1
+fi
+if ! grep -q -- 'destinationMode: passthrough' "${agentgateway_render_output}"; then
+  echo "Agentgateway Helm template did not render passthrough destination mode"
+  exit 1
+fi
+
+agentgateway_service_block="${TEMP_DIR}/standalone-agentgateway-service.yaml"
+sed -n '/^# Source: standalone\/templates\/agentgateway-service.yaml/,/^---/p' "${agentgateway_render_output}" > "${agentgateway_service_block}"
+if ! grep -q -- 'app.kubernetes.io/component: agentgateway-model-service' "${agentgateway_service_block}"; then
+  echo "Agentgateway model Service did not render its component label"
+  exit 1
+fi
+if grep -q -- 'app.kubernetes.io/name:' "${agentgateway_service_block}"; then
+  echo "Agentgateway model Service rendered an app.kubernetes.io/name label"
+  exit 1
+fi

--- a/site-src/guides/standalone.md
+++ b/site-src/guides/standalone.md
@@ -1,17 +1,18 @@
 # Deploy As A Standalone Request Scheduler
+
 The endpoint picker (EPP) at its core is a smart request scheduler for LLM requests, it currently implements a number of LLM-specific load balancing optimizations including:
 
 * Prefix-cache aware scheduling
 * Load-aware scheduling
 
-When using EPP with Gateway API, it works as an ext-proc to an envoy-based proxy fronting model servers running in a k8s cluster; 
-examples of such proxies are cloud managed ones like GKE’s L7LB and open source counterparts like Istio and kGateway.
-EPP as an ext-proc here offers several key advantages:
+When using EPP with Gateway API, it works as an ext-proc service for a proxy fronting model servers running in a k8s cluster;
+examples of such proxies are cloud managed ones like GKE’s L7LB, open source counterparts like Istio and agentgateway. EPP as an ext-proc here offers several key advantages:
 
 * It utilizes robust, pre-existing L7 proxies, including both managed and open-source options.
-* Seamless integration with the Kubernetes networking ecosystem, the Gateway API, allows for:Transforming a Kubernetes gateway into an inference scheduler using familiar APIs. 
-Leveraging Gateway API features like traffic splitting for gradual rollouts and HTTP rule matching. 
-Access to provider-specific features.
+* Seamless integration with the Kubernetes networking ecosystem, the Gateway API, allows for:
+    * Transforming a Kubernetes gateway into an inference scheduler using familiar APIs.
+    * Traffic splitting for gradual roll-outs and HTTP rule matching.
+    * Access to provider-specific features.
 
 These benefits are critical for online services, including MaaS (Model-as-a-Service), which require support for multi-tenancy, demand high availability, scalability, and streamlined operations.
 
@@ -21,11 +22,15 @@ this inference service is specific to the job, it is continuously updated during
 A simpler deployment mode would reduce the barrier to adopting the EPP for such single-tenant workloads.
 
 ## How
-A proxy is deployed as a sidecar to the EPP. The proxy and EPP continue to communicate via ext-proc protocol over localhost.
-For the endpoint discovery, you have two options:
+
+A proxy is deployed as a sidecar to the EPP. The proxy and EPP communicate over localhost. The standalone chart currently provides built-in sidecar presets for Envoy
+and agentgateway. Envoy mirrors the existing ext-proc sidecar flow. Agentgateway uses its standalone `inferenceRouting` local config support and therefore requires a
+Kubernetes `Service` for the model workload. Envoy supports two endpoint discovery modes:
 
 * **With Inference APIs Support**: The EPP is configured using the Inference CRDs, the pool is expressed using an instance of the InferencePool API and the entire suite of inference APIs are supported, including the use of InferenceObjectives for defining priorities.
 * **Without Inference APIs Support**: The EPP is configured using command line flags. This is the simplest method for standalone jobs which doesn't require installing the inference extension apis, which means no support for the features expressed using the inference APIs (such as InferenceObjectives).
+
+Agentgateway standalone does not support `InferencePool`.
 
 ## Example
 
@@ -56,47 +61,87 @@ For the endpoint discovery, you have two options:
     kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/vllm/sim-deployment.yaml
     ```
 
-#### Deploy Endpoint Picker Extension with Envoy sidecar
+#### Deploy Endpoint Picker Extension with a sidecar proxy
 
-Choose one of the following options to deploy an Endpoint Picker Extension with Envoy sidecar.
+Choose one of the following proxy options to deploy an Endpoint Picker Extension with standalone request routing.
 
-=== "With Inference APIs Support"
+=== "Envoy"
 
-      Deploy an InferencePool named `vllm-qwen3-32b` that selects from endpoints with label app: vllm-qwen3-32b and
-      listening on port 8000. The Helm install command automatically deploys an InferencePool instance, the epp along with provider specific resources.
-        
-      Set the chart version and then select a tab to follow the provider-specific instructions.
-           ```bash
-            # Install the Inference Extension CRDs
-            kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
-            
-            export STANDALONE_CHART_VERSION=v0
-            export PROVIDER=<YOUR_PROVIDER> #optional, can be gke as gke needed it specific epp monitoring resources.
-            helm install vllm-qwen3-32b-standalone \
-            --dependency-update \
-            --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
-            --set provider.name=$PROVIDER \
-            --version $STANDALONE_CHART_VERSION \
-             oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
-           ```
+      Envoy remains the default standalone sidecar and preserves the existing chart behavior.
 
-=== "Without Inference APIs Support"
+      **With Inference APIs Support**
 
-     Deploy an Endpoint Picker Extension named `vllm-qwen3-32b` that selects from endpoints with label `app=vllm-qwen3-32b` and listening on port 8000. 
-     The Helm install command automatically deploys the epp along with provider specific resources.
-        
-     Set the chart version and then select a tab to follow the provider-specific instructions.
-           ```bash
-            export STANDALONE_CHART_VERSION=v0
-            export PROVIDER=<YOUR_PROVIDER> #optional, can be gke as gke needed it specific epp monitoring resources.
-            helm install vllm-qwen3-32b-standalone \
-            --dependency-update \
-            --set inferenceExtension.endpointsServer.endpointSelector="app=vllm-qwen3-32b" \
-            --set inferenceExtension.endpointsServer.createInferencePool=false \
-            --set provider.name=$PROVIDER \
-            --version $STANDALONE_CHART_VERSION \
-             oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
-           ```
+      Deploy an InferencePool named `vllm-qwen3-32b` that selects from endpoints with label `app=vllm-qwen3-32b`
+      and listening on port `8000`. The Helm install command automatically deploys an InferencePool instance,
+      the EPP, and provider-specific resources.
+
+      ```bash
+      # Install the Inference Extension CRDs
+      kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
+
+      export STANDALONE_CHART_VERSION=v0
+      export PROVIDER=<YOUR_PROVIDER> # optional, can be gke if you need GKE-specific monitoring resources
+      helm install vllm-qwen3-32b-standalone \
+      --dependency-update \
+      --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
+      --set provider.name=$PROVIDER \
+      --version $STANDALONE_CHART_VERSION \
+      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
+      ```
+
+      **Without Inference APIs Support**
+
+      Deploy an Endpoint Picker Extension named `vllm-qwen3-32b` that selects from endpoints with label
+      `app=vllm-qwen3-32b` and listening on port `8000`. The Helm install command automatically deploys the EPP
+      along with provider-specific resources.
+
+      ```bash
+      export STANDALONE_CHART_VERSION=v0
+      export PROVIDER=<YOUR_PROVIDER> # optional, can be gke if you need GKE-specific monitoring resources
+      helm install vllm-qwen3-32b-standalone \
+      --dependency-update \
+      --set inferenceExtension.endpointsServer.endpointSelector="app=vllm-qwen3-32b" \
+      --set inferenceExtension.endpointsServer.createInferencePool=false \
+      --set provider.name=$PROVIDER \
+      --version $STANDALONE_CHART_VERSION \
+      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
+      ```
+
+=== "Agentgateway"
+
+      Agentgateway can also run as the standalone sidecar proxy. This mode requires a Kubernetes `Service`
+      for the model workload because the local config routes to a `service` backend before consulting the EPP.
+      The standalone chart generates the model `Service` and the minimal agentgateway local config from
+      `inferenceExtension.sidecar.agentgateway.service.*`. The generated `Service` selector is derived from
+      `inferenceExtension.endpointsServer.endpointSelector`, which must use comma-separated `key=value`
+      labels. `inferenceExtension.sidecar.agentgateway.service.ports` must match
+      `inferenceExtension.endpointsServer.targetPorts`. Agentgateway listens on the
+      `inferenceExtension.extraServicePorts` entry named `http` and uses that entry's `port` value.
+      The generated config sets `inferenceRouting.destinationMode: passthrough` so Agentgateway trusts
+      the EPP-selected pod destination directly.
+      `InferencePool` is not supported in this mode.
+
+      **Note:** The chart defaults to `cr.agentgateway.dev/agentgateway:latest-dev` on `main` for this preset.
+      Release tooling rewrites this to a stable Agentgateway tag when cutting a release.
+
+      Example install:
+
+      ```bash
+      export STANDALONE_CHART_VERSION=v0
+      export PROVIDER=<YOUR_PROVIDER> # optional, can be gke if you need GKE-specific monitoring resources
+      helm install vllm-qwen3-32b-standalone \
+      --dependency-update \
+      --set inferenceExtension.sidecar.proxyType=agentgateway \
+      --set inferenceExtension.sidecar.agentgateway.service.name=vllm-qwen3-32b \
+      --set 'inferenceExtension.sidecar.agentgateway.service.ports[0]=8000' \
+      --set inferenceExtension.endpointsServer.endpointSelector="app=vllm-qwen3-32b" \
+      --set inferenceExtension.endpointsServer.createInferencePool=false \
+      --set 'inferenceExtension.endpointsServer.targetPorts[0]=8000' \
+      --set-string inferenceExtension.flags.secure-serving=false \
+      --set provider.name=$PROVIDER \
+      --version $STANDALONE_CHART_VERSION \
+      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
+      ```
 
 #### Try it out
 
@@ -126,7 +171,7 @@ EOF
 ```
 Send an inference request via
 ```bash
-kubectl exec curl -- curl -i http://vllm-qwen3-32b-epp-standalone:8081/v1/completions \
+kubectl exec curl -- curl -i http://vllm-qwen3-32b-standalone-epp:8081/v1/completions \
 -H 'Content-Type: application/json' \
 -d '{"model": "Qwen/Qwen3-32B","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
 ```
@@ -140,7 +185,7 @@ Please be careful not to delete resources you'd like to keep.
 1. Uninstall the EPP, curl pod and model server resources:
 
    ```bash
-   helm uninstall vllm-qwen3-32b
+   helm uninstall vllm-qwen3-32b-standalone
    kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/inferenceobjective.yaml --ignore-not-found
    kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/vllm/cpu-deployment.yaml --ignore-not-found
    kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/vllm/gpu-deployment.yaml --ignore-not-found


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Restores the standalone Agentgateway proxy support from #2882 by reverting #2893.

The revert was based on Helm validation errors from negative chart test cases. Those errors are expected: `hack/verify-helm.sh` intentionally renders invalid standalone Agentgateway values and fails only if Helm unexpectedly succeeds.

Validation run locally:

```bash
hack/verify-helm.sh local
```

Related: #2894 tracks a separate long-term hardening item for HTTPRoute helper usage.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Restored standalone Agentgateway proxy support in the standalone Helm chart.
```
