### PR TITLE
Fix LWEPP full duplex body responses

### DIFF
--- a/pkg/lwepp/handlers/server.go
+++ b/pkg/lwepp/handlers/server.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/common/envoy"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/datastore"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/metadata"
 )
@@ -246,16 +247,18 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				}
 			}
 
-			resp := &extProcPb.ProcessingResponse{
-				Response: &extProcPb.ProcessingResponse_RequestBody{
-					RequestBody: &extProcPb.BodyResponse{
-						Response: &extProcPb.CommonResponse{},
+			for _, commonResp := range envoy.BuildChunkedBodyResponses(v.RequestBody.Body, v.RequestBody.EndOfStream) {
+				resp := &extProcPb.ProcessingResponse{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: commonResp,
+						},
 					},
-				},
-			}
+				}
 
-			if err := srv.Send(resp); err != nil {
-				return status.Errorf(codes.Unknown, "failed to send body response back to Envoy: %v", err)
+				if err := srv.Send(resp); err != nil {
+					return status.Errorf(codes.Unknown, "failed to send body response back to Envoy: %v", err)
+				}
 			}
 
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
@@ -267,16 +270,18 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		case *extProcPb.ProcessingRequest_ResponseBody:
 			logger.V(1).Info("Received response body", "endOfStream", v.ResponseBody.EndOfStream)
-			resp := &extProcPb.ProcessingResponse{
-				Response: &extProcPb.ProcessingResponse_ResponseBody{
-					ResponseBody: &extProcPb.BodyResponse{
-						Response: &extProcPb.CommonResponse{},
+			for _, commonResp := range envoy.BuildChunkedBodyResponses(v.ResponseBody.Body, v.ResponseBody.EndOfStream) {
+				resp := &extProcPb.ProcessingResponse{
+					Response: &extProcPb.ProcessingResponse_ResponseBody{
+						ResponseBody: &extProcPb.BodyResponse{
+							Response: commonResp,
+						},
 					},
-				},
-			}
+				}
 
-			if err := srv.Send(resp); err != nil {
-				return status.Errorf(codes.Unknown, "failed to send response body back to Envoy: %v", err)
+				if err := srv.Send(resp); err != nil {
+					return status.Errorf(codes.Unknown, "failed to send response body back to Envoy: %v", err)
+				}
 			}
 
 		default:

--- a/pkg/lwepp/handlers/server_test.go
+++ b/pkg/lwepp/handlers/server_test.go
@@ -87,21 +87,30 @@ func TestProcess_DeferredHeaderMutationOnStreamingBody(t *testing.T) {
 			},
 		},
 	}
+	respBody := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{
+				Body:        []byte(`{"response": "world"}`),
+				EndOfStream: true,
+			},
+		},
+	}
 
 	stream := &mockProcessServer{
 		ctx:          context.Background(),
-		recvMessages: []*extProcPb.ProcessingRequest{reqHeaders, reqBody},
+		recvMessages: []*extProcPb.ProcessingRequest{reqHeaders, reqBody, respBody},
 	}
 
 	err := server.Process(stream)
 	assert.NoError(t, err)
 
 	// Assertions on the sequence of sent responses:
-	// - We expect exactly 2 responses sent back.
+	// - We expect exactly 3 responses sent back.
 	// - Response 1: The DEFERRED RequestHeaders response containing the target routing mutation headers.
-	// - Response 2: The RequestBody response containing a simple empty body ack.
+	// - Response 2: The RequestBody response preserving the original request body.
+	// - Response 3: The ResponseBody response preserving the original response body.
 	require := assert.New(t)
-	if require.Len(stream.sentMessages, 2) {
+	if require.Len(stream.sentMessages, 3) {
 		// Response 1: RequestHeaders Response
 		firstResp := stream.sentMessages[0].GetRequestHeaders()
 		require.NotNil(firstResp, "First response must be a RequestHeaders frame")
@@ -113,9 +122,21 @@ func TestProcess_DeferredHeaderMutationOnStreamingBody(t *testing.T) {
 		assert.Equal(t, "X-Echo-Set-Header", setHeaders[1].GetHeader().GetKey())
 		assert.Equal(t, metadata.ConformanceTestResultHeader+":10.0.0.1:8080", string(setHeaders[1].GetHeader().GetRawValue()))
 
-		// Response 2: RequestBody Response (Ack)
+		// Response 2: RequestBody Response
 		secondResp := stream.sentMessages[1].GetRequestBody()
-		require.NotNil(secondResp, "Second response must be a RequestBody ack frame")
+		require.NotNil(secondResp, "Second response must be a RequestBody frame")
 		require.Nil(secondResp.GetResponse().GetHeaderMutation(), "Deferred body response must not contain redundant mutations")
+		requestBody := secondResp.GetResponse().GetBodyMutation().GetStreamedResponse()
+		require.NotNil(requestBody)
+		assert.Equal(t, reqBody.GetRequestBody().GetBody(), requestBody.GetBody())
+		assert.Equal(t, reqBody.GetRequestBody().GetEndOfStream(), requestBody.GetEndOfStream())
+
+		// Response 3: ResponseBody Response
+		thirdResp := stream.sentMessages[2].GetResponseBody()
+		require.NotNil(thirdResp, "Third response must be a ResponseBody frame")
+		responseBody := thirdResp.GetResponse().GetBodyMutation().GetStreamedResponse()
+		require.NotNil(responseBody)
+		assert.Equal(t, respBody.GetResponseBody().GetBody(), responseBody.GetBody())
+		assert.Equal(t, respBody.GetResponseBody().GetEndOfStream(), responseBody.GetEndOfStream())
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/area conformance-test

**What this PR does / why we need it**:
Envoy requires body responses in FULL_DUPLEX_STREAMED mode to carry a BodyMutation with a streamed response. Returning an empty CommonResponse causes Gateways to terminate the ext-proc stream and return HTTP 500.\n\nEcho request and response body chunks through the existing chunking helper and propagate end-of-stream. Extend the handler test to verify that both body directions are preserved.


I believe it is currently impossible to pass GIE v1.6 conformance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fixed a bug causing the conformance test EPP to not return any body data.
```
