### PR TITLE
fix appProtocol H2C readiness probe and GKE load balancer health check

### DIFF
--- a/conformance/resources/base.yaml
+++ b/conformance/resources/base.yaml
@@ -164,11 +164,10 @@ spec:
         app: appprotocol-inference-model-server
     spec:
       containers:
-      - name: echoserver
+      - name: echoserver-http
         image: gcr.io/k8s-staging-gateway-api/echo-basic:v20251106-v1.3.0-263-g47c3435c
         ports:
         - containerPort: 3000
-        - containerPort: 3001
         readinessProbe:
           httpGet:
             path: /
@@ -179,6 +178,33 @@ spec:
         env:
         - name: HTTP_PORT
           value: "3000"
+        - name: H2C_PORT
+          value: "3002"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      - name: echoserver-h2c
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20251106-v1.3.0-263-g47c3435c
+        ports:
+        - containerPort: 3001
+        readinessProbe:
+          tcpSocket:
+            port: 3001
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 2
+        env:
+        - name: HTTP_PORT
+          value: "3003"
         - name: H2C_PORT
           value: "3001"
         - name: POD_NAME
@@ -841,3 +867,21 @@ roleRef:
   kind: Role
   name: inference-model-reader
   apiGroup: rbac.authorization.k8s.io
+
+---
+# --- H2C Pool HealthCheckPolicy ---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: appprotocol-h2c-health-check
+  namespace: inference-conformance-app-backend
+spec:
+  targetRef:
+    group: inference.networking.k8s.io
+    kind: InferencePool
+    name: appprotocol-h2c-inference-pool
+  default:
+    config:
+      type: TCP
+      tcpHealthCheck:
+        port: 3001


### PR DESCRIPTION

**What type of PR is this?**
Add one of the following kinds:
/kind bug
/kind cleanup
/kind failing-test
/area conformance-test

**What this PR does / why we need it**:
The `InferencePoolAppProtocol` conformance test suite was failing and timing out due to three network and port-binding issues in the mock backend model server:

1. **K8s Readiness Probe Protocol Mismatch**: Default k8s `httpGet` readiness probe (HTTP/1.1) was configured against the H2C container on port 3001 (HTTP/2). The kubelet prober doesn't support cleartext HTTP/2. The probe then fails -> pod stuck `Not Ready`.
2. **Container Port Collision**: The standard conformance test image (`echo-basic`) starts an HTTP and `h2c` listener. When running HTTP and H2C `echoserver`s in the same pod, both defaulted their HTTP listener to port 3000. Thus there was a collision on port 3000 which caused H2C container to crash on startup.
3. **GKE Load Balancer Health Check Failure**" GKE attempts to infer health by readiness. But when handling cleartext H2C backends, auto-inference can default to HTTP/1.1 checks which fail on the h2c-only ports, causing GKE load balancer to mark backends as unhealthy and block traffic. 
 
**Solution**

1. **Split the mock deployment** into two: `echoserver-http` which serves HTTP/1.1 on port 3000 with `httpGet` readiness probes and `echoserver-h2c` which serves cleartext HTTP/2 `h2c` on port 3001 with a `tcpSocket` readiness probe.
2. **Prevent port bind conflict** by specifying a port 3003 to guide unused HTTP listener away from 3000. Port 3003 is not exposed.
3. **Configure GKE Load Balancer Health Check** Added a `HealthCheckPolicy` targeting the h2c inference pool to override default health checking and force simple TCP check on port 3001.

Note that `tcpSocket` probes were chosen over `httpGet` to avoid having to run a secondary HTTP/1.1 endpoint on a separate port just to handle health checks. Choosing a `tcpSocket` probe directly on port 3001 is more lightweight.

**Note:** This test was executed against the upstream `base.yaml` designed for EPP AND the latest development version of the LWEPP image.

**Which issue(s) this PR fixes**:
Fixes #2965 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
