### PR TITLE
BUGFIX: Failing e2e test --  bypass llm-d render server 

### DIFF
--- a/config/manifests/vllm/sim-deployment.yaml
+++ b/config/manifests/vllm/sim-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: Always
         args:
         - --model
-        - Qwen/Qwen3-32B
+        - dummy-model-name
         - --port
         - "8000"
         - --max-loras


### PR DESCRIPTION


**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
The E2E tests currently time out while waiting for the model server pods to become Ready.

The `llm-d-inference-sim` container seems to be expecting to communicate with a "render server" (a Python tokenization sidecar?) on port 8082 to initialize its dataset for the `Qwen/Qwen3-32B model`. Because this sidecar does not exist in the manifest, the simulator gets connection refused and enters a `CrashLoopBackOff`. This requirement is the result of a recent upstream architectural change.

Swapping out the real Qwen model name for a dummy model name forces the simulator into its native "Simulated Mode," bypassing the external render server requirement. The E2E tests now pass successfully.

**This change should be discussed to make sure that it isn't just a hack.**

**Which issue(s) this PR fixes**:
Fixes #2952

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
