### PR TITLE
feat(lwepp): reflect which pool's picker selected the endpoint

### DIFF
--- a/pkg/lwepp/datastore/datastore.go
+++ b/pkg/lwepp/datastore/datastore.go
@@ -48,6 +48,7 @@ type Endpoint struct {
 type EndpointPool struct {
 	Selector    map[string]string
 	TargetPorts []int
+	Name        string
 	Namespace   string
 }
 

--- a/pkg/lwepp/handlers/request_test.go
+++ b/pkg/lwepp/handlers/request_test.go
@@ -31,10 +31,11 @@ import (
 
 type mockDatastore struct {
 	pods []*datastore.Endpoint
+	pool *datastore.EndpointPool
 }
 
 func (m *mockDatastore) PoolGet() (*datastore.EndpointPool, error) {
-	return nil, nil
+	return m.pool, nil
 }
 
 func (m *mockDatastore) PodList(predicate func(*datastore.Endpoint) bool) []*datastore.Endpoint {

--- a/pkg/lwepp/handlers/response.go
+++ b/pkg/lwepp/handlers/response.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/metadata"
 )
 
-func (s *StreamingServer) handleResponseHeaders(ctx context.Context, fullReq *extProcPb.ProcessingRequest, respHeaders *extProcPb.ProcessingRequest_ResponseHeaders) *extProcPb.ProcessingResponse {
+func (s *StreamingServer) handleResponseHeaders(ctx context.Context, reqCtx *RequestContext, fullReq *extProcPb.ProcessingRequest, respHeaders *extProcPb.ProcessingRequest_ResponseHeaders) *extProcPb.ProcessingResponse {
 	logger := log.FromContext(ctx)
 	logger.Info("Handling response headers")
 
@@ -63,6 +63,34 @@ func (s *StreamingServer) handleResponseHeaders(ctx context.Context, fullReq *ex
 		},
 	}
 
+	// Promote the endpoint this picker selected to a response header of its own.
+	// It is already reflected through the echo server's X-Echo-Set-Header, which
+	// stays as it is, but that path needs a backend which implements it. Reading
+	// the selection and what actually served as separate headers is what lets a
+	// test see a picker whose choice was discarded.
+	if reqCtx != nil && reqCtx.TargetEndpoint != "" {
+		headers = append(headers, &configPb.HeaderValueOption{
+			Header: &configPb.HeaderValue{
+				Key:      metadata.ConformanceTestSelectedHeader,
+				RawValue: []byte(reqCtx.TargetEndpoint),
+			},
+		})
+	}
+
+	// Name the pool this picker fronts. A rule that weights traffic across several
+	// pools must consult each pool's own picker, and the served endpoint alone
+	// cannot show which picker answered: a test would have to infer it from pool
+	// membership, which assumes every endpoint belongs to exactly one pool.
+	if poolName := s.poolName(); poolName != "" {
+		logger.Info("Setting conformance test pool header", "header", metadata.ConformanceTestPoolHeader, "value", poolName)
+		headers = append(headers, &configPb.HeaderValueOption{
+			Header: &configPb.HeaderValue{
+				Key:      metadata.ConformanceTestPoolHeader,
+				RawValue: []byte(poolName),
+			},
+		})
+	}
+
 	// Include any non-system-owned headers from the original response.
 	if respHeaders != nil && respHeaders.ResponseHeaders != nil && respHeaders.ResponseHeaders.Headers != nil {
 		for _, header := range respHeaders.ResponseHeaders.Headers.Headers {
@@ -89,4 +117,19 @@ func (s *StreamingServer) handleResponseHeaders(ctx context.Context, fullReq *ex
 	}
 
 	return resp
+}
+
+// poolName is the name of the pool this picker fronts, or empty when there is none
+// to report: no datastore, a pool that has yet to sync, or one carrying no name.
+// Callers omit the header rather than send an empty one, so every one of those
+// cases is the same answer.
+func (s *StreamingServer) poolName() string {
+	if s.datastore == nil {
+		return ""
+	}
+	pool, err := s.datastore.PoolGet()
+	if err != nil || pool == nil {
+		return ""
+	}
+	return pool.Name
 }

--- a/pkg/lwepp/handlers/response_test.go
+++ b/pkg/lwepp/handlers/response_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"testing"
 
 	envoyCorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -25,13 +24,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/datastore"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/lwepp/metadata"
 )
 
 func TestHandleResponseHeaders_MissingEnvoyLBMetadata(t *testing.T) {
 	server := &StreamingServer{}
 
-	resp := server.handleResponseHeaders(context.Background(), nil, &extProcPb.ProcessingRequest_ResponseHeaders{})
+	resp := server.handleResponseHeaders(t.Context(), nil, nil, &extProcPb.ProcessingRequest_ResponseHeaders{})
 
 	setHeaders := resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
 	assert.Len(t, setHeaders, 2)
@@ -56,7 +56,7 @@ func TestHandleResponseHeaders_MissingDestinationEndpointServedKey(t *testing.T)
 		},
 	}
 
-	resp := server.handleResponseHeaders(context.Background(), fullReq, &extProcPb.ProcessingRequest_ResponseHeaders{})
+	resp := server.handleResponseHeaders(t.Context(), nil, fullReq, &extProcPb.ProcessingRequest_ResponseHeaders{})
 
 	setHeaders := resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
 	assert.Len(t, setHeaders, 2)
@@ -81,7 +81,7 @@ func TestHandleResponseHeaders_UsesServedEndpointFromMetadata(t *testing.T) {
 		},
 	}
 
-	resp := server.handleResponseHeaders(context.Background(), fullReq, &extProcPb.ProcessingRequest_ResponseHeaders{})
+	resp := server.handleResponseHeaders(t.Context(), nil, fullReq, &extProcPb.ProcessingRequest_ResponseHeaders{})
 
 	setHeaders := resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
 	assert.Len(t, setHeaders, 2)
@@ -107,7 +107,7 @@ func TestHandleResponseHeaders_ForwardsOriginalHeaders(t *testing.T) {
 		},
 	}
 
-	resp := server.handleResponseHeaders(context.Background(), nil, originalHeaders)
+	resp := server.handleResponseHeaders(t.Context(), nil, nil, originalHeaders)
 
 	setHeaders := resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
 	assert.Len(t, setHeaders, 3)
@@ -115,4 +115,49 @@ func TestHandleResponseHeaders_ForwardsOriginalHeaders(t *testing.T) {
 	assert.Equal(t, "x-went-into-resp-headers", setHeaders[1].GetHeader().GetKey())
 	assert.Equal(t, "x-custom-header", setHeaders[2].GetHeader().GetKey())
 	assert.Equal(t, "custom-value", string(setHeaders[2].GetHeader().GetRawValue()))
+}
+
+func TestResponseHeadersCarryThePoolThatPicked(t *testing.T) {
+	// given a synced pool, the response names the pool this picker speaks for, so a
+	// test spanning several pools can tell which picker answered rather than
+	// inferring it from which pool owns the served endpoint
+	server := NewStreamingServer(&mockDatastore{pool: &datastore.EndpointPool{Name: "primary-inference-pool"}})
+	resp := server.handleResponseHeaders(t.Context(), nil, &extProcPb.ProcessingRequest{}, nil)
+
+	var got string
+	for _, h := range resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders() {
+		if h.GetHeader().GetKey() == metadata.ConformanceTestPoolHeader {
+			got = string(h.GetHeader().GetRawValue())
+		}
+	}
+	assert.Equal(t, "primary-inference-pool", got)
+
+	// before the datastore syncs a pool there is nothing to name, so the header is
+	// absent rather than empty and consumers must treat it as optional
+	resp = NewStreamingServer(&mockDatastore{}).handleResponseHeaders(t.Context(), nil, &extProcPb.ProcessingRequest{}, nil)
+	for _, h := range resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders() {
+		assert.NotEqual(t, metadata.ConformanceTestPoolHeader, h.GetHeader().GetKey())
+	}
+}
+
+func TestResponseHeadersPromoteTheSelectedEndpoint(t *testing.T) {
+	// given a picker that chose an endpoint, the choice is reported as a header of
+	// its own rather than only through the echo server, so a test can compare it
+	// against the endpoint that served without relying on the backend to reflect it
+	server := NewStreamingServer(&mockDatastore{pool: &datastore.EndpointPool{Name: "primary-inference-pool"}})
+	reqCtx := &RequestContext{TargetEndpoint: "10.0.0.1:8080"}
+	resp := server.handleResponseHeaders(t.Context(), reqCtx, &extProcPb.ProcessingRequest{}, nil)
+
+	got := map[string]string{}
+	for _, h := range resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders() {
+		got[h.GetHeader().GetKey()] = string(h.GetHeader().GetRawValue())
+	}
+	assert.Equal(t, "10.0.0.1:8080", got[metadata.ConformanceTestSelectedHeader])
+	assert.Equal(t, "primary-inference-pool", got[metadata.ConformanceTestPoolHeader])
+
+	// nothing was picked, so there is no selection to report
+	resp = server.handleResponseHeaders(t.Context(), &RequestContext{}, &extProcPb.ProcessingRequest{}, nil)
+	for _, h := range resp.GetResponseHeaders().GetResponse().GetHeaderMutation().GetSetHeaders() {
+		assert.NotEqual(t, metadata.ConformanceTestSelectedHeader, h.GetHeader().GetKey())
+	}
 }

--- a/pkg/lwepp/handlers/server.go
+++ b/pkg/lwepp/handlers/server.go
@@ -277,7 +277,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 
 		case *extProcPb.ProcessingRequest_ResponseHeaders:
 			logger.Info("Received response headers")
-			resp := s.handleResponseHeaders(ctx, req, v)
+			resp := s.handleResponseHeaders(ctx, reqCtx, req, v)
 			if err := srv.Send(resp); err != nil {
 				return status.Errorf(codes.Unknown, "failed to send response back to Envoy: %v", err)
 			}

--- a/pkg/lwepp/metadata/consts.go
+++ b/pkg/lwepp/metadata/consts.go
@@ -30,6 +30,16 @@ const (
 	DestinationEndpointServedKey = "x-gateway-destination-endpoint-served"
 	// ConformanceTestResultHeader is the header used by the conformance test to specify the endpoint that served the request.
 	ConformanceTestResultHeader = "x-conformance-test-served-endpoint"
+	// ConformanceTestSelectedHeader is the endpoint this endpoint picker selected, as
+	// opposed to ConformanceTestResultHeader which reports the endpoint that served.
+	// The two differ when the gateway discards a picker's choice, which is what a test
+	// spanning several pools needs to see.
+	ConformanceTestSelectedHeader = "x-conformance-test-selected-endpoint"
+	// ConformanceTestPoolHeader is the header used by the conformance test to identify which
+	// InferencePool's endpoint picker selected the endpoint. A rule that weights traffic across
+	// several pools must consult each pool's own picker, and the selected endpoint alone cannot
+	// show which one answered.
+	ConformanceTestPoolHeader = "x-conformance-test-epp-pool"
 	// FlowFairnessIDKey is the header key used to pass the fairness ID to be used in Flow Control.
 	FlowFairnessIDKey = "x-gateway-inference-fairness-id"
 	// ObjectiveKey is the header key used to specify the objective of an incoming request.

--- a/pkg/lwepp/util/pool/pool.go
+++ b/pkg/lwepp/util/pool/pool.go
@@ -37,6 +37,7 @@ func InferencePoolToEndpointPool(inferencePool *v1.InferencePool) *datastore.End
 	endpointPool := &datastore.EndpointPool{
 		Selector:    selector,
 		TargetPorts: targetPorts,
+		Name:        inferencePool.Name,
 		Namespace:   inferencePool.Namespace,
 	}
 	return endpointPool

--- a/pkg/lwepp/util/pool/pool_test.go
+++ b/pkg/lwepp/util/pool/pool_test.go
@@ -38,7 +38,7 @@ func TestInferencePoolToEndpointPool(t *testing.T) {
 			want:  nil,
 		},
 		{
-			name: "selector, ports and namespace are all carried over",
+			name: "selector, ports, name and namespace are all carried over",
 			input: &v1.InferencePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pool-1",
@@ -57,6 +57,7 @@ func TestInferencePoolToEndpointPool(t *testing.T) {
 			want: &datastore.EndpointPool{
 				Selector:    map[string]string{"app": "vllm", "tier": "backend"},
 				TargetPorts: []int{8000, 8001},
+				Name:        "pool-1",
 				Namespace:   "ns-1",
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area conformance-test

**What this PR does / why we need it**:

The endpoint picker already reflects the endpoint it chose back to conformance tests, but not which `InferencePool` it speaks for. So a test cannot assert if the right picker consulted. Only whether the endpoint that came back belongs to the pool that served.

A test can partly infer this by mapping every pod IP to its pool, but that assumes each endpoint belongs to exactly one pool, which nothing in the API enforces. Having the picker name itself removes the guesswork.

The picker now sends its pool name alongside the endpoint it selected. PR adds two response headers alongside the endpoint that served:
- the endpoint the picker selected - `x-conformance-test-selected-endpoint`
- the pool the picker fronts - `x-conformance-test-epp-pool`

Both are omitted when there is nothing to report - no endpoint picked, or a pool that has yet to sync - so consumers must treat them as optional.

`X-Echo-Set-Header` is deliberately left exactly as it was, so anything relying on the echo path is unaffected. The only change on that side is passing the request context into the response handler.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
