### PR TITLE
test(conformance): assert each pool's own picker was consulted

### DIFF
--- a/conformance/tests/gateway_weighted_two_pools.go
+++ b/conformance/tests/gateway_weighted_two_pools.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -59,6 +60,10 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 		const (
 			hostname = "primary.example.com"
 			path     = "/weighted-two-pools-test"
+			// The InferencePool names the manifest declares, which are also what each
+			// pool's endpoint picker reports for itself.
+			primaryPool   = "primary-inference-pool"
+			secondaryPool = "secondary-inference-pool"
 
 			// Sample size so the weight signal dominates random noise.
 			totalRequests      = 200
@@ -112,6 +117,15 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 			secondaryPodIPs = append(secondaryPodIPs, p.Status.PodIP)
 		}
 
+		// Map Kubernetes pod IPs to the pod names reported by the echo backends.
+		podByIP := make(map[string]string, len(primaryPodIPs)+len(secondaryPodIPs))
+		for i, ip := range primaryPodIPs {
+			podByIP[ip] = primaryPodNames[i]
+		}
+		for i, ip := range secondaryPodIPs {
+			podByIP[ip] = secondaryPodNames[i]
+		}
+
 		// Provide a union list of eligible endpoints for the test. Each pool's EPP
 		// should filter to endpoints that actually belong to its pool.
 		allIPs := append(append([]string{}, primaryPodIPs...), secondaryPodIPs...)
@@ -158,6 +172,7 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 		// Build quick lookup sets for attributing each hit to a pool by backend pod name.
 		primarySet := sets.New(primaryPodNames...)
 		secondarySet := sets.New(secondaryPodNames...)
+
 		headersMap := map[string]string{
 			headers.HeaderTestEppEndPointSelectionKey: eppHeaderValue,
 		}
@@ -189,14 +204,31 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 					if err == nil {
 						compErr := gwhttp.CompareRoundTrip(t, &req, cReq, cRes, expected)
 						if compErr == nil {
-							if primarySet.Has(cReq.Pod) {
-								primaryHits.Add(1)
-								return nil
-							} else if secondarySet.Has(cReq.Pod) {
-								secondaryHits.Add(1)
-								return nil
+							var servedPool string
+							switch {
+							case primarySet.Has(cReq.Pod):
+								servedPool = primaryPool
+							case secondarySet.Has(cReq.Pod):
+								servedPool = secondaryPool
+							default:
+								return fmt.Errorf("request was handled by unexpected pod %q (not in either pool)", cReq.Pod)
 							}
-							return fmt.Errorf("request was handled by unexpected pod %q (not in either pool)", cReq.Pod)
+							var respHeaders map[string][]string
+							if cRes != nil {
+								respHeaders = cRes.Headers
+							}
+							if err := checkEndpointPickerPool(respHeaders, servedPool, cReq.Pod); err != nil {
+								return err
+							}
+							if err := checkSelectionHonoured(respHeaders, podByIP, cReq.Pod); err != nil {
+								return err
+							}
+							if servedPool == primaryPool {
+								primaryHits.Add(1)
+							} else {
+								secondaryHits.Add(1)
+							}
+							return nil
 						}
 						if cRes != nil && (cRes.StatusCode == http.StatusNotFound || cRes.StatusCode == http.StatusServiceUnavailable) {
 							// Transient unconverged GFE instance; back off and retry
@@ -238,4 +270,69 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 		t.Logf("Weighted split OK: primary=%.3f (hits=%d/%d), expected=%.3f, tolerance=±%.3f; secondary hits=%d",
 			observedPrimary, int64(ph), int64(total), expectedPrimary, absTolerance, int64(sh))
 	},
+}
+
+// checkEndpointPickerPool compares the pool reported by the picker with the pool
+// of the responding pod. The two pools in this test have separate pickers.
+//
+// The weighted split can still be correct if the gateway consults the wrong picker
+// and then load balances within the intended pool. ConformanceTestPoolHeader exposes
+// that mismatch. Missing pool headers skip this check.
+func checkEndpointPickerPool(respHeaders map[string][]string, servedPool, servedPod string) error {
+	picked := firstHeaderValue(respHeaders, headers.ConformanceTestPoolHeader)
+	if picked == "" {
+		return nil
+	}
+	if picked != servedPool {
+		return fmt.Errorf(
+			"endpoint picker for pool %q was consulted for a request served by pool %q "+
+				"(pod %q answered). Each pool's EPP must be consulted for the traffic "+
+				"routed to that pool",
+			picked, servedPool, servedPod)
+	}
+	return nil
+}
+
+// checkSelectionHonoured checks that the IP in ConformanceTestSelectedHeader belongs
+// to the pod identified by the backend's response body. This detects a discarded
+// selection even when another pod in the same pool answers.
+//
+// The IP-to-pod mapping comes from Kubernetes, so the check does not depend on the
+// gateway's served-endpoint header. This check compares pod identity and does not
+// validate the selected port. Missing selection headers and unknown IPs skip the check.
+func checkSelectionHonoured(respHeaders map[string][]string, podByIP map[string]string, servedPod string) error {
+	selected := firstHeaderValue(respHeaders, headers.ConformanceTestSelectedHeader)
+	if selected == "" {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(selected)
+	if err != nil {
+		host = selected
+	}
+	selectedPod, known := podByIP[host]
+	if !known {
+		return nil
+	}
+	if selectedPod != servedPod {
+		return fmt.Errorf(
+			"endpoint picker selected %q (pod %q) but pod %q answered. A gateway must "+
+				"route to the endpoint its picker chose rather than load balancing over "+
+				"the pool",
+			selected, selectedPod, servedPod)
+	}
+	return nil
+}
+
+// firstHeaderValue reads a response header under either casing, since the capture path
+// does not canonicalise consistently, and returns the first comma-separated entry.
+func firstHeaderValue(respHeaders map[string][]string, name string) string {
+	values, ok := respHeaders[http.CanonicalHeaderKey(name)]
+	if !ok {
+		values, ok = respHeaders[name]
+	}
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	first, _, _ := strings.Cut(values[0], ",")
+	return strings.TrimSpace(first)
 }

--- a/conformance/tests/gateway_weighted_two_pools.go
+++ b/conformance/tests/gateway_weighted_two_pools.go
@@ -117,13 +117,12 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 		allIPs := append(append([]string{}, primaryPodIPs...), secondaryPodIPs...)
 		eppHeaderValue := strings.Join(allIPs, ",")
 
-		// Warm up every pod individually across both pools to guarantee that GFE
-		// backend health checks and NEGs for both pools are 100% healthy before kicking off concurrent traffic.
+		// Warm each backend to let health checks and NEGs settle. Failure is logged
+		// so the measured requests can still report routing errors.
 		allPods := append(append([]corev1.Pod{}, primaryPods...), secondaryPods...)
 		for _, pod := range allPods {
-			pod := pod
 			t.Logf("Warming up pod %s (%s)", pod.Name, pod.Status.PodIP)
-			gwhttp.MakeRequestAndExpectEventuallyConsistentResponse(
+			warmUpErr := warmUpBackend(
 				t,
 				s.RoundTripper,
 				s.TimeoutConfig,
@@ -145,6 +144,10 @@ var GatewayWeightedAcrossTwoInferencePools = suite.ConformanceTest{
 					Namespace: resources.AppBackendNamespace,
 				},
 			)
+			if warmUpErr != nil {
+				t.Logf("WARNING: warm-up for pod %s (%s) failed: %v; continuing to routing assertions",
+					pod.Name, pod.Status.PodIP, warmUpErr)
+			}
 		}
 
 		requestBody := `{

--- a/conformance/tests/warmup.go
+++ b/conformance/tests/warmup.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	gatewayconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
+	gwhttp "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+
+	"sigs.k8s.io/gateway-api-inference-extension/conformance/utils/config"
+)
+
+const (
+	warmUpBudgetFraction = 10
+	warmUpRetryInterval  = 500 * time.Millisecond
+)
+
+// warmUpBackend is a best-effort alternative to MakeRequestAndExpectEventuallyConsistentResponse.
+// It waits for consecutive matching responses and returns an error instead of failing the test.
+func warmUpBackend(t *testing.T, rt roundtripper.RoundTripper, tc gatewayconfig.TimeoutConfig, gwAddr string, expected gwhttp.ExpectedResponse) error {
+	t.Helper()
+
+	req := gwhttp.MakeRequest(t, &expected, gwAddr, "HTTP", "http")
+	budget := warmUpBudget(tc)
+	threshold := max(1, tc.RequiredConsecutiveSuccesses)
+	deadline := time.Now().Add(budget)
+	successes := 0
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		cReq, cRes, err := boundedRoundTripper(rt, time.Until(deadline)).CaptureRoundTrip(req)
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = gwhttp.CompareRoundTrip(t, &req, cReq, cRes, expected)
+		}
+
+		if lastErr == nil {
+			successes++
+			if successes >= threshold {
+				return nil
+			}
+			continue
+		}
+
+		successes = 0
+		if time.Until(deadline) <= warmUpRetryInterval {
+			// Stop if there is no time for another attempt after the backoff.
+			break
+		}
+		time.Sleep(warmUpRetryInterval)
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("did not converge within %s: %w", budget, lastErr)
+	}
+	return fmt.Errorf("reached only %d of %d consecutive successes within %s",
+		successes, threshold, budget)
+}
+
+// boundedRoundTripper caps the default transport's request timeout without changing
+// the suite's transport. Custom transports must enforce their own timeout.
+func boundedRoundTripper(rt roundtripper.RoundTripper, remaining time.Duration) roundtripper.RoundTripper {
+	d, ok := rt.(*roundtripper.DefaultRoundTripper)
+	if !ok || d.TimeoutConfig.RequestTimeout <= remaining {
+		return rt
+	}
+	bounded := *d
+	bounded.TimeoutConfig.RequestTimeout = remaining
+	return &bounded
+}
+
+// warmUpBudget gives each backend a tenth of the consistency timeout: 30s by default.
+func warmUpBudget(tc gatewayconfig.TimeoutConfig) time.Duration {
+	if tc.MaxTimeToConsistency <= 0 {
+		tc = config.DefaultInferenceExtensionTimeoutConfig().TimeoutConfig
+	}
+	return tc.MaxTimeToConsistency / warmUpBudgetFraction
+}

--- a/conformance/tests/warmup_test.go
+++ b/conformance/tests/warmup_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	gatewayconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
+	gwhttp "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+)
+
+type warmUpRoundTripper func(roundtripper.Request) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse, error)
+
+func (f warmUpRoundTripper) CaptureRoundTrip(req roundtripper.Request) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse, error) {
+	return f(req)
+}
+
+func warmUpProbe() gwhttp.ExpectedResponse {
+	return gwhttp.ExpectedResponse{
+		Request:   gwhttp.Request{Host: "example.com", Path: "/", Method: http.MethodPost},
+		Response:  gwhttp.Response{StatusCode: http.StatusOK},
+		Backend:   "backend-0",
+		Namespace: "test",
+	}
+}
+
+func warmUpResponse(req roundtripper.Request, pod string) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse, error) {
+	return &roundtripper.CapturedRequest{
+		Path: req.URL.Path, Host: req.Host, Method: req.Method,
+		Namespace: "test", Pod: pod,
+	}, &roundtripper.CapturedResponse{StatusCode: http.StatusOK}, nil
+}
+
+func TestWarmUpBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		consistency time.Duration
+		want        time.Duration
+	}{
+		{"default", 300 * time.Second, 30 * time.Second},
+		{"overridden", 30 * time.Second, 3 * time.Second},
+		{"unset", 0, 30 * time.Second},
+		{"negative", -time.Second, 30 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, warmUpBudget(gatewayconfig.TimeoutConfig{MaxTimeToConsistency: tc.consistency}))
+		})
+	}
+}
+
+func TestWarmUpBackendRequiresConsecutiveSuccesses(t *testing.T) {
+	for _, failure := range []string{"none", "transport error", "wrong backend"} {
+		t.Run(failure, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				rt := warmUpRoundTripper(func(req roundtripper.Request) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse, error) {
+					attempts++
+					if attempts == 3 {
+						switch failure {
+						case "transport error":
+							return nil, nil, errors.New("backend down")
+						case "wrong backend":
+							return warmUpResponse(req, "other-backend")
+						}
+					}
+					return warmUpResponse(req, "backend-0")
+				})
+				cfg := gatewayconfig.TimeoutConfig{RequiredConsecutiveSuccesses: 3}
+
+				start := time.Now()
+				err := warmUpBackend(t, rt, cfg, "127.0.0.1:80", warmUpProbe())
+
+				require.NoError(t, err)
+				if failure == "none" {
+					require.Equal(t, 3, attempts)
+					require.Zero(t, time.Since(start), "successful attempts need no backoff")
+				} else {
+					require.Equal(t, 6, attempts, "failure must reset the consecutive-success count")
+					require.Equal(t, 500*time.Millisecond, time.Since(start))
+				}
+			})
+		})
+	}
+}
+
+func TestWarmUpBackendStopsRetryingAtBudget(t *testing.T) {
+	backendErr := errors.New("backend down")
+	for _, tc := range []struct {
+		name         string
+		budget       time.Duration
+		delay        time.Duration
+		err          error
+		wantAttempts int
+		wantElapsed  time.Duration
+	}{
+		{"too few successes", 300 * time.Millisecond, 200 * time.Millisecond, nil, 2, 400 * time.Millisecond},
+		{"persistent failure", 1200 * time.Millisecond, 0, backendErr, 3, time.Second},
+		{"no time to retry", 300 * time.Millisecond, 200 * time.Millisecond, backendErr, 1, 200 * time.Millisecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				rt := warmUpRoundTripper(func(req roundtripper.Request) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse, error) {
+					attempts++
+					time.Sleep(tc.delay)
+					if tc.err != nil {
+						return nil, nil, tc.err
+					}
+					return warmUpResponse(req, "backend-0")
+				})
+				cfg := gatewayconfig.TimeoutConfig{
+					MaxTimeToConsistency: tc.budget * 10, RequiredConsecutiveSuccesses: 3,
+				}
+
+				start := time.Now()
+				err := warmUpBackend(t, rt, cfg, "127.0.0.1:80", warmUpProbe())
+
+				require.Error(t, err)
+				if tc.err != nil {
+					require.ErrorIs(t, err, tc.err)
+				} else {
+					require.ErrorContains(t, err, "2 of 3 consecutive successes")
+				}
+				require.Equal(t, tc.wantAttempts, attempts)
+				// Custom transports cannot be interrupted; a started request may finish after the budget.
+				require.Equal(t, tc.wantElapsed, time.Since(start))
+			})
+		})
+	}
+}
+
+func TestWarmUpBackendBoundsStalledRequest(t *testing.T) {
+	for _, requestTimeout := range []time.Duration{2 * time.Second, 100 * time.Millisecond} {
+		t.Run(requestTimeout.String(), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				// Stall the HTTP exchange using an in-memory connection and virtual time.
+				client, server := net.Pipe()
+				defer client.Close()
+				defer server.Close()
+				cfg := gatewayconfig.TimeoutConfig{
+					MaxTimeToConsistency: 5 * time.Second, RequestTimeout: requestTimeout,
+				}
+				rt := &roundtripper.DefaultRoundTripper{
+					TimeoutConfig: cfg,
+					CustomDialContext: func(context.Context, string, string) (net.Conn, error) {
+						return client, nil
+					},
+				}
+
+				start := time.Now()
+				err := warmUpBackend(t, rt, cfg, "127.0.0.1:80", warmUpProbe())
+
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				require.Equal(t, min(requestTimeout, 500*time.Millisecond), time.Since(start))
+				require.Equal(t, cfg, rt.TimeoutConfig, "warm-up must preserve the suite's transport settings")
+			})
+		})
+	}
+}

--- a/conformance/utils/headers/headers.go
+++ b/conformance/utils/headers/headers.go
@@ -19,4 +19,11 @@ package headers
 const (
 	HeaderTestEppEndPointSelectionKey = "test-epp-endpoint-selection"
 	ConformanceTestResultHeader       = "x-conformance-test-served-endpoint"
+	// ConformanceTestSelectedHeader carries the endpoint the picker selected, as
+	// opposed to ConformanceTestResultHeader which carries the endpoint that served.
+	ConformanceTestSelectedHeader = "x-conformance-test-selected-endpoint"
+	// ConformanceTestPoolHeader carries the name of the InferencePool whose endpoint
+	// picker selected the endpoint, so a test spanning several pools can tell which
+	// pool's picker was consulted.
+	ConformanceTestPoolHeader = "x-conformance-test-epp-pool"
 )


### PR DESCRIPTION
> [!IMPORTANT]
> Keeping this PR as draft until #3044 lands and the `lwepp` image is rebuilt. The assertion relies on a header that PR adds.
>
> This test will fail on any implementation that routes a whole rule through a single picker. That is the intent, but it does mean the run goes red until the corresponding fix lands.
>
> See istio/istio#61594, with proposed fixed istio/istio#61601.

**What type of PR is this?**

/kind test
/area conformance-test

**What this PR does / why we need it**:

The weighted two-pool test can pass even when a gateway consults the wrong pool’s endpoint picker or ignores its selection.

For example, a rule-wide `ext_proc` override can send every request to one pool's picker. If the selected endpoint is absent from the chosen backend cluster, the gateway may fall back to load balancing within that cluster. The responding pods and traffic split still satisfy the existing assertions.

This PR adds two checks using the headers introduced by #3044:

- the picker’s reported pool matches the pool of the responding pod
- the selected IP belongs to the responding pod

The second check uses Kubernetes pod data and the backend’s response body, so it does not depend on the gateway reporting which endpoint served. Missing headers skip the corresponding check; selected IPs outside the discovered pods are also skipped.

Per-pod warm-up is now best-effort so a convergence failure does not prevent the test from reaching its routing assertions. Unsuccessful warm-ups are logged.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
