### PR TITLE
fix: pin go toolchain version to use the same version of go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,13 @@ LWEPP_IMAGE_NAME := lwepp
 LWEPP_IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(LWEPP_IMAGE_NAME)
 LWEPP_IMAGE_TAG ?= $(LWEPP_IMAGE_REPO):$(GIT_TAG)
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot
-BUILDER_IMAGE ?= golang:1.26
+
+# Ensure correct toolchain is used. The authority for the go version should
+# be the one used on go.mod to avoid drift on generated files running on runners
+# with a different go version
+GO_MOD_VERSION = $(shell sed -n 's/^go //p' go.mod)
+export GOTOOLCHAIN=go$(GO_MOD_VERSION)
+BUILDER_IMAGE ?= golang:$(GO_MOD_VERSION)
 ifdef GO_VERSION
 BUILDER_IMAGE = golang:$(GO_VERSION)
 endif
@@ -286,6 +292,10 @@ GOLANGCI_API_LINT = $(LOCALBIN)/golangci-kube-api-linter
 YQ = $(PROJECT_DIR)/bin/yq
 KUBECTL_VALIDATE = $(PROJECT_DIR)/bin/kubectl-validate
 GCI = $(LOCALBIN)/gci
+
+# Ensure correct toolchain is used. There may be differences between required go versions
+# and the version present on prow Pods, and the authority should be the project go.mod
+export GOTOOLCHAIN=go$(shell sed -n 's/^go //p' go.mod)
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The version of go toolchain to be used is not verified from the go.mod which should be the authority. In this case, pipelines will fail when a bump on a prow runner causes a drift of Go version, and the generated files differ.

This fix is based on a similar problem that we got on Gateway API: https://github.com/kubernetes-sigs/gateway-api/pull/5233/changes


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
