### PR TITLE
docs: correct Request Flow steps 3-4 to EPP, not inference gateway

### DIFF
--- a/site-src/index.md
+++ b/site-src/index.md
@@ -88,11 +88,11 @@ to any Gateway API users or implementers.
 2. If the request should be routed to an InferencePool, the Gateway will forward
 the request information to the endpoint selection extension for that pool.
 
-3. The inference gateway will fetch metrics from whichever portion of the InferencePool
+3. The Endpoint Picker (EPP) will fetch metrics from whichever portion of the InferencePool
 endpoints can best achieve the configured objectives. Note that this kind of
-metrics probing may happen asynchronously, depending on the inference gateway.
+metrics probing may happen asynchronously, depending on the EPP.
 
-4. The inference gateway will instruct the Gateway which endpoint the request should be
+4. The EPP will instruct the Gateway which endpoint the request should be
 routed to.
 
 5. The Gateway will route the request to the desired endpoint.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

In `site-src/index.md`, Request Flow steps 3–4 attributed metric-fetching and endpoint selection to "the inference gateway". But step 2 forwards the request to the Endpoint Picker (EPP), so it is the EPP — not a second gateway — that fetches metrics and instructs the Gateway which endpoint to use. The old wording read as if two separate gateways existed.

This PR names the correct actor:

- Step 3: "the inference gateway will fetch metrics …" → "the Endpoint Picker (EPP) will fetch metrics …" (and the async-probing note now refers to the EPP).
- Step 4: "the inference gateway will instruct the Gateway …" → "the EPP will instruct the Gateway …".

The issue suggested "Inference Scheduler / Endpoint Picker (EPP)", but "Inference Scheduler" is not defined in this doc. The doc formally defines **Endpoint Picker (EPP)**, so that canonical term is used (full form on first mention, "EPP" thereafter) to stay consistent with the document's own vocabulary.

Corrected request flow:

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant EPP as Endpoint Picker (EPP)
    participant Endpoint

    Client->>Gateway: 1. Incoming inference request
    Gateway->>Gateway: Match HTTPRoute → InferencePool
    Gateway->>EPP: 2. Forward request info to endpoint selection extension
    EPP->>EPP: 3. Fetch metrics from InferencePool endpoints (may be async)
    EPP->>Gateway: 4. Instruct Gateway which endpoint to use
    Gateway->>Endpoint: 5. Route request to selected endpoint
```

**Which issue(s) this PR fixes**:

Fixes: #2979

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

