### PR TITLE
test: add unit tests for uncovered utility functions

### DIFF
--- a/pkg/common/observability/metrics/metrics_test.go
+++ b/pkg/common/observability/metrics/metrics_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	compbasemetrics "k8s.io/component-base/metrics"
+)
+
+func TestHelpMsgWithStability(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       string
+		stability compbasemetrics.StabilityLevel
+		expected  string
+	}{
+		{
+			name:      "ALPHA stability",
+			msg:       "tracks request count",
+			stability: compbasemetrics.ALPHA,
+			expected:  "[ALPHA] tracks request count",
+		},
+		{
+			name:      "BETA stability",
+			msg:       "tracks request count",
+			stability: compbasemetrics.BETA,
+			expected:  "[BETA] tracks request count",
+		},
+		{
+			name:      "STABLE stability",
+			msg:       "tracks request count",
+			stability: compbasemetrics.STABLE,
+			expected:  "[STABLE] tracks request count",
+		},
+		{
+			name:      "INTERNAL stability",
+			msg:       "internal use only",
+			stability: compbasemetrics.INTERNAL,
+			expected:  "[INTERNAL] internal use only",
+		},
+		{
+			name:      "empty message",
+			msg:       "",
+			stability: compbasemetrics.ALPHA,
+			expected:  "[ALPHA] ",
+		},
+		{
+			name:      "message with special characters",
+			msg:       "p99 latency (ms) [experimental]",
+			stability: compbasemetrics.BETA,
+			expected:  "[BETA] p99 latency (ms) [experimental]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HelpMsgWithStability(tt.msg, tt.stability)
+			if result != tt.expected {
+				t.Errorf("HelpMsgWithStability(%q, %q) = %q, want %q", tt.msg, tt.stability, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/epp/flowcontrol/types/outcomes_test.go
+++ b/pkg/epp/flowcontrol/types/outcomes_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+)
+
+func TestQueueOutcomeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		outcome  QueueOutcome
+		expected string
+	}{
+		{
+			name:     "NotYetFinalized",
+			outcome:  QueueOutcomeNotYetFinalized,
+			expected: "NotYetFinalized",
+		},
+		{
+			name:     "Dispatched",
+			outcome:  QueueOutcomeDispatched,
+			expected: "Dispatched",
+		},
+		{
+			name:     "RejectedCapacity",
+			outcome:  QueueOutcomeRejectedCapacity,
+			expected: "RejectedCapacity",
+		},
+		{
+			name:     "RejectedOther",
+			outcome:  QueueOutcomeRejectedOther,
+			expected: "RejectedOther",
+		},
+		{
+			name:     "EvictedTTL",
+			outcome:  QueueOutcomeEvictedTTL,
+			expected: "EvictedTTL",
+		},
+		{
+			name:     "EvictedContextCancelled",
+			outcome:  QueueOutcomeEvictedContextCancelled,
+			expected: "EvictedContextCancelled",
+		},
+		{
+			name:     "EvictedOther",
+			outcome:  QueueOutcomeEvictedOther,
+			expected: "EvictedOther",
+		},
+		// default branch: unknown positive value
+		{
+			name:     "unknown positive value",
+			outcome:  QueueOutcome(99),
+			expected: "UnknownOutcome(99)",
+		},
+		// default branch: unknown negative value
+		{
+			name:     "unknown negative value",
+			outcome:  QueueOutcome(-1),
+			expected: "UnknownOutcome(-1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.outcome.String()
+			if result != tt.expected {
+				t.Errorf("QueueOutcome(%d).String() = %q, want %q", int(tt.outcome), result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/epp/util/pool/pool_test.go
+++ b/pkg/epp/util/pool/pool_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/datalayer"
+)
+
+func TestInferencePoolToEndpointPool(t *testing.T) {
+	tests := []struct {
+		name     string
+		pool     *v1.InferencePool
+		expected *datalayer.EndpointPool
+	}{
+		{
+			name:     "nil input returns nil",
+			pool:     nil,
+			expected: nil,
+		},
+		{
+			name: "single port and single label",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8080}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "model-server",
+						},
+					},
+					AppProtocol: v1.AppProtocolHTTP,
+				},
+			},
+			expected: &datalayer.EndpointPool{
+				Name:        "test-pool",
+				Namespace:   "default",
+				TargetPorts: []int{8080},
+				Selector:    map[string]string{"app": "model-server"},
+				AppProtocol: v1.AppProtocolHTTP,
+			},
+		},
+		{
+			name: "multiple ports preserve order",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-port-pool",
+					Namespace: "production",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{
+						{Number: 8080},
+						{Number: 9090},
+						{Number: 5000},
+					},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "llm",
+						},
+					},
+				},
+			},
+			expected: &datalayer.EndpointPool{
+				Name:        "multi-port-pool",
+				Namespace:   "production",
+				TargetPorts: []int{8080, 9090, 5000},
+				Selector:    map[string]string{"app": "llm"},
+			},
+		},
+		{
+			name: "multiple labels all converted",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "labeled-pool",
+					Namespace: "staging",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8000}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app":     "model-server",
+							"version": "v1",
+							"env":     "staging",
+						},
+					},
+				},
+			},
+			expected: &datalayer.EndpointPool{
+				Name:        "labeled-pool",
+				Namespace:   "staging",
+				TargetPorts: []int{8000},
+				Selector: map[string]string{
+					"app":     "model-server",
+					"version": "v1",
+					"env":     "staging",
+				},
+			},
+		},
+		{
+			name: "empty selector produces empty map",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-labels-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8000}},
+					Selector:    v1.LabelSelector{},
+				},
+			},
+			expected: &datalayer.EndpointPool{
+				Name:        "no-labels-pool",
+				Namespace:   "default",
+				TargetPorts: []int{8000},
+				Selector:    map[string]string{},
+			},
+		},
+		{
+			name: "H2C app protocol is preserved",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grpc-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 9000}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "grpc-server",
+						},
+					},
+					AppProtocol: v1.AppProtocolH2C,
+				},
+			},
+			expected: &datalayer.EndpointPool{
+				Name:        "grpc-pool",
+				Namespace:   "default",
+				TargetPorts: []int{9000},
+				Selector:    map[string]string{"app": "grpc-server"},
+				AppProtocol: v1.AppProtocolH2C,
+			},
+		},
+		{
+			name: "max valid port number converts correctly",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "edge-port-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 65535}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "server",
+						},
+					},
+				},
+			},
+			expected: &datalayer.EndpointPool{
+				Name:        "edge-port-pool",
+				Namespace:   "default",
+				TargetPorts: []int{65535},
+				Selector:    map[string]string{"app": "server"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := InferencePoolToEndpointPool(tt.pool)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("InferencePoolToEndpointPool() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
+)
+
+func TestIsSystemOwnedHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		// InputControlHeaders — exact case (already lowercase)
+		{
+			name:     "FlowFairnessIDKey exact",
+			key:      metadata.FlowFairnessIDKey,
+			expected: true,
+		},
+		{
+			name:     "ObjectiveKey exact",
+			key:      metadata.ObjectiveKey,
+			expected: true,
+		},
+		{
+			name:     "ModelNameRewriteKey exact",
+			key:      metadata.ModelNameRewriteKey,
+			expected: true,
+		},
+		{
+			name:     "SubsetFilterKey exact",
+			key:      metadata.SubsetFilterKey,
+			expected: true,
+		},
+		// InputControlHeaders — uppercase input (case-insensitive matching)
+		{
+			name:     "FlowFairnessIDKey uppercase",
+			key:      strings.ToUpper(metadata.FlowFairnessIDKey),
+			expected: true,
+		},
+		{
+			name:     "ObjectiveKey uppercase",
+			key:      strings.ToUpper(metadata.ObjectiveKey),
+			expected: true,
+		},
+		// OutputInjectionHeaders — exact case
+		{
+			name:     "DestinationEndpointKey exact",
+			key:      metadata.DestinationEndpointKey,
+			expected: true,
+		},
+		{
+			name:     "DestinationEndpointServedKey exact",
+			key:      metadata.DestinationEndpointServedKey,
+			expected: true,
+		},
+		// OutputInjectionHeaders — uppercase input
+		{
+			name:     "DestinationEndpointKey uppercase",
+			key:      strings.ToUpper(metadata.DestinationEndpointKey),
+			expected: true,
+		},
+		{
+			name:     "DestinationEndpointServedKey uppercase",
+			key:      strings.ToUpper(metadata.DestinationEndpointServedKey),
+			expected: true,
+		},
+		// ProtocolHeaders
+		{
+			name:     "content-length lowercase",
+			key:      "content-length",
+			expected: true,
+		},
+		{
+			name:     "Content-Length canonical HTTP form",
+			key:      "Content-Length",
+			expected: true,
+		},
+		{
+			name:     "CONTENT-LENGTH uppercase",
+			key:      "CONTENT-LENGTH",
+			expected: true,
+		},
+		// Non-system headers
+		{
+			name:     "arbitrary custom header",
+			key:      "x-custom-header",
+			expected: false,
+		},
+		{
+			name:     "authorization header",
+			key:      "authorization",
+			expected: false,
+		},
+		{
+			name:     "content-type header",
+			key:      "content-type",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			key:      "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsSystemOwnedHeader(tt.key)
+			if result != tt.expected {
+				t.Errorf("IsSystemOwnedHeader(%q) = %v, want %v", tt.key, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInputControlHeadersContents(t *testing.T) {
+	expected := []string{
+		strings.ToLower(metadata.FlowFairnessIDKey),
+		strings.ToLower(metadata.ObjectiveKey),
+		strings.ToLower(metadata.ModelNameRewriteKey),
+		strings.ToLower(metadata.SubsetFilterKey),
+	}
+	for _, key := range expected {
+		if !InputControlHeaders.Has(key) {
+			t.Errorf("InputControlHeaders missing expected key %q", key)
+		}
+	}
+	if got, want := InputControlHeaders.Len(), len(expected); got != want {
+		t.Errorf("InputControlHeaders length = %d, want %d", got, want)
+	}
+}
+
+func TestOutputInjectionHeadersContents(t *testing.T) {
+	expected := []string{
+		strings.ToLower(metadata.DestinationEndpointKey),
+		strings.ToLower(metadata.DestinationEndpointServedKey),
+	}
+	for _, key := range expected {
+		if !OutputInjectionHeaders.Has(key) {
+			t.Errorf("OutputInjectionHeaders missing expected key %q", key)
+		}
+	}
+	if got, want := OutputInjectionHeaders.Len(), len(expected); got != want {
+		t.Errorf("OutputInjectionHeaders length = %d, want %d", got, want)
+	}
+}
+
+func TestProtocolHeadersContents(t *testing.T) {
+	expected := []string{"content-length"}
+	for _, key := range expected {
+		if !ProtocolHeaders.Has(key) {
+			t.Errorf("ProtocolHeaders missing expected key %q", key)
+		}
+	}
+	if got, want := ProtocolHeaders.Len(), len(expected); got != want {
+		t.Errorf("ProtocolHeaders length = %d, want %d", got, want)
+	}
+}

--- a/pkg/epp/util/request/sheddable_test.go
+++ b/pkg/epp/util/request/sheddable_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"math"
+	"testing"
+)
+
+func TestIsSheddable(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority int
+		expected bool
+	}{
+		{
+			name:     "negative one",
+			priority: -1,
+			expected: true,
+		},
+		{
+			name:     "large negative number",
+			priority: -100,
+			expected: true,
+		},
+		{
+			name:     "minimum int",
+			priority: math.MinInt,
+			expected: true,
+		},
+		{
+			name:     "zero",
+			priority: 0,
+			expected: false,
+		},
+		{
+			name:     "positive one",
+			priority: 1,
+			expected: false,
+		},
+		{
+			name:     "large positive number",
+			priority: 100,
+			expected: false,
+		},
+		{
+			name:     "maximum int",
+			priority: math.MaxInt,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsSheddable(tt.priority)
+			if result != tt.expected {
+				t.Errorf("IsSheddable(%d) = %v, want %v", tt.priority, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/lwepp/util/pool/pool_test.go
+++ b/pkg/lwepp/util/pool/pool_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/datastore"
+)
+
+func TestInferencePoolToEndpointPool(t *testing.T) {
+	tests := []struct {
+		name     string
+		pool     *v1.InferencePool
+		expected *datastore.EndpointPool
+	}{
+		{
+			name:     "nil input returns nil",
+			pool:     nil,
+			expected: nil,
+		},
+		{
+			name: "single port and single label",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8080}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "model-server",
+						},
+					},
+				},
+			},
+			expected: &datastore.EndpointPool{
+				Namespace:   "default",
+				TargetPorts: []int{8080},
+				Selector:    map[string]string{"app": "model-server"},
+			},
+		},
+		{
+			name: "multiple ports preserve order",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-port-pool",
+					Namespace: "production",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{
+						{Number: 8080},
+						{Number: 9090},
+						{Number: 5000},
+					},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "llm",
+						},
+					},
+				},
+			},
+			expected: &datastore.EndpointPool{
+				Namespace:   "production",
+				TargetPorts: []int{8080, 9090, 5000},
+				Selector:    map[string]string{"app": "llm"},
+			},
+		},
+		{
+			name: "multiple labels all converted",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "labeled-pool",
+					Namespace: "staging",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8000}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app":     "model-server",
+							"version": "v1",
+							"env":     "staging",
+						},
+					},
+				},
+			},
+			expected: &datastore.EndpointPool{
+				Namespace:   "staging",
+				TargetPorts: []int{8000},
+				Selector: map[string]string{
+					"app":     "model-server",
+					"version": "v1",
+					"env":     "staging",
+				},
+			},
+		},
+		{
+			name: "empty selector produces empty map",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-labels-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8000}},
+					Selector:    v1.LabelSelector{},
+				},
+			},
+			expected: &datastore.EndpointPool{
+				Namespace:   "default",
+				TargetPorts: []int{8000},
+				Selector:    map[string]string{},
+			},
+		},
+		{
+			name: "name field is not carried over",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "named-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 8000}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "server",
+						},
+					},
+				},
+			},
+			expected: &datastore.EndpointPool{
+				Namespace:   "default",
+				TargetPorts: []int{8000},
+				Selector:    map[string]string{"app": "server"},
+			},
+		},
+		{
+			name: "max valid port number converts correctly",
+			pool: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "edge-port-pool",
+					Namespace: "default",
+				},
+				Spec: v1.InferencePoolSpec{
+					TargetPorts: []v1.Port{{Number: 65535}},
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{
+							"app": "server",
+						},
+					},
+				},
+			},
+			expected: &datastore.EndpointPool{
+				Namespace:   "default",
+				TargetPorts: []int{65535},
+				Selector:    map[string]string{"app": "server"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := InferencePoolToEndpointPool(tt.pool)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("InferencePoolToEndpointPool() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds unit tests for utility functions that had 0% test coverage.
These are pure functions with no external dependencies, making them
ideal candidates for isolated unit testing.

## Changes
  | File | Test File | Coverage |
  |---|---|---|
  | pkg/epp/util/request/headers.go | pkg/epp/util/request/headers_test.go | 100% |
  | pkg/epp/util/request/sheddable.go | pkg/epp/util/request/sheddable_test.go | 100% |
  | pkg/epp/util/pool/pool.go | pkg/epp/util/pool/pool_test.go | 100% |
  | pkg/lwepp/util/pool/pool.go | pkg/lwepp/util/pool/pool_test.go | 100% |
  | pkg/epp/flowcontrol/types/outcomes.go | pkg/epp/flowcontrol/types/outcomes_test.go | 100% |
  | pkg/common/observability/metrics/metrics.go | pkg/common/observability/metrics/metrics_test.go | 100% |

## Test Coverage
  Before: `0.0%`
  After:  `100%`

## How to Verify
go test ./pkg/epp/util/request/... \
        ./pkg/epp/util/pool/... \
        ./pkg/lwepp/util/pool/... \
        ./pkg/epp/flowcontrol/types/... \
        ./pkg/common/observability/metrics/... \
        -v -coverprofile=coverage.out

go tool cover -func=coverage.out