### PR TITLE
Add v1.5.0 conformance report for ACK Gateway with Inference Extension

### DIFF
--- a/conformance/reports/v1.5.0/gateway/ack-gateway/README.md
+++ b/conformance/reports/v1.5.0/gateway/ack-gateway/README.md
@@ -1,0 +1,30 @@
+# ACK (AlibabaCloud Container Service for Kubernetes) Gateway with Inference Extension
+
+## Table of Contents
+
+| Extension Version Tested | Profile Tested | Implementation Version | Mode    | Report                                                                                          |
+|--------------------------|----------------|------------------------|---------|-------------------------------------------------------------------------------------------------|
+| v1.5.0                   | Gateway        | [v1.6.1-apsara.3](https://www.alibabacloud.com/help/en/cs/user-guide/gateway-with-inference-extension-overview) | default | [v1.6.1-apsara.3 default Gateway report](./v1.6.1-apsara.3-default-gateway-report.yaml)          |
+
+## Reproduce
+
+ACK Gateway with Inference Extension conformance report can be reproduced by the following steps.
+
+1. Create an ACK managed cluster following [guide](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/create-an-ack-managed-cluster-2/).
+
+2. Install ACK Gateway with Inference Extension at version **v1.6.1-apsara.3** following Step 2 in [documentation](https://www.alibabacloud.com/help/en/cs/user-guide/intelligent-routing-and-traffic-management-with-ack-gateway-inference-extension).
+
+3. Run the following command from within the [Gateway API inference extension repo](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/v1.5.0).
+
+    ```
+    go test -timeout 45m ./conformance -v -args \
+        --gateway-class=ack-gateway \
+        --conformance-profiles=Gateway \
+        --organization=AlibabaCloud \
+        --project=ack-gateway-with-inference-extension \
+        --url=https://www.alibabacloud.com/help/en/cs/user-guide/gateway-with-inference-extension-overview \
+        --version=v1.6.1-apsara.3 \
+        --contact=https://smartservice.console.aliyun.com/service/create-ticket \
+        --allow-crds-mismatch \
+        --report-output="/path/to/report"
+    ```

--- a/conformance/reports/v1.5.0/gateway/ack-gateway/v1.6.1-apsara.3-default-gateway-report.yaml
+++ b/conformance/reports/v1.5.0/gateway/ack-gateway/v1.6.1-apsara.3-default-gateway-report.yaml
@@ -1,0 +1,23 @@
+GatewayAPIInferenceExtensionVersion: v1.5.0
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-07-24T13:11:03+08:00"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.5.0
+implementation:
+  contact:
+  - https://smartservice.console.aliyun.com/service/create-ticket
+  organization: AlibabaCloud
+  project: ack-gateway-with-inference-extension
+  url: https://www.alibabacloud.com/help/en/cs/user-guide/gateway-with-inference-extension-overview
+  version: v1.6.1-apsara.3
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 13
+      Skipped: 0
+  name: Gateway
+  summary: Core tests succeeded.

--- a/site-src/implementations/gateways.md
+++ b/site-src/implementations/gateways.md
@@ -3,6 +3,7 @@
 This project has several conformant Gateway implementations:
 
 - [Gateway Implementations](#gateway-implementations)
+  - [Alibaba Cloud Container Service for Kubernetes](#alibaba-cloud-container-service-for-kubernetes)
   - [Istio](#istio)
   - [Agentgateway](#agentgateway)
   - [NGINX Gateway Fabric](#nginx-gateway-fabric)
@@ -15,6 +16,26 @@ Implementations that have not submitted a successful Gateway profile report for
 the current minor release or either of the two previous minor releases may be
 removed from conformant implementation listings until they submit an accepted
 report.
+
+## Alibaba Cloud Container Service for Kubernetes
+
+[Alibaba Cloud Container Service for Kubernetes (ACK)][ack] is a managed Kubernetes platform 
+offered by Alibaba Cloud. The implementation of the Gateway API in ACK is through the 
+[ACK Gateway with Inference Extension][ack-gie] component, which introduces model-aware, 
+GPU-efficient load balancing for AI workloads beyond basic HTTP routing.
+
+The ACK Gateway with Inference Extension implements the Gateway API Inference Extension 
+and provides optimized routing for serving generative AI workloads, 
+including weighted traffic splitting, mirroring, advanced routing, etc. 
+See the docs for the [usage][ack-gie-usage].
+
+ACK Gateway with Inference Extension v1.6.1-apsara.3 passes the Gateway profile for
+Gateway API Inference Extension v1.5.0. See the [conformance report][ack-gie-report].
+
+[ack]:https://www.alibabacloud.com/help/en/ack
+[ack-gie]:https://www.alibabacloud.com/help/en/ack/product-overview/ack-gateway-with-inference-extension
+[ack-gie-usage]:https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/intelligent-routing-and-traffic-management-with-ack-gateway-inference-extension
+[ack-gie-report]:https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/conformance/reports/v1.5.0/gateway/ack-gateway
 
 ## Istio
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind documentation
/area conformance-test

**What this PR does / why we need it**:

This PR submits the conformance report of ACK (Alibaba Cloud Container Service for Kubernetes) Gateway with Inference Extension for Gateway API Inference Extension v1.5.0, and restores ACK in the conformant Gateway implementations list.

ACK Gateway with Inference Extension `v1.6.1-apsara.3` passes the **Gateway** profile against `GatewayClass ack-gateway`: 13 passed, 0 failed, 0 skipped. The report YAML is added exactly as generated by the official conformance suite, named per the repo convention (`<version>-<mode>-<profile>-report.yaml`), along with the implementation `README.md` describing how to reproduce the run.

ACK was pruned from `site-src/implementations/gateways.md` in #2976 because its newest Gateway profile report was for v1.0.2, which fell outside the accepted release window. With the v1.5.0 report submitted here, ACK is current again under the [Conformance Report Deprecation Policy](https://gateway-api-inference-extension.sigs.k8s.io/concepts/conformance/#conformance-report-deprecation-policy), which states that a removed implementation can be restored by submitting a successful report for an accepted release. Its entry is therefore restored as it was, with one change: the old "progress towards supporting" tracking issue is replaced by a pointer to the conformance report.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```