### PR TITLE
docs: use production inference extension images

### DIFF
--- a/site-src/_includes/epp-latest.md
+++ b/site-src/_includes/epp-latest.md
@@ -10,7 +10,7 @@
       --set inferencePool.modelServerProtocol=${MODEL_SERVER_PROTOCOL} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```
 
 === "Istio"
@@ -24,7 +24,7 @@
       --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```
 
 === "Agentgateway"
@@ -38,7 +38,7 @@
       --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```
 
 === "NGINX Gateway Fabric"
@@ -52,5 +52,5 @@
       --set inferencePool.modelServerType=${MODEL_SERVER} \
       --set experimentalHttpRoute.enabled=true \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```

--- a/site-src/guides/getting-started-latest.md
+++ b/site-src/guides/getting-started-latest.md
@@ -235,7 +235,7 @@ You should see output listing the inference-related CRDs.
    Set the chart version and then select a tab to follow the provider-specific instructions.
 
    ```bash
-   export IGW_CHART_VERSION=v0
+   export IGW_CHART_VERSION=v1.5.0
    ```
 
 --8<-- "site-src/_includes/epp-latest.md"

--- a/site-src/guides/serving-multiple-inference-pools-latest.md
+++ b/site-src/guides/serving-multiple-inference-pools-latest.md
@@ -20,7 +20,7 @@ The BBR extracts the model name from the request body, does a lookup of the base
 ### Deploy Body-Based Routing Extension
 
    ```bash
-   export CHART_VERSION=v0
+   export CHART_VERSION=v1.5.0
    ```
 
 === "GKE"
@@ -30,7 +30,7 @@ The BBR extracts the model name from the request body, does a lookup of the base
       helm install body-based-router \
       --set provider.name=$GATEWAY_PROVIDER \
       --version $CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/body-based-routing
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
       ```
 
 === "Istio"
@@ -40,7 +40,7 @@ The BBR extracts the model name from the request body, does a lookup of the base
       helm install body-based-router \
       --set provider.name=$GATEWAY_PROVIDER \
       --version $CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/body-based-routing
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
       ```
 
 === "Agentgateway"
@@ -75,7 +75,7 @@ The BBR extracts the model name from the request body, does a lookup of the base
       ```bash
       helm install body-based-router \
       --version $CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/body-based-routing
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
       ```
 
 ### Serving a Second Model Server
@@ -97,7 +97,7 @@ base model that should be associated with the `InferencePool`.
 Set the Helm chart version (unless already set).
 
    ```bash
-   export IGW_CHART_VERSION=v0
+   export IGW_CHART_VERSION=v1.5.0
    ```
 
 === "GKE"
@@ -111,7 +111,7 @@ Set the Helm chart version (unless already set).
       --set experimentalHttpRoute.enabled=true \
       --set experimentalHttpRoute.baseModel=deepseek/DeepSeek-r1 \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```
 
 === "Istio"
@@ -125,7 +125,7 @@ Set the Helm chart version (unless already set).
       --set experimentalHttpRoute.enabled=true \
       --set experimentalHttpRoute.baseModel=deepseek/DeepSeek-r1 \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```
 
 === "Agentgateway"
@@ -139,7 +139,7 @@ Set the Helm chart version (unless already set).
     --set experimentalHttpRoute.enabled=true \
     --set experimentalHttpRoute.baseModel=deepseek/DeepSeek-r1 \
     --version $IGW_CHART_VERSION \
-    oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+    oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     ```
 
 === "Other"
@@ -151,7 +151,7 @@ Set the Helm chart version (unless already set).
       --set experimentalHttpRoute.enabled=true \
       --set experimentalHttpRoute.baseModel=deepseek/DeepSeek-r1 \
       --version $IGW_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
       ```
 
 After the installation, verify that you have two `InferencePools` and two EPP pods, one per base model type, running without errors
@@ -178,7 +178,7 @@ Run `helm upgrade` in order to update in place the HttpRoute mapping of the firs
 
       ```bash
       export GATEWAY_PROVIDER=gke
-      helm upgrade vllm-qwen3-32b oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+      helm upgrade vllm-qwen3-32b oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
       --set provider.name=$GATEWAY_PROVIDER \
@@ -191,7 +191,7 @@ Run `helm upgrade` in order to update in place the HttpRoute mapping of the firs
 
       ```bash
       export GATEWAY_PROVIDER=istio
-      helm upgrade vllm-qwen3-32b oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+      helm upgrade vllm-qwen3-32b oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
       --set provider.name=$GATEWAY_PROVIDER \
@@ -204,7 +204,7 @@ Run `helm upgrade` in order to update in place the HttpRoute mapping of the firs
 
       ```bash
       export GATEWAY_PROVIDER=none
-      helm upgrade vllm-qwen3-32b oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+      helm upgrade vllm-qwen3-32b oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
       --set provider.name=$GATEWAY_PROVIDER \
@@ -216,7 +216,7 @@ Run `helm upgrade` in order to update in place the HttpRoute mapping of the firs
 === "Other"
 
       ```bash
-      helm upgrade vllm-qwen3-32b oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+      helm upgrade vllm-qwen3-32b oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
       --set experimentalHttpRoute.enabled=true \

--- a/site-src/guides/standalone.md
+++ b/site-src/guides/standalone.md
@@ -78,14 +78,14 @@ Choose one of the following proxy options to deploy an Endpoint Picker Extension
       # Install the Inference Extension CRDs
       kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
 
-      export STANDALONE_CHART_VERSION=v0
+      export STANDALONE_CHART_VERSION=v1.5.0
       export PROVIDER=<YOUR_PROVIDER> # optional, can be gke if you need GKE-specific monitoring resources
       helm install vllm-qwen3-32b-standalone \
       --dependency-update \
       --set inferencePool.modelServers.matchLabels.app=vllm-qwen3-32b \
       --set provider.name=$PROVIDER \
       --version $STANDALONE_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone
       ```
 
       **Without Inference APIs Support**
@@ -95,7 +95,7 @@ Choose one of the following proxy options to deploy an Endpoint Picker Extension
       along with provider-specific resources.
 
       ```bash
-      export STANDALONE_CHART_VERSION=v0
+      export STANDALONE_CHART_VERSION=v1.5.0
       export PROVIDER=<YOUR_PROVIDER> # optional, can be gke if you need GKE-specific monitoring resources
       helm install vllm-qwen3-32b-standalone \
       --dependency-update \
@@ -103,7 +103,7 @@ Choose one of the following proxy options to deploy an Endpoint Picker Extension
       --set inferenceExtension.endpointsServer.createInferencePool=false \
       --set provider.name=$PROVIDER \
       --version $STANDALONE_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone
       ```
 
 === "Agentgateway"
@@ -119,7 +119,7 @@ Choose one of the following proxy options to deploy an Endpoint Picker Extension
       Example install:
 
       ```bash
-      export STANDALONE_CHART_VERSION=v0
+      export STANDALONE_CHART_VERSION=v1.5.0
       export PROVIDER=<YOUR_PROVIDER> # optional, can be gke if you need GKE-specific monitoring resources
       helm install vllm-qwen3-32b-standalone \
       --dependency-update \
@@ -129,7 +129,7 @@ Choose one of the following proxy options to deploy an Endpoint Picker Extension
       --set-string inferenceExtension.flags.secure-serving=false \
       --set provider.name=$PROVIDER \
       --version $STANDALONE_CHART_VERSION \
-      oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/standalone
+      oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone
       ```
 
 #### Try it out

--- a/site-src/performance/regression-testing/index.md
+++ b/site-src/performance/regression-testing/index.md
@@ -119,9 +119,9 @@ To catch regressions early, we run a fully automated benchmark suite every night
 
 - The benchmarking runs are triggered every 6 hours.
 - It provisions a GKE cluster with several NVIDIA H100 (80 GB) GPUs, deploys N vLLM server replicas along with the latest Gateway API extension and monitoring manifests, then launches the benchmarking script.
-- In the step above we deploy the latest Endpoint Picker from the `main` branch’s latest Docker image:
+- In the step above we deploy the latest released Endpoint Picker image:
   ```
-  us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
+  registry.k8s.io/gateway-api-inference-extension/epp:v1.5.0
   ```
 - It sequentially launches three benchmark runs (as described above) using the existing regression manifests.
 - Results are uploaded to a central GCS bucket.


### PR DESCRIPTION
## Summary
- Replace staging Artifact Registry chart references in the latest docs with production `registry.k8s.io` chart paths.
- Pin the example chart/image versions to the current released tag, `v1.5.0`, instead of the dev placeholders `v0` / `main`.
- Update the regression testing example to use the released EPP image path.

## Validation
- `rg -n "us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension|k8s-staging-images/gateway-api-inference-extension|export (IGW_CHART_VERSION|CHART_VERSION|STANDALONE_CHART_VERSION)=v0" site-src --glob '!*.ipynb' -S` returned no matches.
- `git diff --check`
- Confirmed the latest production GitHub Release is `v1.5.0` via `gh release list --repo kubernetes-sigs/gateway-api-inference-extension --limit 3`.
- `helm version --short` could not be run locally because Helm is not installed on this Windows PATH.

Addresses kubernetes-sigs/gateway-api#4580.

```release-note
NONE
```