### PR TITLE
fix(lwepp): answer request headers before request body

### DIFF
--- a/pkg/lwepp/handlers/server.go
+++ b/pkg/lwepp/handlers/server.go
@@ -111,6 +111,8 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 	reqCtx := &RequestContext{}
 	var body []byte
+	// Request body chunks received while the request headers response is still deferred.
+	var pendingBody []byte
 	var err error
 	headersDeferred := false
 
@@ -197,6 +199,16 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				return status.Errorf(codes.ResourceExhausted, "request body size limit of %d bytes exceeded", maxRequestBodySize)
 			}
 			body = append(body, v.RequestBody.Body...)
+			pendingBody = append(pendingBody, v.RequestBody.Body...)
+
+			// Envoy treats a request body response that arrives before the response to the
+			// request headers as out of order, marks it spurious and tears the stream down.
+			// The endpoint can only be picked once the whole body has arrived, so while the
+			// headers response is still deferred the body chunks are held back and flushed
+			// after it has been sent.
+			if headersDeferred && !v.RequestBody.EndOfStream {
+				continue
+			}
 
 			if v.RequestBody.EndOfStream {
 				err = s.pickEndpoint(ctx, reqCtx, body)
@@ -244,10 +256,11 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					if err := srv.Send(headerResp); err != nil {
 						return status.Errorf(codes.Unknown, "failed to send deferred headers response back to Envoy: %v", err)
 					}
+					headersDeferred = false
 				}
 			}
 
-			for _, commonResp := range envoy.BuildChunkedBodyResponses(v.RequestBody.Body, v.RequestBody.EndOfStream) {
+			for _, commonResp := range envoy.BuildChunkedBodyResponses(pendingBody, v.RequestBody.EndOfStream) {
 				resp := &extProcPb.ProcessingResponse{
 					Response: &extProcPb.ProcessingResponse_RequestBody{
 						RequestBody: &extProcPb.BodyResponse{
@@ -260,6 +273,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					return status.Errorf(codes.Unknown, "failed to send body response back to Envoy: %v", err)
 				}
 			}
+			pendingBody = nil
 
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
 			logger.Info("Received response headers")

--- a/pkg/lwepp/handlers/server_test.go
+++ b/pkg/lwepp/handlers/server_test.go
@@ -140,3 +140,86 @@ func TestProcess_DeferredHeaderMutationOnStreamingBody(t *testing.T) {
 		assert.Equal(t, respBody.GetResponseBody().GetEndOfStream(), responseBody.GetEndOfStream())
 	}
 }
+
+// TestProcess_DeferredHeaderMutationOnChunkedStreamingBody covers a body that arrives in
+// more than one chunk. The endpoint is only known once the whole body has been received, so
+// the request headers response is deferred to end of stream. Envoy accepts responses in the
+// order it asked for them, and a request body response sent while the headers response is
+// still outstanding is treated as spurious: Envoy abandons the stream and the request fails.
+//
+// The body chunks must therefore be held until the deferred headers response has been sent.
+func TestProcess_DeferredHeaderMutationOnChunkedStreamingBody(t *testing.T) {
+	pods := []*datastore.Endpoint{
+		{Address: "10.0.0.1", Port: "8080"},
+	}
+	ds := &mockDatastore{pods: pods}
+	server := NewStreamingServer(ds)
+
+	reqHeaders := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extProcPb.HttpHeaders{
+				Headers: &envoyCorev3.HeaderMap{
+					Headers: []*envoyCorev3.HeaderValue{
+						{Key: "test-epp-endpoint-selection", Value: "10.0.0.1"},
+					},
+				},
+				EndOfStream: false,
+			},
+		},
+	}
+
+	// The body arrives in two chunks. Only the second ends the stream, so at the time the
+	// first is received the endpoint is still unknown and the headers response is deferred.
+	firstChunk := []byte(`{"prompt": "hel`)
+	lastChunk := []byte(`lo"}`)
+
+	reqBodyFirst := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body:        firstChunk,
+				EndOfStream: false,
+			},
+		},
+	}
+	reqBodyLast := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{
+				Body:        lastChunk,
+				EndOfStream: true,
+			},
+		},
+	}
+
+	stream := &mockProcessServer{
+		ctx:          t.Context(),
+		recvMessages: []*extProcPb.ProcessingRequest{reqHeaders, reqBodyFirst, reqBodyLast},
+	}
+
+	err := server.Process(stream)
+	assert.NoError(t, err)
+
+	require := assert.New(t)
+
+	// Nothing may be sent before the deferred headers response. A body response emitted for
+	// the first chunk would appear here and would be the failure this test guards against.
+	if require.NotEmpty(stream.sentMessages, "expected the deferred headers response") {
+		require.NotNil(stream.sentMessages[0].GetRequestHeaders(),
+			"the first response must be the deferred RequestHeaders frame, not a body frame")
+	}
+
+	// One headers response and one body response carrying the reassembled body.
+	if require.Len(stream.sentMessages, 2) {
+		setHeaders := stream.sentMessages[0].GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
+		require.Len(setHeaders, 2)
+		assert.Equal(t, metadata.DestinationEndpointKey, setHeaders[0].GetHeader().GetKey())
+		assert.Equal(t, "10.0.0.1:8080", string(setHeaders[0].GetHeader().GetRawValue()))
+
+		bodyResp := stream.sentMessages[1].GetRequestBody()
+		require.NotNil(bodyResp, "the second response must be a RequestBody frame")
+		streamed := bodyResp.GetResponse().GetBodyMutation().GetStreamedResponse()
+		require.NotNil(streamed)
+		assert.Equal(t, append(append([]byte{}, firstChunk...), lastChunk...), streamed.GetBody(),
+			"both chunks must be forwarded, in arrival order")
+		assert.True(t, streamed.GetEndOfStream(), "the flushed body response ends the stream")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**:

The lightweight EPP answers `ext_proc` streams out of order. Envoy expects responses in the order it asked for them, so a `request_body` response arriving while the filter is still waiting on `request_headers` gets counted in `spurious_msgs_received`. Envoy logs `Spurious response message 3 received on gRPC stream` and abandons the stream for the rest of the request.

This is problematic in `FULL_DUPLEX_STREAMED` mode. We only know the endpoint once the whole body has arrived, so the `request_headers` response carrying the endpoint mutation is deferred to end of stream - but body chunks have already been echoed back ahead of it. Any gateway that turns on full-duplex body processing fails *every request with a body*. Bodyless requests still work, which is why it looks intermittent at first.

The fix is to hold the body chunks until the deferred `request_headers` response has gone out, then flush them in arrival order. The bytes we return are unchanged - only the ordering is.

**Testing**

Reproduced against Istio 1.30.2, whose `InferencePool` `ext_proc` override sets `requestBodyMode: FULL_DUPLEX_STREAMED`. Before this change, every conformance request carrying a body came back as HTTP 500 with an empty body. After it, the suite runs normally.

#3028 ("Fix LWEPP full duplex body responses") is already in `main` and doesn't cover this. That one fixed the *payload* of the body responses; this one fixes *when* they're sent relative to the deferred headers response.

```release-note
Fixed the lightweight EPP sending ext_proc body responses ahead of a deferred request-headers response, which caused gateways using FULL_DUPLEX_STREAMED body processing to fail every request carrying a body.
```
