### PR TITLE
Update community meeting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ Follow this [README](./test/e2e/epp/README.md) to learn more about running the i
 
 ## Contributing
 
-Our community meeting is weekly at Thursday 10AM PDT ([Zoom](https://zoom.us/j/96271651417?pwd=NViXawg6lMsRjgXbu2YmW8DxWqbjta.1), [Meeting Notes](https://www.google.com/url?q=https://docs.google.com/document/d/1frfPE5L1sI3737rdQV04IcDGeOcGJj2ItjMg6z2SRH0/edit?usp%3Dsharing&sa=D&source=calendar&usd=2&usg=AOvVaw1pUVy7UN_2PMj8qJJcFm1U)).
+Community meetings have moved to the llm-d Inference Scheduler community
+meeting. See the [llm-d Inference Scheduler contributing
+section](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/README.md#contributing)
+for current meeting details.
 
 We currently utilize the [#gateway-api-inference-extension](https://kubernetes.slack.com/?redir=%2Fmessages%2Fgateway-api-inference-extension) channel in Kubernetes Slack workspace for communications.
 

--- a/site-src/contributing/index.md
+++ b/site-src/contributing/index.md
@@ -27,21 +27,26 @@ Our conversations are currently split between the following Kubernetes Slack cha
 
 ## Meetings
 
-Gateway API community meetings happen every Thursday at 10am Pacific Time
-([convert to your
-timezone](https://dateful.com/time-zone-converter?t=10:00&tz=PT%20%28Pacific%20Time%29)).
-To receive an invite to this and other WG-Serving community meetings, join the
-[WG-Serving mailing
-list](https://groups.google.com/a/kubernetes.io/g/wg-serving).
-
-* [Zoom link](https://zoom.us/j/9955436256?pwd=Z2FQWU1jeDZkVC9RRTN4TlZyZTBHZz09) (passcode in [meeting notes](https://docs.google.com/document/d/1frfPE5L1sI3737rdQV04IcDGeOcGJj2ItjMg6z2SRH0/edit?tab=t.0#heading=h.jvz2pwvdpit0) doc)
+Community meetings have moved to the llm-d Inference Scheduler community
+meeting. See the [llm-d Inference Scheduler contributing
+section](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/README.md#contributing)
+for current meeting details.
 
 ### Meeting Notes and Recordings
 
-Meeting agendas and notes are maintained in the [meeting
-notes](https://docs.google.com/document/d/1frfPE5L1sI3737rdQV04IcDGeOcGJj2ItjMg6z2SRH0/edit?tab=t.0#heading=h.jvz2pwvdpit0)
-doc. Feel free to add topics for discussion at an upcoming meeting.
+Meeting agendas, notes, and access information are maintained by the [llm-d
+Inference Scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/README.md#contributing).
 
-All meetings are recorded and automatically uploaded to the [WG-Serving meetings
-YouTube
-playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP2io2Gg92njBfh-DX9sk7O3).
+### Historical Meeting Assets
+
+The following assets are retained for historical purposes only. Current meeting
+details, agendas, and notes are maintained by the llm-d Inference Scheduler.
+
+The legacy Gateway API Inference Extension community meeting was held every
+Thursday at 10am Pacific Time. Invites were shared through the [WG-Serving
+mailing list](https://groups.google.com/a/kubernetes.io/g/wg-serving).
+
+* [Legacy Zoom link](https://zoom.us/j/9955436256?pwd=Z2FQWU1jeDZkVC9RRTN4TlZyZTBHZz09)
+* [Legacy meeting notes](https://docs.google.com/document/d/1frfPE5L1sI3737rdQV04IcDGeOcGJj2ItjMg6z2SRH0/edit?tab=t.0#heading=h.jvz2pwvdpit0)
+* [Legacy WG-Serving meetings YouTube
+  playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP2io2Gg92njBfh-DX9sk7O3)


### PR DESCRIPTION
## Summary
- point current meeting details to llm-d Inference Scheduler docs
- keep legacy meeting links as historical assets

## Testing
- git diff --check