### PR TITLE
Bump aquasecurity/trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/trivy-image-scan.yaml
+++ b/.github/workflows/trivy-image-scan.yaml
@@ -61,7 +61,7 @@ jobs:
             -f Dockerfile .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e2f6a1c8dc2b8433 # v0.31.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'gwie-epp:scan'
           format: 'sarif'
@@ -76,7 +76,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy scanner (table output for PR comment)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e2f6a1c8dc2b8433 # v0.31.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'gwie-epp:scan'
           format: 'table'


### PR DESCRIPTION
# What type of PR is this?

/kind cleanup
/kind flake

# What this PR does / why we need it

The `aquasecurity/trivy-action` SHA currently pinned in `.github/workflows/trivy-image-scan.yaml` (`18f2510ee396bbf400402947e2f6a1c8dc2b8433`, annotated as `v0.31.0`) is no longer resolvable upstream. Every PR's Trivy Image Vulnerability Scan job now fails at `Set up job` with:

> Unable to resolve action `aquasecurity/trivy-action@18f2510e...`, unable to find version `18f2510e...`

Example failure: https://github.com/kubernetes-sigs/gateway-api-inference-extension/actions/runs/25799242156/job/75784426762

This PR bumps the pin to `v0.36.0` (`ed142fd0673e97e23eac54620cfb913e5ce36c25`), which is the version already used by other kubernetes-sigs projects (cloud-provider-azure, azurefile-csi-driver, azuredisk-csi-driver, blob-csi-driver, sig-storage-local-static-provisioner).

# Which issue(s) this PR fixes

None.

# Does this PR introduce a user-facing change?

```release-note
NONE
```