### PR TITLE
Preallocate EPP request body buffer

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -158,6 +159,8 @@ type recvResult struct {
 	req *extProcPb.ProcessingRequest
 	err error
 }
+
+const maxRequestBodyPreallocBytes = 1 << 20
 
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	ctx := srv.Context()
@@ -302,6 +305,11 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			ctx = log.IntoContext(ctx, logger)
 
 			err = s.HandleRequestHeaders(ctx, reqCtx, v)
+			if err == nil && !v.RequestHeaders.EndOfStream {
+				if capacity := requestBodyCapacity(v); capacity > 0 {
+					body = make([]byte, 0, capacity)
+				}
+			}
 		case *extProcPb.ProcessingRequest_RequestBody:
 			loggerTrace.Info("Incoming body chunk", "EoS", v.RequestBody.EndOfStream)
 			// In the stream case, we can receive multiple request bodies.
@@ -417,6 +425,18 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			return err
 		}
 	}
+}
+
+func requestBodyCapacity(req *extProcPb.ProcessingRequest_RequestHeaders) int {
+	contentLength := envoy.ExtractHeaderValue(req, "content-length")
+	if contentLength == "" {
+		return 0
+	}
+	bodyLength, err := strconv.Atoi(contentLength)
+	if err != nil || bodyLength <= 0 || bodyLength > maxRequestBodyPreallocBytes {
+		return 0
+	}
+	return bodyLength
 }
 
 // finishResponse ensures all post-response logic, such as metric recording


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This is a small, targeted optimization for the EPP ext_proc request path.

`StreamingServer.Process` currently accumulates streamed request body
chunks into a `[]byte` with repeated `append` growth. For large prompts
this causes repeated buffer reallocations and copies before the request
is parsed and routed.

This PR preallocates the request-body buffer from the `content-length`
header when it is present and reasonable, capped at 1 MiB to avoid eager
allocation from unexpectedly large or invalid headers. If the header is
missing, invalid, or above the cap, the existing append-growth behavior
is preserved — behavior is fully backward compatible.

**Impact**:

In an e2e repro with 220 KiB prompts at concurrency 150, TTFT rose to
roughly 1.1s, with `StreamingServer.Process` dominating `alloc_space`
for the request path. This PR significantly reduces allocation overhead
on that hotspot and mitigates the TTFT regression under large inputs.

This PR only addresses the request-body accumulation hotspot; the
remaining JSON parse/marshal and metrics collector hotspots are left to
follow-up PRs.

**Benchmark results**:

Full reproduction harness (KIND cluster, upstream v1.5.0 helm chart,
4× llm-d-inference-sim, A/B with only the EPP image swapped) is checked
in at https://github.com/yankay/gateway-api-inference-extension/tree/bench
— see `bench/pure-gie/` for the TTFT > 1s reproducer and
`bench/pure-gie-prealloc/` for the A/B harness.

TTFT > 1s baseline reproduction
(`bench/pure-gie/stable-1s.sh`, 24 vCPU host, c=1200, 220 KiB prompt,
3 rounds × 1500 reqs against the unfixed `epp:baseline` image built
from this PR's parent commit `8ed5a0cd`):

```
per_round_ttft_mean_ms:  1352.97  1406.27  1592.90   (median 1406.27)
threshold:               1100 ms   PASS
```

A/B comparison (`bench/pure-gie-prealloc/compare-ab.sh`, same cluster,
2 rounds × 1500 reqs per arm, alternating order, image-only swap
between PR parent `8ed5a0cd` and PR head `ad645c92`):

| metric                                     | baseline | prealloc | drop  |
|--------------------------------------------|---------:|---------:|------:|
| TTFT median-of-round-means (ms)            |     1331 |     1286 |  3.3% |
| `(*StreamingServer).Process` flat alloc %  |    30.0% |    13.2% | 56.0% |
| `(*StreamingServer).Process` cum  alloc %  |    69.9% |    64.0% |  8.4% |
| total alloc_space (round 1, MB)            |     6627 |     5236 | ~21%  |

The flat allocation share attributable to `Process()` drops from ~30%
to ~13% — a ~2× reduction, matching what the PR targets: eliminating
the per-chunk `append(buf, chunk...)` reallocations.

TTFT improves only ~3% because the body-allocation hotspot is one of
five hotspots on this path; the remaining four (OpenAI parser double
unmarshal, Director re-marshal, approximateprefix marshal, datalayer
Collector gzip dict reallocation) are not addressed here.

Raw pprof artifacts, per-arm summaries and `compare.md` are at
`bench/pure-gie-prealloc/results/run-20260514T033959Z/` on the
`bench` branch above.

**Which issue(s) this PR fixes**:

Part of the large-input EPP request-path overhead investigation.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
