### PR TITLE
fix(epp): skip transfer-encoding in EPP response header sanitization

### DIFF
--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -344,7 +344,8 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 				"x-backend-server":              "vllm-v0.6.3",            // should passthrough
 				metadata.ObjectiveKey:           "sensitive-objective-id", // should be stripped
 				metadata.DestinationEndpointKey: "10.2.0.5:8080",          // should be stripped
-				"content-length":                "500",                    // hould be stripped
+				"content-length":                "500",                    // should be stripped
+				"transfer-encoding":             "chunked",                // should be stripped
 			},
 		},
 	}
@@ -361,6 +362,7 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	assert.NotContains(t, gotHeaders, metadata.ObjectiveKey)
 	assert.NotContains(t, gotHeaders, metadata.DestinationEndpointKey)
 	assert.NotContains(t, gotHeaders, "content-length")
+	assert.NotContains(t, gotHeaders, "transfer-encoding")
 }
 
 func TestRewriteModelName(t *testing.T) {

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -42,7 +42,11 @@ var (
 	)
 
 	// ProtocolHeaders are managed by the proxy layer (Envoy/EPP).
-	ProtocolHeaders = sets.New("content-length")
+	// transfer-encoding is a hop-by-hop header that is invalid in HTTP/2.
+	// If the EPP copies it from the upstream response as a SetHeader mutation,
+	// Envoy may compute content-length from the first body chunk on the
+	// HTTP/2 hop, truncating streaming responses (e.g. /v1/responses SSE).
+	ProtocolHeaders = sets.New("content-length", "transfer-encoding")
 )
 
 func IsSystemOwnedHeader(key string) bool {


### PR DESCRIPTION
## What happened

The EPP copies `transfer-encoding: chunked` from the upstream model server's response headers back as a `SetHeader` mutation via `generateResponseHeaders()`. When the response is sent over HTTP/2 (e.g., from an inference cluster gateway to a public LLM gateway), `transfer-encoding` is invalid and Envoy computes `content-length` from the first body chunk. This truncates streaming responses — the client receives only the first few SSE events (e.g., `response.created` + `response.in_progress`) and never gets `response.output_text.delta` or `response.completed`.

## What you expected to happen

`transfer-encoding` should be treated as a system-owned header (like `content-length`) and skipped by `IsSystemOwnedHeader()` so the EPP never copies it back as a `SetHeader` mutation.

## How to reproduce

1. Deploy vLLM behind an Envoy gateway with the EPP as the extProc endpoint picker
2. Place a second Envoy gateway (with the ai-gateway extProc from `envoyproxy/ai-gateway`) in front, connected over HTTP/2
3. Send a streaming request to `/v1/responses` with `stream: true`
4. Observe: only `response.created` + `response.in_progress` events arrive; `response.output_text.delta` and `response.completed` are lost
5. Check response headers: `content-length` is present with a value matching only the first two SSE events

`/v1/chat/completions` streaming works correctly because the ai-gateway extProc's `ModeOverride: STREAMED` takes effect before `content-length` is computed for that endpoint. The issue is specific to `/v1/responses` due to timing of the first body chunk arrival vs the mode override.

## Root cause

`pkg/epp/util/request/headers.go:38` — `ProtocolHeaders` only includes `content-length`:

```go
ProtocolHeaders = sets.New("content-length")
```

`transfer-encoding` is missing. The EPP's `generateResponseHeaders()` in `pkg/epp/handlers/response.go` copies all non-system-owned headers from the upstream response, including `transfer-encoding: chunked`.

## Proposed fix

Add `transfer-encoding` to `ProtocolHeaders`:

```go
ProtocolHeaders = sets.New("content-length", "transfer-encoding")
```

## Environment

- EPP version: v1.5.0
- Upstream: vLLM with `/v1/responses` streaming
- Two-hop topology: Client → public LLM gateway (Envoy + ai-gateway extProc) → inference cluster gateway (Envoy + EPP) → vLLM