### PR TITLE
docs: use tagged agentgateway manifest

### DIFF
--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -181,18 +181,7 @@ You should see output listing the inference-related CRDs.
       1. Deploy the Inference Gateway:
 
          ```bash
-         cat <<'EOF' | kubectl apply -f -
-         apiVersion: gateway.networking.k8s.io/v1
-         kind: Gateway
-         metadata:
-           name: inference-gateway
-         spec:
-           gatewayClassName: agentgateway
-           listeners:
-           - name: http
-             port: 80
-             protocol: HTTP
-         EOF
+         kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/tags/${IGW_LATEST_RELEASE}/config/manifests/gateway/agentgateway/gateway.yaml
          ```
 
       1. Confirm that the Gateway was assigned an IP address and reports a `Programmed=True` status:


### PR DESCRIPTION
## Summary
- Replace the inline Agentgateway `Gateway` YAML in the released quickstart with the tagged release manifest URL.
- Keep the Agentgateway tab consistent with the GKE, Istio, and NGINX Gateway Fabric tabs, which already apply manifests from `${IGW_LATEST_RELEASE}`.

## Validation
- `rg -n "cat <<'EOF'|gatewayClassName: agentgateway|refs/tags/\$\{IGW_LATEST_RELEASE\}/config/manifests/gateway/agentgateway/gateway.yaml" site-src/guides/index.md site-src/guides/getting-started-latest.md -S`
- `git diff --check`
- Confirmed `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/tags/v1.5.0/config/manifests/gateway/agentgateway/gateway.yaml` returns HTTP 200.

Fixes #2506.

```release-note
NONE
```