### PR TITLE
api: add optional Role field (Serving|Metrics|Health) to InferencePool targetPorts

### DIFF
--- a/api/v1/inferencepool_types.go
+++ b/api/v1/inferencepool_types.go
@@ -107,6 +107,59 @@ type Port struct {
 	//
 	// +required
 	Number PortNumber `json:"number,omitempty"`
+
+	// Role designates the function this port serves for the InferencePool.
+	//
+	// If unspecified, the role defaults to "Serving".
+	//
+	// Supported values include:
+	// * "Serving": the port used for inference traffic. This is the default. Only ports with
+	//   this role are treated as distinctive endpoints addressable as a 'podIP:portNumber'
+	//   combination; a pool with no "Serving" port exposes no inference endpoints.
+	// * "Metrics": the port model server metrics are scraped from. Consumers that scrape
+	//   metrics should prefer a port with this role and fall back to the "Serving" port
+	//   when none is present.
+	// * "Health": the port used for liveness/readiness probing. Consumers that perform health
+	//   checks should prefer a port with this role and fall back to the "Serving" port when
+	//   none is present.
+	//
+	// Multiple ports may share a role, and a single port entry has exactly one role.
+	//
+	// +kubebuilder:validation:Enum=Serving;Metrics;Health
+	// +kubebuilder:default=Serving
+	// +optional
+	Role PortRole `json:"role,omitempty"`
+}
+
+// PortRole describes the function a Port serves within an InferencePool.
+type PortRole string
+
+const (
+	// PortRoleServing designates a port used for inference traffic. This is the default role
+	// for a Port when Role is unspecified.
+	PortRoleServing PortRole = "Serving"
+
+	// PortRoleMetrics designates a port used for scraping model server metrics.
+	PortRoleMetrics PortRole = "Metrics"
+
+	// PortRoleHealth designates a port used for liveness/readiness health checking.
+	PortRoleHealth PortRole = "Health"
+)
+
+// PortNumberForRole returns the port number of the first targetPort with the given role. If no
+// targetPort has that role, it falls back to the first targetPort with the "Serving" role, and
+// returns 0 when the spec has no "Serving" port at all.
+func (s *InferencePoolSpec) PortNumberForRole(role PortRole) PortNumber {
+	var servingPort PortNumber
+	for _, p := range s.TargetPorts {
+		if p.Role == role {
+			return p.Number
+		}
+		if servingPort == 0 && (p.Role == PortRoleServing || p.Role == "") {
+			servingPort = p.Number
+		}
+	}
+	return servingPort
 }
 
 // AppProtocol describes the application protocol for a port.

--- a/api/v1/inferencepool_types_test.go
+++ b/api/v1/inferencepool_types_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "testing"
+
+func TestPortNumberForRole(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports []Port
+		role  PortRole
+		want  PortNumber
+	}{
+		{
+			name:  "unspecified role defaults to serving and is returned for Serving",
+			ports: []Port{{Number: 8000}},
+			role:  PortRoleServing,
+			want:  8000,
+		},
+		{
+			name:  "falls back to serving port when requested role absent",
+			ports: []Port{{Number: 8000, Role: PortRoleServing}},
+			role:  PortRoleMetrics,
+			want:  8000,
+		},
+		{
+			name:  "falls back to unspecified-role port treated as serving",
+			ports: []Port{{Number: 8000}},
+			role:  PortRoleHealth,
+			want:  8000,
+		},
+		{
+			name: "dedicated port for role wins over serving fallback",
+			ports: []Port{
+				{Number: 8000, Role: PortRoleServing},
+				{Number: 9090, Role: PortRoleMetrics},
+			},
+			role: PortRoleMetrics,
+			want: 9090,
+		},
+		{
+			name: "falls back to the first serving port, not the last",
+			ports: []Port{
+				{Number: 8000, Role: PortRoleServing},
+				{Number: 8001, Role: PortRoleServing},
+			},
+			role: PortRoleMetrics,
+			want: 8000,
+		},
+		{
+			name:  "returns 0 when the spec has no serving port",
+			ports: []Port{{Number: 9090, Role: PortRoleMetrics}},
+			role:  PortRoleHealth,
+			want:  0,
+		},
+		{
+			name: "dedicated health port is independent of metrics port",
+			ports: []Port{
+				{Number: 8000, Role: PortRoleServing},
+				{Number: 9090, Role: PortRoleMetrics},
+				{Number: 8080, Role: PortRoleHealth},
+			},
+			role: PortRoleHealth,
+			want: 8080,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := InferencePoolSpec{TargetPorts: tc.ports}
+			if got := spec.PortNumberForRole(tc.role); got != tc.want {
+				t.Errorf("PortNumberForRole(%v) = %v, want %v", tc.role, got, tc.want)
+			}
+		})
+	}
+}

--- a/client-go/applyconfiguration/api/v1/port.go
+++ b/client-go/applyconfiguration/api/v1/port.go
@@ -30,6 +30,23 @@ type PortApplyConfiguration struct {
 	// Number defines the port number to access the selected model server Pods.
 	// The number must be in the range 1 to 65535.
 	Number *apiv1.PortNumber `json:"number,omitempty"`
+	// Role designates the function this port serves for the InferencePool.
+	//
+	// If unspecified, the role defaults to "Serving".
+	//
+	// Supported values include:
+	// * "Serving": the port used for inference traffic. This is the default. Only ports with
+	// this role are treated as distinctive endpoints addressable as a 'podIP:portNumber'
+	// combination; a pool with no "Serving" port exposes no inference endpoints.
+	// * "Metrics": the port model server metrics are scraped from. Consumers that scrape
+	// metrics should prefer a port with this role and fall back to the "Serving" port
+	// when none is present.
+	// * "Health": the port used for liveness/readiness probing. Consumers that perform health
+	// checks should prefer a port with this role and fall back to the "Serving" port when
+	// none is present.
+	//
+	// Multiple ports may share a role, and a single port entry has exactly one role.
+	Role *apiv1.PortRole `json:"role,omitempty"`
 }
 
 // PortApplyConfiguration constructs a declarative configuration of the Port type for use with
@@ -43,5 +60,13 @@ func Port() *PortApplyConfiguration {
 // If called multiple times, the Number field is set to the value of the last call.
 func (b *PortApplyConfiguration) WithNumber(value apiv1.PortNumber) *PortApplyConfiguration {
 	b.Number = &value
+	return b
+}
+
+// WithRole sets the Role field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Role field is set to the value of the last call.
+func (b *PortApplyConfiguration) WithRole(value apiv1.PortRole) *PortApplyConfiguration {
+	b.Role = &value
 	return b
 }

--- a/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
+++ b/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
@@ -119,6 +119,30 @@ spec:
                         maximum: 65535
                         minimum: 1
                         type: integer
+                      role:
+                        default: Serving
+                        description: |-
+                          Role designates the function this port serves for the InferencePool.
+
+                          If unspecified, the role defaults to "Serving".
+
+                          Supported values include:
+                          * "Serving": the port used for inference traffic. This is the default. Only ports with
+                            this role are treated as distinctive endpoints addressable as a 'podIP:portNumber'
+                            combination; a pool with no "Serving" port exposes no inference endpoints.
+                          * "Metrics": the port model server metrics are scraped from. Consumers that scrape
+                            metrics should prefer a port with this role and fall back to the "Serving" port
+                            when none is present.
+                          * "Health": the port used for liveness/readiness probing. Consumers that perform health
+                            checks should prefer a port with this role and fall back to the "Serving" port when
+                            none is present.
+
+                          Multiple ports may share a role, and a single port entry has exactly one role.
+                        enum:
+                        - Serving
+                        - Metrics
+                        - Health
+                        type: string
                     required:
                     - number
                     type: object
@@ -184,6 +208,30 @@ spec:
                       maximum: 65535
                       minimum: 1
                       type: integer
+                    role:
+                      default: Serving
+                      description: |-
+                        Role designates the function this port serves for the InferencePool.
+
+                        If unspecified, the role defaults to "Serving".
+
+                        Supported values include:
+                        * "Serving": the port used for inference traffic. This is the default. Only ports with
+                          this role are treated as distinctive endpoints addressable as a 'podIP:portNumber'
+                          combination; a pool with no "Serving" port exposes no inference endpoints.
+                        * "Metrics": the port model server metrics are scraped from. Consumers that scrape
+                          metrics should prefer a port with this role and fall back to the "Serving" port
+                          when none is present.
+                        * "Health": the port used for liveness/readiness probing. Consumers that perform health
+                          checks should prefer a port with this role and fall back to the "Serving" port when
+                          none is present.
+
+                        Multiple ports may share a role, and a single port entry has exactly one role.
+                      enum:
+                      - Serving
+                      - Metrics
+                      - Health
+                      type: string
                   required:
                   - number
                   type: object

--- a/docs/proposals/2857-inferencepool-port-roles/README.md
+++ b/docs/proposals/2857-inferencepool-port-roles/README.md
@@ -1,0 +1,157 @@
+# InferencePool port role specification
+
+Author(s): @UgaTheDev
+
+Issue: #2857
+
+## Motivation
+
+`InferencePoolSpec.TargetPorts` is a flat list of `Port{Number}` entries. EPP and other
+consumers treat every entry as an equivalent inference endpoint (`podIP:portNumber`). There is
+no way to tell the API that a given port serves a different function — metrics scraping or
+health/liveness probing — from the ports that actually carry inference traffic.
+
+This gap is structural, not incidental. #1396 and PR #2762 describe a concrete failure mode: in
+Istio **mTLS STRICT** environments, EPP scrapes pod metrics by dialing the pod IP directly,
+bypassing the Service and its sidecar-aware routing. The sidecar rejects the connection with 503
+because it expects mTLS on that port and receives plain HTTP. PR #2762 worked around this by
+adding a `metricsPort` field to the `metrics-data-source` **plugin** configuration, but that only
+fixes metrics scraping for one plugin's configuration surface. It doesn't help conformance, other
+data sources, health checking, or any future consumer that needs a "which port is X for" answer —
+each would need its own bespoke config field. The InferencePool API is the natural place to
+answer that question once, for every consumer.
+
+## Goals
+
+* Let an InferencePool author designate which of its `targetPorts` serve inference traffic
+  ("Serving"), metrics scraping ("Metrics"), and health/liveness probing ("Health").
+* Preserve full backward compatibility: an InferencePool written against the current API (no role
+  field at all) must continue to validate and behave identically.
+* Keep the change additive and small enough to land as a single PR behind this proposal, rather
+  than a multi-phase effort.
+
+## Non-Goals
+
+* Rewiring the full production EPP (`pkg/epp/...`)'s metrics/health scraping to consume this
+  field. That is real follow-up work once the API shape lands, tracked separately — this proposal
+  only changes the API and the parts of the reference EPP implementation (`pkg/lwepp`) that build
+  the traffic-endpoint list directly from `targetPorts`.
+* Superseding or removing the `metricsPort` field added to the `metrics-data-source` plugin by PR
+  #2762. That field is a plugin-scoped override; this proposal is the spec-scoped generalization
+  the PR description explicitly called out as unaddressed.
+* A generic "labels on ports" mechanism. Three well-known roles are the concrete, requested need;
+  an open-ended label/annotation scheme is speculative beyond that.
+
+## Proposed API Changes
+
+Add a `Role` field to the existing `Port` struct, defaulting to `"Serving"` so that every
+InferencePool written before this change is unaffected — an absent `role` is indistinguishable
+from `role: Serving` at admission time (CRD structural-schema defaulting fills it in before
+validation runs).
+
+```go
+// Port defines the network port that will be exposed by this InferencePool.
+type Port struct {
+    // Number defines the port number to access the selected model server Pods.
+    // The number must be in the range 1 to 65535.
+    //
+    // +required
+    Number PortNumber `json:"number,omitempty"`
+
+    // Role designates the function this port serves for the InferencePool.
+    //
+    // Supported values include:
+    // * "Serving": the port used for inference traffic. This is the default. At least one
+    //   targetPort must have this role.
+    // * "Metrics": the port model server metrics are scraped from. Consumers that scrape
+    //   metrics should prefer a port with this role and fall back to the "Serving" port
+    //   when none is present.
+    // * "Health": the port used for liveness/readiness probing. Consumers that perform health
+    //   checks should prefer a port with this role and fall back to the "Serving" port when
+    //   none is present.
+    //
+    // Multiple ports may share a role, and a single port entry has exactly one role.
+    //
+    // +kubebuilder:validation:Enum=Serving;Metrics;Health
+    // +kubebuilder:default=Serving
+    // +optional
+    Role PortRole `json:"role,omitempty"`
+}
+
+type PortRole string
+
+const (
+    PortRoleServing PortRole = "Serving"
+    PortRoleMetrics PortRole = "Metrics"
+    PortRoleHealth  PortRole = "Health"
+)
+```
+
+### Validation
+
+No new CEL rule is added. An earlier draft of this proposal put an
+`XValidation` rule on `targetPorts` requiring at least one `Serving`-role port, but adding a
+shape constraint to a stable (`v1`) API is a backward-incompatible schema change: it can reject
+updates to InferencePools that are already stored in etcd, and the repository's `crdify` gate
+correctly rejects it. The precedent is `appProtocol` (#2162), which ships as an enum with a
+default and no accompanying CEL rule.
+
+The constraint is not needed for safety. Because defaulting runs before validation, every
+existing spec that never mentions `role` gets `Serving` on every port, so the only way to reach
+a pool with no `Serving` port is for an author to explicitly set every `targetPort`'s role to
+`Metrics` and/or `Health`. Such a pool is well-defined rather than invalid: it simply exposes no
+inference endpoints, and `PortNumberForRole` returns `0` for a `Serving` lookup. Enforcement of
+"a pool ought to serve traffic" belongs to the controller's status conditions, not the schema.
+
+Port-number uniqueness is unaffected by role: a given port number appears in exactly one
+`targetPorts` entry, with exactly one role. If a deployment's serving port also happens to be the
+health-check port (the common case, matching today's behavior), authors simply omit a separate
+`Health` entry — role-aware consumers fall back to the `Serving` port when no dedicated
+`Metrics`/`Health` port is declared, per the sketch in #2857.
+
+### Consumer-facing accessor
+
+To avoid every consumer re-implementing the "look for my role, else fall back to Serving" search,
+`InferencePoolSpec` gains a small helper:
+
+```go
+// PortNumberForRole returns the port number of the first targetPort with the given role. If no
+// targetPort has that role, it falls back to the first targetPort with the "Serving" role, and
+// returns 0 when the spec has no "Serving" port at all.
+func (s *InferencePoolSpec) PortNumberForRole(role PortRole) PortNumber
+```
+
+### `pkg/lwepp` wiring
+
+The reference EPP's `InferencePoolToEndpointPool` conversion (`pkg/lwepp/util/pool`) currently
+turns every `targetPorts` entry into a traffic endpoint. With roles, only `Serving`-role ports
+(including the pre-existing default) are endpoints; `Metrics`/`Health`-only ports are excluded
+from `EndpointPool.TargetPorts` so they are never dialed for inference traffic.
+
+## Backward compatibility
+
+* Existing manifests with no `role` field: unaffected. Defaulting fills `Serving` on every port,
+  so `pkg/lwepp`'s endpoint list is unchanged.
+* No new validation constraint is added to `targetPorts`, so no already-stored InferencePool can
+  become unupdatable. This is verified by the `crdify` CRD-compatibility gate.
+* Existing manifests are also unaffected by CRD schema changes elsewhere (`appProtocol`,
+  `endpointPickerRef`, etc.) — this is purely an additive field on `Port`.
+* No conversion webhook is needed: `v1` is the only served/stored version of `InferencePool`.
+
+## Alternatives considered
+
+* **Plugin-level config only** (status quo via PR #2762's `metricsPort`): rejected as the
+  motivating issue — it doesn't generalize to health checking or other consumers, and requires
+  every future consumer to reinvent per-plugin port configuration.
+* **A separate `metricsPort`/`healthPort` field directly on `InferencePoolSpec`** instead of a
+  `Role` enum on `Port`: rejected because it doesn't compose with `TargetPorts`' existing
+  uniqueness/cardinality validation and conformance test surface, and can't express "the health
+  port is also a serving port" without a second field meaning "same as serving."
+
+## Open questions for maintainers
+
+* Should `pkg/epp` (the full production EPP)'s metrics-data-source plugin be updated in this same
+  PR to prefer `PortNumberForRole(Metrics)` over its own `metricsPort` parameter, or is that
+  better left as separate follow-up once the API shape itself is approved?
+* Conformance: should a new conformance test assert that an implementation's Service/target-port
+  wiring honors `Role`, or is that premature before an implementation actually consumes it?

--- a/pkg/lwepp/util/pool/pool.go
+++ b/pkg/lwepp/util/pool/pool.go
@@ -27,8 +27,12 @@ func InferencePoolToEndpointPool(inferencePool *v1.InferencePool) *datastore.End
 	}
 	targetPorts := make([]int, 0, len(inferencePool.Spec.TargetPorts))
 	for _, p := range inferencePool.Spec.TargetPorts {
+		// Only "Serving" ports (the default when Role is unset) are traffic endpoints. Ports
+		// dedicated to the metrics or health role are not addressable as inference endpoints.
+		if p.Role != v1.PortRoleServing && p.Role != "" {
+			continue
+		}
 		targetPorts = append(targetPorts, int(p.Number))
-
 	}
 	selector := make(map[string]string, len(inferencePool.Spec.Selector.MatchLabels))
 	for k, v := range inferencePool.Spec.Selector.MatchLabels {

--- a/pkg/lwepp/util/pool/pool_test.go
+++ b/pkg/lwepp/util/pool/pool_test.go
@@ -127,6 +127,44 @@ func TestInferencePoolToEndpointPool(t *testing.T) {
 			},
 		},
 		{
+			name: "ports with unspecified role are treated as serving endpoints",
+			input: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-6"},
+				Spec: v1.InferencePoolSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{"app": "vllm"},
+					},
+					TargetPorts: []v1.Port{{Number: 8000, Role: v1.PortRoleServing}, {Number: 8001}},
+				},
+			},
+			want: &datastore.EndpointPool{
+				Selector:    map[string]string{"app": "vllm"},
+				TargetPorts: []int{8000, 8001},
+				Namespace:   "ns-6",
+			},
+		},
+		{
+			name: "metrics and health ports are excluded from traffic endpoints",
+			input: &v1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-7"},
+				Spec: v1.InferencePoolSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: map[v1.LabelKey]v1.LabelValue{"app": "vllm"},
+					},
+					TargetPorts: []v1.Port{
+						{Number: 8000, Role: v1.PortRoleServing},
+						{Number: 9090, Role: v1.PortRoleMetrics},
+						{Number: 8080, Role: v1.PortRoleHealth},
+					},
+				},
+			},
+			want: &datastore.EndpointPool{
+				Selector:    map[string]string{"app": "vllm"},
+				TargetPorts: []int{8000},
+				Namespace:   "ns-7",
+			},
+		},
+		{
 			name: "empty namespace is carried over as empty",
 			input: &v1.InferencePool{
 				Spec: v1.InferencePoolSpec{

--- a/pkg/lwepp/util/testing/wrappers.go
+++ b/pkg/lwepp/util/testing/wrappers.go
@@ -155,6 +155,12 @@ func (m *InferencePoolWrapper) TargetPorts(p int32) *InferencePoolWrapper {
 	return m
 }
 
+// TargetPortsWithRoles replaces the wrapped InferencePool's targetPorts with the given ports.
+func (m *InferencePoolWrapper) TargetPortsWithRoles(ports ...v1.Port) *InferencePoolWrapper {
+	m.Spec.TargetPorts = ports
+	return m
+}
+
 func (m *InferencePoolWrapper) EndpointPickerRef(name string) *InferencePoolWrapper {
 	m.Spec.EndpointPickerRef = &v1.EndpointPickerRef{Name: v1.ObjectName(name)}
 	return m

--- a/test/cel/inferencepool_test.go
+++ b/test/cel/inferencepool_test.go
@@ -102,6 +102,44 @@ func TestValidateInferencePool(t *testing.T) {
 			},
 			wantErrors: []string{"port number must be unique"},
 		},
+		{
+			desc: "passes validation with an unspecified role defaulting to Serving",
+			mutate: func(ip *v1.InferencePool) {
+				ip.Spec.TargetPorts = []v1.Port{{Number: 8000}}
+			},
+			wantErrors: nil,
+		},
+		{
+			desc: "passes validation with dedicated metrics and health ports alongside a serving port",
+			mutate: func(ip *v1.InferencePool) {
+				ip.Spec.TargetPorts = []v1.Port{
+					{Number: 8000, Role: v1.PortRoleServing},
+					{Number: 9090, Role: v1.PortRoleMetrics},
+					{Number: 8080, Role: v1.PortRoleHealth},
+				}
+			},
+			wantErrors: nil,
+		},
+		{
+			// A pool with no Serving port exposes no inference endpoints, but the API does not
+			// reject it: constraining the shape of targetPorts on a stable API would invalidate
+			// already-stored InferencePools. Consumers handle it via the Serving fallback.
+			desc: "passes validation when no targetPort has the Serving role",
+			mutate: func(ip *v1.InferencePool) {
+				ip.Spec.TargetPorts = []v1.Port{
+					{Number: 9090, Role: v1.PortRoleMetrics},
+					{Number: 8080, Role: v1.PortRoleHealth},
+				}
+			},
+			wantErrors: nil,
+		},
+		{
+			desc: "fails validation with an invalid role value",
+			mutate: func(ip *v1.InferencePool) {
+				ip.Spec.TargetPorts = []v1.Port{{Number: 8000, Role: "bogus"}}
+			},
+			wantErrors: []string{"Unsupported value"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds an optional `Role` field to `InferencePool`'s `Port` type (`Serving` | `Metrics` | `Health`,
defaulting to `Serving`), so EPP and other consumers have a spec-level way to know which port to
scrape metrics from and which to health-check, instead of assuming every `targetPorts` entry is an
inference endpoint.

This generalizes the workaround added in #2762 (`metricsPort` on the `metrics-data-source` plugin)
to the API level, as that PR's description called for: a plugin-scoped field only fixes metrics
scraping for one plugin's configuration surface, not health checking or any other consumer, and
every future consumer would otherwise need its own bespoke port field.

See `docs/proposals/2857-inferencepool-port-roles/README.md` for the full design, alternatives
considered, and open questions for maintainers (notably: whether wiring `pkg/epp`'s
`metrics-data-source` plugin to prefer this field belongs in this PR or a follow-up).

Summary of the change:
* `Port.Role` (`PortRole`): optional, enum-validated, defaults to `Serving`.
* No new validation constraint on `InferencePoolSpec.TargetPorts`. An earlier revision of this PR
  added a CEL rule requiring at least one `Serving`-role port, but adding a shape constraint to a
  stable API is backward-incompatible (it can reject updates to already-stored InferencePools) and
  the `crdify` gate rightly rejected it. A pool whose every port is `Metrics`/`Health` is instead
  accepted and simply exposes no inference endpoints. This follows the `appProtocol` precedent
  (#2162): enum plus default, no CEL rule.
* `InferencePoolSpec.PortNumberForRole(role)`: looks up the port number for a role, falling back
  to the `Serving` port when no dedicated port for that role is declared.
* `pkg/lwepp/util/pool.InferencePoolToEndpointPool`: only `Serving`-role ports (including the
  default) become traffic endpoints; `Metrics`/`Health`-only ports are excluded.
* Regenerated CRD manifests, deepcopy, and `client-go` applyconfiguration via `make generate`.

**Which issue(s) this PR fixes**:

Fixes #2857

**Does this PR introduce a user-facing change?**:
```release-note
Add an optional `role` field to `InferencePool`'s `targetPorts` entries (`Serving`, `Metrics`,
`Health`), defaulting to `Serving` so existing InferencePools are unaffected. Consumers can use
`InferencePoolSpec.PortNumberForRole` to look up the port for a given role, falling back to the
`Serving` port when no dedicated port is declared.
```

---

## Verification (run locally, offline)

* `go build ./...` — clean.
* `go vet ./...` — clean.
* `gofmt -l` on all changed files — clean.
* `go test ./api/... ./pkg/lwepp/...` — all packages pass, including new
  `TestPortNumberForRole` and the new role-filtering cases in
  `pkg/lwepp/util/pool/pool_test.go`.
* `KUBEBUILDER_ASSETS=... go test ./test/cel/... -run TestValidateInferencePool` (envtest,
  real API server) — all cases pass, including the new role-defaulting, dedicated-port,
  missing-Serving-port, and invalid-role-value cases.
* `make verify-crds` (`kubectl-validate` against the generated CRD manifests) — `OK` on all CRDs.
* `make generate` — regenerated `zz_generated.deepcopy.go` (unchanged; `PortRole` is a plain
  string with no pointer fields), the CRD YAML, and `client-go/applyconfiguration`.

## Open questions for maintainers (also in the proposal doc)

1. API shape sign-off: `Role` enum on `Port` vs. separate `metricsPort`/`healthPort` fields
   directly on `InferencePoolSpec`.
2. Should this PR also wire `pkg/epp`'s `metrics-data-source` plugin to prefer
   `PortNumberForRole(Metrics)` over its existing `metricsPort` parameter, or is that better left
   as a separate follow-up PR once the API shape itself is approved?
3. Is a new conformance test warranted here, or premature before any implementation actually
   consumes `Role`?

