### PR TITLE
Simplify integration response assertions

### DIFF
--- a/test/integration/bbr/body_mutation_test.go
+++ b/test/integration/bbr/body_mutation_test.go
@@ -24,13 +24,10 @@ import (
 
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/basemodelextractor"
-	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
@@ -106,11 +103,7 @@ func TestBodyMutation_Unary(t *testing.T) {
 		},
 	}
 
-	envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{want})
-	envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{resp})
-	if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-		t.Errorf("Response mismatch (-want +got): %v", diff)
-	}
+	integration.RequireProcessingResponseEqual(t, want, resp)
 }
 
 // TestBodyMutation_Streaming verifies the streaming path: when a plugin mutates the body,
@@ -193,9 +186,5 @@ func TestBodyMutation_Streaming(t *testing.T) {
 	responses, err := integration.StreamedRequest(t, h.Client, reqs, len(wantResponses))
 	require.NoError(t, err, "unexpected stream error")
 
-	envoytest.SortSetHeadersInResponses(wantResponses)
-	envoytest.SortSetHeadersInResponses(responses)
-	if diff := cmp.Diff(wantResponses, responses, protocmp.Transform()); diff != "" {
-		t.Errorf("Response mismatch (-want +got): %v", diff)
-	}
+	integration.RequireProcessingResponsesEqual(t, wantResponses, responses)
 }

--- a/test/integration/bbr/hermetic_test.go
+++ b/test/integration/bbr/hermetic_test.go
@@ -26,14 +26,11 @@ import (
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/basemodelextractor"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/plugins/bodyfieldtoheader"
-	envoytest "sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy/test"
 	epp "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
@@ -92,11 +89,7 @@ func TestBodyBasedRouting(t *testing.T) {
 				return
 			}
 
-			envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{tc.wantResponse})
-			envoytest.SortSetHeadersInResponses([]*extProcPb.ProcessingResponse{res})
-			if diff := cmp.Diff(tc.wantResponse, res, protocmp.Transform()); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
+			integration.RequireProcessingResponseEqual(t, tc.wantResponse, res)
 		})
 	}
 }
@@ -196,11 +189,7 @@ func TestResponsePlugins(t *testing.T) {
 			require.NoError(t, err, "unexpected error during streamed request")
 			require.Len(t, responses, len(tc.wantResponses))
 
-			envoytest.SortSetHeadersInResponses(tc.wantResponses)
-			envoytest.SortSetHeadersInResponses(responses)
-			if diff := cmp.Diff(tc.wantResponses, responses, protocmp.Transform()); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
+			integration.RequireProcessingResponsesEqual(t, tc.wantResponses, responses)
 		})
 	}
 }
@@ -298,12 +287,7 @@ func TestFullDuplexStreamed_BodyBasedRouting(t *testing.T) {
 				return
 			}
 
-			// sort headers in responses for deterministic tests
-			envoytest.SortSetHeadersInResponses(tc.wantResponses)
-			envoytest.SortSetHeadersInResponses(responses)
-			if diff := cmp.Diff(tc.wantResponses, responses, protocmp.Transform()); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
+			integration.RequireProcessingResponsesEqual(t, tc.wantResponses, responses)
 		})
 	}
 }

--- a/test/integration/epp/datalayer_integration_test.go
+++ b/test/integration/epp/datalayer_integration_test.go
@@ -20,10 +20,7 @@ import (
 	"context"
 	"testing"
 
-	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	"sigs.k8s.io/gateway-api-inference-extension/test/integration"
 )
@@ -49,14 +46,7 @@ func TestFullDuplexStreamed_DataLayer(t *testing.T) {
 			responses, err := integration.StreamedRequest(t, h.Client, tc.requests, len(tc.wantResponses))
 			require.NoError(t, err)
 
-			if diff := cmp.Diff(tc.wantResponses, responses,
-				protocmp.Transform(),
-				protocmp.SortRepeated(func(a, b *configPb.HeaderValueOption) bool {
-					return a.GetHeader().GetKey() < b.GetHeader().GetKey()
-				}),
-			); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
+			integration.RequireProcessingResponsesEqual(t, tc.wantResponses, responses)
 
 			if len(tc.wantMetrics) > 0 {
 				h.ExpectMetrics(tc.wantMetrics)

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -23,9 +23,7 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
 	pb "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen"
@@ -480,14 +478,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			responses, err := integration.StreamedRequest(t, h.Client, tc.requests, len(tc.wantResponses))
 			require.NoError(t, err)
 
-			if diff := cmp.Diff(tc.wantResponses, responses,
-				protocmp.Transform(),
-				protocmp.SortRepeated(func(a, b *configPb.HeaderValueOption) bool {
-					return a.GetHeader().GetKey() < b.GetHeader().GetKey()
-				}),
-			); diff != "" {
-				t.Errorf("Response mismatch (-want +got): %v", diff)
-			}
+			integration.RequireProcessingResponsesEqual(t, tc.wantResponses, responses)
 
 			if len(tc.wantMetrics) > 0 {
 				h.ExpectMetrics(tc.wantMetrics)

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -25,12 +25,9 @@ import (
 	"testing"
 	"time"
 
-	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/testing/protocmp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -443,14 +440,7 @@ featureGates:
 					responses, err := integration.StreamedRequest(t, h.Client, tc.requests, len(tc.wantResponses))
 					require.NoError(t, err)
 
-					if diff := cmp.Diff(tc.wantResponses, responses,
-						protocmp.Transform(),
-						protocmp.SortRepeated(func(a, b *configPb.HeaderValueOption) bool {
-							return a.GetHeader().GetKey() < b.GetHeader().GetKey()
-						}),
-					); diff != "" {
-						t.Errorf("Response mismatch (-want +got): %v", diff)
-					}
+					integration.RequireProcessingResponsesEqual(t, tc.wantResponses, responses)
 
 					if len(tc.wantMetrics) > 0 {
 						h.ExpectMetrics(tc.wantMetrics)

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -38,14 +38,16 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
-	pb "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen"
 
 	reqcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/request"
+	pb "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/metadata"
 )
 
@@ -452,6 +454,31 @@ func NewImmediateErrorResponse(code envoyTypePb.StatusCode, body string) []*extP
 			},
 		},
 	}}
+}
+
+func processingResponseCmpOptions() []cmp.Option {
+	return []cmp.Option{
+		protocmp.Transform(),
+		protocmp.SortRepeated(func(a, b *envoyCorev3.HeaderValueOption) bool {
+			return a.GetHeader().GetKey() < b.GetHeader().GetKey()
+		}),
+	}
+}
+
+// RequireProcessingResponseEqual compares a single ext_proc response with stable protobuf sorting.
+func RequireProcessingResponseEqual(t *testing.T, want, got *extProcPb.ProcessingResponse) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, processingResponseCmpOptions()...); diff != "" {
+		t.Errorf("Response mismatch (-want +got): %v", diff)
+	}
+}
+
+// RequireProcessingResponsesEqual compares a sequence of ext_proc responses with stable protobuf sorting.
+func RequireProcessingResponsesEqual(t *testing.T, want, got []*extProcPb.ProcessingResponse) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, processingResponseCmpOptions()...); diff != "" {
+		t.Errorf("Response mismatch (-want +got): %v", diff)
+	}
 }
 
 // --- Execution Helpers ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Use shared helpers to compare ext_proc responses in integration tests.
This removes duplicated protobuf diff and header-sorting logic across BBR and EPP tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
