### PR TITLE
fix: NewDefaultExtProcServerRunner drops GrpcHealthPort and SecureServing defaults

### DIFF
--- a/pkg/lwepp/server/runserver.go
+++ b/pkg/lwepp/server/runserver.go
@@ -68,8 +68,10 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 	}
 	return &ExtProcServerRunner{
 		GrpcPort:       opts.GRPCPort,
+		GrpcHealthPort: opts.GRPCHealthPort,
 		GKNN:           gknn,
 		HealthChecking: opts.HealthChecking,
+		SecureServing:  opts.SecureServing,
 		// Datastore can be assigned later.
 	}
 }

--- a/pkg/lwepp/server/runserver_test.go
+++ b/pkg/lwepp/server/runserver_test.go
@@ -36,3 +36,22 @@ func TestRunnable(t *testing.T) {
 		t.Error("runner returned NeedLeaderElection = true, expected false")
 	}
 }
+
+func TestNewDefaultExtProcServerRunnerAppliesOptionDefaults(t *testing.T) {
+	opts := server.NewOptions()
+	runner := server.NewDefaultExtProcServerRunner()
+
+	if runner.GrpcPort != opts.GRPCPort {
+		t.Errorf("GrpcPort = %d, want %d", runner.GrpcPort, opts.GRPCPort)
+	}
+	if runner.GrpcHealthPort != opts.GRPCHealthPort {
+		t.Errorf("GrpcHealthPort = %d, want %d", runner.GrpcHealthPort, opts.GRPCHealthPort)
+	}
+	if runner.HealthChecking != opts.HealthChecking {
+		t.Errorf("HealthChecking = %t, want %t", runner.HealthChecking, opts.HealthChecking)
+	}
+	// SecureServing defaults to true, so a runner built from the defaults must serve TLS.
+	if runner.SecureServing != opts.SecureServing {
+		t.Errorf("SecureServing = %t, want %t", runner.SecureServing, opts.SecureServing)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

`NewDefaultExtProcServerRunner` reads defaults from `NewOptions` but copies only `GrpcPort`, `GKNN` and `HealthChecking` into the returned runner. `GrpcHealthPort` and `SecureServing` are left at their zero values, so the constructor silently disagrees with the options it is built from:

- `GrpcHealthPort` becomes 0 instead of `DefaultGrpcHealthPort` (9003), so `HealthServerRunnable` binds an OS-assigned port rather than the port the liveness and readiness probes target.
- `SecureServing` becomes false instead of the documented default of true, so `AsRunnable` takes the plaintext branch and serves ext-proc without TLS.

`cmd/lwepp/main.go` populates every field explicitly and is unaffected, so no shipped binary changes behavior. The exported constructor is part of the reference surface for embedders of lwepp though, and a "default" runner that turns TLS off is a trap for them.

This copies both fields from `Options` and adds a regression test asserting the runner returned by `NewDefaultExtProcServerRunner` matches `NewOptions` for each field it derives. On the previous code the test fails with `GrpcHealthPort = 0, want 9003` and `SecureServing = false, want true`.

Verified with `make test-unit` (envtest, no cluster required): the new test is red before the change and green after, and the full unit suite passes. `gofmt -l` and `go vet` are clean.

**Which issue(s) this PR fixes**

None; found while reading the lwepp server setup path.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
