### PR TITLE
docs: prune stale gateway implementations

### DIFF
--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -1,23 +1,11 @@
 # Gateway Implementations
 
-This project has several implementations that are planned or in progress:
+This project has several conformant Gateway implementations:
 
 - [Gateway Implementations](#gateway-implementations)
-  - [Alibaba Cloud Container Service for Kubernetes](#alibaba-cloud-container-service-for-kubernetes)
-  - [Envoy AI Gateway](#envoy-ai-gateway)
-  - [Google Kubernetes Engine](#google-kubernetes-engine)
   - [Istio](#istio)
   - [Agentgateway](#agentgateway)
-  - [Kubvernor](#kubvernor)
   - [NGINX Gateway Fabric](#nginx-gateway-fabric)
-
-[1]:#alibaba-cloud-container-service-for-kubernetes
-[2]:#envoy-ai-gateway
-[3]:#google-kubernetes-engine
-[4]:#istio
-[5]:#agentgateway
-[6]:#kubvernor
-[7]:#nginx-gateway-fabric
 
 Agentgateway supports both standalone and Kubernetes deployment modes.
 
@@ -27,60 +15,6 @@ Implementations that have not submitted a successful Gateway profile report for
 the current minor release or either of the two previous minor releases may be
 removed from conformant implementation listings until they submit an accepted
 report.
-
-## Alibaba Cloud Container Service for Kubernetes
-
-[Alibaba Cloud Container Service for Kubernetes (ACK)][ack] is a managed Kubernetes platform 
-offered by Alibaba Cloud. The implementation of the Gateway API in ACK is through the 
-[ACK Gateway with Inference Extension][ack-gie] component, which introduces model-aware, 
-GPU-efficient load balancing for AI workloads beyond basic HTTP routing.
-
-The ACK Gateway with Inference Extension implements the Gateway API Inference Extension 
-and provides optimized routing for serving generative AI workloads, 
-including weighted traffic splitting, mirroring, advanced routing, etc. 
-See the docs for the [usage][ack-gie-usage].
-
-Progress towards supporting Gateway API Inference Extension is being tracked 
-by [this Issue](https://github.com/AliyunContainerService/ack-gateway-api/issues/1).
-
-[ack]:https://www.alibabacloud.com/help/en/ack
-[ack-gie]:https://www.alibabacloud.com/help/en/ack/product-overview/ack-gateway-with-inference-extension
-[ack-gie-usage]:https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/intelligent-routing-and-traffic-management-with-ack-gateway-inference-extension
-
-## Envoy AI Gateway
-
-[Envoy AI Gateway][aigw-home] is an open source project built on top of 
-[Envoy][envoy-org] and [Envoy Gateway][envoy-gateway] to handle request traffic 
-from application clients to GenAI services. The features and capabilities are outlined [here][aigw-capabilities]. Use the [quickstart][aigw-quickstart] to get Envoy AI Gateway running with Gateway API in a few simple steps.
-
-Progress towards supporting this project is tracked with a [GitHub
-Issue](https://github.com/envoyproxy/ai-gateway/issues/423).
-
-[aigw-home]:https://aigateway.envoyproxy.io/
-[envoy-org]:https://github.com/envoyproxy
-[envoy-gateway]: https://gateway.envoyproxy.io/
-[aigw-capabilities]:https://aigateway.envoyproxy.io/docs/capabilities/
-[aigw-quickstart]:https://aigateway.envoyproxy.io/docs/capabilities/gateway-api-inference-extension
-
-## Google Kubernetes Engine
-
-[Google Kubernetes Engine (GKE)][gke] is a managed Kubernetes platform offered
-by Google Cloud. GKE's implementation of the Gateway API is through the [GKE
-Gateway controller][gke-gateway] which provisions Google Cloud Load Balancers
-for Pods in GKE clusters.
-
-The GKE Gateway controller supports weighted traffic splitting, mirroring,
-advanced routing, multi-cluster load balancing and more. See the docs to deploy
-[private or public Gateways][gke-gateway-deploy] and also [multi-cluster
-Gateways][gke-multi-cluster-gateway].
-
-Progress towards supporting this project is tracked with a [GitHub
-Issue](https://github.com/GoogleCloudPlatform/gke-gateway-api/issues/20).
-
-[gke]:https://cloud.google.com/kubernetes-engine
-[gke-gateway]:https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
-[gke-gateway-deploy]:https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways
-[gke-multi-cluster-gateway]:https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-multi-cluster-gateways
 
 ## Istio
 
@@ -103,13 +37,6 @@ on a local machine or server without Kubernetes, or be deployed on
 environments, or within your
 [llm-d infrastructure](https://github.com/llm-d-incubation/llm-d-infra) to
 improve accelerator (GPU) utilization for AI inference workloads.
-
-## Kubvernor
-
-[Kubvernor Rust API Gateway][krg] is an open-source, highly experimental implementation of API controller in Rust programming language. Currently, Kubvernor supports Envoy Proxy. The project aims to be as generic as possible so Kubvernor can be used to manage/deploy different gateways (Envoy, Nginx, HAProxy, etc.). See the docs for the [usage][krgu].
-
-[krg]:https://github.com/kubvernor/kubvernor
-[krgu]: https://github.com/kubvernor/kubvernor/blob/main/README.md
 
 ## NGINX Gateway Fabric
 


### PR DESCRIPTION
## Summary
- Update the gateway implementations page to describe conformant Gateway implementations instead of implementations that are planned or in progress.
- Prune implementations that do not currently have an accepted Gateway profile report in the active conformance window.
- Keep the existing conformance deprecation policy note so removed implementations can be restored after submitting an accepted report.

Fixes #2931.

## Evidence
- Issue #2931 is open, accepted, unassigned, and has no existing PR matching 2931 in body/title.
- Latest stable release checked with gh release list: v1.5.0.
- The conformance policy accepts reports from the current minor release or either of the two previous minor releases.
- Current-window Gateway profile reports present locally:
  - conformance/reports/v1.5.0/gateway/istio
  - conformance/reports/v1.4.0/gateway/agentgateway
  - conformance/reports/v1.4.0/gateway/nginx-nginx-gateway-fabric
- No v1.3.x Gateway report directory exists in conformance/reports.
- Stale page entries removed from the conformant list: ACK, Envoy AI Gateway, GKE, and Kubvernor.

## Validation
- Stale-entry rg check returned no matches for the removed implementation names and anchors.
- git diff --check
- python -m pip install --user -r hack/mkdocs/image/requirements.txt
- python -m mkdocs build passed. The build still reports existing unrelated MkDocs warnings in other pages, but no failure.