### PR TITLE
[WIP] Skip duplicate JSON decode for OpenAI completions requests

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -96,7 +96,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
 	}
-	extractedBody, err := extractRequestBody(body, headers)
+	extractedBody, err := extractRequestBody(body, bodyMap, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -187,8 +187,9 @@ func determineAPITypeFromPath(path string) string {
 	return completionsAPI
 }
 
-// extractRequestBody extracts the LLMRequestBody from the given request body map using path-based detection.
-func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.InferenceRequestBody, error) {
+// extractRequestBody builds the typed request body for the API path.
+// It reuses bodyMap for completions to avoid decoding large prompts twice.
+func extractRequestBody(rawBody []byte, bodyMap map[string]any, headers map[string]string) (*fwkrh.InferenceRequestBody, error) {
 	// Determine API type from request path
 	path := getRequestPath(headers)
 	apiType := determineAPITypeFromPath(path)
@@ -218,11 +219,11 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 		return nil, errors.New("invalid chat completions request: must have valid messages field")
 
 	case completionsAPI:
-		var completions fwkrh.CompletionsRequest
-		if err := json.Unmarshal(rawBody, &completions); err == nil && !completions.Prompt.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Completions: &completions}, nil
+		completions, err := completionsFromMap(bodyMap)
+		if err != nil {
+			return nil, err
 		}
-		return nil, errors.New("invalid completions request: must have prompt field")
+		return &fwkrh.InferenceRequestBody{Completions: completions}, nil
 
 	case embeddingsAPI:
 		var embeddings fwkrh.EmbeddingsRequest
@@ -232,6 +233,75 @@ func extractRequestBody(rawBody []byte, headers map[string]string) (*fwkrh.Infer
 		return nil, errors.New("invalid embeddings request: must have input field")
 	default:
 		return nil, errors.New("unsupported API endpoint")
+	}
+}
+
+// completionsFromMap mirrors CompletionsRequest JSON decoding from bodyMap.
+// Keep this in sync with CompletionsRequest if it starts parsing more fields.
+func completionsFromMap(bodyMap map[string]any) (*fwkrh.CompletionsRequest, error) {
+	var c fwkrh.CompletionsRequest
+	prompt, err := completionsPromptFromMapValue(bodyMap["prompt"])
+	if err != nil {
+		return nil, err
+	}
+	c.Prompt = prompt
+
+	if v, ok := bodyMap["cache_salt"]; ok && v != nil {
+		s, ok := v.(string)
+		if !ok {
+			return nil, errors.New("invalid completions request: cache_salt must be a string")
+		}
+		c.CacheSalt = s
+	}
+	if c.Prompt.IsEmpty() {
+		return nil, errors.New("invalid completions request: must have prompt field")
+	}
+	return &c, nil
+}
+
+func completionsPromptFromMapValue(v any) (fwkrh.Prompt, error) {
+	switch p := v.(type) {
+	case nil:
+		return fwkrh.Prompt{}, nil
+	case string:
+		return fwkrh.Prompt{Raw: p}, nil
+	case []any:
+		return completionsPromptFromArray(p)
+	default:
+		return fwkrh.Prompt{}, errors.New("invalid completions request: prompt must be a string or an array")
+	}
+}
+
+func completionsPromptFromArray(v []any) (fwkrh.Prompt, error) {
+	if len(v) == 0 {
+		return fwkrh.Prompt{}, nil
+	}
+	switch v[0].(type) {
+	case string:
+		strings := make([]string, len(v))
+		for i, val := range v {
+			str, ok := val.(string)
+			if !ok {
+				return fwkrh.Prompt{}, errors.New("prompt: mixed types in array")
+			}
+			strings[i] = str
+		}
+		return fwkrh.Prompt{Strings: strings}, nil
+	case float64:
+		tokenIDs := make([]uint32, len(v))
+		for i, val := range v {
+			flt, ok := val.(float64)
+			if !ok {
+				return fwkrh.Prompt{}, errors.New("prompt: mixed types in array")
+			}
+			if flt != float64(uint32(flt)) {
+				return fwkrh.Prompt{}, fmt.Errorf("prompt: floating-point number %f is not a valid token ID", flt)
+			}
+			tokenIDs[i] = uint32(flt)
+		}
+		return fwkrh.Prompt{TokenIDs: tokenIDs}, nil
+	default:
+		return fwkrh.Prompt{}, errors.New("prompt: unsupported array element type")
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -19,6 +19,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -125,6 +126,34 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 			body: map[string]any{
 				"model":  "test",
 				"prompt": []any{},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "completions request with null prompt rejected",
+			headers: map[string]string{":path": "/v1/completions"},
+			body: map[string]any{
+				"model":  "test",
+				"prompt": nil,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "completions request with non-string non-array prompt rejected",
+			headers: map[string]string{":path": "/v1/completions"},
+			body: map[string]any{
+				"model":  "test",
+				"prompt": 42,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "completions request with non-string cache_salt rejected",
+			headers: map[string]string{":path": "/v1/completions"},
+			body: map[string]any{
+				"model":      "test",
+				"prompt":     "valid prompt",
+				"cache_salt": 123,
 			},
 			wantErr: true,
 		},
@@ -1103,7 +1132,11 @@ func BenchmarkExtractRequestData_ChatCompletionsWithOptionals(b *testing.B) {
 		if err != nil {
 			b.Errorf("body cannot be marshalled to JSON bytes")
 		}
-		_, err = extractRequestBody(jsonBytes, headers)
+		bodyMap := make(map[string]any)
+		if err := json.Unmarshal(jsonBytes, &bodyMap); err != nil {
+			b.Fatal(err)
+		}
+		_, err = extractRequestBody(jsonBytes, bodyMap, headers)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1171,6 +1204,31 @@ func BenchmarkExtractRequestData_Embeddings(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err = parser.ParseRequest(context.Background(), jsonBytes, headers)
 		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseRequest_LargeCompletions measures a completions request with a
+// large prompt.
+func BenchmarkParseRequest_LargeCompletions(b *testing.B) {
+	prompt := strings.Repeat("a", 220*1024)
+	body := map[string]any{
+		"model":  "test",
+		"prompt": prompt,
+		"stream": true,
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		b.Fatalf("body cannot be marshalled to JSON bytes: %v", err)
+	}
+	headers := map[string]string{":path": "/v1/completions"}
+	parser := NewOpenAIParser()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := parser.ParseRequest(context.Background(), jsonBytes, headers); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This is a small optimization for the EPP OpenAI request parser.

`OpenAIParser.ParseRequest` decodes `/v1/completions` request bodies twice on the hot path: first into `map[string]any` for `PayloadMap`, then again into a typed `CompletionsRequest`. For large prompts, this repeats JSON decoding over the largest field in the request body.

This PR keeps the existing generic decode for `PayloadMap`, but builds the typed `CompletionsRequest` from the already-decoded map for `/v1/completions`. Other OpenAI-compatible endpoints keep their existing typed decode path.

Behavior is preserved for valid and invalid completion prompts, including string prompts, string arrays, token ID arrays, missing/null prompts, empty prompts, and `cache_salt` handling. The request-control/director contract is unchanged: `PayloadMap` still exposes the full decoded request map.

Scope / non-goals:

This PR is intentionally limited to the `/v1/completions` large-prompt hot path.

It does not remove the generic `map[string]any` decode in `ParseRequest`, because the current `PayloadMap` contract still exposes that map to request-control plugins.

It also does not change forwarding/repackaging behavior. `Director.repackage` may still marshal `PayloadMap` again, so preserving and forwarding the original raw `[]byte` when no mutation is needed is left for follow-up work.

Other OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/embeddings`, `/v1/responses`, `/v1/conversations`) still use the existing typed `json.Unmarshal` path.

**Limitations / why the benchmark improvement is bounded**:

This PR only removes the parser-level double JSON decode. It does **not** remove `Director.repackage`'s `json.Marshal` of `PayloadMap`. The natural follow-up — skipping that marshal when no plugin mutates the request body — is intentionally left out of this PR.

The follow-up, as currently planned, is deliberately conservative: it can only skip the re-marshal when **no `PreRequest` plugin is registered**. Today the request-control framework treats every `PreRequest` plugin as potentially body-mutating, so the presence of any `PreRequest` plugin forces `Director.repackage` to fall back to `json.Marshal` of `PayloadMap`.

The pure-GIE default `EndpointPickerConfig` registers `PreRequest` plugins, so on the default benchmark path `Director.repackage` will still hit `json.Marshal` even after that follow-up lands. That is why the benchmark numbers in this PR plus the planned Director-side change are still bounded — the largest remaining marshal on the default config is not actually being skipped.

To actually realize the `Director.repackage` saving in this benchmark, a separate change is needed first: explicitly mark whether a `PreRequest` plugin mutates the request body (for example via an extension-point flag or a dedicated interface), so the director can detect "no body mutation" even when `PreRequest` plugins are configured. Until that lands, the Director-side marshal saving is only effective in configurations with **no** `PreRequest` plugin registered, which is not the default.

Benchmark context:

Pure-GIE large-input repro (`bench/pure-gie/stable-1s.sh` on the reproduction branch), single EPP replica, KIND + Istio + llm-d-inference-sim x4, 220 KiB `/v1/completions` streaming requests:

```text
CONCURRENCY=1200 WARMUP_REQS=300 ROUND_REQS=1500 ROUNDS=3 THRESHOLD_MS=1100
```

OpenAI-only image A/B, two runs per arm:

| metric | baseline | this PR | delta |
|---|---:|---:|---:|
| TTFT median-of-means | 1409 ms | 1272 ms | -137 ms (-9.7%) |
| Throughput, mean across rounds | 646 req/s | 712 req/s | +66 req/s (+10%) |
| EPP `inference_objective_request_duration_seconds` avg/request | 617 ms | 545 ms | -72 ms (-11.7%) |

Fresh local rebuild ABC check, comparing `main`, this PR only, and this PR combined with #2924:

| image | avg median TTFT |
|---|---:|
| baseline | 1397.04 ms |
| this PR only | 1349.74 ms |
| this PR + #2924 | 1282.58 ms |

The combined result is best, but TTFT still remains above the 1100 ms reproduction threshold because other hot paths remain: director re-marshal (see Limitations above), approximate-prefix marshal, and datalayer Collector allocations. This PR intentionally addresses only the redundant OpenAI completions decode.

**Which issue(s) this PR fixes**:

Related to #2928

Part of the large-input EPP request-path overhead investigation.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Tested:

```text
go test ./pkg/epp/framework/plugins/requesthandling/parsers/openai ./pkg/epp/framework/interface/requesthandling
```
