### PR TITLE
fix lwepp for envoy ext_proc duplex stream mode

### DIFF
--- a/cmd/lwepp/main.go
+++ b/cmd/lwepp/main.go
@@ -89,6 +89,7 @@ func main() {
 		Datastore:      ds,
 		HealthChecking: opts.HealthChecking,
 		SecureServing:  opts.SecureServing,
+		BodyMode:       opts.BodyMode,
 	}
 
 	if err := runner.SetupWithManager(mgr); err != nil {

--- a/pkg/lwepp/handlers/request.go
+++ b/pkg/lwepp/handlers/request.go
@@ -138,12 +138,11 @@ func (s *StreamingServer) handleRequestHeaders(ctx context.Context, reqCtx *Requ
 	return nil
 }
 
-func (s *StreamingServer) pickEndpoint(ctx context.Context, reqCtx *RequestContext, body []byte) error {
+func (s *StreamingServer) pickEndpoint(ctx context.Context, reqCtx *RequestContext) error {
 	logger := log.FromContext(ctx)
 
 	pickReq := &PickRequest{
 		Headers: reqCtx.Headers,
-		Body:    body,
 	}
 
 	res, err := s.picker.Pick(ctx, pickReq, reqCtx.Candidates)

--- a/pkg/lwepp/handlers/request_test.go
+++ b/pkg/lwepp/handlers/request_test.go
@@ -65,14 +65,14 @@ func TestHandleRequestHeaders_RoundRobin(t *testing.T) {
 	reqCtx1 := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx1, nil, req)
 	assert.NoError(t, err)
-	err = server.pickEndpoint(context.Background(), reqCtx1, nil)
+	err = server.pickEndpoint(context.Background(), reqCtx1)
 	assert.NoError(t, err)
 
 	// Second request
 	reqCtx2 := &RequestContext{}
 	err = server.handleRequestHeaders(context.Background(), reqCtx2, nil, req)
 	assert.NoError(t, err)
-	err = server.pickEndpoint(context.Background(), reqCtx2, nil)
+	err = server.pickEndpoint(context.Background(), reqCtx2)
 	assert.NoError(t, err)
 
 	// They should be different pods (round-robin)
@@ -82,7 +82,7 @@ func TestHandleRequestHeaders_RoundRobin(t *testing.T) {
 	reqCtx3 := &RequestContext{}
 	err = server.handleRequestHeaders(context.Background(), reqCtx3, nil, req)
 	assert.NoError(t, err)
-	err = server.pickEndpoint(context.Background(), reqCtx3, nil)
+	err = server.pickEndpoint(context.Background(), reqCtx3)
 	assert.NoError(t, err)
 	assert.Equal(t, reqCtx1.SelectedPodIP, reqCtx3.SelectedPodIP)
 }
@@ -109,7 +109,7 @@ func TestHandleRequestHeaders_FilteringViaHeader(t *testing.T) {
 	reqCtx := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx, nil, req)
 	assert.NoError(t, err)
-	err = server.pickEndpoint(context.Background(), reqCtx, nil)
+	err = server.pickEndpoint(context.Background(), reqCtx)
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", reqCtx.SelectedPodIP)
 }
@@ -162,7 +162,7 @@ func TestHandleRequestHeaders_FilteringViaFilterMetadata(t *testing.T) {
 	reqCtx := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
 	assert.NoError(t, err)
-	err = server.pickEndpoint(context.Background(), reqCtx, nil)
+	err = server.pickEndpoint(context.Background(), reqCtx)
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.3", reqCtx.SelectedPodIP)
 }
@@ -239,7 +239,7 @@ func TestHandleRequestHeaders_HeaderTakesPrecedenceOverMetadata(t *testing.T) {
 	reqCtx := &RequestContext{}
 	err := server.handleRequestHeaders(context.Background(), reqCtx, fullReq, req)
 	assert.NoError(t, err)
-	err = server.pickEndpoint(context.Background(), reqCtx, nil)
+	err = server.pickEndpoint(context.Background(), reqCtx)
 	assert.NoError(t, err)
 	// The test header should override metadata-based filtering.
 	assert.Equal(t, "10.0.0.2", reqCtx.SelectedPodIP)

--- a/pkg/lwepp/handlers/server.go
+++ b/pkg/lwepp/handlers/server.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	processingModePb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,9 +43,14 @@ type Datastore interface {
 }
 
 func NewStreamingServer(datastore Datastore) *StreamingServer {
+	return NewStreamingServerWithBodyMode(datastore, processingModePb.ProcessingMode_FULL_DUPLEX_STREAMED)
+}
+
+func NewStreamingServerWithBodyMode(datastore Datastore, bodyMode processingModePb.ProcessingMode_BodySendMode) *StreamingServer {
 	return &StreamingServer{
 		datastore: datastore,
 		picker:    &RoundRobinPicker{},
+		bodyMode:  bodyMode,
 	}
 }
 
@@ -52,6 +58,7 @@ func NewStreamingServer(datastore Datastore) *StreamingServer {
 type StreamingServer struct {
 	datastore Datastore
 	picker    EndpointPicker
+	bodyMode  processingModePb.ProcessingMode_BodySendMode
 }
 
 // RequestContext stores context information during the life time of an HTTP request.
@@ -103,6 +110,61 @@ func (p *RoundRobinPicker) Pick(ctx context.Context, req *PickRequest, endpoints
 
 const maxRequestBodySize = 10 * 1024 * 1024 // 10MB
 
+func requestHeadersResponse(reqCtx *RequestContext) *extProcPb.ProcessingResponse {
+	return &extProcPb.ProcessingResponse{
+		Response: &extProcPb.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extProcPb.HeadersResponse{
+				Response: &extProcPb.CommonResponse{
+					ClearRouteCache: true,
+					HeaderMutation: &extProcPb.HeaderMutation{
+						SetHeaders: []*configPb.HeaderValueOption{
+							{
+								Header: &configPb.HeaderValue{
+									Key:      metadata.DestinationEndpointKey,
+									RawValue: []byte(reqCtx.TargetEndpoint),
+								},
+							},
+							{
+								Header: &configPb.HeaderValue{
+									Key:      "X-Echo-Set-Header",
+									RawValue: []byte(metadata.ConformanceTestResultHeader + ":" + reqCtx.TargetEndpoint),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		DynamicMetadata: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				metadata.DestinationEndpointNamespace: structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						metadata.DestinationEndpointKey: structpb.NewStringValue(reqCtx.TargetEndpoint),
+					},
+				}),
+			},
+		},
+	}
+}
+
+func (s *StreamingServer) bodyResponses(body []byte, endOfStream bool, responseType func(*extProcPb.BodyResponse) *extProcPb.ProcessingResponse) []*extProcPb.ProcessingResponse {
+	if s.bodyMode == processingModePb.ProcessingMode_BUFFERED {
+		return []*extProcPb.ProcessingResponse{responseType(&extProcPb.BodyResponse{
+			Response: &extProcPb.CommonResponse{
+				BodyMutation: &extProcPb.BodyMutation{
+					Mutation: &extProcPb.BodyMutation_Body{Body: body},
+				},
+			},
+		})}
+	}
+
+	responses := make([]*extProcPb.ProcessingResponse, 0)
+	for _, commonResp := range envoy.BuildChunkedBodyResponses(body, endOfStream) {
+		responses = append(responses, responseType(&extProcPb.BodyResponse{Response: commonResp}))
+	}
+	return responses
+}
+
 func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 	ctx := srv.Context()
 	logger := ctrl.Log.WithName("ext-proc")
@@ -112,7 +174,6 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 	reqCtx := &RequestContext{}
 	var body []byte
 	var err error
-	headersDeferred := false
 
 	for {
 		select {
@@ -138,56 +199,14 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				return status.Errorf(codes.Internal, "internal error: %v", err)
 			}
 
-			var resp *extProcPb.ProcessingResponse
-			if v.RequestHeaders.EndOfStream {
-				err = s.pickEndpoint(ctx, reqCtx, nil)
-				if err != nil {
-					logger.Error(err, "Failed to pick endpoint")
-					return status.Errorf(codes.Internal, "internal error: %v", err)
-				}
-
-				resp = &extProcPb.ProcessingResponse{
-					Response: &extProcPb.ProcessingResponse_RequestHeaders{
-						RequestHeaders: &extProcPb.HeadersResponse{
-							Response: &extProcPb.CommonResponse{
-								ClearRouteCache: true,
-								HeaderMutation: &extProcPb.HeaderMutation{
-									SetHeaders: []*configPb.HeaderValueOption{
-										{
-											Header: &configPb.HeaderValue{
-												Key:      metadata.DestinationEndpointKey,
-												RawValue: []byte(reqCtx.TargetEndpoint),
-											},
-										},
-										{
-											Header: &configPb.HeaderValue{
-												Key:      "X-Echo-Set-Header",
-												RawValue: []byte(metadata.ConformanceTestResultHeader + ":" + reqCtx.TargetEndpoint),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					DynamicMetadata: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							metadata.DestinationEndpointNamespace: structpb.NewStructValue(&structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									metadata.DestinationEndpointKey: structpb.NewStringValue(reqCtx.TargetEndpoint),
-								},
-							}),
-						},
-					},
-				}
-			} else {
-				headersDeferred = true
+			err = s.pickEndpoint(ctx, reqCtx, nil)
+			if err != nil {
+				logger.Error(err, "Failed to pick endpoint")
+				return status.Errorf(codes.Internal, "internal error: %v", err)
 			}
 
-			if resp != nil {
-				if err := srv.Send(resp); err != nil {
-					return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
-				}
+			if err := srv.Send(requestHeadersResponse(reqCtx)); err != nil {
+				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
 			}
 
 		case *extProcPb.ProcessingRequest_RequestBody:
@@ -199,63 +218,14 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			body = append(body, v.RequestBody.Body...)
 
 			if v.RequestBody.EndOfStream {
-				err = s.pickEndpoint(ctx, reqCtx, body)
-				if err != nil {
-					logger.Error(err, "Failed to pick endpoint")
-					return status.Errorf(codes.Internal, "internal error: %v", err)
-				}
 				body = nil
-
-				if headersDeferred {
-					headerResp := &extProcPb.ProcessingResponse{
-						Response: &extProcPb.ProcessingResponse_RequestHeaders{
-							RequestHeaders: &extProcPb.HeadersResponse{
-								Response: &extProcPb.CommonResponse{
-									ClearRouteCache: true,
-									HeaderMutation: &extProcPb.HeaderMutation{
-										SetHeaders: []*configPb.HeaderValueOption{
-											{
-												Header: &configPb.HeaderValue{
-													Key:      metadata.DestinationEndpointKey,
-													RawValue: []byte(reqCtx.TargetEndpoint),
-												},
-											},
-											{
-												Header: &configPb.HeaderValue{
-													Key:      "X-Echo-Set-Header",
-													RawValue: []byte(metadata.ConformanceTestResultHeader + ":" + reqCtx.TargetEndpoint),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						DynamicMetadata: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								metadata.DestinationEndpointNamespace: structpb.NewStructValue(&structpb.Struct{
-									Fields: map[string]*structpb.Value{
-										metadata.DestinationEndpointKey: structpb.NewStringValue(reqCtx.TargetEndpoint),
-									},
-								}),
-							},
-						},
-					}
-					if err := srv.Send(headerResp); err != nil {
-						return status.Errorf(codes.Unknown, "failed to send deferred headers response back to Envoy: %v", err)
-					}
-				}
 			}
 
-			for _, commonResp := range envoy.BuildChunkedBodyResponses(v.RequestBody.Body, v.RequestBody.EndOfStream) {
-				resp := &extProcPb.ProcessingResponse{
-					Response: &extProcPb.ProcessingResponse_RequestBody{
-						RequestBody: &extProcPb.BodyResponse{
-							Response: commonResp,
-						},
-					},
+			for _, resp := range s.bodyResponses(v.RequestBody.Body, v.RequestBody.EndOfStream, func(bodyResp *extProcPb.BodyResponse) *extProcPb.ProcessingResponse {
+				return &extProcPb.ProcessingResponse{
+					Response: &extProcPb.ProcessingResponse_RequestBody{RequestBody: bodyResp},
 				}
-
+			}) {
 				if err := srv.Send(resp); err != nil {
 					return status.Errorf(codes.Unknown, "failed to send body response back to Envoy: %v", err)
 				}
@@ -270,15 +240,11 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		case *extProcPb.ProcessingRequest_ResponseBody:
 			logger.V(1).Info("Received response body", "endOfStream", v.ResponseBody.EndOfStream)
-			for _, commonResp := range envoy.BuildChunkedBodyResponses(v.ResponseBody.Body, v.ResponseBody.EndOfStream) {
-				resp := &extProcPb.ProcessingResponse{
-					Response: &extProcPb.ProcessingResponse_ResponseBody{
-						ResponseBody: &extProcPb.BodyResponse{
-							Response: commonResp,
-						},
-					},
+			for _, resp := range s.bodyResponses(v.ResponseBody.Body, v.ResponseBody.EndOfStream, func(bodyResp *extProcPb.BodyResponse) *extProcPb.ProcessingResponse {
+				return &extProcPb.ProcessingResponse{
+					Response: &extProcPb.ProcessingResponse_ResponseBody{ResponseBody: bodyResp},
 				}
-
+			}) {
 				if err := srv.Send(resp); err != nil {
 					return status.Errorf(codes.Unknown, "failed to send response body back to Envoy: %v", err)
 				}

--- a/pkg/lwepp/handlers/server.go
+++ b/pkg/lwepp/handlers/server.go
@@ -199,7 +199,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				return status.Errorf(codes.Internal, "internal error: %v", err)
 			}
 
-			err = s.pickEndpoint(ctx, reqCtx, nil)
+			err = s.pickEndpoint(ctx, reqCtx)
 			if err != nil {
 				logger.Error(err, "Failed to pick endpoint")
 				return status.Errorf(codes.Internal, "internal error: %v", err)

--- a/pkg/lwepp/handlers/server_test.go
+++ b/pkg/lwepp/handlers/server_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	processingModePb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -56,7 +57,7 @@ func (m *mockProcessServer) Recv() (*extProcPb.ProcessingRequest, error) {
 	return msg, nil
 }
 
-func TestProcess_DeferredHeaderMutationOnStreamingBody(t *testing.T) {
+func TestProcess_HeaderMutationOnStreamingBody(t *testing.T) {
 	pods := []*datastore.Endpoint{
 		{Address: "10.0.0.1", Port: "8080"},
 	}
@@ -138,5 +139,97 @@ func TestProcess_DeferredHeaderMutationOnStreamingBody(t *testing.T) {
 		require.NotNil(responseBody)
 		assert.Equal(t, respBody.GetResponseBody().GetBody(), responseBody.GetBody())
 		assert.Equal(t, respBody.GetResponseBody().GetEndOfStream(), responseBody.GetEndOfStream())
+	}
+}
+
+func TestProcess_FullDuplexStreamedBodyInterleaving(t *testing.T) {
+	server := NewStreamingServer(&mockDatastore{
+		pods: []*datastore.Endpoint{{Address: "10.0.0.1", Port: "8080"}},
+	})
+
+	recvMessages := []*extProcPb.ProcessingRequest{
+		{
+			Request: &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{
+					Headers:     &envoyCorev3.HeaderMap{},
+					EndOfStream: false,
+				},
+			},
+		},
+		{
+			Request: &extProcPb.ProcessingRequest_RequestBody{
+				RequestBody: &extProcPb.HttpBody{Body: []byte("request-1"), EndOfStream: false},
+			},
+		},
+		{
+			Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+				ResponseHeaders: &extProcPb.HttpHeaders{Headers: &envoyCorev3.HeaderMap{}},
+			},
+		},
+		{
+			Request: &extProcPb.ProcessingRequest_ResponseBody{
+				ResponseBody: &extProcPb.HttpBody{Body: []byte("response-1"), EndOfStream: false},
+			},
+		},
+		{
+			Request: &extProcPb.ProcessingRequest_RequestBody{
+				RequestBody: &extProcPb.HttpBody{Body: []byte("request-2"), EndOfStream: true},
+			},
+		},
+		{
+			Request: &extProcPb.ProcessingRequest_ResponseBody{
+				ResponseBody: &extProcPb.HttpBody{Body: []byte("response-2"), EndOfStream: true},
+			},
+		},
+	}
+
+	stream := &mockProcessServer{ctx: context.Background(), recvMessages: recvMessages}
+	assert.NoError(t, server.Process(stream))
+
+	if assert.Len(t, stream.sentMessages, len(recvMessages)) {
+		assert.NotNil(t, stream.sentMessages[0].GetRequestHeaders())
+		assert.NotNil(t, stream.sentMessages[1].GetRequestBody())
+		assert.NotNil(t, stream.sentMessages[2].GetResponseHeaders())
+		assert.NotNil(t, stream.sentMessages[3].GetResponseBody())
+		assert.NotNil(t, stream.sentMessages[4].GetRequestBody())
+		assert.NotNil(t, stream.sentMessages[5].GetResponseBody())
+	}
+}
+
+func TestProcess_BufferedBodyMode(t *testing.T) {
+	server := NewStreamingServerWithBodyMode(&mockDatastore{
+		pods: []*datastore.Endpoint{{Address: "10.0.0.1", Port: "8080"}},
+	}, processingModePb.ProcessingMode_BUFFERED)
+
+	reqBody := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_RequestBody{
+			RequestBody: &extProcPb.HttpBody{Body: []byte("request"), EndOfStream: true},
+		},
+	}
+	respBody := &extProcPb.ProcessingRequest{
+		Request: &extProcPb.ProcessingRequest_ResponseBody{
+			ResponseBody: &extProcPb.HttpBody{Body: []byte("response"), EndOfStream: true},
+		},
+	}
+	stream := &mockProcessServer{
+		ctx: context.Background(),
+		recvMessages: []*extProcPb.ProcessingRequest{
+			{Request: &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{Headers: &envoyCorev3.HeaderMap{}},
+			}},
+			reqBody,
+			respBody,
+		},
+	}
+
+	assert.NoError(t, server.Process(stream))
+	if assert.Len(t, stream.sentMessages, 3) {
+		requestMutation := stream.sentMessages[1].GetRequestBody().GetResponse().GetBodyMutation()
+		assert.Equal(t, reqBody.GetRequestBody().GetBody(), requestMutation.GetBody())
+		assert.Nil(t, requestMutation.GetStreamedResponse())
+
+		responseMutation := stream.sentMessages[2].GetResponseBody().GetResponse().GetBodyMutation()
+		assert.Equal(t, respBody.GetResponseBody().GetBody(), responseMutation.GetBody())
+		assert.Nil(t, responseMutation.GetStreamedResponse())
 	}
 }

--- a/pkg/lwepp/server/options.go
+++ b/pkg/lwepp/server/options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -25,6 +27,8 @@ const (
 	DefaultGrpcPort       = 9002
 	DefaultGrpcHealthPort = 9003
 	DefaultPoolNamespace  = "default" // default when pool namespace is empty (CLI flag default is empty)
+	BodyModeBuffered      = "buffered"
+	BodyModeFullDuplex    = "full-duplex-streamed"
 )
 
 // Options contains configuration values necessary to create and run the lwepp.
@@ -38,6 +42,7 @@ type Options struct {
 	EndpointTargetPorts []int  // Target ports of model server pods.
 	HealthChecking      bool   // Enables health checking.
 	SecureServing       bool   // Enables TLS on the ext-proc gRPC server.
+	BodyMode            string // Envoy ext-proc body processing mode.
 }
 
 // NewOptions returns a new Options struct initialized with the default values.
@@ -49,6 +54,7 @@ func NewOptions() *Options {
 		EndpointTargetPorts: []int{},
 		MetricsPort:         9090,
 		SecureServing:       true,
+		BodyMode:            BodyModeFullDuplex,
 	}
 }
 
@@ -69,6 +75,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.GRPCHealthPort, "grpc-health-port", opts.GRPCHealthPort, "Port for gRPC liveness and readiness probes.")
 	fs.BoolVar(&opts.HealthChecking, "health-checking", opts.HealthChecking, "Enables health checking.")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables TLS on the ext-proc gRPC server.")
+	fs.StringVar(&opts.BodyMode, "body-mode", opts.BodyMode, "Envoy ext-proc body processing mode: buffered or full-duplex-streamed.")
 }
 
 func (opts *Options) Complete() error {
@@ -77,6 +84,9 @@ func (opts *Options) Complete() error {
 }
 
 func (opts *Options) Validate() error {
+	if opts.BodyMode != BodyModeBuffered && opts.BodyMode != BodyModeFullDuplex {
+		return fmt.Errorf("invalid body mode %q: must be %q or %q", opts.BodyMode, BodyModeBuffered, BodyModeFullDuplex)
+	}
 	return nil
 }
 

--- a/pkg/lwepp/server/runserver.go
+++ b/pkg/lwepp/server/runserver.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	processingModePb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -49,6 +50,7 @@ type ExtProcServerRunner struct {
 	Datastore      datastore.Datastore
 	HealthChecking bool
 	SecureServing  bool
+	BodyMode       string
 }
 
 // NewDefaultExtProcServerRunner creates a runner with default values.
@@ -72,6 +74,7 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 		GKNN:           gknn,
 		HealthChecking: opts.HealthChecking,
 		SecureServing:  opts.SecureServing,
+		BodyMode:       opts.BodyMode,
 		// Datastore can be assigned later.
 	}
 }
@@ -113,7 +116,11 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 			srv = grpc.NewServer()
 		}
 
-		extProcServer := handlers.NewStreamingServer(r.Datastore)
+		bodyMode := processingModePb.ProcessingMode_FULL_DUPLEX_STREAMED
+		if r.BodyMode == BodyModeBuffered {
+			bodyMode = processingModePb.ProcessingMode_BUFFERED
+		}
+		extProcServer := handlers.NewStreamingServerWithBodyMode(r.Datastore, bodyMode)
 		extProcPb.RegisterExternalProcessorServer(srv, extProcServer)
 
 		if r.HealthChecking {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/area conformance-test

**What this PR does / why we need it**:

lwepp didn't worked with envoy duplex stream mode, I tested this in https://github.com/envoyproxy/ai-gateway/pull/2639.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/3035

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
fix lwepp didn't worked with envoy duplex stream mode
```
