### PR TITLE
 Validate EPP CPU and memory resource requests in Helm chart

### DIFF
--- a/config/charts/inferencepool/templates/_validations.tpl
+++ b/config/charts/inferencepool/templates/_validations.tpl
@@ -5,4 +5,10 @@ common validations
 {{- if or (empty $.Values.inferencePool.modelServers) (not $.Values.inferencePool.modelServers.matchLabels) }}
 {{- fail ".Values.inferencePool.modelServers.matchLabels is required" }}
 {{- end }}
+{{- if or (not $.Values.inferenceExtension.resources) (not $.Values.inferenceExtension.resources.requests) (not $.Values.inferenceExtension.resources.requests.cpu) }}
+{{- fail ".Values.inferenceExtension.resources.requests.cpu is required" }}
+{{- end }}
+{{- if or (not $.Values.inferenceExtension.resources) (not $.Values.inferenceExtension.resources.requests) (not $.Values.inferenceExtension.resources.requests.memory) }}
+{{- fail ".Values.inferenceExtension.resources.requests.memory is required" }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
- Add Helm validation to ensure `inferenceExtension.resources.requests.cpu` and                                       
    `inferenceExtension.resources.requests.memory` are always set                                                     
  - Uses `fail` with nested nil guards in `_validations.tpl` to provide clear                                           
    error messages when users supply a custom values file that omits resource requests                                  
  - EPP is a critical component — running without resource requests risks                                               
    node-level resource contention                                                                                      
                                                                                                                        
  Fixes #2499                         

 ## Test plan                                                                                                          
  - [x] `helm template` with `--set inferenceExtension.resources=null` fails with                                       
        `.Values.inferenceExtension.resources.requests.cpu is required`          
  - [x] `helm template` with default `values.yaml` renders successfully                                                 
  - [x] `make verify-helm-charts MODE=local` passes all existing test cases        
  
  ## Test used 
    # Should FAIL — resources set to null  
`helm template test config/charts/inferencepool  --set inferencePool.modelServers.matchLabels.app=test --set inferenceExtension.resources=null `

  Should PASS — defaults from values.yaml                                                                           
`helm template test config/charts/inferencepool --set inferencePool.modelServers.matchLabels.app=test   `