### PR TITLE
chore: update v1.5.0 conformance base.yaml resources to not use the 1.5.0-rc.1 build epp image

### DIFF
--- a/conformance/resources/base.yaml
+++ b/conformance/resources/base.yaml
@@ -249,7 +249,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0-rc.1
+        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
@@ -347,7 +347,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0-rc.1
+        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
@@ -445,7 +445,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0-rc.1
+        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
@@ -543,7 +543,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0-rc.1
+        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
@@ -752,7 +752,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0-rc.1
+        image: registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/area conformance-machinery

**What this PR does / why we need it**:

I noticed the epp image used throughout the conformance base.yaml epp deployments was for the outdated rc.1 build. Updated it in case it makes any noticeable changes for implementations running conformance off of this branch. Feel free to close if this is not needed for whatever reason.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
