### PR TITLE
Fix GatewayFollowingEPPRoutingWithDataParallelism Test Failure

### DIFF
--- a/pkg/lwepp/handlers/request.go
+++ b/pkg/lwepp/handlers/request.go
@@ -104,20 +104,28 @@ func (s *StreamingServer) handleRequestHeaders(ctx context.Context, reqCtx *Requ
 
 	var candidates []*datastore.Endpoint
 	if hasSubsetFilter || len(filterEndpoints) > 0 {
-		// Build a set of IP addresses from the filter list. Filter entries may be
-		// "ip" or "ip:port"; we match only on the IP portion.
-		allowedIPs := make(map[string]struct{}, len(filterEndpoints))
+		// Map of IP -> set of allowed ports. If an IP exists in allowAllPorts, then all ports are allowed.
+		allowedPorts := make(map[string]map[string]struct{})
+		allowAllPorts := make(map[string]bool)
 		for _, ep := range filterEndpoints {
 			ep = strings.TrimSpace(ep)
-			if host, _, err := net.SplitHostPort(ep); err == nil {
-				allowedIPs[host] = struct{}{}
+			if host, port, err := net.SplitHostPort(ep); err == nil {
+				if _, ok := allowedPorts[host]; !ok {
+					allowedPorts[host] = make(map[string]struct{})
+				}
+				allowedPorts[host][port] = struct{}{}
 			} else {
-				allowedIPs[ep] = struct{}{}
+				allowAllPorts[ep] = true
 			}
 		}
+
 		for _, pod := range allPods {
-			if _, ok := allowedIPs[pod.Address]; ok {
+			if allowAllPorts[pod.Address] {
 				candidates = append(candidates, pod)
+			} else if ports, ok := allowedPorts[pod.Address]; ok {
+				if _, ok := ports[pod.Port]; ok {
+					candidates = append(candidates, pod)
+				}
 			}
 		}
 		// If a subset filter was explicitly set, we must strictly respect it. If no pods match,

--- a/pkg/lwepp/handlers/request_test.go
+++ b/pkg/lwepp/handlers/request_test.go
@@ -477,3 +477,75 @@ func TestHandleRequestHeaders_MixedArrayAndCommaStringElements(t *testing.T) {
 	assert.Len(t, reqCtx.Candidates, 2)
 	assert.ElementsMatch(t, []string{"10.0.0.2", "10.0.0.3"}, []string{reqCtx.Candidates[0].Address, reqCtx.Candidates[1].Address})
 }
+
+func TestHandleRequestHeaders_PortAwareFiltering(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+		{Address: "10.0.0.1", Port: "9090"},
+		{Address: "10.0.0.2", Port: "8080"},
+		{Address: "10.0.0.2", Port: "9090"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	tests := []struct {
+		name               string
+		filterValue        string
+		expectedCandidates []*datastore.Endpoint
+	}{
+		{
+			name:        "Match specific port only",
+			filterValue: "10.0.0.1:8080",
+			expectedCandidates: []*datastore.Endpoint{
+				{Address: "10.0.0.1", Port: "8080"},
+			},
+		},
+		{
+			name:        "Match all ports for IP when no port specified",
+			filterValue: "10.0.0.1",
+			expectedCandidates: []*datastore.Endpoint{
+				{Address: "10.0.0.1", Port: "8080"},
+				{Address: "10.0.0.1", Port: "9090"},
+			},
+		},
+		{
+			name:        "Mix of IP:Port and IP-only filters",
+			filterValue: "10.0.0.1:8080,10.0.0.2",
+			expectedCandidates: []*datastore.Endpoint{
+				{Address: "10.0.0.1", Port: "8080"},
+				{Address: "10.0.0.2", Port: "8080"},
+				{Address: "10.0.0.2", Port: "9090"},
+			},
+		},
+		{
+			name:               "No matching ports for the filtered IP",
+			filterValue:        "10.0.0.1:3000",
+			expectedCandidates: []*datastore.Endpoint{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fullReq := &extProcPb.ProcessingRequest{
+				MetadataContext: &envoyCorev3.Metadata{
+					FilterMetadata: map[string]*structpb.Struct{
+						metadata.SubsetFilterNamespace: {
+							Fields: map[string]*structpb.Value{
+								metadata.SubsetFilterKey: structpb.NewStringValue(tc.filterValue),
+							},
+						},
+					},
+				},
+			}
+			req := &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{
+					Headers: &envoyCorev3.HeaderMap{},
+				},
+			}
+			reqCtx := &RequestContext{}
+			err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedCandidates, reqCtx.Candidates)
+		})
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/kind cleanup
/kind failing-test
/area conformance-test

**What this PR does / why we need it**:
This PR fixes a bug that causes the GatewayFollowingEPPRoutingWithDataParallelism conformance test to fail. A recent change broke this test.

**Which issue(s) this PR fixes**:

Fixes #2962 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
