### PR TITLE
lwepp: incorporate body content in routing

### DIFF
--- a/pkg/lwepp/handlers/request.go
+++ b/pkg/lwepp/handlers/request.go
@@ -36,17 +36,42 @@ func (s *StreamingServer) handleRequestHeaders(ctx context.Context, reqCtx *Requ
 	req *extProcPb.ProcessingRequest_RequestHeaders) error {
 	logger := log.FromContext(ctx)
 
+	// Store headers in RequestContext.
+	reqCtx.Headers = make(map[string][]string)
+	for _, header := range req.RequestHeaders.Headers.Headers {
+		reqCtx.Headers[header.Key] = append(reqCtx.Headers[header.Key], envoy.GetHeaderValue(header))
+	}
+
 	var metadataEndpoints []string
 
 	// Read endpoint subset from filter metadata per the EPP protocol.
 	// The data plane sets envoy.lb.subset_hint / x-gateway-destination-endpoint-subset
 	// to constrain which endpoints the EPP may pick from.
 	requestMetadata := envoy.ExtractMetadataValues(fullReq)
+	hasSubsetFilter := false
 	if subsetMap, ok := requestMetadata[metadata.SubsetFilterNamespace].(map[string]any); ok {
-		if endpointList, ok := subsetMap[metadata.SubsetFilterKey].([]any); ok {
-			for _, ep := range endpointList {
-				if epStr, ok := ep.(string); ok {
-					metadataEndpoints = append(metadataEndpoints, epStr)
+		if val, ok := subsetMap[metadata.SubsetFilterKey]; ok {
+			hasSubsetFilter = true
+			// We must support both string and []any types because different Envoy configuration pathways populate metadata differently:
+			// 1. Declarative Ingress/Gateway Filters (e.g., standard HeaderToMetadata rules) extract client list headers as a single flat string (e.g. "10.0.0.1,10.0.0.2").
+			// 2. Programmatic Control Planes or Test Harnesses (e.g., test/integration/util.go) write JSON-native array lists.
+			// Supporting both prevents silent fail-opens (routing to all pods instead of respecting subsets) under standard sidecar setups.
+			switch v := val.(type) {
+			case string:
+				for _, ep := range strings.Split(v, ",") {
+					if trimmed := strings.TrimSpace(ep); trimmed != "" {
+						metadataEndpoints = append(metadataEndpoints, trimmed)
+					}
+				}
+			case []any:
+				for _, ep := range v {
+					if epStr, ok := ep.(string); ok {
+						for _, subEp := range strings.Split(epStr, ",") {
+							if trimmed := strings.TrimSpace(subEp); trimmed != "" {
+								metadataEndpoints = append(metadataEndpoints, trimmed)
+							}
+						}
+					}
 				}
 			}
 		}
@@ -78,7 +103,7 @@ func (s *StreamingServer) handleRequestHeaders(ctx context.Context, reqCtx *Requ
 	}
 
 	var candidates []*datastore.Endpoint
-	if len(filterEndpoints) > 0 {
+	if hasSubsetFilter || len(filterEndpoints) > 0 {
 		// Build a set of IP addresses from the filter list. Filter entries may be
 		// "ip" or "ip:port"; we match only on the IP portion.
 		allowedIPs := make(map[string]struct{}, len(filterEndpoints))
@@ -95,15 +120,26 @@ func (s *StreamingServer) handleRequestHeaders(ctx context.Context, reqCtx *Requ
 				candidates = append(candidates, pod)
 			}
 		}
+		// If a subset filter was explicitly set, we must strictly respect it. If no pods match,
+		// return the empty candidate set so the EPP can return a 503 instead of failing open.
+		reqCtx.Candidates = candidates
+		return nil
 	}
 
-	// If no matches or header not present, use all pods.
-	if len(candidates) == 0 {
-		candidates = allPods
+	// Default fallback: route to all active pods when no subset filter was set.
+	reqCtx.Candidates = allPods
+	return nil
+}
+
+func (s *StreamingServer) pickEndpoint(ctx context.Context, reqCtx *RequestContext, body []byte) error {
+	logger := log.FromContext(ctx)
+
+	pickReq := &PickRequest{
+		Headers: reqCtx.Headers,
+		Body:    body,
 	}
 
-	// For the lightweight implementation (Round Robin), no request context is required.
-	res, err := s.picker.Pick(ctx, &PickRequest{}, candidates)
+	res, err := s.picker.Pick(ctx, pickReq, reqCtx.Candidates)
 	if err != nil {
 		return err
 	}
@@ -116,6 +152,5 @@ func (s *StreamingServer) handleRequestHeaders(ctx context.Context, reqCtx *Requ
 	}
 
 	logger.V(4).Info("Selected endpoint", "podIP", reqCtx.SelectedPodIP, "endpoint", reqCtx.TargetEndpoint)
-
 	return nil
 }

--- a/pkg/lwepp/handlers/request_test.go
+++ b/pkg/lwepp/handlers/request_test.go
@@ -65,10 +65,14 @@ func TestHandleRequestHeaders_RoundRobin(t *testing.T) {
 	reqCtx1 := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx1, nil, req)
 	assert.NoError(t, err)
+	err = server.pickEndpoint(context.Background(), reqCtx1, nil)
+	assert.NoError(t, err)
 
 	// Second request
 	reqCtx2 := &RequestContext{}
 	err = server.handleRequestHeaders(context.Background(), reqCtx2, nil, req)
+	assert.NoError(t, err)
+	err = server.pickEndpoint(context.Background(), reqCtx2, nil)
 	assert.NoError(t, err)
 
 	// They should be different pods (round-robin)
@@ -77,6 +81,8 @@ func TestHandleRequestHeaders_RoundRobin(t *testing.T) {
 	// Third request should wrap around
 	reqCtx3 := &RequestContext{}
 	err = server.handleRequestHeaders(context.Background(), reqCtx3, nil, req)
+	assert.NoError(t, err)
+	err = server.pickEndpoint(context.Background(), reqCtx3, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, reqCtx1.SelectedPodIP, reqCtx3.SelectedPodIP)
 }
@@ -102,6 +108,8 @@ func TestHandleRequestHeaders_FilteringViaHeader(t *testing.T) {
 
 	reqCtx := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx, nil, req)
+	assert.NoError(t, err)
+	err = server.pickEndpoint(context.Background(), reqCtx, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", reqCtx.SelectedPodIP)
 }
@@ -154,7 +162,44 @@ func TestHandleRequestHeaders_FilteringViaFilterMetadata(t *testing.T) {
 	reqCtx := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
 	assert.NoError(t, err)
+	err = server.pickEndpoint(context.Background(), reqCtx, nil)
+	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.3", reqCtx.SelectedPodIP)
+}
+
+func TestHandleRequestHeaders_FilteringViaFilterMetadata_StringValue(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+		{Address: "10.0.0.3", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	fullReq := &extProcPb.ProcessingRequest{
+		MetadataContext: &envoyCorev3.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{
+				metadata.SubsetFilterNamespace: {
+					Fields: map[string]*structpb.Value{
+						metadata.SubsetFilterKey: structpb.NewStringValue("10.0.0.2:8080,10.0.0.3:8080"),
+					},
+				},
+			},
+		},
+	}
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+	assert.NoError(t, err)
+
+	// Candidates resolved should contain only 10.0.0.2 and 10.0.0.3
+	assert.Len(t, reqCtx.Candidates, 2)
+	assert.ElementsMatch(t, []string{"10.0.0.2", "10.0.0.3"}, []string{reqCtx.Candidates[0].Address, reqCtx.Candidates[1].Address})
 }
 
 func TestHandleRequestHeaders_HeaderTakesPrecedenceOverMetadata(t *testing.T) {
@@ -194,6 +239,241 @@ func TestHandleRequestHeaders_HeaderTakesPrecedenceOverMetadata(t *testing.T) {
 	reqCtx := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
 	assert.NoError(t, err)
+	err = server.pickEndpoint(context.Background(), reqCtx, nil)
+	assert.NoError(t, err)
 	// The test header should override metadata-based filtering.
 	assert.Equal(t, "10.0.0.2", reqCtx.SelectedPodIP)
+}
+
+func TestHandleRequestHeaders_DuplicateHeadersArePreserved(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{
+				Headers: []*envoyCorev3.HeaderValue{
+					{Key: "X-Forwarded-For", Value: "1.1.1.1"},
+					{Key: "X-Forwarded-For", Value: "2.2.2.2"},
+					{Key: "Cookie", Value: "session=abc"},
+					{Key: "Cookie", Value: "user=xyz"},
+				},
+			},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, nil, req)
+	assert.NoError(t, err)
+
+	// Duplicate header keys must be preserved in sequence arrays instead of getting overwritten.
+	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, reqCtx.Headers["X-Forwarded-For"])
+	assert.Equal(t, []string{"session=abc", "user=xyz"}, reqCtx.Headers["Cookie"])
+}
+
+func TestHandleRequestHeaders_NoSubsetMetadataReturnsAllPods(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, nil, req)
+	assert.NoError(t, err)
+
+	// If no metadata is present on fullReq, all pods should be candidates
+	assert.Len(t, reqCtx.Candidates, 2)
+	assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, []string{reqCtx.Candidates[0].Address, reqCtx.Candidates[1].Address})
+}
+
+func TestHandleRequestHeaders_MetadataNamespaceEmptyReturnsAllPods(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	fullReq := &extProcPb.ProcessingRequest{
+		MetadataContext: &envoyCorev3.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{
+				metadata.SubsetFilterNamespace: {
+					Fields: map[string]*structpb.Value{
+						"some-other-unrelated-key": structpb.NewStringValue("val"),
+					},
+				},
+			},
+		},
+	}
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+	assert.NoError(t, err)
+
+	// If the subset key is missing from the namespace struct, all pods should be candidates
+	assert.Len(t, reqCtx.Candidates, 2)
+	assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, []string{reqCtx.Candidates[0].Address, reqCtx.Candidates[1].Address})
+}
+
+func TestHandleRequestHeaders_SubsetFilterEmptyReturnsNoPods(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	fullReq := &extProcPb.ProcessingRequest{
+		MetadataContext: &envoyCorev3.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{
+				metadata.SubsetFilterNamespace: {
+					Fields: map[string]*structpb.Value{
+						metadata.SubsetFilterKey: structpb.NewListValue(&structpb.ListValue{
+							Values: []*structpb.Value{},
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+	assert.NoError(t, err)
+
+	// If the subset list is present but empty, it must strictly restrict candidates to empty (fail closed to 503)
+	assert.Empty(t, reqCtx.Candidates)
+}
+
+func TestHandleRequestHeaders_StringMetadataMalformedWhitespaceTrimming(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+		{Address: "10.0.0.3", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	fullReq := &extProcPb.ProcessingRequest{
+		MetadataContext: &envoyCorev3.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{
+				metadata.SubsetFilterNamespace: {
+					Fields: map[string]*structpb.Value{
+						metadata.SubsetFilterKey: structpb.NewStringValue("  10.0.0.2:8080 ,  ,  10.0.0.3:8080  "),
+					},
+				},
+			},
+		},
+	}
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+	assert.NoError(t, err)
+
+	// Trimmed string should result only in pods 2 and 3
+	assert.Len(t, reqCtx.Candidates, 2)
+	assert.ElementsMatch(t, []string{"10.0.0.2", "10.0.0.3"}, []string{reqCtx.Candidates[0].Address, reqCtx.Candidates[1].Address})
+}
+
+func TestHandleRequestHeaders_StringMetadataNoMatchesReturnsNoPods(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	fullReq := &extProcPb.ProcessingRequest{
+		MetadataContext: &envoyCorev3.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{
+				metadata.SubsetFilterNamespace: {
+					Fields: map[string]*structpb.Value{
+						metadata.SubsetFilterKey: structpb.NewStringValue("192.168.1.1:8080"), // No match
+					},
+				},
+			},
+		},
+	}
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+	assert.NoError(t, err)
+
+	// If no pods match a subset filter, it must strictly return zero candidates (fail closed to 503)
+	assert.Empty(t, reqCtx.Candidates)
+}
+
+func TestHandleRequestHeaders_MixedArrayAndCommaStringElements(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.2", Port: "8080"},
+		{Address: "10.0.0.3", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	fullReq := &extProcPb.ProcessingRequest{
+		MetadataContext: &envoyCorev3.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{
+				metadata.SubsetFilterNamespace: {
+					Fields: map[string]*structpb.Value{
+						metadata.SubsetFilterKey: structpb.NewListValue(&structpb.ListValue{
+							Values: []*structpb.Value{
+								structpb.NewStringValue("10.0.0.2:8080, 10.0.0.3:8080"), // Mixed format inside list element
+							},
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	req := &extProcPb.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &extProcPb.HttpHeaders{
+			Headers: &envoyCorev3.HeaderMap{},
+		},
+	}
+
+	reqCtx := &RequestContext{}
+	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+	assert.NoError(t, err)
+
+	// Mixed comma element inside list should be correctly resolved to pods 2 and 3
+	assert.Len(t, reqCtx.Candidates, 2)
+	assert.ElementsMatch(t, []string{"10.0.0.2", "10.0.0.3"}, []string{reqCtx.Candidates[0].Address, reqCtx.Candidates[1].Address})
 }

--- a/pkg/lwepp/handlers/server.go
+++ b/pkg/lwepp/handlers/server.go
@@ -57,11 +57,13 @@ type StreamingServer struct {
 type RequestContext struct {
 	TargetEndpoint string
 	SelectedPodIP  string
+	Candidates     []*datastore.Endpoint
+	Headers        map[string][]string
 }
 
 // PickRequest contains metadata from the incoming request to guide endpoint selection.
 type PickRequest struct {
-	Headers map[string]string
+	Headers map[string][]string
 	Body    []byte
 	Model   string
 }
@@ -98,6 +100,8 @@ func (p *RoundRobinPicker) Pick(ctx context.Context, req *PickRequest, endpoints
 	}, nil
 }
 
+const maxRequestBodySize = 10 * 1024 * 1024 // 10MB
+
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	ctx := srv.Context()
 	logger := ctrl.Log.WithName("ext-proc")
@@ -105,6 +109,9 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 	logger.Info("Processing new stream")
 
 	reqCtx := &RequestContext{}
+	var body []byte
+	var err error
+	headersDeferred := false
 
 	for {
 		select {
@@ -124,52 +131,121 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
 			logger.Info("Received request headers")
-			err := s.handleRequestHeaders(ctx, reqCtx, req, v)
+			err = s.handleRequestHeaders(ctx, reqCtx, req, v)
 			if err != nil {
 				logger.Error(err, "Failed to handle request headers")
 				return status.Errorf(codes.Internal, "internal error: %v", err)
 			}
 
-			resp := &extProcPb.ProcessingResponse{
-				Response: &extProcPb.ProcessingResponse_RequestHeaders{
-					RequestHeaders: &extProcPb.HeadersResponse{
-						Response: &extProcPb.CommonResponse{
-							ClearRouteCache: true,
-							HeaderMutation: &extProcPb.HeaderMutation{
-								SetHeaders: []*configPb.HeaderValueOption{
-									{
-										Header: &configPb.HeaderValue{
-											Key:      metadata.DestinationEndpointKey,
-											RawValue: []byte(reqCtx.TargetEndpoint),
+			var resp *extProcPb.ProcessingResponse
+			if v.RequestHeaders.EndOfStream {
+				err = s.pickEndpoint(ctx, reqCtx, nil)
+				if err != nil {
+					logger.Error(err, "Failed to pick endpoint")
+					return status.Errorf(codes.Internal, "internal error: %v", err)
+				}
+
+				resp = &extProcPb.ProcessingResponse{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								ClearRouteCache: true,
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*configPb.HeaderValueOption{
+										{
+											Header: &configPb.HeaderValue{
+												Key:      metadata.DestinationEndpointKey,
+												RawValue: []byte(reqCtx.TargetEndpoint),
+											},
 										},
-									},
-									{
-										Header: &configPb.HeaderValue{
-											Key:      "X-Echo-Set-Header",
-											RawValue: []byte(metadata.ConformanceTestResultHeader + ":" + reqCtx.TargetEndpoint),
+										{
+											Header: &configPb.HeaderValue{
+												Key:      "X-Echo-Set-Header",
+												RawValue: []byte(metadata.ConformanceTestResultHeader + ":" + reqCtx.TargetEndpoint),
+											},
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-				DynamicMetadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						metadata.DestinationEndpointNamespace: structpb.NewStructValue(&structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								metadata.DestinationEndpointKey: structpb.NewStringValue(reqCtx.TargetEndpoint),
-							},
-						}),
+					DynamicMetadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							metadata.DestinationEndpointNamespace: structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									metadata.DestinationEndpointKey: structpb.NewStringValue(reqCtx.TargetEndpoint),
+								},
+							}),
+						},
 					},
-				},
+				}
+			} else {
+				headersDeferred = true
 			}
-			if err := srv.Send(resp); err != nil {
-				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
+
+			if resp != nil {
+				if err := srv.Send(resp); err != nil {
+					return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
+				}
 			}
 
 		case *extProcPb.ProcessingRequest_RequestBody:
 			logger.V(1).Info("Received request body", "endOfStream", v.RequestBody.EndOfStream)
+			if len(body)+len(v.RequestBody.Body) > maxRequestBodySize {
+				logger.Error(nil, "Request body size limit exceeded", "limit", maxRequestBodySize, "currentSize", len(body))
+				return status.Errorf(codes.ResourceExhausted, "request body size limit of %d bytes exceeded", maxRequestBodySize)
+			}
+			body = append(body, v.RequestBody.Body...)
+
+			if v.RequestBody.EndOfStream {
+				err = s.pickEndpoint(ctx, reqCtx, body)
+				if err != nil {
+					logger.Error(err, "Failed to pick endpoint")
+					return status.Errorf(codes.Internal, "internal error: %v", err)
+				}
+				body = nil
+
+				if headersDeferred {
+					headerResp := &extProcPb.ProcessingResponse{
+						Response: &extProcPb.ProcessingResponse_RequestHeaders{
+							RequestHeaders: &extProcPb.HeadersResponse{
+								Response: &extProcPb.CommonResponse{
+									ClearRouteCache: true,
+									HeaderMutation: &extProcPb.HeaderMutation{
+										SetHeaders: []*configPb.HeaderValueOption{
+											{
+												Header: &configPb.HeaderValue{
+													Key:      metadata.DestinationEndpointKey,
+													RawValue: []byte(reqCtx.TargetEndpoint),
+												},
+											},
+											{
+												Header: &configPb.HeaderValue{
+													Key:      "X-Echo-Set-Header",
+													RawValue: []byte(metadata.ConformanceTestResultHeader + ":" + reqCtx.TargetEndpoint),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						DynamicMetadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								metadata.DestinationEndpointNamespace: structpb.NewStructValue(&structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										metadata.DestinationEndpointKey: structpb.NewStringValue(reqCtx.TargetEndpoint),
+									},
+								}),
+							},
+						},
+					}
+					if err := srv.Send(headerResp); err != nil {
+						return status.Errorf(codes.Unknown, "failed to send deferred headers response back to Envoy: %v", err)
+					}
+				}
+			}
+
 			resp := &extProcPb.ProcessingResponse{
 				Response: &extProcPb.ProcessingResponse_RequestBody{
 					RequestBody: &extProcPb.BodyResponse{
@@ -177,6 +253,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					},
 				},
 			}
+
 			if err := srv.Send(resp); err != nil {
 				return status.Errorf(codes.Unknown, "failed to send body response back to Envoy: %v", err)
 			}

--- a/pkg/lwepp/handlers/server_test.go
+++ b/pkg/lwepp/handlers/server_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/datastore"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/metadata"
+)
+
+type mockProcessServer struct {
+	grpc.ServerStream
+	ctx          context.Context
+	sentMessages []*extProcPb.ProcessingResponse
+	recvMessages []*extProcPb.ProcessingRequest
+	recvIndex    int
+}
+
+func (m *mockProcessServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockProcessServer) Send(resp *extProcPb.ProcessingResponse) error {
+	m.sentMessages = append(m.sentMessages, resp)
+	return nil
+}
+
+func (m *mockProcessServer) Recv() (*extProcPb.ProcessingRequest, error) {
+	if m.recvIndex >= len(m.recvMessages) {
+		return nil, io.EOF
+	}
+	msg := m.recvMessages[m.recvIndex]
+	m.recvIndex++
+	return msg, nil
+}
+
+func TestProcess_DeferredHeaderMutationOnStreamingBody(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	// Construct a standard Envoy request stream:
+	// 1. Request headers (with EndOfStream = false)
+	// 2. Request body (with EndOfStream = true)
+	reqHeaders := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &envoyCorev3.HeaderMap{
+					Headers: []*envoyCorev3.HeaderValue{
+						{Key: "test-epp-endpoint-selection", Value: "10.0.0.1"},
+					},
+				},
+				EndOfStream: false,
+			},
+		},
+	}
+
+	reqBody := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"prompt": "hello"}`),
+				EndOfStream: true,
+			},
+		},
+	}
+
+	stream := &mockProcessServer{
+		ctx:          context.Background(),
+		recvMessages: []*extProcPb.ProcessingRequest{reqHeaders, reqBody},
+	}
+
+	err := server.Process(stream)
+	assert.NoError(t, err)
+
+	// Assertions on the sequence of sent responses:
+	// - We expect exactly 2 responses sent back.
+	// - Response 1: The DEFERRED RequestHeaders response containing the target routing mutation headers.
+	// - Response 2: The RequestBody response containing a simple empty body ack.
+	require := assert.New(t)
+	if require.Len(stream.sentMessages, 2) {
+		// Response 1: RequestHeaders Response
+		firstResp := stream.sentMessages[0].GetRequestHeaders()
+		require.NotNil(firstResp, "First response must be a RequestHeaders frame")
+
+		setHeaders := firstResp.GetResponse().GetHeaderMutation().GetSetHeaders()
+		require.Len(setHeaders, 2)
+		assert.Equal(t, metadata.DestinationEndpointKey, setHeaders[0].GetHeader().GetKey())
+		assert.Equal(t, "10.0.0.1:8080", string(setHeaders[0].GetHeader().GetRawValue()))
+		assert.Equal(t, "X-Echo-Set-Header", setHeaders[1].GetHeader().GetKey())
+		assert.Equal(t, metadata.ConformanceTestResultHeader+":10.0.0.1:8080", string(setHeaders[1].GetHeader().GetRawValue()))
+
+		// Response 2: RequestBody Response (Ack)
+		secondResp := stream.sentMessages[1].GetRequestBody()
+		require.NotNil(secondResp, "Second response must be a RequestBody ack frame")
+		require.Nil(secondResp.GetResponse().GetHeaderMutation(), "Deferred body response must not contain redundant mutations")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR enables the body of the request to be considered in routing:

It defers calling `pickEndpoint` (which invokes the picker) until the end of the request stream. If a request body exists, it accumulates the body chunks and passes the complete body slice into `PickRequest{Body: body}`.

It then returns the selected endpoint and dynamic metadata to Envoy during the request body end-of-stream phase rather than the headers phase.

**Which issue(s) this PR fixes**:

Fixes #2934 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
