### PR TITLE
Add NGINX Gateway Fabric 2.7 conformance report

### DIFF
--- a/conformance/reports/v1.6.0/gateway/nginx-nginx-gateway-fabric/README.md
+++ b/conformance/reports/v1.6.0/gateway/nginx-nginx-gateway-fabric/README.md
@@ -1,0 +1,29 @@
+# Nginx NGINX Gateway Fabric
+
+## Table of Contents
+
+| Extension Version Tested | Profile Tested | Implementation Version | Mode    | Report                                                                     |
+|--------------------------|----------------|------------------------|---------|----------------------------------------------------------------------------|
+| v1.6.0                   | Gateway        | v2.7.0                 | default | [v2.7.0 report](./inference-v2.7.0-report.yaml)                            |                          |
+
+## Reproduce
+
+To reproduce results, clone the NGF repository:
+
+```shell
+git clone https://github.com/nginx/nginx-gateway-fabric.git && cd nginx-gateway-fabric/tests
+```
+
+Follow the steps in the [NGINX Gateway Fabric Testing](https://github.com/nginx/nginx-gateway-fabric/blob/main/tests/README.md#conformance-testing) document to run the conformance tests. If you are running tests on the `edge` version, then you don't need to build any images. Otherwise, you'll need to check out the specific release tag that you want to test, and then build and load the images onto your cluster, per the steps in the README.
+
+Note: Enable this flag to install all CRDs and required resources:
+
+```shell
+export ENABLE_INFERENCE_EXTENSION=true
+```
+
+After running, see the conformance report:
+
+```shell
+cat conformance-profile-inference.yaml
+```

--- a/conformance/reports/v1.6.0/gateway/nginx-nginx-gateway-fabric/inference-v2.7.0-report.yaml
+++ b/conformance/reports/v1.6.0/gateway/nginx-nginx-gateway-fabric/inference-v2.7.0-report.yaml
@@ -1,0 +1,26 @@
+GatewayAPIInferenceExtensionVersion: v1.6.0
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-09-02T19:25:03Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.6.1
+implementation:
+  contact:
+  - https://github.com/nginx/nginx-gateway-fabric/discussions/new/choose
+  organization: nginx
+  project: nginx-gateway-fabric
+  url: https://github.com/nginx/nginx-gateway-fabric
+  version: v2.7.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - GatewayDestinationEndpointServed
+    - InferencePoolAppProtocol
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 2
+  name: Gateway
+  summary: Core tests partially succeeded with 2 test skips.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind documentation

**What this PR does / why we need it**:

Conformance Report

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
