### PR TITLE
fix: EppUnAvailableFailOpen conformance test

### DIFF
--- a/conformance/tests/epp_unavailable_fail_open.go
+++ b/conformance/tests/epp_unavailable_fail_open.go
@@ -95,11 +95,11 @@ var EppUnAvailableFailOpen = suite.ConformanceTest{
 		})
 
 		t.Run("Phase 2: Verify fail-open behavior after EPP becomes unavailable", func(t *testing.T) {
-			t.Logf("Making EPP service %v unavailable...", resources.PrimaryEppServiceNN)
+			t.Logf("Making EPP service %v unavailable...", resources.SecondaryEppServiceNN)
 			timeconfig := config.DefaultInferenceExtensionTimeoutConfig()
-			restore, err := k8sutils.MakeServiceUnavailable(t, s.Client, resources.PrimaryEppServiceNN, timeconfig.ServiceUpdateTimeout)
+			restore, err := k8sutils.MakeServiceUnavailable(t, s.Client, resources.SecondaryEppServiceNN, timeconfig.ServiceUpdateTimeout)
 			t.Cleanup(restore)
-			require.NoError(t, err, "Failed to make the EPP service %v unavailable", resources.PrimaryEppServiceNN)
+			require.NoError(t, err, "Failed to make the EPP service %v unavailable", resources.SecondaryEppServiceNN)
 
 			t.Log("Sending request again, expecting success to verify fail-open...")
 			gwhttp.MakeRequestAndExpectEventuallyConsistentResponse(


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area conformance-test

**What this PR does / why we need it**:

`EppUnAvailableFailOpen` runs both phases entirely against the *secondary* Gateway/InferencePool — the only one configured with `failureMode: failOpen` (see the comment in `epp_unavailable_fail_open.yaml`: "Use secondary-inferencePool because it has failureMode set to failOpen"). Phase 2, however, was making the *primary* EPP service (`primary-endpoint-picker-svc`) unavailable instead of `secondary-endpoint-picker-svc`, which is the one actually fronting the pool under test.

Since the primary EPP has no bearing on this path, disabling it left the secondary EPP running throughout Phase 2. The request therefore kept being routed by a healthy EPP that still honored the `test-epp-endpoint-selection` header and landed on the same deterministic target pod as Phase 1 — it never actually depended on Envoy's fail-open fallback. The test passed regardless of whether fail-open routing worked, so it gave no real signal on the behavior it claims to verify.

This fixes Phase 2 to disable `secondary-endpoint-picker-svc` instead, so the test genuinely exercises fail-open: with the EPP guiding `secondary-inference-pool` down, the request must now succeed via Envoy falling back directly to a backend pod, which is why the assertion also relaxes from the exact target pod to the `secondary-inference-model-server` prefix (any pod, since no EPP is left to steer it).

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
Fixed `EppUnAvailableFailOpen` to make the secondary EPP service (the one actually fronting the fail-open InferencePool) unavailable in Phase 2, instead of the primary EPP. Previously the test never disabled the EPP that mattered, so it passed regardless of whether fail-open routing actually worked.
