### PR TITLE
fix: skip transfer-encoding in EPP response header sanitization [release-1.5]

### DIFF
--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -344,7 +344,8 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 				"x-backend-server":              "vllm-v0.6.3",            // should passthrough
 				metadata.ObjectiveKey:           "sensitive-objective-id", // should be stripped
 				metadata.DestinationEndpointKey: "10.2.0.5:8080",          // should be stripped
-				"content-length":                "500",                    // hould be stripped
+				"content-length":                "500",                    // should be stripped
+				"transfer-encoding":             "chunked",               // should be stripped
 			},
 		},
 	}
@@ -361,6 +362,7 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	assert.NotContains(t, gotHeaders, metadata.ObjectiveKey)
 	assert.NotContains(t, gotHeaders, metadata.DestinationEndpointKey)
 	assert.NotContains(t, gotHeaders, "content-length")
+	assert.NotContains(t, gotHeaders, "transfer-encoding")
 }
 
 func TestRewriteModelName(t *testing.T) {

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -42,7 +42,11 @@ var (
 	)
 
 	// ProtocolHeaders are managed by the proxy layer (Envoy/EPP).
-	ProtocolHeaders = sets.New("content-length")
+	// transfer-encoding is a hop-by-hop header that is invalid in HTTP/2.
+	// If the EPP copies it from the upstream response as a SetHeader mutation,
+	// Envoy may compute content-length from the first body chunk on the
+	// HTTP/2 hop, truncating streaming responses (e.g. /v1/responses SSE).
+	ProtocolHeaders = sets.New("content-length", "transfer-encoding")
 )
 
 func IsSystemOwnedHeader(key string) bool {


### PR DESCRIPTION
## What this PR does / why we need it

The EPP's `generateResponseHeaders()` copies upstream response headers back as `SetHeader` mutations. `transfer-encoding: chunked` was not in the `ProtocolHeaders` skip list, so it was copied verbatim. When the response traverses an HTTP/2 hop (e.g. from an inference cluster gateway to a public LLM gateway), `transfer-encoding` is invalid and Envoy computes `content-length` from the first body chunk — truncating streaming responses.

This was observed with `/v1/responses` streaming: the client received only `response.created` + `response.in_progress` (matching the `content-length` computed from the first body chunk) and never got `response.output_text.delta` or `response.completed`. `/v1/chat/completions` streaming was unaffected due to different timing of the `ModeOverride: STREAMED` taking effect.

## Which issue(s) this PR fixes

Fixes #2993

## What type of PR is this

/kind bug

## Testing

Added `transfer-encoding` to the existing `TestGenerateResponseHeaders_Sanitization` test case and verified it is stripped alongside `content-length`.

```bash
go test ./pkg/epp/handlers/ -run TestGenerateResponseHeaders -v
=== RUN   TestGenerateResponseHeaders_Sanitization
--- PASS: TestGenerateResponseHeaders_Sanitization (0.00s)
PASS
```

## Changelog

* Added `transfer-encoding` to `ProtocolHeaders` in `pkg/epp/util/request/headers.go` so `IsSystemOwnedHeader()` skips it, preventing the EPP from copying it back as a `SetHeader` mutation.