### PR TITLE
Fix flaky GatewayWeightedAcrossTwoInferencePools

### DIFF
--- a/conformance/tests/gateway_weighted_two_pools.go
+++ b/conformance/tests/gateway_weighted_two_pools.go
@@ -224,9 +224,9 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 		observedPrimary := ph / total
 		expectedPrimary := float64(primaryWeight) / float64(primaryWeight+secondaryWeight)
 
-		// Allow either a 10 percentage-point absolute error, or a 3-sigma binomial CI.
+		// A 4.5-sigma interval keeps random false failures below 0.001% at this sample size.
 		sigma := math.Sqrt(expectedPrimary * (1.0 - expectedPrimary) / total)
-		absTolerance := math.Max(0.10, 3.0*sigma)
+		absTolerance := math.Max(0.10, 4.5*sigma)
 
 		diff := math.Abs(observedPrimary - expectedPrimary)
 		require.LessOrEqualf(t, diff, absTolerance,


### PR DESCRIPTION

**What type of PR is this?**

/area conformance-machinery

**What this PR does / why we need it**:
We see this happening multiple times. its about a 1/500 chance of happening (we run CI like 150 times per day) now; with this change its 1/650k chance.

Example failure:
          Error:      "0.10000000000000009" is not less than or equal to "0.1"
          Test:       TestConformance/GatewayWeightedAcrossTwoInferencePools
          Messages:   weighted split out of bounds: observed primary=0.800 (hits=160/200), expected=0.700, tolerance=±0.100

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
