### PR TITLE
docs: add Higress v2.2.4 Gateway conformance report

### DIFF
--- a/conformance/reports/v1.4.0/gateway/higress-group-higress/README.md
+++ b/conformance/reports/v1.4.0/gateway/higress-group-higress/README.md
@@ -1,0 +1,32 @@
+# Higress
+
+[Higress](https://higress.ai/) is a cloud-native API gateway built on Istio and
+Envoy and is a CNCF project.
+
+## Table of Contents
+
+| Extension Version Tested | Profile Tested | Implementation Version | Mode | Report |
+|--------------------------|----------------|------------------------|------|--------|
+| v1.4.0 | Gateway | [v2.2.4](https://github.com/higress-group/higress/releases/tag/v2.2.4) | default | [v2.2.4 Gateway report](./v2.2.4-default-gateway-report.yaml) |
+
+## Reproduce
+
+Check out the Higress v2.2.4 release and create a Kubernetes cluster with
+Gateway API v1.5.0 standard CRDs, the InferencePool CRD from Gateway API
+Inference Extension v1.4.0, and MetalLB. Install `helm/core` with the v2.2.4
+controller, Pilot, and Gateway images and `global.enableInferenceExtension=true`.
+
+Apply `test/inference-extension/manifests/epp-tls.yaml`, then run the official
+v1.4.0 conformance suite through the Higress wrapper:
+
+```sh
+INFERENCE_EXTENSION_VERSION=v1.4.0 \
+INFERENCE_EXTENSION_SOURCE_DIR="$PWD/out/gateway-api-inference-extension-source/v1.4.0" \
+INFERENCE_EXTENSION_REPORT="$PWD/out/gateway-api-inference-extension-v1.4.0-report.yaml" \
+INFERENCE_EXTENSION_EXPECTED_PASSED=12 \
+INFERENCE_EXTENSION_CONTACT=@higress-group/maintainers \
+HIGRESS_CONFORMANCE_VERSION=v2.2.4 \
+tools/hack/run-inference-extension-conformance.sh
+```
+
+The test uses the release images referenced by the Higress v2.2.4 Helm chart.

--- a/conformance/reports/v1.4.0/gateway/higress-group-higress/v2.2.4-default-gateway-report.yaml
+++ b/conformance/reports/v1.4.0/gateway/higress-group-higress/v2.2.4-default-gateway-report.yaml
@@ -1,0 +1,23 @@
+GatewayAPIInferenceExtensionVersion: v1.4.0
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-08-14T17:27:49+08:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.5.0
+implementation:
+  contact:
+  - '@higress-group/maintainers'
+  organization: higress-group
+  project: higress
+  url: https://github.com/higress-group/higress
+  version: v2.2.4
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 0
+  name: Gateway
+  summary: Core tests succeeded.

--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -5,6 +5,7 @@ This project has several conformant Gateway implementations:
 - [Gateway Implementations](#gateway-implementations)
   - [Istio](#istio)
   - [Agentgateway](#agentgateway)
+  - [Higress](#higress)
   - [NGINX Gateway Fabric](#nginx-gateway-fabric)
 
 Agentgateway supports both standalone and Kubernetes deployment modes.
@@ -37,6 +38,16 @@ on a local machine or server without Kubernetes, or be deployed on
 environments, or within your
 [llm-d infrastructure](https://github.com/llm-d-incubation/llm-d-infra) to
 improve accelerator (GPU) utilization for AI inference workloads.
+
+## Higress
+
+[Higress](https://higress.ai/) is a cloud-native API gateway built on Istio and
+Envoy. It supports the Gateway API Inference Extension for inference-aware
+routing and provides API management and AI gateway capabilities. Higress is an
+open source [CNCF project](https://www.cncf.io/projects/higress/).
+
+Source code, documentation, and issue tracking are available in the
+[Higress repository](https://github.com/higress-group/higress).
 
 ## NGINX Gateway Fabric
 


### PR DESCRIPTION
/kind documentation
/area conformance-test

**What type of PR is this?**

Adds the generated Higress v2.2.4 Gateway API Inference Extension v1.4.0 Gateway-profile conformance report and lists Higress as a conformant Gateway implementation.

The submitted Gateway Core profile result is 12 passed, 0 failed, and 0 skipped. The report is included exactly as generated by the official v1.4.0 suite.

**Why is this PR needed?**

Higress v2.2.4 includes Gateway API Inference Extension v1.4.0 support and now has release-level conformance evidence using the canonical project identity:

- organization: `higress-group`
- project: `higress`
- URL: https://github.com/higress-group/higress

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

**Additional documentation**

The implementation README contains reproduction steps and links the exact Higress v2.2.4 release. The report SHA-256 is `79406981458f4989c8270126bd9b2a526b8e9d63e0c086ea2f5e6be9086216ca`.

**AI assistance disclosure**

OpenAI Codex assisted with running the official suite, verifying the generated report, and preparing this submission. The commit is authored and signed off by EndlessSeeker.
